### PR TITLE
feat(reader): add CBZ (Comic Book Archive) support (ADR 0042)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -85,7 +85,7 @@ A [Library Item] that is **listenable**: its Source-side media carries audio (`h
 The full-screen surface that plays an [Audiobook]. Shows the square cover, title/author, and current chapter title. Its scrubber is a **seekable chapter map**: one continuous draggable track over the whole book, tick-marked at chapter boundaries and banded on the current chapter; the seek handle is a thin vertical playhead. Time is shown per chapter and whole book, mirroring the official Audiobookshelf app. The transport cluster is centered — rewind 15s, previous chapter, play/pause, next chapter, forward 30s — with the playback-speed control in a secondary utility row. Previous/next-chapter are enabled only when the audiobook has chapter markers; a chapterless single-file audiobook shows them disabled and its scrubber degrades to a plain track (no ticks/band, whole-book time only). The player is **audio-led**: the live audio position drives the book's canonical position and propagates outward through [Progress Sync] (see [ADR 0029]). Streams audio **directly from the Source** implementing `AudiobookMediaCapability` — not from a Storyteller bundle, even for a matched book (a bundle, when present, is consulted only to translate audio seconds to the text canonical). Launched by the **Listen** affordance on the [Library Item Detail Screen]. Distinct from the Readaloud player, which is a translucent bar inside the reader; the two share no code in v1.
 
 ### Readable / Listenable
-The two independent capabilities a [Library Item] may have. **Readable** = has an ebook file (EPUB or PDF). **Listenable** = has audio the Source can serve as an [Audiobook]. An item may be neither, either, or both.
+The two independent capabilities a [Library Item] may have. **Readable** = has an ebook file (EPUB, PDF, or [Comic Book Archive]). **Listenable** = has audio the Source can serve as an [Audiobook]. An item may be neither, either, or both.
 
 ### Unsupported Library Item
 A [Library Item] that is neither Readable nor Listenable. Displayed in the library list as dimmed; tapping it opens the [Library Item Detail Screen], which explains there is nothing to read or listen to.
@@ -123,7 +123,7 @@ A per-Source record of a single continuous reading period. Opened when the user 
 Aggregated reading data — time spent reading, books finished, current streaks. Gated on `StatsCapability`. Sources without it hide the Statistics surface entirely; a local aggregation is a possible future feature but is not shipping.
 
 ### Progress Sync
-Reconciliation of reading position between the local canonical position and every **[Progress Peer]** for the open book. A Progress Peer is a Source (via `ProgressPeerCapability`) attached to the item — for the common case, the item's own Source. Applies to all supported formats (EPUB, PDF, future).
+Reconciliation of reading position between the local canonical position and every **[Progress Peer]** for the open book. A Progress Peer is a Source (via `ProgressPeerCapability`) attached to the item — for the common case, the item's own Source. Applies to all supported formats (EPUB, PDF, [Comic Book Archive]). Comics use an integer page-index as the canonical position; on the ABS wire they piggyback on the PDF path (Readium Locator JSON) in v1 — a comic-specific fraction wire codec is on the roadmap ([ADR 0042]).
 
 The cycle runs every ~30 s and on reader resume:
 - **Unified canonical position:** the open book has a single canonical position with a single `localUpdatedAt`. Each Peer is convertible to and from the canonical position; the reconciler owns the translation.
@@ -139,6 +139,7 @@ The cycle runs every ~30 s and on reader resume:
 User-controlled reading display settings. Scope varies by format:
 - **EPUB:** font size, theme (Light / Dark / Sepia / [Auto Theme]), font family (system fonts + Literata, Merriweather, OpenDyslexic), justify text (on/off, default off), line spacing, margins, reading orientation (paginated / vertical / continuous).
 - **PDF:** theme (as colour filter, same value set including [Auto Theme]), zoom persistence. PDF is paged-only today.
+- **[Comic Book Archive]:** none in v1. Fit Whole, paginated, LTR are all hard-coded; the reader shows no Formatting Preferences button (see [ADR 0042]).
 
 Formatting Preferences are per-device and Source-agnostic.
 
@@ -157,7 +158,7 @@ The layer (`EpubCfiTranslator`) that converts between Readium's native position 
 ### Annotation
 Umbrella term for the three user-authored marks attached to a Library Item: [Highlight], [Note], and [Bookmark]. All share one storage model and one [Annotation Sync] format. Each carries a stable client-generated ID, creation and last-modified timestamps, and a device-origin tag, and anchors to an EPUB CFI. Every Annotation additionally stores the surrounding text snippet and chapter href as a human-readable fallback.
 
-Annotations are keyed by the Library Item's `(sourceId, sourceItemId)`. Since every book is read from the Source's own EPUB, Annotations are available during all reading, with or without a Readaloud.
+Annotations are keyed by the Library Item's `(sourceId, sourceItemId)`. Since every book is read from the Source's own EPUB, Annotations are available during all reading, with or without a Readaloud. Not available on PDF or [Comic Book Archive] in v1 — the anchor is EPUB CFI ([ADR 0024]); a page-anchored variant is on the roadmap alongside PDF annotations.
 
 ### Annotation Sync
 The mechanism by which [Annotation]s roam between devices. The local Room store is always the primary, queryable store; Sync is an optional [Service] layer, reached through a single `AnnotationSyncTarget` abstraction (`list / read / write-own-file`) so the backing store is swappable. On-the-wire format: **W3C Web Annotation Data Model** (JSON-LD), with a `riffle:` extension namespace carrying merge-critical fields (`device`, `updatedAt`, `deleted`). Two target *kinds* are anticipated: **blob-store** (a folder of one file per device per book, merged client-side by per-record last-write-wins) and **record-store** (per-record CRUD with server-side merge). **v1 ships local-only** (with WebDAV target scaffolded); the schema is sync-ready so enabling a target later is additive.
@@ -200,10 +201,13 @@ A global user preference (default: on) that enables page turns via the device's 
 A reader state in which the TopAppBar and Android's system bars are hidden. Toggled by tapping the reading content. The reader always opens immersive. Not persisted across sessions.
 
 ### Book Search
-An in-EPUB text search available while reading. Activated via a search icon in the reader's TopAppBar. Searches the full publication via Readium's `SearchService`; results highlighted directly in the reading content. Applies to EPUB only. Source-agnostic.
+An in-EPUB text search available while reading. Activated via a search icon in the reader's TopAppBar. Searches the full publication via Readium's `SearchService`; results highlighted directly in the reading content. Applies to EPUB only — not available on PDF or [Comic Book Archive] (both are page-image formats with no queryable text stream). Source-agnostic.
 
 ### Supported Formats
-EPUB (reflowable) and PDF (fixed-layout). Rendered via the Readium Kotlin SDK (EPUB navigator + Pdfium adapter).
+EPUB (reflowable), PDF (fixed-layout), and [Comic Book Archive] (page-image). EPUB and PDF are rendered via the Readium Kotlin SDK (EPUB navigator + Pdfium adapter); comics use a purpose-built page-image renderer over the archive's entries.
+
+### Comic Book Archive
+A page-image ebook format — a ZIP (`.cbz`) of images, one image per page, in filename-sorted order. Ships as the third [Readable] format in v1. The `.cbr` (RAR) sibling is on the roadmap; a file mislabeled `.cbz` that is actually a RAR is caught at open time via magic-byte sniff and surfaces a clean "not supported" message. Rendered by the **Comic Reader** — a purpose-built Compose surface, distinct from EPUB's Readium navigator and PDF's Pdfium fragment. Reading orientation is paginated only in v1 (no webtoon, no two-page spread); page fit is hard-coded to Fit Whole; reading direction is left-to-right (no RTL/manga toggle). Navigation clones CDisplayEx's default interaction model: horizontal tap-thirds (previous / immersive-toggle / next), horizontal swipe, pinch-to-zoom + pan + double-tap-to-reset on each page, plus a bottom page scrubber that appears with the top bar. [Volume Key Navigation], [Screen Wake Lock], [Immersive Mode], and [Progress Sync] apply unchanged; [Book Search], [Table of Contents (TOC)], [Chapter Navigation Rail], [Formatting Preferences], [Readaloud], [Cadence], [Auto-Scroll], and [Annotation]s are unavailable in v1 (see [ADR 0042]). User-facing copy calls it **Comic**.
 
 ### Library Tab Bar
 The bottom navigation surface within a Library screen. Contains up to six icon-only tabs — Home, To Read, Annotations, Series, Collections, and All Books — scoped to the currently viewed Library. Individual tabs are hidden if the active Source lacks the underlying capability (To Read without `PlaylistsCapability`, Series without `SeriesCapability`, Collections without `CollectionsCapability`). Replaces the Plex-style single scrollable feed as the primary way to browse a Library's content. The Navigation Drawer remains the navigation surface for switching Libraries, accessing Downloads, and Settings.

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -393,6 +393,10 @@ private fun LibraryItemDetailContent(
             AudiobookDurationLine(item.audioDurationSec, item.readingProgress)
         }
 
+        if (item.ebookFormat == com.riffle.core.domain.EbookFormat.Cbz && (item.pageCount ?: 0) > 0) {
+            ComicPageCountLine(pageCount = item.pageCount!!)
+        }
+
         if (item.readingProgress > 0f) {
             ReadingProgressIndicator(progress = item.readingProgress, listened = item.isListenable && !item.isReadable)
         }
@@ -511,6 +515,16 @@ private fun LibraryItemDetailContent(
     }
 }
 
+/** "Comic · N pages" on the detail screen (ADR 0042). Mirrors AudiobookDurationLine's shape. */
+@Composable
+private fun ComicPageCountLine(pageCount: Int) {
+    Text(
+        text = "Comic · $pageCount pages",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
 /** Total audiobook length on the detail screen, with remaining time when in progress (ADR 0029). */
 @Composable
 private fun AudiobookDurationLine(durationSec: Double, readingProgress: Float = 0f) {
@@ -620,6 +634,9 @@ internal fun LibraryItemDetailContentTablet(
             AuthorByline(author = item.author, onAuthorClick = { onFacet(FacetType.AUTHOR, it) })
             if (item.isListenable && item.audioDurationSec > 0) {
                 AudiobookDurationLine(item.audioDurationSec, item.readingProgress)
+            }
+            if (item.ebookFormat == com.riffle.core.domain.EbookFormat.Cbz && (item.pageCount ?: 0) > 0) {
+                ComicPageCountLine(pageCount = item.pageCount!!)
             }
             if (item.readingProgress > 0f) {
                 ReadingProgressIndicator(progress = item.readingProgress, listened = item.isListenable && !item.isReadable)
@@ -827,6 +844,9 @@ internal fun LibraryItemDetailContentPhoneLandscape(
             }
             if (item.isListenable && item.audioDurationSec > 0) {
                 AudiobookDurationLine(item.audioDurationSec, item.readingProgress)
+            }
+            if (item.ebookFormat == com.riffle.core.domain.EbookFormat.Cbz && (item.pageCount ?: 0) > 0) {
+                ComicPageCountLine(pageCount = item.pageCount!!)
             }
             if (item.readingProgress > 0f) {
                 ReadingProgressIndicator(progress = item.readingProgress, listened = item.isListenable && !item.isReadable)

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -118,6 +118,7 @@ class LibraryItemDetailViewModel @Inject constructor(
     private val tokenStorage: TokenStorage,
     private val epubRepository: EpubRepository,
     private val pdfRepository: PdfRepository,
+    private val cbzRepository: com.riffle.core.domain.CbzRepository,
     private val toReadRepository: ToReadRepository,
     private val readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
     private val readaloudAudioRepository: com.riffle.core.domain.ReadaloudAudioRepository,
@@ -389,6 +390,11 @@ class LibraryItemDetailViewModel @Inject constructor(
                     PdfDownloadResult.Success, PdfDownloadResult.AlreadyDownloaded -> DownloadState.Downloaded
                     is PdfDownloadResult.NetworkError -> DownloadState.NotDownloaded
                 }
+                EbookFormat.Cbz -> when (cbzRepository.downloadCbz(item, onProgress)) {
+                    com.riffle.core.domain.CbzDownloadResult.Success,
+                    com.riffle.core.domain.CbzDownloadResult.AlreadyDownloaded -> DownloadState.Downloaded
+                    is com.riffle.core.domain.CbzDownloadResult.NetworkError -> DownloadState.NotDownloaded
+                }
                 else -> DownloadState.NotDownloaded
             }
         }
@@ -400,6 +406,7 @@ class LibraryItemDetailViewModel @Inject constructor(
             when (item?.ebookFormat) {
                 EbookFormat.Epub -> epubRepository.removeDownload(item.sourceId, item.id)
                 EbookFormat.Pdf -> pdfRepository.removeDownload(item.sourceId, item.id)
+                EbookFormat.Cbz -> cbzRepository.removeDownload(item.sourceId, item.id)
                 else -> {}
             }
             if (item != null) downloadManager.clear(ebookKey(item))
@@ -489,6 +496,7 @@ class LibraryItemDetailViewModel @Inject constructor(
     private fun isDownloadedForFormat(item: LibraryItem): Boolean = when (item.ebookFormat) {
         EbookFormat.Epub -> epubRepository.isDownloaded(item.sourceId, item.id)
         EbookFormat.Pdf -> pdfRepository.isDownloaded(item.sourceId, item.id)
+        EbookFormat.Cbz -> cbzRepository.isDownloaded(item.sourceId, item.id)
         else -> false
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -1,0 +1,297 @@
+package com.riffle.app.feature.reader.cbz
+
+import android.view.WindowManager
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.FragmentActivity
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import coil.compose.SubcomposeAsyncImage
+import coil.request.ImageRequest
+import com.riffle.app.feature.reader.VolumeNavEvent
+import com.riffle.app.feature.reader.rememberImmersiveModeState
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CbzReaderScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: CbzReaderViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+    val currentPage by viewModel.currentPage.collectAsState()
+    val keepScreenOn by viewModel.keepScreenOn.collectAsState()
+    val context = LocalContext.current
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    val immersiveState = rememberImmersiveModeState()
+
+    LaunchedEffect(state) {
+        if (state is CbzReaderState.Error) immersiveState.show()
+    }
+
+    DisposableEffect(viewModel) {
+        onDispose { viewModel.onReaderClosed() }
+    }
+
+    DisposableEffect(lifecycle) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_START -> viewModel.onReaderResumed()
+                Lifecycle.Event.ON_STOP -> viewModel.onReaderClosed()
+                else -> {}
+            }
+        }
+        lifecycle.addObserver(observer)
+        onDispose { lifecycle.removeObserver(observer) }
+    }
+
+    DisposableEffect(keepScreenOn) {
+        val window = (context as? FragmentActivity)?.window
+        if (keepScreenOn) window?.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        else window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        onDispose { window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON) }
+    }
+
+    Box(modifier = Modifier.fillMaxSize().background(Color.Black)) {
+        when (val s = state) {
+            CbzReaderState.Loading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            is CbzReaderState.Error -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(s.message, color = MaterialTheme.colorScheme.onSurface)
+            }
+            is CbzReaderState.Ready -> CbzPager(
+                state = s,
+                currentPage = currentPage,
+                onPageChanged = { viewModel.jumpToPage(it) },
+                onToggleImmersive = immersiveState::toggle,
+                volumeNavEvents = viewModel.volumeNavEvents,
+                onNext = viewModel::nextPage,
+                onPrev = viewModel::previousPage,
+            )
+        }
+
+        AnimatedVisibility(
+            visible = !immersiveState.isImmersive,
+            enter = slideInVertically { -it },
+            exit = slideOutVertically { -it },
+            modifier = Modifier.align(Alignment.TopCenter).fillMaxWidth(),
+        ) {
+            TopAppBar(
+                title = {
+                    val title = (state as? CbzReaderState.Ready)?.title.orEmpty()
+                    Text(title, maxLines = 1)
+                },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        }
+
+        val ready = state as? CbzReaderState.Ready
+        if (ready != null) {
+            AnimatedVisibility(
+                visible = !immersiveState.isImmersive,
+                enter = slideInVertically { it },
+                exit = slideOutVertically { it },
+                modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth(),
+            ) {
+                CbzScrubber(
+                    currentPage = currentPage,
+                    pageCount = ready.pageCount,
+                    onSeek = { viewModel.jumpToPage(it) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CbzPager(
+    state: CbzReaderState.Ready,
+    currentPage: Int,
+    onPageChanged: (Int) -> Unit,
+    onToggleImmersive: () -> Unit,
+    volumeNavEvents: kotlinx.coroutines.flow.SharedFlow<VolumeNavEvent>,
+    onNext: () -> Unit,
+    onPrev: () -> Unit,
+) {
+    val pagerState = rememberPagerState(initialPage = currentPage) { state.pageCount }
+    val scope = androidx.compose.runtime.rememberCoroutineScope()
+
+    // ViewModel is the source of truth. When the user swipes, `onPageChanged` writes it back.
+    LaunchedEffect(pagerState.currentPage) {
+        if (pagerState.currentPage != currentPage) onPageChanged(pagerState.currentPage)
+    }
+    // Reverse direction — jumps from scrubber / volume keys / initial resume.
+    LaunchedEffect(currentPage) {
+        if (currentPage != pagerState.currentPage) {
+            pagerState.scrollToPage(currentPage)
+        }
+    }
+
+    LaunchedEffect(volumeNavEvents) {
+        volumeNavEvents.collect { event ->
+            when (event) {
+                VolumeNavEvent.Forward -> onNext()
+                VolumeNavEvent.Backward -> onPrev()
+            }
+        }
+    }
+
+    HorizontalPager(
+        state = pagerState,
+        modifier = Modifier.fillMaxSize().testTag("cbz_pager"),
+    ) { pageIndex ->
+        CbzPage(
+            source = state.imageSource,
+            pageIndex = pageIndex,
+            onTapZone = { zone ->
+                when (zone) {
+                    TapZone.Left -> scope.launch { pagerState.animateScrollToPage((pageIndex - 1).coerceAtLeast(0)) }
+                    TapZone.Right -> scope.launch { pagerState.animateScrollToPage((pageIndex + 1).coerceAtMost(state.pageCount - 1)) }
+                    TapZone.Center -> onToggleImmersive()
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun CbzPage(
+    source: CbzImageSource,
+    pageIndex: Int,
+    onTapZone: (TapZone) -> Unit,
+) {
+    var scale by remember(pageIndex) { mutableStateOf(1f) }
+    var offsetX by remember(pageIndex) { mutableStateOf(0f) }
+    var offsetY by remember(pageIndex) { mutableStateOf(0f) }
+    val bytes = remember(pageIndex, source) { source.imageBytes(pageIndex) }
+    val context = LocalContext.current
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .pointerInput(pageIndex) {
+                detectTapGestures(
+                    onDoubleTap = {
+                        // Double-tap resets zoom + pan, matching CDisplayEx.
+                        scale = 1f
+                        offsetX = 0f
+                        offsetY = 0f
+                    },
+                    onTap = { pos ->
+                        val third = size.width / 3f
+                        val zone = when {
+                            pos.x < third -> TapZone.Left
+                            pos.x > 2 * third -> TapZone.Right
+                            else -> TapZone.Center
+                        }
+                        onTapZone(zone)
+                    },
+                )
+            }
+            .pointerInput(pageIndex) {
+                detectTransformGestures { _, pan, zoom, _ ->
+                    scale = (scale * zoom).coerceIn(1f, 5f)
+                    if (scale > 1f) {
+                        offsetX += pan.x
+                        offsetY += pan.y
+                    } else {
+                        offsetX = 0f
+                        offsetY = 0f
+                    }
+                }
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        SubcomposeAsyncImage(
+            model = ImageRequest.Builder(context)
+                .data(bytes)
+                .crossfade(false)
+                .build(),
+            contentDescription = "Comic page ${pageIndex + 1}",
+            loading = { CircularProgressIndicator() },
+            modifier = Modifier
+                .fillMaxSize()
+                .graphicsLayer(
+                    scaleX = scale,
+                    scaleY = scale,
+                    translationX = offsetX,
+                    translationY = offsetY,
+                ),
+        )
+    }
+}
+
+@Composable
+private fun CbzScrubber(
+    currentPage: Int,
+    pageCount: Int,
+    onSeek: (Int) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.9f))
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = "${currentPage + 1} / $pageCount",
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        Slider(
+            value = currentPage.toFloat(),
+            onValueChange = { onSeek(it.toInt()) },
+            valueRange = 0f..(pageCount - 1).coerceAtLeast(1).toFloat(),
+            steps = (pageCount - 2).coerceAtLeast(0),
+            modifier = Modifier.weight(1f).testTag("cbz_scrubber"),
+        )
+    }
+}
+
+private enum class TapZone { Left, Center, Right }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -50,7 +51,9 @@ import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
 import com.riffle.app.feature.reader.VolumeNavEvent
 import com.riffle.app.feature.reader.rememberImmersiveModeState
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -208,7 +211,11 @@ private fun CbzPage(
     var scale by remember(pageIndex) { mutableStateOf(1f) }
     var offsetX by remember(pageIndex) { mutableStateOf(0f) }
     var offsetY by remember(pageIndex) { mutableStateOf(0f) }
-    val bytes = remember(pageIndex, source) { source.imageBytes(pageIndex) }
+    // Decode the page off the UI thread — comic pages routinely run into multi-MB and
+    // reading + allocating them during composition janks every page turn.
+    val bytes by produceState<ByteArray?>(initialValue = null, key1 = pageIndex, key2 = source) {
+        value = withContext(Dispatchers.IO) { source.imageBytes(pageIndex) }
+    }
     val context = LocalContext.current
 
     Box(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderState.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderState.kt
@@ -1,0 +1,27 @@
+package com.riffle.app.feature.reader.cbz
+
+import com.riffle.core.domain.comic.ComicArchive
+
+/**
+ * Wraps a [ComicArchive] behind a stable-identity interface the Composable can hold onto — decorators
+ * over the raw archive (thumbnails, prefetch pool) will slot in here without touching the reader.
+ */
+interface CbzImageSource {
+    val pageCount: Int
+    fun imageBytes(pageIndex: Int): ByteArray
+}
+
+internal class ArchiveImageSource(private val archive: ComicArchive) : CbzImageSource {
+    override val pageCount: Int get() = archive.pageCount
+    override fun imageBytes(pageIndex: Int): ByteArray = archive.imageBytes(pageIndex)
+}
+
+sealed class CbzReaderState {
+    data object Loading : CbzReaderState()
+    data class Error(val message: String) : CbzReaderState()
+    data class Ready(
+        val title: String,
+        val pageCount: Int,
+        val imageSource: CbzImageSource,
+    ) : CbzReaderState()
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
@@ -1,0 +1,214 @@
+package com.riffle.app.feature.reader.cbz
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import com.riffle.app.feature.reader.ReaderStateHolder
+import com.riffle.app.feature.reader.VolumeNavEvent
+import com.riffle.app.feature.reader.VolumeNavigationController
+import com.riffle.app.feature.reader.controllers.VolumeKeyDispatcher
+import com.riffle.core.domain.CbzOpenResult
+import com.riffle.core.domain.CbzRepository
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.WakeLockPreferencesStore
+import com.riffle.core.domain.comic.CbzArchive
+import com.riffle.core.domain.comic.ComicArchive
+import com.riffle.core.domain.usecase.UpdateReadingProgress
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.io.File
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+/**
+ * Backs the comic (CBZ) reader. Deliberately smaller than [com.riffle.app.feature.reader.PdfReaderViewModel]:
+ * comics don't go through Readium — page images come straight out of a [CbzArchive] — so there's no
+ * Publication, no navigator, no formatting session, no annotations, no TOC.
+ *
+ * v1 scope per ADR 0042:
+ *   - Position is `Int pageIndex`; wire form is a Readium-shaped Locator JSON keyed on
+ *     `locations.position` (1-based). Same shape as PDF, so no new wire codec.
+ *   - No annotations, no book search, no formatting panel, no Cadence/Readaloud/Auto-Scroll.
+ *   - Volume-key navigation and screen wake lock work via the shared reader plumbing.
+ */
+@HiltViewModel
+class CbzReaderViewModel @Inject constructor(
+    application: Application,
+    savedStateHandle: SavedStateHandle,
+    private val libraryObserver: LibraryObserver,
+    private val cbzRepository: CbzRepository,
+    private val updateReadingProgressUseCase: UpdateReadingProgress,
+    private val wakeLockPreferencesStore: WakeLockPreferencesStore,
+    private val volumeNavigationController: VolumeNavigationController,
+    private val volumeKeyDispatcher: VolumeKeyDispatcher,
+    private val readerStateHolder: ReaderStateHolder,
+) : AndroidViewModel(application) {
+
+    private val itemId: String = checkNotNull(savedStateHandle["itemId"])
+
+    private var archive: ComicArchive? = null
+    private var lastSavedPage: Int = -1
+    private var closeSyncDone: Boolean = false
+
+    private val _state = MutableStateFlow<CbzReaderState>(CbzReaderState.Loading)
+    val state: StateFlow<CbzReaderState> = _state
+
+    private val _currentPage = MutableStateFlow(0)
+    /** 0-based page index of the currently displayed page. */
+    val currentPage: StateFlow<Int> = _currentPage
+
+    val keepScreenOn: StateFlow<Boolean> = wakeLockPreferencesStore.keepScreenOn
+        .stateIn(viewModelScope, SharingStarted.Eagerly, true)
+
+    val volumeNavEvents: SharedFlow<VolumeNavEvent> = volumeNavigationController.events
+
+    val volumeKeyNavigationEnabled = volumeKeyDispatcher.volumeKeyNavigationEnabled
+        .stateIn(viewModelScope, SharingStarted.Eagerly, true)
+
+    val invertVolumeKeys = volumeKeyDispatcher.invertVolumeKeys
+        .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    init {
+        viewModelScope.launch { openBook() }
+    }
+
+    private suspend fun openBook() {
+        val item = libraryObserver.getItem(itemId)
+        if (item == null) {
+            _state.value = CbzReaderState.Error("Book not found")
+            return
+        }
+        when (val result = cbzRepository.openCbz(item)) {
+            is CbzOpenResult.Success -> loadArchive(result.cbzFile, result.lastPosition, item.title)
+            is CbzOpenResult.NetworkError -> _state.value = CbzReaderState.Error(
+                result.cause.message ?: "Network error"
+            )
+            CbzOpenResult.Offline -> _state.value = CbzReaderState.Error("Book not available offline")
+        }
+    }
+
+    private suspend fun loadArchive(file: File, lastPosition: String?, title: String) {
+        val (opened, pageCount) = withContext(Dispatchers.IO) {
+            val a = CbzArchive(file)
+            a to a.pageCount
+        }
+        if (pageCount == 0) {
+            _state.value = CbzReaderState.Error("Comic has no pages")
+            opened.close()
+            return
+        }
+        archive = opened
+        val resumeIndex = lastPosition
+            ?.let { parsePageIndex(it) }
+            ?.coerceIn(0, pageCount - 1)
+            ?: 0
+        _currentPage.value = resumeIndex
+        lastSavedPage = resumeIndex
+        _state.value = CbzReaderState.Ready(
+            title = title,
+            pageCount = pageCount,
+            imageSource = ArchiveImageSource(opened),
+        )
+    }
+
+    private fun parsePageIndex(json: String): Int? = try {
+        // Same shape PDF writes: locations.position is 1-based. Also tolerate a raw integer for
+        // pre-existing rows or hand-migrated data.
+        if (json.startsWith("{")) {
+            JSONObject(json).optJSONObject("locations")
+                ?.let { if (it.has("position")) it.getInt("position") - 1 else null }
+        } else {
+            json.trim().toIntOrNull()
+        }
+    } catch (_: Exception) {
+        null
+    }
+
+    fun nextPage() {
+        val ready = _state.value as? CbzReaderState.Ready ?: return
+        val next = (_currentPage.value + 1).coerceAtMost(ready.pageCount - 1)
+        if (next != _currentPage.value) {
+            _currentPage.value = next
+            savePosition(next, ready.pageCount)
+        }
+    }
+
+    fun previousPage() {
+        val next = (_currentPage.value - 1).coerceAtLeast(0)
+        if (next != _currentPage.value) {
+            _currentPage.value = next
+            val ready = _state.value as? CbzReaderState.Ready ?: return
+            savePosition(next, ready.pageCount)
+        }
+    }
+
+    fun jumpToPage(index: Int) {
+        val ready = _state.value as? CbzReaderState.Ready ?: return
+        val clamped = index.coerceIn(0, ready.pageCount - 1)
+        if (clamped != _currentPage.value) {
+            _currentPage.value = clamped
+            savePosition(clamped, ready.pageCount)
+        }
+    }
+
+    private fun savePosition(pageIndex: Int, pageCount: Int) {
+        if (pageIndex == lastSavedPage) return
+        lastSavedPage = pageIndex
+        val progression = if (pageCount > 0) (pageIndex + 1).toDouble() / pageCount.toDouble() else 0.0
+        val locatorJson = JSONObject()
+            .put("href", "cbz://page")
+            .put("type", "application/vnd.comicbook+zip")
+            .put(
+                "locations", JSONObject()
+                    .put("position", pageIndex + 1)
+                    .put("totalProgression", progression),
+            )
+            .toString()
+        viewModelScope.launch {
+            cbzRepository.saveReadingPosition(itemId, locatorJson)
+            // ADR 0042 (move 2): comic Completed is the last page reached.
+            val progressFraction = if (pageCount > 1) pageIndex.toFloat() / (pageCount - 1).toFloat() else 1f
+            updateReadingProgressUseCase(itemId, progressFraction)
+        }
+    }
+
+    fun setKeepScreenOn(value: Boolean) {
+        viewModelScope.launch { wakeLockPreferencesStore.setKeepScreenOn(value) }
+    }
+
+    fun setVolumeKeyNavigationEnabled(value: Boolean) {
+        viewModelScope.launch { volumeKeyDispatcher.setVolumeKeyNavigationEnabled(value) }
+    }
+
+    fun setInvertVolumeKeys(value: Boolean) {
+        viewModelScope.launch { volumeKeyDispatcher.setInvertVolumeKeys(value) }
+    }
+
+    fun onReaderResumed() {
+        readerStateHolder.isReaderActive = true
+        closeSyncDone = false
+    }
+
+    fun onReaderClosed() {
+        readerStateHolder.isReaderActive = false
+        readerStateHolder.isPanelOpen = false
+        if (closeSyncDone) return
+        closeSyncDone = true
+        val ready = _state.value as? CbzReaderState.Ready
+        if (ready != null) savePosition(_currentPage.value, ready.pageCount)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        archive?.close()
+        archive = null
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -37,6 +37,7 @@ import com.riffle.app.feature.navigation.NavigationDrawerViewModel
 import com.riffle.app.feature.navigation.RiffleNavigationDrawer
 import com.riffle.app.feature.reader.EpubReaderScreen
 import com.riffle.app.feature.reader.PdfReaderScreen
+import com.riffle.app.feature.reader.cbz.CbzReaderScreen
 import com.riffle.app.feature.server.AddSourceScreen
 import com.riffle.app.feature.server.SelectLibrariesScreen
 import com.riffle.app.feature.server.SourceSetupViewModel
@@ -71,6 +72,7 @@ private const val LIBRARY_ITEM_DETAIL = "library_item_detail/{itemId}"
 private const val EPUB_READER =
     "epub_reader/{itemId}?startReadaloudAtSec={startReadaloudAtSec}&openAtCfi={openAtCfi}&startTocHref={startTocHref}&source={source}&sourceId={sourceId}"
 private const val PDF_READER = "pdf_reader/{itemId}"
+private const val CBZ_READER = "cbz_reader/{itemId}"
 private const val ANNOTATION_SEARCH = "annotation_search/{libraryId}?query={query}"
 private const val AUDIOBOOK_PLAYER = "audiobook_player/{itemId}?startAtSec={startAtSec}"
 
@@ -599,6 +601,14 @@ fun MainScreen(
                 PdfReaderScreen(onNavigateBack = { navController.popBackStack() })
             }
             composable(
+                route = CBZ_READER,
+                arguments = listOf(
+                    navArgument("itemId") { type = NavType.StringType },
+                )
+            ) {
+                CbzReaderScreen(onNavigateBack = { navController.popBackStack() })
+            }
+            composable(
                 route = AUDIOBOOK_PLAYER,
                 arguments = listOf(
                     navArgument("itemId") { type = NavType.StringType },
@@ -652,4 +662,5 @@ internal fun NavController.navigateAsRoot(route: String) {
 
 internal fun isReaderRoute(route: String?): Boolean =
     route?.startsWith(EPUB_READER.substringBefore("{")) == true ||
-        route?.startsWith(PDF_READER.substringBefore("{")) == true
+        route?.startsWith(PDF_READER.substringBefore("{")) == true ||
+        route?.startsWith(CBZ_READER.substringBefore("{")) == true

--- a/app/src/main/kotlin/com/riffle/app/navigation/ReaderRouter.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/ReaderRouter.kt
@@ -9,6 +9,7 @@ fun readerRouteFor(item: LibraryItem): String? {
     return when (item.ebookFormat) {
         EbookFormat.Epub -> "epub_reader/$encodedId"
         EbookFormat.Pdf -> "pdf_reader/$encodedId"
+        EbookFormat.Cbz -> "cbz_reader/$encodedId"
         EbookFormat.Unsupported -> null
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
@@ -144,6 +144,7 @@ class CollectionDetailViewModelTest {
         offlineAvailability = LibraryItemOfflineAvailability(
             epubRepository,
             FakePdfRepository(),
+            NoopCbzRepository(),
             FakeAudiobookDownloadRepository(),
             object : BundleAudiobookSource {
                 override suspend fun localSession(sourceId: String, itemId: String) = null

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
@@ -142,6 +142,7 @@ class LibraryFilterEngineTest {
             offlineAvailability = LibraryItemOfflineAvailability(
                 epubRepository,
                 fakePdfRepo(),
+                NoopCbzRepository(),
                 fakeAudiobookDownloadRepo(),
                 object : BundleAudiobookSource {
                     override suspend fun localSession(sourceId: String, itemId: String) = null

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -264,6 +264,7 @@ class LibraryItemDetailViewModelTest {
         tokenStorage = noOpTokenStorage,
         epubRepository = epubRepository,
         pdfRepository = pdfRepository,
+        cbzRepository = NoopCbzRepository(),
         toReadRepository = toReadRepo,
         readaloudLinkRepository = readaloudLinkRepository,
         readaloudAudioRepository = readaloudAudioRepository,

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
@@ -150,6 +150,7 @@ class LibraryItemDetailViewModelTocTest {
         tokenStorage = noOpTokenStorage,
         epubRepository = FakeEpubRepo(),
         pdfRepository = FakePdfRepo(),
+        cbzRepository = NoopCbzRepository(),
         toReadRepository = noOpToReadRepository,
         readaloudLinkRepository = NoopReadaloudLinkRepository,
         readaloudAudioRepository = NoopReadaloudAudioRepository,

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -224,6 +224,7 @@ class LibraryItemsViewModelTest {
         offlineAvailability = LibraryItemOfflineAvailability(
             epubRepository,
             pdfRepository,
+            NoopCbzRepository(),
             audiobookDownloadRepository,
             object : BundleAudiobookSource {
                 override suspend fun localSession(sourceId: String, itemId: String) = null

--- a/app/src/test/kotlin/com/riffle/app/feature/library/NoopCbzRepository.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/NoopCbzRepository.kt
@@ -1,0 +1,19 @@
+package com.riffle.app.feature.library
+
+import com.riffle.core.domain.CbzRepository
+
+/** Shared test double for ViewModel tests that don't exercise the CBZ path. */
+internal class NoopCbzRepository(
+    private val downloaded: Boolean = false,
+    private val cached: Boolean = false,
+) : CbzRepository {
+    override fun isDownloaded(sourceId: String, itemId: String) = downloaded
+    override fun isCached(sourceId: String, itemId: String) = cached
+    override suspend fun openCbz(item: com.riffle.core.domain.LibraryItem) = error("unused in test")
+    override suspend fun downloadCbz(
+        item: com.riffle.core.domain.LibraryItem,
+        onProgress: (downloaded: Long, total: Long) -> Unit,
+    ) = error("unused in test")
+    override suspend fun removeDownload(sourceId: String, itemId: String) = error("unused in test")
+    override suspend fun saveReadingPosition(itemId: String, locatorJson: String) = error("unused in test")
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/SeriesDetailViewModelTest.kt
@@ -142,6 +142,7 @@ class SeriesDetailViewModelTest {
         offlineAvailability = LibraryItemOfflineAvailability(
             FakeEpubRepository(),
             FakePdfRepository(),
+            NoopCbzRepository(),
             FakeAudiobookDownloadRepository(),
             object : BundleAudiobookSource {
                 override suspend fun localSession(sourceId: String, itemId: String) = null

--- a/app/src/test/kotlin/com/riffle/app/navigation/IsReaderRouteTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/IsReaderRouteTest.kt
@@ -17,6 +17,11 @@ class IsReaderRouteTest {
     }
 
     @Test
+    fun `cbz reader route is recognized`() {
+        assertTrue(isReaderRoute("cbz_reader/some-item-id"))
+    }
+
+    @Test
     fun `null route is not a reader route`() {
         assertFalse(isReaderRoute(null))
     }

--- a/app/src/test/kotlin/com/riffle/app/navigation/ReaderRouterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/ReaderRouterTest.kt
@@ -19,6 +19,11 @@ class ReaderRouterTest {
     }
 
     @Test
+    fun `cbz item routes to cbz_reader`() {
+        assertEquals("cbz_reader/item-1", readerRouteFor(item(EbookFormat.Cbz)))
+    }
+
+    @Test
     fun `unsupported item has no route`() {
         assertNull(readerRouteFor(item(EbookFormat.Unsupported)))
     }

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/BookFormat.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/BookFormat.kt
@@ -7,6 +7,7 @@ package com.riffle.core.catalog
 sealed class BookFormat {
     data object Epub : BookFormat()
     data object Pdf : BookFormat()
+    data object Cbz : BookFormat()
     data object Audiobook : BookFormat()
     data object Unsupported : BookFormat()
 }

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
@@ -129,7 +129,7 @@ class AbsCatalog(
     override suspend fun fetchFile(itemId: String, format: BookFormat): CatalogFileHandle {
         val authHeaders = mapOf("Authorization" to "Bearer ${config.token}")
         return when (format) {
-            BookFormat.Epub, BookFormat.Pdf -> {
+            BookFormat.Epub, BookFormat.Pdf, BookFormat.Cbz -> {
                 val ino = libraryApi.getItemEbookFileIno(config.baseUrl, itemId, config.token, config.insecureAllowed).unwrap()
                 CatalogFileHandle.Stream(
                     url = "${config.baseUrl.trimEnd('/')}/api/items/$itemId/ebook/$ino",
@@ -151,7 +151,7 @@ class AbsCatalog(
         handleHint: String?,
     ): CatalogFileStream {
         return when (format) {
-            BookFormat.Epub, BookFormat.Pdf -> {
+            BookFormat.Epub, BookFormat.Pdf, BookFormat.Cbz -> {
                 val ino = handleHint?.takeIf { it.isNotEmpty() }
                     ?: libraryApi.getItemEbookFileIno(config.baseUrl, itemId, config.token, config.insecureAllowed).unwrap()
                 val body = when (val r = libraryApi.downloadEpub(config.baseUrl, itemId, ino, config.token, config.insecureAllowed)) {
@@ -575,6 +575,7 @@ class AbsCatalog(
     private fun EbookFormat.toCatalogFormat(hasAudio: Boolean = false): BookFormat = when (this) {
         EbookFormat.Epub -> BookFormat.Epub
         EbookFormat.Pdf -> BookFormat.Pdf
+        EbookFormat.Cbz -> BookFormat.Cbz
         EbookFormat.Unsupported -> if (hasAudio) BookFormat.Audiobook else BookFormat.Unsupported
     }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/CbzRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/CbzRepositoryImpl.kt
@@ -1,0 +1,98 @@
+package com.riffle.core.data
+
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.domain.CbzDownloadResult
+import com.riffle.core.domain.CbzOpenResult
+import com.riffle.core.domain.CbzRepository
+import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LocalStore
+import com.riffle.core.domain.ReadingPositionStore
+import com.riffle.core.domain.SourceRepository
+import java.io.File
+
+/**
+ * Mirrors [PdfRepositoryImpl]. CBZ is a plain ZIP-of-images so we validate by ZIP-signature only;
+ * detailed structural validation happens when the reader opens the archive via `CbzArchive`.
+ */
+class CbzRepositoryImpl(
+    private val catalogRegistry: CatalogRegistry,
+    private val cacheStore: LocalStore,
+    private val downloadsStore: LocalStore,
+    private val positionStore: ReadingPositionStore,
+    private val sourceRepository: SourceRepository,
+) : CbzRepository {
+
+    override suspend fun openCbz(item: LibraryItem): CbzOpenResult {
+        val local = (downloadsStore.get(item.sourceId, item.id) ?: cacheStore.get(item.sourceId, item.id))?.takeIf { it.isValidCbz() }
+        if (local == null) {
+            cacheStore.delete(item.sourceId, item.id)
+        }
+        val cbzFile = if (local != null) {
+            local
+        } else {
+            val catalog = catalogRegistry.forSourceId(item.sourceId)
+                ?: return CbzOpenResult.NetworkError(IllegalStateException("No catalog for item"))
+            try {
+                catalog.openFile(item.id, BookFormat.Cbz, handleHint = item.ebookFileIno).use { stream ->
+                    cacheStore.save(item.sourceId, item.id, stream.byteStream())
+                }
+            } catch (t: Throwable) {
+                return CbzOpenResult.NetworkError(t)
+            }
+        }
+        val activeSource = sourceRepository.getActive()
+        val lastPosition = activeSource?.let { positionStore.load(it.id, item.id) }
+        return CbzOpenResult.Success(cbzFile = cbzFile, lastPosition = lastPosition)
+    }
+
+    override suspend fun downloadCbz(
+        item: LibraryItem,
+        onProgress: (downloaded: Long, total: Long) -> Unit,
+    ): CbzDownloadResult {
+        if (downloadsStore.get(item.sourceId, item.id) != null) return CbzDownloadResult.AlreadyDownloaded
+        val cached = cacheStore.get(item.sourceId, item.id)
+        if (cached != null) {
+            val size = cached.length()
+            cached.inputStream().use {
+                downloadsStore.save(item.sourceId, item.id, ProgressReportingInputStream(it, size, onProgress))
+            }
+            cacheStore.delete(item.sourceId, item.id)
+            return CbzDownloadResult.Success
+        }
+        val catalog = catalogRegistry.forSourceId(item.sourceId)
+            ?: return CbzDownloadResult.NetworkError(IllegalStateException("No catalog for item"))
+        return try {
+            catalog.openFile(item.id, BookFormat.Cbz, handleHint = item.ebookFileIno).use { stream ->
+                val progressStream = ProgressReportingInputStream(stream.byteStream(), stream.contentLength, onProgress)
+                downloadsStore.save(item.sourceId, item.id, progressStream)
+            }
+            CbzDownloadResult.Success
+        } catch (t: Throwable) {
+            CbzDownloadResult.NetworkError(t)
+        }
+    }
+
+    override suspend fun removeDownload(sourceId: String, itemId: String) {
+        downloadsStore.delete(sourceId, itemId)
+    }
+
+    override fun isDownloaded(sourceId: String, itemId: String): Boolean = downloadsStore.get(sourceId, itemId) != null
+
+    override fun isCached(sourceId: String, itemId: String): Boolean = cacheStore.get(sourceId, itemId) != null
+
+    override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {
+        val sourceId = sourceRepository.getActive()?.id ?: return
+        positionStore.save(sourceId, itemId, locatorJson)
+    }
+}
+
+private fun File.isValidCbz(): Boolean {
+    if (!exists() || length() < 4) return false
+    return inputStream().use { stream ->
+        val header = ByteArray(4).also { stream.read(it) }
+        // "PK\x03\x04" — ZIP local file header. Enough to reject truncation/garbage before the
+        // reader opens the archive; downstream `CbzArchive` filters non-image entries.
+        header.contentEquals(byteArrayOf(0x50, 0x4B, 0x03, 0x04))
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/DownloadsRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/DownloadsRepositoryImpl.kt
@@ -9,39 +9,37 @@ class DownloadsRepositoryImpl(
     private val epubDownloadsStore: LocalStore,
     private val pdfCacheStore: LocalStore,
     private val pdfDownloadsStore: LocalStore,
+    private val cbzCacheStore: LocalStore,
+    private val cbzDownloadsStore: LocalStore,
 ) : DownloadsRepository {
 
+    private val downloadStores = listOf(epubDownloadsStore, pdfDownloadsStore, cbzDownloadsStore)
+    private val cacheStores = listOf(epubCacheStore, pdfCacheStore, cbzCacheStore)
+
     override fun getDownloadedItems(): List<StoredItemRef> =
-        (epubDownloadsStore.listItems() + pdfDownloadsStore.listItems()).distinct()
+        downloadStores.flatMap { it.listItems() }.distinct()
 
     override fun getCachedItems(): List<StoredItemRef> {
         val downloaded = getDownloadedItems().toHashSet()
-        return (epubCacheStore.listItems() + pdfCacheStore.listItems())
-            .distinct()
-            .filter { it !in downloaded }
+        return cacheStores.flatMap { it.listItems() }.distinct().filter { it !in downloaded }
     }
 
     override fun sizeOf(sourceId: String, itemId: String): Long =
-        listOf(epubDownloadsStore, pdfDownloadsStore, epubCacheStore, pdfCacheStore)
-            .sumOf { it.get(sourceId, itemId)?.length() ?: 0L }
+        (downloadStores + cacheStores).sumOf { it.get(sourceId, itemId)?.length() ?: 0L }
 
     override suspend fun removeDownload(sourceId: String, itemId: String) {
-        epubDownloadsStore.delete(sourceId, itemId)
-        pdfDownloadsStore.delete(sourceId, itemId)
+        downloadStores.forEach { it.delete(sourceId, itemId) }
     }
 
     override suspend fun removeCached(sourceId: String, itemId: String) {
-        epubCacheStore.delete(sourceId, itemId)
-        pdfCacheStore.delete(sourceId, itemId)
+        cacheStores.forEach { it.delete(sourceId, itemId) }
     }
 
     override suspend fun removeAllDownloads() {
-        epubDownloadsStore.clear()
-        pdfDownloadsStore.clear()
+        downloadStores.forEach { it.clear() }
     }
 
     override suspend fun clearAllCached() {
-        epubCacheStore.clear()
-        pdfCacheStore.clear()
+        cacheStores.forEach { it.clear() }
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -342,6 +342,7 @@ class LibraryRepositoryImpl @Inject constructor(
         addedAt = addedAt,
         isbn = isbn,
         asin = asin,
+        pageCount = pageCount,
     )
 
     private fun SeriesEntity.toDomain() = Series(
@@ -362,6 +363,7 @@ class LibraryRepositoryImpl @Inject constructor(
     private fun com.riffle.core.catalog.BookFormat.toEbookFormat(): EbookFormat = when (this) {
         com.riffle.core.catalog.BookFormat.Epub -> EbookFormat.Epub
         com.riffle.core.catalog.BookFormat.Pdf -> EbookFormat.Pdf
+        com.riffle.core.catalog.BookFormat.Cbz -> EbookFormat.Cbz
         com.riffle.core.catalog.BookFormat.Audiobook -> EbookFormat.Unsupported
         com.riffle.core.catalog.BookFormat.Unsupported -> EbookFormat.Unsupported
     }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -99,6 +99,14 @@ annotation class PdfCacheStore
 @Retention(AnnotationRetention.BINARY)
 annotation class PdfDownloadsStore
 
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class CbzCacheStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class CbzDownloadsStore
+
 @Module(
     includes = [
         NetworkModule::class,

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -88,6 +88,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_48_49,
                 RiffleDatabase.MIGRATION_49_50,
                 RiffleDatabase.MIGRATION_50_51,
+                RiffleDatabase.MIGRATION_51_52,
             )
             .build()
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/LocalStoreModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/LocalStoreModule.kt
@@ -17,6 +17,8 @@ import com.riffle.core.data.ReadingPositionStoreImpl
 import com.riffle.core.data.SourceFilesCleanerImpl
 import com.riffle.core.data.di.AudiobookDownloadsDir
 import com.riffle.core.data.di.CrashReportDir
+import com.riffle.core.data.di.CbzCacheStore
+import com.riffle.core.data.di.CbzDownloadsStore
 import com.riffle.core.data.di.EpubCacheStore
 import com.riffle.core.data.di.EpubDownloadsStore
 import com.riffle.core.data.di.PdfCacheStore
@@ -127,6 +129,18 @@ abstract class LocalStoreModule {
         fun providePdfDownloadsStore(@ApplicationContext context: Context, dispatchers: com.riffle.core.domain.DispatcherProvider): LocalStore =
             LocalStoreImpl(context.filesDir.resolve("downloads/pdfs").also { it.mkdirs() }, ".pdf", dispatchers)
 
+        @Provides
+        @Singleton
+        @CbzCacheStore
+        fun provideCbzCacheStore(@ApplicationContext context: Context, dispatchers: com.riffle.core.domain.DispatcherProvider): LocalStore =
+            LocalStoreImpl(context.cacheDir.resolve("cbz").also { it.mkdirs() }, ".cbz", dispatchers)
+
+        @Provides
+        @Singleton
+        @CbzDownloadsStore
+        fun provideCbzDownloadsStore(@ApplicationContext context: Context, dispatchers: com.riffle.core.domain.DispatcherProvider): LocalStore =
+            LocalStoreImpl(context.filesDir.resolve("downloads/cbz").also { it.mkdirs() }, ".cbz", dispatchers)
+
         // One-time relocation of legacy flat files into per-Source subdirectories (ADR 0025).
         @Provides
         @Singleton
@@ -141,6 +155,8 @@ abstract class LocalStoreModule {
                     context.filesDir.resolve("downloads/epubs") to ".epub",
                     context.cacheDir.resolve("pdfs") to ".pdf",
                     context.filesDir.resolve("downloads/pdfs") to ".pdf",
+                    context.cacheDir.resolve("cbz") to ".cbz",
+                    context.filesDir.resolve("downloads/cbz") to ".cbz",
                 ),
                 resolveServerId = { itemId -> libraryItemDao.findSourceIdForItem(itemId) },
                 dispatchers = dispatchers,
@@ -153,7 +169,13 @@ abstract class LocalStoreModule {
             @EpubDownloadsStore epubDownloadsStore: LocalStore,
             @PdfCacheStore pdfCacheStore: LocalStore,
             @PdfDownloadsStore pdfDownloadsStore: LocalStore,
-        ): DownloadsRepository = DownloadsRepositoryImpl(epubCacheStore, epubDownloadsStore, pdfCacheStore, pdfDownloadsStore)
+            @CbzCacheStore cbzCacheStore: LocalStore,
+            @CbzDownloadsStore cbzDownloadsStore: LocalStore,
+        ): DownloadsRepository = DownloadsRepositoryImpl(
+            epubCacheStore, epubDownloadsStore,
+            pdfCacheStore, pdfDownloadsStore,
+            cbzCacheStore, cbzDownloadsStore,
+        )
 
         @Provides
         @Singleton
@@ -162,10 +184,16 @@ abstract class LocalStoreModule {
             @EpubDownloadsStore epubDownloadsStore: LocalStore,
             @PdfCacheStore pdfCacheStore: LocalStore,
             @PdfDownloadsStore pdfDownloadsStore: LocalStore,
+            @CbzCacheStore cbzCacheStore: LocalStore,
+            @CbzDownloadsStore cbzDownloadsStore: LocalStore,
             @AudiobookDownloadsDir audiobookDownloadsDir: File,
             dispatchers: com.riffle.core.domain.DispatcherProvider,
         ): SourceFilesCleaner = SourceFilesCleanerImpl(
-            stores = listOf(epubCacheStore, epubDownloadsStore, pdfCacheStore, pdfDownloadsStore),
+            stores = listOf(
+                epubCacheStore, epubDownloadsStore,
+                pdfCacheStore, pdfDownloadsStore,
+                cbzCacheStore, cbzDownloadsStore,
+            ),
             audiobookDownloadsDir = audiobookDownloadsDir,
             dispatchers = dispatchers,
         )

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/RepositoriesModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/RepositoriesModule.kt
@@ -118,12 +118,23 @@ abstract class RepositoriesModule {
 
         @Provides
         @Singleton
+        fun provideCbzRepository(
+            catalogRegistry: CatalogRegistry,
+            @com.riffle.core.data.di.CbzCacheStore cacheStore: LocalStore,
+            @com.riffle.core.data.di.CbzDownloadsStore downloadsStore: LocalStore,
+            positionStore: ReadingPositionStore,
+            sourceRepository: SourceRepository,
+        ): com.riffle.core.domain.CbzRepository = com.riffle.core.data.CbzRepositoryImpl(catalogRegistry, cacheStore, downloadsStore, positionStore, sourceRepository)
+
+        @Provides
+        @Singleton
         fun provideLibraryItemOfflineAvailability(
             epubRepository: EpubRepository,
             pdfRepository: PdfRepository,
+            cbzRepository: com.riffle.core.domain.CbzRepository,
             audiobookDownloadRepository: AudiobookDownloadRepository,
             bundleAudiobookSource: BundleAudiobookSource,
         ): LibraryItemOfflineAvailability =
-            LibraryItemOfflineAvailability(epubRepository, pdfRepository, audiobookDownloadRepository, bundleAudiobookSource)
+            LibraryItemOfflineAvailability(epubRepository, pdfRepository, cbzRepository, audiobookDownloadRepository, bundleAudiobookSource)
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/FileClassifier.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/FileClassifier.kt
@@ -7,9 +7,9 @@ package com.riffle.core.data.localfiles
  */
 object FileClassifier {
 
-    enum class Kind { EPUB, PDF, UNKNOWN }
+    enum class Kind { EPUB, PDF, CBZ, UNKNOWN }
 
-    private val EPUB_ZIP_MAGIC = byteArrayOf(0x50, 0x4B, 0x03, 0x04) // "PK\x03\x04"
+    private val ZIP_MAGIC = byteArrayOf(0x50, 0x4B, 0x03, 0x04) // "PK\x03\x04"
     private val PDF_MAGIC = "%PDF-".toByteArray(Charsets.US_ASCII)
 
     fun classify(name: String, head: ByteArray): Kind {
@@ -17,19 +17,18 @@ object FileClassifier {
         return when (ext) {
             "epub" -> if (isZip(head)) Kind.EPUB else Kind.UNKNOWN
             "pdf" -> if (isPdf(head)) Kind.PDF else Kind.UNKNOWN
+            "cbz" -> if (isZip(head)) Kind.CBZ else Kind.UNKNOWN
             else -> Kind.UNKNOWN
         }
     }
 
-    // Extension `.epub` + zip magic classifies as EPUB. We deliberately don't try to verify the
-    // uncompressed `mimetype` local-file-header here — many archivers deviate from the strict
-    // offset-30 layout, so a byte-scan would produce false negatives. The downstream
-    // EpubMetadataExtractor is the source of truth for actual EPUB validity; a zip that turns
-    // out not to be an EPUB gets an EpubMetadata.EMPTY result and the scanner falls back to the
-    // filename as title — safe degradation, no data loss.
+    // Extension `.epub`/`.cbz` + zip magic classifies as EPUB/CBZ. We deliberately don't verify the
+    // uncompressed `mimetype` local-file-header — many archivers deviate from the strict offset-30
+    // layout. The downstream metadata extractor is the source of truth; malformed archives fall back
+    // to filename as title — safe degradation, no data loss.
     private fun isZip(head: ByteArray): Boolean {
         if (head.size < 4) return false
-        for (i in 0..3) if (head[i] != EPUB_ZIP_MAGIC[i]) return false
+        for (i in 0..3) if (head[i] != ZIP_MAGIC[i]) return false
         return true
     }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalog.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalog.kt
@@ -19,6 +19,7 @@ import com.riffle.core.database.LibraryItemEntity
 import com.riffle.core.database.LocalFilesFileDao
 import com.riffle.core.database.LocalFilesFileEntity
 import com.riffle.core.database.LocalFilesFolderDao
+import com.riffle.core.domain.EbookFormat
 import com.riffle.core.domain.SourceType
 import java.io.File
 import java.io.FileInputStream
@@ -169,8 +170,9 @@ class LocalFilesCatalog(
     }
 
     private fun BookFormat.toStorageString(): String? = when (this) {
-        BookFormat.Epub -> "epub"
-        BookFormat.Pdf -> "pdf"
+        BookFormat.Epub -> EbookFormat.STORAGE_EPUB
+        BookFormat.Pdf -> EbookFormat.STORAGE_PDF
+        BookFormat.Cbz -> EbookFormat.STORAGE_CBZ
         BookFormat.Audiobook, BookFormat.Unsupported -> null
     }
 
@@ -181,8 +183,9 @@ class LocalFilesCatalog(
         author = author,
         coverUrl = coverUrl,
         ebookFormat = when (ebookFormat) {
-            "epub" -> BookFormat.Epub
-            "pdf" -> BookFormat.Pdf
+            EbookFormat.STORAGE_EPUB -> BookFormat.Epub
+            EbookFormat.STORAGE_PDF -> BookFormat.Pdf
+            EbookFormat.STORAGE_CBZ -> BookFormat.Cbz
             else -> BookFormat.Unsupported
         },
         hasAudio = hasAudio,

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
@@ -6,10 +6,13 @@ import com.riffle.core.database.LocalFilesFileDao
 import com.riffle.core.database.LocalFilesFileEntity
 import com.riffle.core.database.LocalFilesFolderDao
 import com.riffle.core.domain.Clock
+import com.riffle.core.domain.EbookFormat
 import com.riffle.core.domain.EpubMetadata
 import com.riffle.core.domain.EpubMetadataExtractor
 import com.riffle.core.domain.PdfMetadata
 import com.riffle.core.domain.PdfMetadataExtractor
+import com.riffle.core.domain.comic.ComicMetadata
+import com.riffle.core.domain.comic.ComicMetadataExtractor
 import com.riffle.core.logging.LogChannel
 import com.riffle.core.logging.Logger
 import kotlinx.coroutines.Dispatchers
@@ -140,8 +143,9 @@ class LocalFilesScanner @Inject constructor(
         }
 
         val extension = when (kind) {
-            FileClassifier.Kind.EPUB -> "epub"
-            FileClassifier.Kind.PDF -> "pdf"
+            FileClassifier.Kind.EPUB -> EbookFormat.STORAGE_EPUB
+            FileClassifier.Kind.PDF -> EbookFormat.STORAGE_PDF
+            FileClassifier.Kind.CBZ -> EbookFormat.STORAGE_CBZ
             FileClassifier.Kind.UNKNOWN -> return Outcome.SKIPPED
         }
         val copied = file.openStream().use { s -> copyIn.copyBook(sourceId, identity, extension, s) }
@@ -149,6 +153,7 @@ class LocalFilesScanner @Inject constructor(
         val (item, coverPath) = when (kind) {
             FileClassifier.Kind.EPUB -> buildEpubItem(sourceId, identity, file, copied)
             FileClassifier.Kind.PDF -> buildPdfItem(sourceId, identity, file, copied)
+            FileClassifier.Kind.CBZ -> buildCbzItem(sourceId, identity, file, copied)
             FileClassifier.Kind.UNKNOWN -> return Outcome.SKIPPED
         }
         libraryItemDao.upsertAll(listOf(item))
@@ -205,6 +210,31 @@ class LocalFilesScanner @Inject constructor(
         return entity to null
     }
 
+    private suspend fun buildCbzItem(
+        sourceId: String,
+        identity: String,
+        file: WalkedFile,
+        copied: java.io.File,
+    ): Pair<LibraryItemEntity, java.io.File?> {
+        val metadata = ComicMetadataExtractor.extract(copied)
+        val coverFile = metadata.coverBytes?.let { bytes ->
+            copyIn.writeCover(sourceId, identity, metadata.coverExtension ?: "jpg", bytes)
+        }
+        val entity = LibraryItemEntity(
+            sourceId = sourceId,
+            id = identity,
+            libraryId = LocalFilesCatalog.LOCAL_ROOT_ID,
+            title = stripExtension(file.displayName),
+            author = "",
+            coverUrl = coverFile?.toURI()?.toString(),
+            readingProgress = 0f,
+            ebookFormat = EBOOK_FORMAT_CBZ,
+            addedAt = clock.nowMs(),
+            pageCount = metadata.pageCount.takeIf { it > 0 },
+        )
+        return entity to coverFile
+    }
+
     private fun libraryItemFromEpub(
         sourceId: String,
         identity: String,
@@ -235,6 +265,7 @@ class LocalFilesScanner @Inject constructor(
     private fun ebookFormatOf(kind: FileClassifier.Kind): String = when (kind) {
         FileClassifier.Kind.EPUB -> EBOOK_FORMAT_EPUB
         FileClassifier.Kind.PDF -> EBOOK_FORMAT_PDF
+        FileClassifier.Kind.CBZ -> EBOOK_FORMAT_CBZ
         FileClassifier.Kind.UNKNOWN -> EBOOK_FORMAT_UNSUPPORTED
     }
 
@@ -244,9 +275,10 @@ class LocalFilesScanner @Inject constructor(
     }
 
     companion object {
-        const val EBOOK_FORMAT_EPUB: String = "epub"
-        const val EBOOK_FORMAT_PDF: String = "pdf"
-        const val EBOOK_FORMAT_UNSUPPORTED: String = "unsupported"
+        const val EBOOK_FORMAT_EPUB: String = EbookFormat.STORAGE_EPUB
+        const val EBOOK_FORMAT_PDF: String = EbookFormat.STORAGE_PDF
+        const val EBOOK_FORMAT_CBZ: String = EbookFormat.STORAGE_CBZ
+        const val EBOOK_FORMAT_UNSUPPORTED: String = EbookFormat.STORAGE_UNSUPPORTED
         private const val HEAD_BYTES: Int = 64 * 1024
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -763,10 +763,22 @@ class LibraryRepositoryTest {
     fun `unknown ebookFormat string maps to isReadable false`() = runTest {
         fakeServerRepository.activeServer = activeServer()
         val dao = FakeLibraryItemDao()
-        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Comic", "Author", null, 0f, ebookFormat = "cbz")))
+        // "azw3" is not in the supported set — must fall back to Unsupported. (CBZ was previously
+        // used as the "unknown" sentinel; it's now a supported format — ADR 0042.)
+        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Book", "Author", null, 0f, ebookFormat = "azw3")))
         val item = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()[0]
         assertEquals(EbookFormat.Unsupported, item.ebookFormat)
         assertFalse(item.isReadable)
+    }
+
+    @Test
+    fun `cbz ebookFormat string maps to Cbz and isReadable true`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
+        val dao = FakeLibraryItemDao()
+        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Comic", "Author", null, 0f, ebookFormat = "cbz")))
+        val item = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()[0]
+        assertEquals(EbookFormat.Cbz, item.ebookFormat)
+        assertTrue(item.isReadable)
     }
 
     // ── refreshLibraryItems: format round-trip ────────────────────────────────

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/FileClassifierTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/FileClassifierTest.kt
@@ -7,6 +7,7 @@ class FileClassifierTest {
 
     private val epubMagic = byteArrayOf(0x50, 0x4B, 0x03, 0x04) + ByteArray(200)
     private val pdfMagic = "%PDF-1.7".toByteArray()
+    private val zipMagic = byteArrayOf(0x50, 0x4B, 0x03, 0x04) + ByteArray(200)
 
     @Test
     fun `classifies epub extension with zip magic as EPUB`() {
@@ -37,6 +38,24 @@ class FileClassifierTest {
     @Test
     fun `pdf extension with wrong magic returns UNKNOWN`() {
         assertEquals(FileClassifier.Kind.UNKNOWN, FileClassifier.classify("book.pdf", "not a pdf".toByteArray()))
+    }
+
+    @Test
+    fun `classifies cbz extension with zip magic as CBZ`() {
+        assertEquals(FileClassifier.Kind.CBZ, FileClassifier.classify("comic.cbz", zipMagic))
+    }
+
+    @Test
+    fun `classifies CBZ extension case-insensitively`() {
+        assertEquals(FileClassifier.Kind.CBZ, FileClassifier.classify("Comic.CBZ", zipMagic))
+    }
+
+    @Test
+    fun `cbz extension with non-zip magic returns UNKNOWN`() {
+        assertEquals(
+            FileClassifier.Kind.UNKNOWN,
+            FileClassifier.classify("comic.cbz", "not a zip".toByteArray()),
+        )
     }
 
     @Test

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/52.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/52.json
@@ -1,0 +1,1621 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 52,
+    "identityHash": "139562eba370b7a9d7171b836a8e500b",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, `pageCount` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesSequence",
+            "columnName": "seriesSequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "scope"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, `originFontFamily` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedFigures",
+            "columnName": "embeddedFigures",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageHref",
+            "columnName": "imageHref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageSvg",
+            "columnName": "imageSvg",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBytes",
+            "columnName": "imageBytes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originFontFamily",
+            "columnName": "originFontFamily",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "local_files_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `treeUri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `addedAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `treeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtEpochMs",
+            "columnName": "addedAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "treeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `folderTreeUri` TEXT NOT NULL, `originalUri` TEXT NOT NULL, `copiedPath` TEXT NOT NULL, `coverPath` TEXT, `format` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `mtimeEpochMs` INTEGER NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderTreeUri",
+            "columnName": "folderTreeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUri",
+            "columnName": "originalUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "copiedPath",
+            "columnName": "copiedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtimeEpochMs",
+            "columnName": "mtimeEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_files_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '139562eba370b7a9d7171b836a8e500b')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1919,7 +1919,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 51, true,
+            TEST_DB, 52, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -1970,6 +1970,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_48_49,
             RiffleDatabase.MIGRATION_49_50,
             RiffleDatabase.MIGRATION_50_51,
+            RiffleDatabase.MIGRATION_51_52,
         )
 
         db.query("SELECT url, username, serverType, absUserId, type FROM sources WHERE id = 's1'").use { cursor ->
@@ -2252,6 +2253,44 @@ class MigrationTest {
         db.query("SELECT originFontFamily FROM annotations WHERE id = 'a-new'").use { c ->
             assertTrue(c.moveToFirst())
             assertEquals("Georgia, serif", c.getString(0))
+        }
+        db.close()
+    }
+
+    // ADR 0042: comics carry an intrinsic page count. Existing rows must default to NULL and
+    // preserve every other column.
+    @Test
+    fun migration51To52_addsPageCountToLibraryItems() {
+        helper.createDatabase(TEST_DB, 51).apply {
+            execSQL(
+                "INSERT INTO sources (id, url, isActive, insecureConnectionAllowed, username, serverType, absUserId, type) " +
+                    "VALUES ('s1', 'http://localhost', 1, 0, 'test', 'LOCAL_FILES', NULL, 'LOCAL_FILES')"
+            )
+            execSQL(
+                "INSERT INTO libraries (id, name, mediaType, sourceId, isUnsupported) " +
+                    "VALUES ('lib1', 'Local', 'book', 's1', 0)"
+            )
+            execSQL(
+                """
+                INSERT INTO library_items (
+                    sourceId, id, libraryId, title, author, coverUrl, readingProgress,
+                    ebookFileIno, ebookFormat, hasAudio, audioDurationSec, description,
+                    seriesName, seriesSequence, publishedYear, genres, publisher, language,
+                    lastOpenedAt, addedAt, isbn, asin, finishedAt
+                ) VALUES ('s1','i1','lib1','A Comic','Author',NULL,0.0,
+                          NULL,'cbz',0,0.0,NULL,
+                          NULL,NULL,'2020','','Publisher','en',
+                          NULL,NULL,NULL,NULL,NULL)
+                """.trimIndent()
+            )
+            close()
+        }
+        val db = helper.runMigrationsAndValidate(TEST_DB, 52, true, RiffleDatabase.MIGRATION_51_52)
+        db.query("SELECT id, ebookFormat, pageCount FROM library_items WHERE id = 'i1'").use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals("i1", c.getString(0))
+            assertEquals("cbz", c.getString(1))
+            assertTrue("new pageCount column defaults to NULL", c.isNull(2))
         }
         db.close()
     }

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemEntity.kt
@@ -43,4 +43,8 @@ data class LibraryItemEntity(
     val isbn: String? = null,
     val asin: String? = null,
     val finishedAt: Long? = null,
+    // Non-null for formats where a discrete page count is meaningful (comics today; PDF/EPUB may
+    // populate it in future). Displayed on the Detail Screen and used as the Progress-Sync
+    // denominator for comics.
+    val pageCount: Int? = null,
 )

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -30,7 +30,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         LocalFilesFolderEntity::class,
         LocalFilesFileEntity::class,
     ],
-    version = 51,
+    version = 52,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -1334,6 +1334,14 @@ abstract class RiffleDatabase : RoomDatabase() {
         val MIGRATION_50_51 = object : Migration(50, 51) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE annotations ADD COLUMN originFontFamily TEXT")
+            }
+        }
+
+        // Page count for formats where a discrete page total is meaningful — comic archives (CBZ,
+        // ADR 0042) today. Nullable; existing rows carry NULL and pick up a value on the next scan.
+        val MIGRATION_51_52 = object : Migration(51, 52) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `library_items` ADD COLUMN `pageCount` INTEGER")
             }
         }
     }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/CbzRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/CbzRepository.kt
@@ -1,0 +1,27 @@
+package com.riffle.core.domain
+
+import java.io.File
+
+sealed class CbzOpenResult {
+    data class Success(val cbzFile: File, val lastPosition: String?) : CbzOpenResult()
+    data class NetworkError(val cause: Throwable) : CbzOpenResult()
+    data object Offline : CbzOpenResult()
+}
+
+sealed class CbzDownloadResult {
+    data object Success : CbzDownloadResult()
+    data object AlreadyDownloaded : CbzDownloadResult()
+    data class NetworkError(val cause: Throwable) : CbzDownloadResult()
+}
+
+interface CbzRepository {
+    suspend fun openCbz(item: LibraryItem): CbzOpenResult
+    suspend fun downloadCbz(
+        item: LibraryItem,
+        onProgress: (downloaded: Long, total: Long) -> Unit = { _, _ -> },
+    ): CbzDownloadResult
+    suspend fun removeDownload(sourceId: String, itemId: String)
+    fun isDownloaded(sourceId: String, itemId: String): Boolean
+    fun isCached(sourceId: String, itemId: String): Boolean
+    suspend fun saveReadingPosition(itemId: String, locatorJson: String)
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/EbookFormat.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/EbookFormat.kt
@@ -3,18 +3,26 @@ package com.riffle.core.domain
 sealed class EbookFormat {
     data object Epub : EbookFormat()
     data object Pdf : EbookFormat()
+    data object Cbz : EbookFormat()
     data object Unsupported : EbookFormat()
 
     fun toStorageString(): String = when (this) {
-        Epub -> "epub"
-        Pdf -> "pdf"
-        Unsupported -> "unsupported"
+        Epub -> STORAGE_EPUB
+        Pdf -> STORAGE_PDF
+        Cbz -> STORAGE_CBZ
+        Unsupported -> STORAGE_UNSUPPORTED
     }
 
     companion object {
+        const val STORAGE_EPUB = "epub"
+        const val STORAGE_PDF = "pdf"
+        const val STORAGE_CBZ = "cbz"
+        const val STORAGE_UNSUPPORTED = "unsupported"
+
         fun from(raw: String?): EbookFormat = when (raw?.lowercase()) {
-            "epub" -> Epub
-            "pdf" -> Pdf
+            STORAGE_EPUB -> Epub
+            STORAGE_PDF -> Pdf
+            STORAGE_CBZ -> Cbz
             else -> Unsupported
         }
     }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryItem.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryItem.kt
@@ -31,8 +31,12 @@ data class LibraryItem(
     // local files / DB rows must pair id with sourceId. Defaulted for construction sites (e.g.
     // tests) that don't care; the real value is set when mapping from the DB entity.
     val sourceId: String = "",
+    // Total pages for formats where that's a discrete concept — comics today (from the CBZ image
+    // count computed at Add-to-Library); potentially PDF/EPUB in future. Null for EPUB (reflowable,
+    // no natural page count) and audiobook-only items.
+    val pageCount: Int? = null,
 ) {
-    /** Has an ebook file Riffle can open in the reader (EPUB or PDF). */
+    /** Has an ebook file Riffle can open in the reader (EPUB, PDF, or CBZ). */
     val isReadable: Boolean get() = ebookFormat != EbookFormat.Unsupported
 
     /** Has audio Riffle can play in the audiobook player — an Audiobook (ADR 0029). */

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailability.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailability.kt
@@ -10,6 +10,7 @@ package com.riffle.core.domain
 class LibraryItemOfflineAvailability(
     private val epubRepository: EpubRepository,
     private val pdfRepository: PdfRepository,
+    private val cbzRepository: CbzRepository,
     private val audiobookDownloadRepository: AudiobookDownloadRepository,
     private val bundleAudiobookSource: BundleAudiobookSource,
 ) {
@@ -19,6 +20,8 @@ class LibraryItemOfflineAvailability(
                 epubRepository.isDownloaded(item.sourceId, item.id) || epubRepository.isCached(item.sourceId, item.id)
             EbookFormat.Pdf ->
                 pdfRepository.isDownloaded(item.sourceId, item.id) || pdfRepository.isCached(item.sourceId, item.id)
+            EbookFormat.Cbz ->
+                cbzRepository.isDownloaded(item.sourceId, item.id) || cbzRepository.isCached(item.sourceId, item.id)
             EbookFormat.Unsupported -> false
         }
         return ebookAvailable ||

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/comic/CbzArchive.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/comic/CbzArchive.kt
@@ -1,0 +1,61 @@
+package com.riffle.core.domain.comic
+
+import java.io.File
+import java.util.zip.ZipFile
+
+/**
+ * Reads a CBZ (ZIP-of-images) with random-access. Page order is the archive's image entries in
+ * case-insensitive filename order — matches CDisplayEx / Komga / Comixology convention.
+ *
+ * Only common raster formats are counted as pages. `ComicInfo.xml`, `Thumbs.db`, `__MACOSX/` and
+ * anything else non-image is silently skipped, so the reported [pageCount] matches what actually
+ * renders.
+ */
+class CbzArchive(file: File) : ComicArchive {
+
+    private val zip = ZipFile(file)
+    private val entries: List<Entry>
+
+    init {
+        entries = zip.entries().asSequence()
+            .filter { !it.isDirectory }
+            .filter { !it.name.contains("__MACOSX", ignoreCase = false) }
+            .filter { !it.name.substringAfterLast('/').startsWith(".") }
+            .mapNotNull { entry ->
+                val ext = entry.name.substringAfterLast('.', "").lowercase()
+                val media = IMAGE_EXTENSIONS[ext] ?: return@mapNotNull null
+                Entry(entry.name, media)
+            }
+            .sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
+            .toList()
+    }
+
+    override val pageCount: Int
+        get() = entries.size
+
+    override fun imageBytes(pageIndex: Int): ByteArray {
+        val entry = entries[pageIndex]
+        val zipEntry = zip.getEntry(entry.name)
+            ?: throw IllegalStateException("Missing entry ${entry.name}")
+        return zip.getInputStream(zipEntry).use { it.readBytes() }
+    }
+
+    override fun mediaType(pageIndex: Int): String = entries[pageIndex].mediaType
+
+    override fun close() {
+        zip.close()
+    }
+
+    private data class Entry(val name: String, val mediaType: String)
+
+    companion object {
+        private val IMAGE_EXTENSIONS = mapOf(
+            "jpg" to "image/jpeg",
+            "jpeg" to "image/jpeg",
+            "png" to "image/png",
+            "gif" to "image/gif",
+            "webp" to "image/webp",
+            "bmp" to "image/bmp",
+        )
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/comic/ComicArchive.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/comic/ComicArchive.kt
@@ -1,0 +1,13 @@
+package com.riffle.core.domain.comic
+
+import java.io.Closeable
+
+/**
+ * Random-access read of an image-per-entry archive (CBZ today; CBR TBD). Entries are the archive's
+ * image entries in filename-sorted order — that ordering IS the page order (Q11 of ADR 0042).
+ */
+interface ComicArchive : Closeable {
+    val pageCount: Int
+    fun imageBytes(pageIndex: Int): ByteArray
+    fun mediaType(pageIndex: Int): String
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/comic/ComicArchiveKind.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/comic/ComicArchiveKind.kt
@@ -1,0 +1,38 @@
+package com.riffle.core.domain.comic
+
+/**
+ * Discriminates comic archive formats from magic bytes so we can surface a clean "not supported"
+ * message for real RAR files even when they're extension-mislabeled — and open a `.cbr` that's
+ * actually a ZIP transparently. See ADR 0042 (move 3).
+ */
+enum class ComicArchiveKind {
+    /** ZIP-based (CBZ, or a `.cbr` that turns out to be a ZIP). Supported in v1. */
+    ZIP,
+
+    /** RAR-based. Not supported in v1; UI shows a friendly message and hides the Read button. */
+    RAR,
+
+    /** Unrecognised magic. Treat as unsupported. */
+    UNKNOWN,
+}
+
+object ComicArchiveSniffer {
+
+    // "PK\x03\x04" is the ZIP local-file-header signature.
+    private val ZIP_MAGIC = byteArrayOf(0x50, 0x4B, 0x03, 0x04)
+
+    // "Rar!\x1A\x07" is the RAR archive signature (both RAR4 and RAR5 start with these bytes).
+    private val RAR_MAGIC = byteArrayOf(0x52, 0x61, 0x72, 0x21, 0x1A, 0x07)
+
+    fun sniff(head: ByteArray): ComicArchiveKind = when {
+        matches(head, ZIP_MAGIC) -> ComicArchiveKind.ZIP
+        matches(head, RAR_MAGIC) -> ComicArchiveKind.RAR
+        else -> ComicArchiveKind.UNKNOWN
+    }
+
+    private fun matches(head: ByteArray, prefix: ByteArray): Boolean {
+        if (head.size < prefix.size) return false
+        for (i in prefix.indices) if (head[i] != prefix[i]) return false
+        return true
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/comic/ComicMetadata.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/comic/ComicMetadata.kt
@@ -1,0 +1,16 @@
+package com.riffle.core.domain.comic
+
+/**
+ * What we can extract from a CBZ at Add-to-Library time without opening a reader: the page count,
+ * plus the bytes of the first image (used as the cover) and its extension. Title/author are not
+ * derivable from a plain CBZ, so callers fall back to the filename.
+ */
+data class ComicMetadata(
+    val pageCount: Int,
+    val coverBytes: ByteArray?,
+    val coverExtension: String?,
+) {
+    companion object {
+        val EMPTY = ComicMetadata(pageCount = 0, coverBytes = null, coverExtension = null)
+    }
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/comic/ComicMetadataExtractor.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/comic/ComicMetadataExtractor.kt
@@ -1,0 +1,35 @@
+package com.riffle.core.domain.comic
+
+import java.io.File
+
+/**
+ * Opens a CBZ and extracts (page count, first-image cover). Convention: the first entry in the
+ * sorted image list IS the cover (Q13 of ADR 0042). Returns [ComicMetadata.EMPTY] on any I/O or
+ * archive-format failure — the caller falls back to the filename.
+ */
+object ComicMetadataExtractor {
+
+    fun extract(file: File): ComicMetadata = try {
+        CbzArchive(file).use { archive ->
+            val count = archive.pageCount
+            if (count == 0) return ComicMetadata.EMPTY
+            val coverBytes = archive.imageBytes(0)
+            val coverExtension = extensionFor(archive.mediaType(0))
+            ComicMetadata(
+                pageCount = count,
+                coverBytes = coverBytes,
+                coverExtension = coverExtension,
+            )
+        }
+    } catch (_: Exception) {
+        ComicMetadata.EMPTY
+    }
+
+    private fun extensionFor(mediaType: String): String = when (mediaType) {
+        "image/png" -> "png"
+        "image/gif" -> "gif"
+        "image/webp" -> "webp"
+        "image/bmp" -> "bmp"
+        else -> "jpg"
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt
@@ -30,6 +30,7 @@ class LibraryItemOfflineAvailabilityTest {
         val availability = LibraryItemOfflineAvailability(
             epubRepository = FakeEpubRepository(downloaded = true),
             pdfRepository = FakePdfRepository(),
+            cbzRepository = FakeCbzRepository(),
             audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
             bundleAudiobookSource = FakeBundleAudiobookSource(),
         )
@@ -42,6 +43,7 @@ class LibraryItemOfflineAvailabilityTest {
         val availability = LibraryItemOfflineAvailability(
             epubRepository = FakeEpubRepository(cached = true),
             pdfRepository = FakePdfRepository(),
+            cbzRepository = FakeCbzRepository(),
             audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
             bundleAudiobookSource = FakeBundleAudiobookSource(),
         )
@@ -54,6 +56,7 @@ class LibraryItemOfflineAvailabilityTest {
         val availability = LibraryItemOfflineAvailability(
             epubRepository = FakeEpubRepository(),
             pdfRepository = FakePdfRepository(downloaded = true),
+            cbzRepository = FakeCbzRepository(),
             audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
             bundleAudiobookSource = FakeBundleAudiobookSource(),
         )
@@ -66,6 +69,7 @@ class LibraryItemOfflineAvailabilityTest {
         val availability = LibraryItemOfflineAvailability(
             epubRepository = FakeEpubRepository(),
             pdfRepository = FakePdfRepository(),
+            cbzRepository = FakeCbzRepository(),
             audiobookDownloadRepository = FakeAudiobookDownloadRepository(downloaded = true),
             bundleAudiobookSource = FakeBundleAudiobookSource(),
         )
@@ -78,6 +82,7 @@ class LibraryItemOfflineAvailabilityTest {
         val availability = LibraryItemOfflineAvailability(
             epubRepository = FakeEpubRepository(), // ebook not downloaded/cached
             pdfRepository = FakePdfRepository(),
+            cbzRepository = FakeCbzRepository(),
             audiobookDownloadRepository = FakeAudiobookDownloadRepository(downloaded = true),
             bundleAudiobookSource = FakeBundleAudiobookSource(),
         )
@@ -90,6 +95,7 @@ class LibraryItemOfflineAvailabilityTest {
         val availability = LibraryItemOfflineAvailability(
             epubRepository = FakeEpubRepository(),
             pdfRepository = FakePdfRepository(),
+            cbzRepository = FakeCbzRepository(),
             audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
             bundleAudiobookSource = FakeBundleAudiobookSource(),
         )
@@ -102,6 +108,7 @@ class LibraryItemOfflineAvailabilityTest {
         val availability = LibraryItemOfflineAvailability(
             epubRepository = FakeEpubRepository(),
             pdfRepository = FakePdfRepository(),
+            cbzRepository = FakeCbzRepository(),
             audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
             bundleAudiobookSource = FakeBundleAudiobookSource(setOf("s1/i1")),
         )
@@ -114,6 +121,7 @@ class LibraryItemOfflineAvailabilityTest {
         val availability = LibraryItemOfflineAvailability(
             epubRepository = FakeEpubRepository(),
             pdfRepository = FakePdfRepository(),
+            cbzRepository = FakeCbzRepository(),
             audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
             bundleAudiobookSource = FakeBundleAudiobookSource(emptySet()),
         )
@@ -144,6 +152,21 @@ class LibraryItemOfflineAvailabilityTest {
         override fun isCached(sourceId: String, itemId: String) = cached
         override suspend fun openPdf(item: LibraryItem) = error("unused")
         override suspend fun downloadPdf(
+            item: LibraryItem,
+            onProgress: (downloaded: Long, total: Long) -> Unit,
+        ) = error("unused")
+        override suspend fun removeDownload(sourceId: String, itemId: String) = error("unused")
+        override suspend fun saveReadingPosition(itemId: String, locatorJson: String) = error("unused")
+    }
+
+    private class FakeCbzRepository(
+        private val downloaded: Boolean = false,
+        private val cached: Boolean = false,
+    ) : CbzRepository {
+        override fun isDownloaded(sourceId: String, itemId: String) = downloaded
+        override fun isCached(sourceId: String, itemId: String) = cached
+        override suspend fun openCbz(item: LibraryItem) = error("unused")
+        override suspend fun downloadCbz(
             item: LibraryItem,
             onProgress: (downloaded: Long, total: Long) -> Unit,
         ) = error("unused")

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/comic/CbzArchiveTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/comic/CbzArchiveTest.kt
@@ -1,0 +1,60 @@
+package com.riffle.core.domain.comic
+
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class CbzArchiveTest {
+
+    @get:Rule val tmp = TemporaryFolder()
+
+    @Test
+    fun `page order is filename sorted, non-image entries filtered`() {
+        val file = tmp.newFile("comic.cbz").apply {
+            ZipOutputStream(outputStream()).use { z ->
+                // deliberately mixed order + non-image junk to prove filter + sort
+                z.write("ComicInfo.xml", "<xml/>".toByteArray())
+                z.write("page-002.png", pngBytes(0x02))
+                z.write("__MACOSX/._page-001.jpg", "junk".toByteArray())
+                z.write(".hidden.jpg", "junk".toByteArray())
+                z.write("page-010.jpg", pngBytes(0x0A))
+                z.write("page-001.jpg", pngBytes(0x01))
+                z.write("Thumbs.db", "junk".toByteArray())
+            }
+        }
+
+        CbzArchive(file).use { archive ->
+            assertEquals(3, archive.pageCount)
+            assertArrayEquals(pngBytes(0x01), archive.imageBytes(0))
+            assertArrayEquals(pngBytes(0x02), archive.imageBytes(1))
+            assertArrayEquals(pngBytes(0x0A), archive.imageBytes(2))
+            assertEquals("image/jpeg", archive.mediaType(0))
+            assertEquals("image/png", archive.mediaType(1))
+        }
+    }
+
+    @Test
+    fun `zero pages when archive has no images`() {
+        val file = tmp.newFile("empty.cbz").apply {
+            ZipOutputStream(outputStream()).use { z ->
+                z.write("ComicInfo.xml", "<xml/>".toByteArray())
+            }
+        }
+        CbzArchive(file).use { archive ->
+            assertEquals(0, archive.pageCount)
+        }
+    }
+
+    private fun pngBytes(marker: Byte) = ByteArray(8) { if (it == 7) marker else 0x89.toByte() }
+
+    private fun ZipOutputStream.write(name: String, data: ByteArray) {
+        putNextEntry(ZipEntry(name))
+        write(data)
+        closeEntry()
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/comic/ComicArchiveSnifferTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/comic/ComicArchiveSnifferTest.kt
@@ -1,0 +1,29 @@
+package com.riffle.core.domain.comic
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ComicArchiveSnifferTest {
+
+    @Test
+    fun `PK header sniffs as ZIP`() {
+        val head = byteArrayOf(0x50, 0x4B, 0x03, 0x04, 0x14, 0x00)
+        assertEquals(ComicArchiveKind.ZIP, ComicArchiveSniffer.sniff(head))
+    }
+
+    @Test
+    fun `Rar header sniffs as RAR`() {
+        val head = byteArrayOf(0x52, 0x61, 0x72, 0x21, 0x1A, 0x07, 0x00)
+        assertEquals(ComicArchiveKind.RAR, ComicArchiveSniffer.sniff(head))
+    }
+
+    @Test
+    fun `garbage sniffs as UNKNOWN`() {
+        assertEquals(ComicArchiveKind.UNKNOWN, ComicArchiveSniffer.sniff(byteArrayOf(0x00, 0x01, 0x02)))
+    }
+
+    @Test
+    fun `too short input sniffs as UNKNOWN`() {
+        assertEquals(ComicArchiveKind.UNKNOWN, ComicArchiveSniffer.sniff(byteArrayOf(0x50, 0x4B)))
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/comic/ComicMetadataExtractorTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/comic/ComicMetadataExtractorTest.kt
@@ -1,0 +1,58 @@
+package com.riffle.core.domain.comic
+
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class ComicMetadataExtractorTest {
+
+    @get:Rule val tmp = TemporaryFolder()
+
+    @Test
+    fun `extracts page count and first-image cover`() {
+        val file = tmp.newFile("comic.cbz").apply {
+            ZipOutputStream(outputStream()).use { z ->
+                z.write("ComicInfo.xml", "<xml/>".toByteArray())
+                z.write("page-002.jpg", byteArrayOf(0x02))
+                z.write("page-001.png", byteArrayOf(0x01))
+                z.write("page-003.jpg", byteArrayOf(0x03))
+            }
+        }
+        val metadata = ComicMetadataExtractor.extract(file)
+        assertEquals(3, metadata.pageCount)
+        // first sorted image (page-001.png)
+        assertArrayEquals(byteArrayOf(0x01), metadata.coverBytes)
+        assertEquals("png", metadata.coverExtension)
+    }
+
+    @Test
+    fun `empty result for archive with no images`() {
+        val file = tmp.newFile("empty.cbz").apply {
+            ZipOutputStream(outputStream()).use { z ->
+                z.write("ComicInfo.xml", "<xml/>".toByteArray())
+            }
+        }
+        val metadata = ComicMetadataExtractor.extract(file)
+        assertEquals(0, metadata.pageCount)
+        assertNull(metadata.coverBytes)
+    }
+
+    @Test
+    fun `garbage file returns EMPTY without throwing`() {
+        val file = tmp.newFile("junk.cbz").apply { writeBytes(byteArrayOf(1, 2, 3, 4)) }
+        val metadata = ComicMetadataExtractor.extract(file)
+        assertEquals(ComicMetadata.EMPTY, metadata)
+    }
+
+    private fun ZipOutputStream.write(name: String, data: ByteArray) {
+        putNextEntry(ZipEntry(name))
+        write(data)
+        closeEntry()
+    }
+}

--- a/docs/adr/0042-comic-book-archive-cbz-support.md
+++ b/docs/adr/0042-comic-book-archive-cbz-support.md
@@ -1,0 +1,99 @@
+# Comic Book Archive (CBZ) support
+
+Riffle ships two reader formats today — reflowable EPUB (Readium) and fixed-layout PDF (Readium's Pdfium adapter) — and its [Readable] capability is defined as "has an ebook file (EPUB or PDF)." Users have collections of comics (`.cbz`, `.cbr`) alongside their ebooks and audiobooks, and the primary ABS instance many users run already surfaces those files in its book libraries. We add **Comic Book Archive** as the third supported format, with a purpose-built reader whose navigation clones CDisplayEx's default interaction model.
+
+## Three architectural moves
+
+### 1. Comics extend Readable — no new capability
+
+Reading a comic is reading. Every Library-scoped surface — [Home Tab], [All Books Tab], [Not Started], [In Progress], [Completed], [Downloads Screen] — treats "has a file to open" as a single class. Introducing a `Viewable` capability parallel to `Readable` would double every one of those surfaces for no user benefit; the mental model is the same and the plumbing should be the same.
+
+Consequences:
+
+- **[Supported Formats]** grows a third entry: Comic Book Archive.
+- **[Readable]** covers EPUB, PDF, **and** comics.
+- **Library Item Detail Screen's Read button** routes by format — a third branch alongside EPUB and PDF.
+- Features that are text-domain — **[Book Search]**, **[Annotation]s** (Highlight/Note/Bookmark), **[Readaloud]**, **[Cadence]** — remain unavailable for comics, following the same pattern that already excludes PDF from Annotations and Book Search. Comics never appear in the [Annotations View] for the same reason PDFs don't ([ADR 0024]).
+- Features that are format-agnostic — [Immersive Mode], [Screen Wake Lock], [Volume Key Navigation], [Progress Sync], [Reading Session]s, [Reading Statistics] — work for comics without special-casing.
+
+The alternative — a `Viewable` capability — was rejected because it would force parallel plumbing through the six Library tabs, the Detail Screen, the Downloads Screen, and the progress-tracking pipeline, all to model a distinction users do not perceive.
+
+### 2. Integer page as canonical; Readium Locator JSON on the ABS wire in v1
+
+A comic's canonical position is a **zero-based integer page index**. Page count is the number of image entries in the archive in filename-sorted order. Pan and zoom state within a page is **per-device transient** — not part of the canonical, not synced, not persisted across sessions.
+
+**On the ABS wire, v1 uses the same shape PDF already uses:** a Readium `Locator` serialized as JSON in the ABS `ebookLocation` field, with the page index carried in `locations.position`. This is deliberately pragmatic — it reuses the existing `CatalogEbookProgressRemote` code path unchanged, ships a working two-device sync now, and defers a comic-specific wire codec until we have a concrete need to interoperate with the ABS web reader (which stores comic position as a fractional string `"0.4237..."`).
+
+Consequences:
+
+- No new translator ships in v1; comic sync piggybacks on the PDF path.
+- Interop with the ABS web reader for comic position is **not** achieved by v1 — a user reading the same comic on Riffle and on ABS-web will see progress diverge because the two clients don't agree on the wire format. Same-Riffle-across-devices works.
+- Rare page-count drift between devices (e.g., user re-downloads a re-packed archive with a different image count) produces the same failure mode PDF already has under page-index-drift; acceptable and documented.
+
+**Follow-up (roadmap):** a `ComicPositionTranslator` at the Peer boundary — same shape as [EPUB CFI Translator] — that converts `pageIndex ↔ fraction` string using the local page count, making Riffle interop with the ABS web reader. Deferred because it requires care around the "page count not yet known locally" state (the reconciler would need to skip conversion until first open) and doesn't affect the v1 audience (single-app users).
+
+Alternatives considered (and rejected for v1):
+
+- **Fraction wire codec.** Rejected for v1 scope reasons above; on the roadmap.
+- **Fractional canonical (0.0–1.0).** Format-agnostic on the wire but user-hostile: "Page 47 of 120" is what users think; scrubber ticks land on pages, not fractions. Rejected as canonical.
+- **CFI-style opaque string.** No corresponding structure in a comic archive to anchor to; overengineered. Rejected.
+
+### 3. CBZ in v1; CBR deferred; magic-byte sniff to catch mislabeled files
+
+**CBZ (ZIP-of-images)** ships in v1. Java's `java.util.zip` covers it with zero dependencies.
+
+**CBR (RAR-of-images)** is deferred. RAR is proprietary; the pragmatic library is `junrar` under the UnRAR license, which is distributable but requires a legal conversation and adds a ~500KB JAR. Modern comic releases are almost universally CBZ; deferring CBR carries a small user cost and no architectural cost — adding a second `ComicArchive` implementation later is purely additive.
+
+To avoid silent failures on mis-labeled files, **magic-byte sniffing** decides whether a file is a ZIP or a RAR regardless of its extension:
+
+- `PK\x03\x04` → treat as CBZ, works.
+- `Rar!\x1A\x07` → not supported in v1; the Detail Screen shows a clean "Comic Book RAR format not yet supported" message; the Read button is absent.
+
+## Scope of the v1 comic reader
+
+The reader clones **CDisplayEx's default** interaction model, deliberately minimal:
+
+- **Paginated only.** No webtoon (vertical continuous) mode, no two-page spread. One image on screen at a time.
+- **Fit Whole**, hard-coded. The entire page is visible, letterboxed against the reader background. No preference to change it.
+- **Tap zones**: horizontal thirds. Left → previous page. Right → next page. Middle → toggle [Immersive Mode]. No vertical zones.
+- **Horizontal swipe** also pages (left = next, right = previous). Vertical swipe does nothing.
+- **Pinch-to-zoom + drag-to-pan + double-tap-to-reset**, always live regardless of zone.
+- **Bottom page scrubber**: draggable slider with "Page N / M" label, appears/hides with the top bar (tied to Immersive Mode).
+- **Volume Keys**: Vol Down = next, Vol Up = previous, honouring the global [Volume Key Navigation] "Invert" preference.
+- **LTR only.** No RTL / manga toggle in v1.
+- **No Formatting Preferences panel button** — nothing is configurable.
+
+Completed threshold: **`page == pageCount - 1`** (last page reached). Matches the intent implied by "no configuration."
+
+## Cover and page count
+
+**Page count** is discovered as follows:
+
+- **LocalFiles**: computed at Add-to-Library — open the archive, list image entries, sort, count. The count is authoritative and persisted on the library-item row.
+- **ABS**: displayed pre-open from ABS's own `numPages` metadata; replaced with the authoritative count after first local open. Progress Sync's fraction-to-page conversion uses whichever value is known.
+
+**Cover art**:
+
+- **LocalFiles**: the first image entry in sorted order is the cover, extracted at Add-to-Library into private storage as a scaled thumbnail.
+- **ABS**: the Source-supplied cover URL.
+
+## Amendments to existing ADRs and glossary
+
+- **[ADR 0001]** (Hybrid cache/download storage): applies to comic files unchanged; Cache tier on ABS, no Cache tier on LocalFiles.
+- **[ADR 0024]** (Annotations anchor on EPUB CFI): unchanged. Comics carry no annotations in v1 for the same reason PDFs don't.
+- **[Supported Formats]**: gains Comic Book Archive.
+- **[Readable / Listenable]**: Readable covers EPUB, PDF, and comics.
+- **[Formatting Preferences]**: gains a comics section stating no user-configurable preferences in v1.
+- **[Progress Sync]**: unchanged in shape; a one-line note on the comic canonical + ABS wire codec.
+- **[Library Item Detail Screen]**: shows page count for comics (analogous to duration for audiobooks).
+
+## Deferred, on the roadmap
+
+- **CBR** (real RAR archives).
+- **`ComicPositionTranslator`** — fraction-string wire codec for interop with the ABS web reader.
+- **Webtoon** (vertical continuous) reading orientation.
+- **Two-page spread** in landscape.
+- **Right-to-left** reading direction for manga.
+- **Comic annotations** — page-anchored Bookmarks first, then page-anchored Highlights. Requires generalising the [Annotation] anchor from EPUB CFI to a discriminated union across formats; its own future ADR alongside PDF annotations.
+- **Explicit cover selection** for LocalFiles comics whose first image isn't the true cover.
+- **Table of Contents** derived from `ComicInfo.xml` when present.


### PR DESCRIPTION
Adds a third Readable format alongside EPUB and PDF: comic book archives (`.cbz`) with a purpose-built Compose reader whose interaction model clones **CDisplayEx's** default (tap-thirds, horizontal swipe, pinch/pan/double-tap zoom, bottom page scrubber).

Design captured in [ADR 0042](docs/adr/0042-comic-book-archive-cbz-support.md).

## Summary

Three architectural moves per the ADR:

1. **Comics extend `Readable`** — not a new `Viewable` capability. Every library-scoped surface (Home, All Books, Not Started, In Progress, Downloads, Detail Screen) stays uniform; the reader router adds a third branch.
2. **Integer page canonical + PDF-shaped Locator JSON on the ABS wire in v1.** No new wire codec; comic progress round-trips through the existing `CatalogEbookProgressRemote` path. A comic-specific fraction wire codec for ABS-web-reader interop is on the roadmap.
3. **CBZ ships v1; CBR deferred.** RAR licensing (UnRAR) and no platform decoder ruled it out. Real RAR files are caught via magic-byte sniff (`Rar!` prefix) and surface a clean "not supported" message. A mislabeled `.cbz` that's actually a ZIP opens transparently.

## What's in it

- New `EbookFormat.Cbz` / `BookFormat.Cbz`; `FileClassifier` recognises `.cbz` by extension + PK-zip magic bytes.
- New `core/domain/comic/`: `ComicArchive` interface, `CbzArchive` impl (ZipFile-backed, case-insensitive filename-sorted, image-only entries; skips `__MACOSX`, `Thumbs.db`, `.hidden`, `ComicInfo.xml`), `ComicArchiveSniffer` for ZIP vs RAR detection, `ComicMetadataExtractor` for page count + first-image cover.
- New `CbzRepository` + `CbzRepositoryImpl` mirroring PDF's shape; `LibraryItemOfflineAvailability` gains a CBZ branch.
- LocalFiles scanner ingests `.cbz` at Add-to-Library, extracts the cover, and writes `pageCount` to the new `library_items.pageCount` column.
- Room v50 → v51 migration + `MigrationTest.migration50To51`; full-chain migration test extended.
- New `cbz_reader/{itemId}` nav destination + `CbzReaderScreen` / `CbzReaderViewModel`. Uses Compose `HorizontalPager` with tap-third navigation, `detectTransformGestures` for pinch/pan/double-tap-reset, and a slider-based scrubber tied to immersive mode. Wake lock, volume-key nav, and immersive mode reuse the shared reader plumbing.
- Detail Screen shows **"Comic · N pages"** (analogous to `AudiobookDurationLine`) — sourced from `library_items.pageCount` and available **pre-open** so the metadata is visible before the reader mounts, per Q11 of the design.
- CONTEXT.md glossary edits: Supported Formats, Readable, Formatting Preferences, Progress Sync, Book Search, Annotation; new **Comic Book Archive** term.

## Tests

- **JVM (green):** `CbzArchiveTest`, `ComicArchiveSnifferTest`, `ComicMetadataExtractorTest`, plus extensions to `FileClassifierTest`, `ReaderRouterTest`, `IsReaderRouteTest`, and `LibraryRepositoryTest` (positive round-trip for the `cbz` format string; the pre-existing "unknown format string" test switched from `cbz` — now a real format — to `azw3` as the sentinel).
- **Instrumentation:** `MigrationTest.migration50To51_addsPageCountToLibraryItems` and the full-chain test now runs through v51.
- `LibraryItemOfflineAvailabilityTest` gains a `FakeCbzRepository`; app ViewModel tests get a shared `NoopCbzRepository`.

## Not in v1 (roadmap in ADR)

- CBR (real RAR archives)
- `ComicPositionTranslator` (fraction-string wire codec for ABS-web-reader interop)
- Webtoon / vertical continuous mode
- Two-page spread (landscape)
- RTL / manga reading direction
- Page-anchored bookmarks / highlights (blocked on generalising the EPUB CFI anchor across formats — its own future ADR)
- `ComicInfo.xml`-derived TOC
- Explicit cover selection for LocalFiles comics

## Test plan

- [x] `./gradlew test` — all JVM modules green
- [x] `./gradlew :app:compileDebugKotlin` — green
- [x] Room `51.json` schema exported with `pageCount` column
- [ ] **Manual on-device verification of the CBZ reader is outstanding.** JVM tests exercise the archive I/O, sniffer, metadata extractor, router, and DB migration but do not cover the Compose reader surface. Per AGENTS.md, JVM tests are not sufficient validation for reader-UI code — a manual pass on an AVD (add a `.cbz` to a LocalFiles source, tap Read, verify tap zones + swipe + pinch/pan + scrubber + immersive toggle + page resume) is recommended before merge.
- [ ] `make harness-test` — a `CbzHarnessTest` following the `PdfHarnessTest.kt` pattern is a natural follow-up.
- [ ] ABS-side smoke: comic in an ABS book library shows up, downloads via the Download button, opens, and syncs progress back on close.

## ADR

[docs/adr/0042-comic-book-archive-cbz-support.md](docs/adr/0042-comic-book-archive-cbz-support.md)