### PR TITLE
fix(reader): stop elided-view infinite reload + WebDAV push loop when book has bookmarks

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -958,8 +958,15 @@ class EpubReaderViewModel @Inject constructor(
             highlightsResumeServerId = sourceId
             // Snapshot what we just rendered so the observer can diff each incoming emission
             // per-annotation and pick the right response: targeted DOM patch for a colour/note/
-            // delete/in-chapter-add, or a full rebuild for a structural change.
-            highlightsRenderedById = rows.associateBy { it.id }
+            // delete/in-chapter-add, or a full rebuild for a structural change. Filter to
+            // TYPE_HIGHLIGHT so this baseline matches the observer's own filter — otherwise every
+            // bookmark on the book appears as a "removed" id on the first emission, triggers the
+            // structural-change path, and reloadHighlightsView loops (open → observer → reload →
+            // open → …) with a WebDAV syncOnOpen fired on every cycle (issue: elided-view infinite
+            // load + repeated WebDAV pushes when the book has bookmarks).
+            highlightsRenderedById = rows
+                .filter { it.type == AnnotationEntity.TYPE_HIGHLIGHT }
+                .associateBy { it.id }
             // Start observing (once per (sourceId, itemId)). Kept alive across the openBook()
             // reruns triggered by reloadHighlightsView, since cancelling and re-launching each
             // rebuild would drop emissions during the Loading→Ready gap.

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightsLiveUpdateObserverTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightsLiveUpdateObserverTest.kt
@@ -52,6 +52,32 @@ class HighlightsLiveUpdateObserverTest {
     }
 
     @Test
+    fun `openBook Highlights branch filters the baseline snapshot to TYPE_HIGHLIGHT`() {
+        // Regression guard for the elided-view infinite-load + repeated-WebDAV-push bug:
+        // getForItem returns ALL annotation types (highlights, bookmarks, images), but the observer
+        // filters incomingById to TYPE_HIGHLIGHT. If openBook's baseline associated over the raw
+        // rows, every bookmark would appear as a removed id on the first emission, structural=true
+        // fires (any bookmark in a chapter with zero highlights), reloadHighlightsView() runs → openBook
+        // rewrites the same all-types baseline → infinite loop, each cycle re-binding the annotation
+        // session and firing a WebDAV syncOnOpen.
+        val body = extractFunctionBody(vmSource(), "openBook")
+            ?: error("openBook not found in EpubReaderViewModel.kt")
+        val hlBranch = body.substringAfter("source == ReaderSource.Highlights")
+        val assignment = Regex(
+            """highlightsRenderedById\s*=\s*rows[\s\S]*?\.associateBy\s*\{\s*it\.id\s*}""",
+        ).find(hlBranch)?.value ?: error(
+            "highlightsRenderedById = rows…associateBy { it.id } not found in Highlights branch",
+        )
+        assertTrue(
+            "openBook's Highlights baseline must filter rows to AnnotationEntity.TYPE_HIGHLIGHT " +
+                "before associating by id — otherwise bookmarks in the same book perpetually mismatch " +
+                "the observer's TYPE_HIGHLIGHT-filtered incomingById and reloadHighlightsView() loops " +
+                "forever, firing a WebDAV syncOnOpen on every cycle.",
+            assignment.contains("AnnotationEntity.TYPE_HIGHLIGHT"),
+        )
+    }
+
+    @Test
     fun `ensureHighlightsObserver subscribes and emits DOM patches on partial change`() {
         val body = extractFunctionBody(vmSource(), "ensureHighlightsObserver")
             ?: error("ensureHighlightsObserver not found — did it move?")


### PR DESCRIPTION
## Summary

Opening the elided (Annotations) view on any book that had bookmarks caused the reader to loop forever between Loading and Ready, and to fire a WebDAV `syncOnOpen` on every cycle.

Root cause: `openBook`'s Highlights branch built the live-diff baseline as `rows.associateBy { it.id }` over `annotationDao.getForItem(...)`, which returns **all** annotation types (highlights, bookmarks, images). `ensureHighlightsObserver` filters `incomingById` to `TYPE_HIGHLIGHT` only, so `sameById` mismatched on the very first emission — every bookmark id looked "removed." Any bookmark whose chapter had no highlight peers hit the structural-change branch → `reloadHighlightsView()` → `openBook` re-planted the same all-types baseline → observer re-fired → infinite loop. Each cycle called `annotationSession.bind()`, which triggers `syncOnOpen` → WebDAV push+pull.

Debug log fingerprint from a real repro:
```
applyAnnotationHighlights hrefsWithMarks=0 loadedHrefs=[]    ← Loading (state reset)
applyAnnotationHighlights hrefsWithMarks=4 loadedHrefs=[]    ← Ready re-mount
...
applyAnnotationHighlights hrefsWithMarks=0 loadedHrefs=[]    ← Loading again
applyAnnotationHighlights hrefsWithMarks=4 loadedHrefs=[...] ← Ready with chapters
```
alternating every ~150 ms until the user backs out.

## Fix

Filter `rows` to `AnnotationEntity.TYPE_HIGHLIGHT` before associating by id, so the baseline matches the observer's own filter and `sameById` returns true on the first echo emission — the loop terminates.

## Test plan

- [x] `HighlightsLiveUpdateObserverTest.openBook Highlights branch filters the baseline snapshot to TYPE_HIGHLIGHT` — asserts the filter is present in the baseline assignment; flips red on revert.
- [x] Existing `HighlightsLiveUpdateObserverTest` suite still green (`./gradlew :app:testDebugUnitTest --tests "…HighlightsLiveUpdateObserverTest"`).
- [ ] Manually reproduce: open the Annotations View on a book with ≥1 bookmark in a chapter that has no highlights. Verify no reload flicker, no repeated WebDAV pushes.