### PR TITLE
feat(localfiles): library-per-folder + hide source picker after install

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
@@ -14,6 +14,7 @@ import com.riffle.core.database.CrossEpubIndexDao
 import com.riffle.core.database.LibraryDao
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.LocalFilesFileDao
+import com.riffle.core.database.LocalFilesFileFolderDao
 import com.riffle.core.database.LocalFilesFolderDao
 import com.riffle.core.database.ReadaloudCandidateDao
 import com.riffle.core.database.ReadaloudDismissalDao
@@ -73,6 +74,11 @@ object TestDatabaseModule {
     @Provides
     @Singleton
     fun provideLocalFilesFileDao(db: RiffleDatabase): LocalFilesFileDao = db.localFilesFileDao()
+
+    @Provides
+    @Singleton
+    fun provideLocalFilesFileFolderDao(db: RiffleDatabase): LocalFilesFileFolderDao =
+        db.localFilesFileFolderDao()
 
     @Provides
     @Singleton

--- a/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerScreen.kt
@@ -28,6 +28,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -36,6 +38,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.disabled
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.riffle.app.ui.TabletContentWidthContainer
 
 sealed interface SourceTypeChoice {
@@ -52,29 +55,43 @@ data class SourceTypeCard(
     val comingSoon: Boolean,
 )
 
-internal fun sourceTypeCards(): List<SourceTypeCard> = listOf(
-    SourceTypeCard(
-        type = SourceTypeChoice.Audiobookshelf,
-        title = "Audiobookshelf",
-        subtitle = "Stream ebooks and audiobooks from your Audiobookshelf server.",
-        enabled = true,
-        comingSoon = false,
-    ),
-    SourceTypeCard(
-        type = SourceTypeChoice.LocalFiles,
-        title = "Local files",
-        subtitle = "Read EPUBs and PDFs from a folder on this device.",
-        enabled = true,
-        comingSoon = false,
-    ),
-    SourceTypeCard(
-        type = SourceTypeChoice.Chitanka,
-        title = "Chitanka",
-        subtitle = "Browse Bulgarian ebooks (chitanka.info) and audiobooks (gramofonche).",
-        enabled = true,
-        comingSoon = false,
-    ),
-)
+/**
+ * The cards shown by [SourceTypePickerScreen]. When [hasLocalFilesSource] is true the "Local
+ * files" card is omitted — LocalFiles is a device singleton, so a second install would attach to
+ * the existing row, which the picker's "add source" framing hides. Adding another folder to that
+ * existing source is a dedicated action in Settings.
+ */
+internal fun sourceTypeCards(hasLocalFilesSource: Boolean = false): List<SourceTypeCard> = buildList {
+    add(
+        SourceTypeCard(
+            type = SourceTypeChoice.Audiobookshelf,
+            title = "Audiobookshelf",
+            subtitle = "Stream ebooks and audiobooks from your Audiobookshelf server.",
+            enabled = true,
+            comingSoon = false,
+        ),
+    )
+    if (!hasLocalFilesSource) {
+        add(
+            SourceTypeCard(
+                type = SourceTypeChoice.LocalFiles,
+                title = "Local files",
+                subtitle = "Read EPUBs and PDFs from a folder on this device.",
+                enabled = true,
+                comingSoon = false,
+            ),
+        )
+    }
+    add(
+        SourceTypeCard(
+            type = SourceTypeChoice.Chitanka,
+            title = "Chitanka",
+            subtitle = "Browse Bulgarian ebooks (chitanka.info) and audiobooks (gramofonche).",
+            enabled = true,
+            comingSoon = false,
+        ),
+    )
+}
 
 private fun iconFor(type: SourceTypeChoice): ImageVector = when (type) {
     SourceTypeChoice.Audiobookshelf -> Icons.Default.Cloud
@@ -96,7 +113,9 @@ fun SourceTypePickerScreen(
     onPickAudiobookshelf: () -> Unit,
     onPickLocalFiles: () -> Unit,
     onPickChitanka: () -> Unit,
+    viewModel: SourceTypePickerViewModel = hiltViewModel(),
 ) {
+    val hasLocalFilesSource by viewModel.hasLocalFilesSource.collectAsState()
     Scaffold(
         topBar = {
             TopAppBar(
@@ -117,7 +136,7 @@ fun SourceTypePickerScreen(
                 modifier = Modifier.fillMaxSize().padding(24.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                sourceTypeCards().forEach { card ->
+                sourceTypeCards(hasLocalFilesSource = hasLocalFilesSource).forEach { card ->
                     SourceTypeCardRow(
                         card = card,
                         onClick = when (card.type) {

--- a/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerScreen.kt
@@ -28,8 +28,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -38,7 +36,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.disabled
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import com.riffle.app.ui.TabletContentWidthContainer
 
 sealed interface SourceTypeChoice {
@@ -113,9 +110,8 @@ fun SourceTypePickerScreen(
     onPickAudiobookshelf: () -> Unit,
     onPickLocalFiles: () -> Unit,
     onPickChitanka: () -> Unit,
-    viewModel: SourceTypePickerViewModel = hiltViewModel(),
+    hasLocalFilesSource: Boolean = false,
 ) {
-    val hasLocalFilesSource by viewModel.hasLocalFilesSource.collectAsState()
     Scaffold(
         topBar = {
             TopAppBar(

--- a/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerViewModel.kt
@@ -1,0 +1,27 @@
+package com.riffle.app.feature.server
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.SourceType
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * Backs [SourceTypePickerScreen] with the "is LocalFiles already installed?" flag. LocalFiles is a
+ * device singleton — one row max — so after the first install the picker hides its tile and points
+ * the user at the Settings folder-management row to add another folder to that existing source.
+ */
+@HiltViewModel
+class SourceTypePickerViewModel @Inject constructor(
+    sourceRepository: SourceRepository,
+) : ViewModel() {
+
+    val hasLocalFilesSource: StateFlow<Boolean> = sourceRepository.observeAll()
+        .map { sources -> sources.any { it.type == SourceType.LOCAL_FILES } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), initialValue = false)
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerViewModel.kt
@@ -21,7 +21,11 @@ class SourceTypePickerViewModel @Inject constructor(
     sourceRepository: SourceRepository,
 ) : ViewModel() {
 
+    // Default to true (tile hidden) so a user who already has a LocalFiles source doesn't see
+    // the tile flash into view for a frame before the flow's first emission removes it. First-run
+    // users on a fresh device see the ABS card immediately and the LocalFiles card fades in on
+    // the first emission — a less-jarring order than "tile appears, then vanishes".
     val hasLocalFilesSource: StateFlow<Boolean> = sourceRepository.observeAll()
         .map { sources -> sources.any { it.type == SourceType.LOCAL_FILES } }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), initialValue = false)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), initialValue = true)
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Schedule
@@ -98,6 +99,7 @@ fun SettingsScreen(
     windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onNavigateToAddSource: (backend: AddSourceBackend, editId: String?) -> Unit,
+    onNavigateToAddLocalFolder: () -> Unit = {},
     onNavigateToReadaloudMatches: (String) -> Unit = {},
     onNavigateToAnnotationSyncMaintenance: () -> Unit = {},
     onNavigateToDebugLogs: () -> Unit = {},
@@ -215,6 +217,7 @@ fun SettingsScreen(
                         onToggleExpanded = {
                             expandedServers[lfs.id] = expandedServers[lfs.id] != true
                         },
+                        onAddFolder = onNavigateToAddLocalFolder,
                         onRemoveFolder = { treeUri -> viewModel.removeLocalFolder(treeUri) },
                         onRemoveSource = { viewModel.removeLocalFilesSource() },
                     )
@@ -1048,6 +1051,7 @@ private fun LocalFilesSourceRow(
     folderHealth: Map<String, Boolean>,
     isExpanded: Boolean,
     onToggleExpanded: () -> Unit,
+    onAddFolder: () -> Unit,
     onRemoveFolder: (String) -> Unit,
     onRemoveSource: () -> Unit,
 ) {
@@ -1092,11 +1096,26 @@ private fun LocalFilesSourceRow(
         )
         androidx.compose.animation.AnimatedVisibility(visible = isExpanded) {
             Column {
+                ListItem(
+                    modifier = Modifier
+                        .clickable(onClick = onAddFolder)
+                        .testTag("LocalFilesSourceRow.AddFolder"),
+                    leadingContent = {
+                        Icon(
+                            Icons.Default.Add,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                        )
+                    },
+                    headlineContent = {
+                        Text("Add folder", color = MaterialTheme.colorScheme.primary)
+                    },
+                )
                 if (folders.isEmpty()) {
                     ListItem(
                         headlineContent = { Text("No folders yet") },
                         supportingContent = {
-                            Text("Use \"Add source\" below to pick a folder for this device.")
+                            Text("Tap \"Add folder\" above to pick a folder to monitor.")
                         },
                     )
                 } else {

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -202,6 +202,9 @@ fun MainScreen(
             composable(ADD_SOURCE_TYPE_PICKER) {
                 val cameFromSettings = navController.previousBackStackEntry
                     ?.destination?.route == SETTINGS
+                val pickerViewModel: com.riffle.app.feature.server.SourceTypePickerViewModel =
+                    androidx.hilt.navigation.compose.hiltViewModel()
+                val hasLocalFilesSource by pickerViewModel.hasLocalFilesSource.collectAsState()
                 com.riffle.app.feature.server.SourceTypePickerScreen(
                     windowSizeClass = windowSizeClass,
                     onNavigateBack = {
@@ -224,6 +227,7 @@ fun MainScreen(
                             popUpTo(ADD_SOURCE_TYPE_PICKER) { inclusive = true }
                         }
                     },
+                    hasLocalFilesSource = hasLocalFilesSource,
                 )
             }
             composable(

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -347,6 +347,7 @@ fun MainScreen(
                             navController.navigate("$ADD_SOURCE?$params")
                         }
                     },
+                    onNavigateToAddLocalFolder = { navController.navigate(ADD_LOCAL_FILES) },
                     onNavigateToReadaloudMatches = { sourceId ->
                         val encoded = URLEncoder.encode(sourceId, "UTF-8")
                         navController.navigate("readaloud_matches/$encoded")

--- a/app/src/test/kotlin/com/riffle/app/feature/server/SourceTypePickerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/server/SourceTypePickerTest.kt
@@ -52,7 +52,9 @@ class SourceTypePickerTest {
     @Test
     fun `LocalFiles card is hidden once a LocalFiles source exists`() {
         val cards = sourceTypeCards(hasLocalFilesSource = true)
-        assertEquals(1, cards.size)
-        assertEquals(SourceTypeChoice.Audiobookshelf, cards.single().type)
+        // ABS + Chitanka remain; the LocalFiles card is omitted because a device already has
+        // its (singleton) LocalFiles source and "add another folder" lives in Settings.
+        assertTrue(cards.none { it.type is SourceTypeChoice.LocalFiles })
+        assertTrue(cards.any { it.type is SourceTypeChoice.Audiobookshelf })
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/server/SourceTypePickerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/server/SourceTypePickerTest.kt
@@ -44,4 +44,15 @@ class SourceTypePickerTest {
         assertFalse(lf.comingSoon)
         assertEquals("Local files", lf.title)
     }
+
+    // LocalFiles is a device singleton — once installed, the Add-Source picker must not offer
+    // to "add" a second one. Adding another folder to the existing source is a dedicated action
+    // in Settings. If this predicate ever flips, the picker will start creating duplicate rows
+    // (or silently no-op'ing) instead of guiding the user to the right entry point.
+    @Test
+    fun `LocalFiles card is hidden once a LocalFiles source exists`() {
+        val cards = sourceTypeCards(hasLocalFilesSource = true)
+        assertEquals(1, cards.size)
+        assertEquals(SourceTypeChoice.Audiobookshelf, cards.single().type)
+    }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -11,6 +11,7 @@ import com.riffle.core.database.CollectionDao
 import com.riffle.core.database.LibraryDao
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.LocalFilesFileDao
+import com.riffle.core.database.LocalFilesFileFolderDao
 import com.riffle.core.database.LocalFilesFolderDao
 import com.riffle.core.database.CrossEpubIndexDao
 import com.riffle.core.database.ReadaloudCandidateDao
@@ -89,6 +90,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_49_50,
                 RiffleDatabase.MIGRATION_50_51,
                 RiffleDatabase.MIGRATION_51_52,
+                RiffleDatabase.MIGRATION_52_53,
             )
             .build()
 
@@ -173,4 +175,9 @@ object DatabaseModule {
     @Provides
     @Singleton
     fun provideLocalFilesFileDao(db: RiffleDatabase): LocalFilesFileDao = db.localFilesFileDao()
+
+    @Provides
+    @Singleton
+    fun provideLocalFilesFileFolderDao(db: RiffleDatabase): LocalFilesFileFolderDao =
+        db.localFilesFileFolderDao()
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/CatalogModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/CatalogModule.kt
@@ -46,10 +46,12 @@ object CatalogModule {
     fun provideLocalFilesCatalogFactory(
         folderDao: LocalFilesFolderDao,
         fileDao: LocalFilesFileDao,
+        fileFolderDao: com.riffle.core.database.LocalFilesFileFolderDao,
         itemDao: LibraryItemDao,
     ): CatalogFactory = LocalFilesCatalogFactory(
         folderDao = folderDao,
         fileDao = fileDao,
+        fileFolderDao = fileFolderDao,
         itemDao = itemDao,
     )
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalog.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalog.kt
@@ -19,6 +19,7 @@ import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.LibraryItemEntity
 import com.riffle.core.database.LocalFilesFileDao
 import com.riffle.core.database.LocalFilesFileEntity
+import com.riffle.core.database.LocalFilesFileFolderDao
 import com.riffle.core.database.LocalFilesFolderDao
 import com.riffle.core.domain.EbookFormat
 import com.riffle.core.domain.SourceType
@@ -26,30 +27,30 @@ import java.io.File
 import java.io.FileInputStream
 
 /**
- * The LocalFiles-backed [Catalog]. Reads from local Room storage populated by
- * [LocalFilesScanner]: `library_items` rows carry the browsable metadata, `local_files_files`
- * rows carry the copied-in file path used to serve bytes. There is no network — every method
- * is trivially offline-safe, which is why LocalFiles implements [OfflineBrowseCapability]. The
- * catalog exposes a single synthetic root (`local:root`) matching the `libraryId` the scanner
- * writes for every ingested file. [SeriesCapability] is derived from EPUB `belongs-to-collection`
- * metadata already extracted into `library_items.seriesName` — position within the series comes
- * from `library_items.seriesSequence` (EPUB3 `group-position` / Calibre `series_index`), and
- * ordering flows through [SeriesEntryOrdering] so numbered entries sort by value, non-numeric
- * sequences fall in after, and unnumbered books land last by title. The Series tab hides itself
- * in the UI when the aggregation yields zero series.
+ * The LocalFiles-backed [Catalog]. Each configured folder is its own root, named after the
+ * folder's `displayName`. Items in a root are the files whose `local_files_file_folders`
+ * membership row points at that folder's `treeUri` — a book present in two folders appears
+ * under both roots, backed by a single `library_items` row (identity-hashed).
+ *
+ * The catalog never uses `library_items.libraryId` directly for browse — the source of truth for
+ * folder membership is the junction table. `library_items.libraryId` is written for compatibility
+ * with the rest of the codebase (it names *some* folder that currently contains the book) but is
+ * a hint, not the query key.
  */
 class LocalFilesCatalog(
     private val sourceId: String,
     private val folderDao: LocalFilesFolderDao,
     private val fileDao: LocalFilesFileDao,
+    private val fileFolderDao: LocalFilesFileFolderDao,
     private val itemDao: LibraryItemDao,
 ) : Catalog, SeriesCapability, OfflineBrowseCapability {
 
     override val sourceType: SourceType = SourceType.LOCAL_FILES
 
-    override suspend fun listRoots(): List<CatalogRoot> = listOf(
-        CatalogRoot(id = LOCAL_ROOT_ID, name = "Local Files", mediaType = "book"),
-    )
+    override suspend fun listRoots(): List<CatalogRoot> =
+        folderDao.forSource(sourceId).map { folder ->
+            CatalogRoot(id = folder.libraryId, name = folder.displayName, mediaType = "book")
+        }
 
     override suspend fun browse(
         rootId: String,
@@ -59,7 +60,7 @@ class LocalFilesCatalog(
         facet: FacetSelection?,
     ): List<CatalogItem> {
         // LocalFiles has no server-side facets — `facet` is ignored.
-        val items = itemDao.listByLibraryId(sourceId, rootId)
+        val items = itemsInFolderLibrary(rootId)
             .map { it.toCatalogItem() }
             .sortedWith(comparatorFor(sort))
         return items.pageOf(page, pageSize)
@@ -73,7 +74,7 @@ class LocalFilesCatalog(
     ): List<CatalogItem> {
         val needle = query.trim().lowercase()
         if (needle.isEmpty()) return emptyList()
-        val hits = itemDao.listByLibraryId(sourceId, rootId)
+        val hits = itemsInFolderLibrary(rootId)
             .filter {
                 it.title.lowercase().contains(needle) || it.author.lowercase().contains(needle)
             }
@@ -101,9 +102,6 @@ class LocalFilesCatalog(
     ): CatalogFileStream {
         val file = requireFile(itemId, format)
         val f = File(file.copiedPath)
-        // Row exists but the copied-in blob is gone (external cleanup, storage corruption). Surface
-        // this the same way the "no row" branch does so reader code catching CatalogException gets
-        // a uniform error rather than a raw FileNotFoundException.
         if (!f.exists()) {
             throw CatalogException.UnsupportedFormat(
                 "LocalFiles copied path missing for itemId=$itemId path=${file.copiedPath}",
@@ -118,11 +116,6 @@ class LocalFilesCatalog(
         }
     }
 
-    /**
-     * LocalFiles has no server to check — it's always reachable. Callers that need to gate on
-     * "can this Source actually serve a book" use [OfflineBrowseCapability] + folder-level health
-     * (see [LocalFilesFolderHealth]), which surfaces SAF-URI revocation separately.
-     */
     override suspend fun connectivityCheck(): CatalogHealth = CatalogHealth(
         isReachable = true,
         serverVersion = "local",
@@ -132,8 +125,7 @@ class LocalFilesCatalog(
     // region SeriesCapability
 
     override suspend fun listSeries(rootId: String): List<CatalogSeries> {
-        val rows = itemDao.listByLibraryId(sourceId, rootId)
-            .filter { !it.seriesName.isNullOrBlank() }
+        val rows = itemsInFolderLibrary(rootId).filter { !it.seriesName.isNullOrBlank() }
         if (rows.isEmpty()) return emptyList()
         return rows.groupBy { it.seriesName!! }
             .toSortedMap()
@@ -151,12 +143,25 @@ class LocalFilesCatalog(
     }
 
     override suspend fun listItemsInSeries(rootId: String, seriesId: String): List<CatalogItem> =
-        itemDao.listByLibraryId(sourceId, rootId)
+        itemsInFolderLibrary(rootId)
             .filter { it.seriesName == seriesId }
             .sortedWith(entityOrdering)
             .map { it.toCatalogItem() }
 
     // endregion
+
+    /**
+     * Every library_item row whose file has a membership in the folder named by [libraryId].
+     * Callers that expect all items in a library at once — browse, search, listSeries — pull the
+     * full list and page/filter in memory, matching the pre-junction implementation. Never falls
+     * back to `library_items.libraryId`: that column is a compatibility hint, not a query key.
+     */
+    private suspend fun itemsInFolderLibrary(libraryId: String): List<LibraryItemEntity> {
+        val folder = folderDao.getByLibraryId(sourceId, libraryId) ?: return emptyList()
+        val ids = fileFolderDao.itemIdsInFolder(sourceId, folder.treeUri)
+        if (ids.isEmpty()) return emptyList()
+        return itemDao.listByIds(sourceId, ids)
+    }
 
     private suspend fun requireFile(itemId: String, format: BookFormat): LocalFilesFileEntity {
         val row = fileDao.findById(sourceId, itemId)
@@ -207,8 +212,6 @@ class LocalFilesCatalog(
         updatedAt = null,
     )
 
-    // Delegated to SeriesEntryOrdering so the sequence semantics (numeric-first, non-numeric next,
-    // missing last, title tiebreaker) match every other Catalog. Never sort a series by title alone.
     private val entityOrdering: Comparator<LibraryItemEntity> =
         SeriesEntryOrdering.comparator(sequenceOf = { it.seriesSequence }, titleOf = { it.title })
 
@@ -227,9 +230,5 @@ class LocalFilesCatalog(
         if (from >= size) return emptyList()
         val to = (from + pageSize).coerceAtMost(size)
         return subList(from, to)
-    }
-
-    companion object {
-        const val LOCAL_ROOT_ID: String = "local:root"
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalog.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalog.kt
@@ -160,7 +160,9 @@ class LocalFilesCatalog(
         val folder = folderDao.getByLibraryId(sourceId, libraryId) ?: return emptyList()
         val ids = fileFolderDao.itemIdsInFolder(sourceId, folder.treeUri)
         if (ids.isEmpty()) return emptyList()
-        return itemDao.listByIds(sourceId, ids)
+        // Chunk to stay under SQLite's SQLITE_MAX_VARIABLE_NUMBER (999 on pre-Android 12 devices).
+        // A single folder library over 999 books would otherwise crash on browse/search.
+        return ids.chunked(BIND_VAR_CHUNK).flatMap { itemDao.listByIds(sourceId, it) }
     }
 
     private suspend fun requireFile(itemId: String, format: BookFormat): LocalFilesFileEntity {
@@ -230,5 +232,11 @@ class LocalFilesCatalog(
         if (from >= size) return emptyList()
         val to = (from + pageSize).coerceAtMost(size)
         return subList(from, to)
+    }
+
+    companion object {
+        // Below SQLITE_MAX_VARIABLE_NUMBER=999 on pre-Android-12 devices, with headroom for the
+        // WHERE clause's non-bind-var operands.
+        private const val BIND_VAR_CHUNK: Int = 900
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalogFactory.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalogFactory.kt
@@ -4,6 +4,7 @@ import com.riffle.core.catalog.Catalog
 import com.riffle.core.catalog.CatalogFactory
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.LocalFilesFileDao
+import com.riffle.core.database.LocalFilesFileFolderDao
 import com.riffle.core.database.LocalFilesFolderDao
 import com.riffle.core.domain.Source
 import com.riffle.core.domain.SourceType
@@ -17,6 +18,7 @@ import javax.inject.Inject
 class LocalFilesCatalogFactory @Inject constructor(
     private val folderDao: LocalFilesFolderDao,
     private val fileDao: LocalFilesFileDao,
+    private val fileFolderDao: LocalFilesFileFolderDao,
     private val itemDao: LibraryItemDao,
 ) : CatalogFactory {
 
@@ -26,6 +28,7 @@ class LocalFilesCatalogFactory @Inject constructor(
         sourceId = source.id,
         folderDao = folderDao,
         fileDao = fileDao,
+        fileFolderDao = fileFolderDao,
         itemDao = itemDao,
     )
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesFolderRepository.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesFolderRepository.kt
@@ -92,5 +92,14 @@ class LocalFilesFolderRepository @Inject constructor(
 
     suspend fun folders(sourceId: String): List<LocalFilesFolderEntity> = folderDao.forSource(sourceId)
 
-    private fun newFolderLibraryId(): String = "local:folder:" + UUID.randomUUID().toString()
+    private fun newFolderLibraryId(): String = LOCAL_FILES_LIBRARY_ID_PREFIX + UUID.randomUUID().toString()
+
+    companion object {
+        /**
+         * Prefix for the stable per-folder [LibraryEntity.id]. The full id is
+         * `local:folder:<uuid>`, generated once at folder-add time and stored on both the folder
+         * row and the library row so the two stay linked across SAF re-grants.
+         */
+        const val LOCAL_FILES_LIBRARY_ID_PREFIX: String = "local:folder:"
+    }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesFolderRepository.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesFolderRepository.kt
@@ -4,53 +4,93 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.documentfile.provider.DocumentFile
+import com.riffle.core.database.LibraryDao
+import com.riffle.core.database.LibraryEntity
+import com.riffle.core.database.LocalFilesFileFolderDao
 import com.riffle.core.database.LocalFilesFolderDao
 import com.riffle.core.database.LocalFilesFolderEntity
 import com.riffle.core.domain.Clock
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Adds/removes configured LocalFiles folders. On add, takes persistable read permission on the
- * tree URI so the folder survives process death; on remove, releases the grant.
+ * Adds/removes configured LocalFiles folders. Each folder maps 1:1 to a [LibraryEntity] named
+ * after the folder — added together on [addFolder], deleted together on [removeFolder]. On add,
+ * takes persistable read permission on the tree URI so the folder survives process death; on
+ * remove, releases the grant and drops every junction row tying files to that folder.
  */
 @Singleton
 class LocalFilesFolderRepository @Inject constructor(
     @ApplicationContext private val context: Context,
     private val folderDao: LocalFilesFolderDao,
+    private val libraryDao: LibraryDao,
+    private val fileFolderDao: LocalFilesFileFolderDao,
     private val clock: Clock,
 ) {
 
-    suspend fun addFolder(sourceId: String, treeUri: Uri) {
+    /**
+     * Adds [treeUri] as a monitored folder under [sourceId]. Idempotent on the treeUri: if the
+     * folder is already configured, its existing libraryId is returned unchanged.
+     *
+     * Returns the folder's stable libraryId — the id of the [LibraryEntity] that surfaces the
+     * folder's books in the drawer and catalog.
+     */
+    suspend fun addFolder(sourceId: String, treeUri: Uri): String {
         context.contentResolver.takePersistableUriPermission(
             treeUri,
             Intent.FLAG_GRANT_READ_URI_PERMISSION,
         )
+        val treeUriStr = treeUri.toString()
         val displayName = DocumentFile.fromTreeUri(context, treeUri)?.name
             ?: treeUri.lastPathSegment
-            ?: treeUri.toString()
+            ?: treeUriStr
+        val existing = folderDao.forSource(sourceId).firstOrNull { it.treeUri == treeUriStr }
+        val libraryId = existing?.libraryId ?: newFolderLibraryId()
         folderDao.upsert(
             LocalFilesFolderEntity(
                 sourceId = sourceId,
-                treeUri = treeUri.toString(),
+                treeUri = treeUriStr,
                 displayName = displayName,
-                addedAtEpochMs = clock.nowMs(),
+                addedAtEpochMs = existing?.addedAtEpochMs ?: clock.nowMs(),
+                libraryId = libraryId,
             ),
         )
+        libraryDao.upsertAll(
+            listOf(
+                LibraryEntity(
+                    id = libraryId,
+                    name = displayName,
+                    mediaType = "book",
+                    sourceId = sourceId,
+                ),
+            ),
+        )
+        return libraryId
     }
 
+    /**
+     * Removes the folder identified by [treeUri] from [sourceId]. Drops every file-membership row
+     * pointing at that folder — the scanner's post-remove sweep handles files that lost their last
+     * membership. Also deletes the folder's [LibraryEntity] so it disappears from the drawer.
+     */
     suspend fun removeFolder(sourceId: String, treeUri: String) {
+        val folder = folderDao.forSource(sourceId).firstOrNull { it.treeUri == treeUri }
         try {
             context.contentResolver.releasePersistableUriPermission(
                 Uri.parse(treeUri),
                 Intent.FLAG_GRANT_READ_URI_PERMISSION,
             )
         } catch (_: SecurityException) {
-            // Grant may already be gone (e.g. user cleared app data). Fall through to db delete.
+            // Grant may already be gone (e.g. user cleared app data). Fall through.
         }
+        fileFolderDao.deleteFolder(sourceId, treeUri)
         folderDao.delete(sourceId, treeUri)
+        folder?.let { libraryDao.deleteById(sourceId, it.libraryId) }
     }
 
     suspend fun folders(sourceId: String): List<LocalFilesFolderEntity> = folderDao.forSource(sourceId)
+
+    private fun newFolderLibraryId(): String = "local:folder:" + UUID.randomUUID().toString()
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
@@ -4,6 +4,8 @@ import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.LibraryItemEntity
 import com.riffle.core.database.LocalFilesFileDao
 import com.riffle.core.database.LocalFilesFileEntity
+import com.riffle.core.database.LocalFilesFileFolderDao
+import com.riffle.core.database.LocalFilesFileFolderEntity
 import com.riffle.core.database.LocalFilesFolderDao
 import com.riffle.core.domain.Clock
 import com.riffle.core.domain.EbookFormat
@@ -22,19 +24,25 @@ import javax.inject.Inject
 /**
  * Walks the LocalFiles Source's configured folders, classifies EPUB/PDF files by extension +
  * magic bytes, computes a content-identity hash, and idempotently upserts:
- *   - a `library_items` row per unique file (title/author/…, cover URL where extractable),
+ *   - a `library_items` row per unique file (title/author/…, cover URL where extractable), with
+ *     `libraryId` set to whichever folder-library currently contains it (if a file lives in
+ *     several folders, the row's libraryId names any one of them — folder-scoped browsing goes
+ *     through `local_files_file_folders`).
  *   - a `local_files_files` row per unique file (originalUri, copiedPath, coverPath, lastSeenAt).
+ *   - one `local_files_file_folders` membership row per (file, folder) pairing found this pass.
  *
- * A single scan pass runs across *all* configured folders of the source; rows whose
- * `lastSeenAtEpochMs` predates `scanStart` after the pass are hard-deleted along with their copied
- * bytes and library rows. This unifies "file removed from folder" with "folder permission revoked"
- * — both surface as absence during the walk.
+ * A single scan pass runs across *all* configured folders of the source. After a fully-clean walk,
+ * membership rows whose `lastSeenAtEpochMs` predates `scanStart` are hard-deleted; a file that
+ * loses its last membership takes the `library_items` row, the file row, and the copied bytes with
+ * it. This unifies "file removed from folder", "folder no longer configured", and "folder
+ * permission revoked" — all surface as absence during the walk.
  *
  * Not thread-safe: only one scan should be in-flight per source at a time.
  */
 class LocalFilesScanner @Inject constructor(
     private val folderDao: LocalFilesFolderDao,
     private val fileDao: LocalFilesFileDao,
+    private val fileFolderDao: LocalFilesFileFolderDao,
     private val libraryItemDao: LibraryItemDao,
     private val walker: FolderWalker,
     private val copyIn: CopyInService,
@@ -81,7 +89,7 @@ class LocalFilesScanner @Inject constructor(
             }
             for (file in files) {
                 val outcome = try {
-                    ingest(sourceId, folder.treeUri, file, scanStart)
+                    ingest(sourceId, folder.treeUri, folder.libraryId, file, scanStart)
                 } catch (e: Exception) {
                     failures += ScanFailure(file.displayName, "ingest-failed: ${e.message ?: e::class.simpleName}")
                     completed = false
@@ -99,15 +107,25 @@ class LocalFilesScanner @Inject constructor(
         ScanReport(added = added, refreshed = refreshed, removed = removed, failures = failures)
     }
 
+    /**
+     * Prunes junction rows (file-in-folder memberships) not touched by this scan, plus any file
+     * row whose last membership just disappeared. Returns the number of removed **files** — files
+     * that lost their last folder and were fully evicted — not the number of removed memberships.
+     * Matches the pre-junction contract callers already assert.
+     */
     private suspend fun sweepStale(sourceId: String, scanStart: Long): Int {
-        val stale = fileDao.stale(sourceId, scanStart)
-        for (row in stale) {
+        val staleMemberships = fileFolderDao.stale(sourceId, scanStart)
+        for (m in staleMemberships) {
+            fileFolderDao.delete(m.sourceId, m.sourceItemId, m.folderTreeUri)
+        }
+        val orphans = fileFolderDao.orphanedFiles(sourceId)
+        for (row in orphans) {
             libraryItemDao.deleteById(row.sourceId, row.sourceItemId)
             copyIn.deleteBook(row.sourceId, row.sourceItemId)
             if (row.coverPath != null) copyIn.deleteCover(row.sourceId, row.sourceItemId)
             fileDao.delete(row.sourceId, row.sourceItemId)
         }
-        return stale.size
+        return orphans.size
     }
 
     private enum class Outcome { ADDED, REFRESHED, SKIPPED }
@@ -115,6 +133,7 @@ class LocalFilesScanner @Inject constructor(
     private suspend fun ingest(
         sourceId: String,
         folderTreeUri: String,
+        folderLibraryId: String,
         file: WalkedFile,
         scanStart: Long,
     ): Outcome {
@@ -138,7 +157,15 @@ class LocalFilesScanner @Inject constructor(
         val identity = IdentityHasher.hash(head, file.sizeBytes)
         val existing = fileDao.findById(sourceId, identity)
         if (existing != null) {
-            fileDao.touchLastSeen(sourceId, identity, folderTreeUri, scanStart)
+            fileDao.touchLastSeen(sourceId, identity, scanStart)
+            fileFolderDao.upsert(
+                LocalFilesFileFolderEntity(
+                    sourceId = sourceId,
+                    sourceItemId = identity,
+                    folderTreeUri = folderTreeUri,
+                    lastSeenAtEpochMs = scanStart,
+                ),
+            )
             return Outcome.REFRESHED
         }
 
@@ -151,9 +178,9 @@ class LocalFilesScanner @Inject constructor(
         val copied = file.openStream().use { s -> copyIn.copyBook(sourceId, identity, extension, s) }
 
         val (item, coverPath) = when (kind) {
-            FileClassifier.Kind.EPUB -> buildEpubItem(sourceId, identity, file, copied)
-            FileClassifier.Kind.PDF -> buildPdfItem(sourceId, identity, file, copied)
-            FileClassifier.Kind.CBZ -> buildCbzItem(sourceId, identity, file, copied)
+            FileClassifier.Kind.EPUB -> buildEpubItem(sourceId, identity, folderLibraryId, file, copied)
+            FileClassifier.Kind.PDF -> buildPdfItem(sourceId, identity, folderLibraryId, file, copied)
+            FileClassifier.Kind.CBZ -> buildCbzItem(sourceId, identity, folderLibraryId, file, copied)
             FileClassifier.Kind.UNKNOWN -> return Outcome.SKIPPED
         }
         libraryItemDao.upsertAll(listOf(item))
@@ -161,7 +188,6 @@ class LocalFilesScanner @Inject constructor(
             LocalFilesFileEntity(
                 sourceId = sourceId,
                 sourceItemId = identity,
-                folderTreeUri = folderTreeUri,
                 originalUri = file.originalUri,
                 copiedPath = copied.absolutePath,
                 coverPath = coverPath?.absolutePath,
@@ -171,12 +197,21 @@ class LocalFilesScanner @Inject constructor(
                 lastSeenAtEpochMs = scanStart,
             ),
         )
+        fileFolderDao.upsert(
+            LocalFilesFileFolderEntity(
+                sourceId = sourceId,
+                sourceItemId = identity,
+                folderTreeUri = folderTreeUri,
+                lastSeenAtEpochMs = scanStart,
+            ),
+        )
         return Outcome.ADDED
     }
 
     private suspend fun buildEpubItem(
         sourceId: String,
         identity: String,
+        folderLibraryId: String,
         file: WalkedFile,
         copied: java.io.File,
     ): Pair<LibraryItemEntity, java.io.File?> {
@@ -185,12 +220,13 @@ class LocalFilesScanner @Inject constructor(
         val coverFile = if (coverBytes != null) {
             copyIn.writeCover(sourceId, identity, metadata.coverExtension ?: "jpg", coverBytes)
         } else null
-        return libraryItemFromEpub(sourceId, identity, file, metadata, coverFile) to coverFile
+        return libraryItemFromEpub(sourceId, identity, folderLibraryId, file, metadata, coverFile) to coverFile
     }
 
     private suspend fun buildPdfItem(
         sourceId: String,
         identity: String,
+        folderLibraryId: String,
         file: WalkedFile,
         copied: java.io.File,
     ): Pair<LibraryItemEntity, java.io.File?> {
@@ -198,7 +234,7 @@ class LocalFilesScanner @Inject constructor(
         val entity = LibraryItemEntity(
             sourceId = sourceId,
             id = identity,
-            libraryId = LocalFilesCatalog.LOCAL_ROOT_ID,
+            libraryId = folderLibraryId,
             title = metadata.title?.ifBlank { null } ?: stripExtension(file.displayName),
             author = metadata.author?.ifBlank { null } ?: "",
             coverUrl = null,
@@ -213,6 +249,7 @@ class LocalFilesScanner @Inject constructor(
     private suspend fun buildCbzItem(
         sourceId: String,
         identity: String,
+        folderLibraryId: String,
         file: WalkedFile,
         copied: java.io.File,
     ): Pair<LibraryItemEntity, java.io.File?> {
@@ -223,7 +260,7 @@ class LocalFilesScanner @Inject constructor(
         val entity = LibraryItemEntity(
             sourceId = sourceId,
             id = identity,
-            libraryId = LocalFilesCatalog.LOCAL_ROOT_ID,
+            libraryId = folderLibraryId,
             title = stripExtension(file.displayName),
             author = "",
             coverUrl = coverFile?.toURI()?.toString(),
@@ -238,13 +275,14 @@ class LocalFilesScanner @Inject constructor(
     private fun libraryItemFromEpub(
         sourceId: String,
         identity: String,
+        folderLibraryId: String,
         file: WalkedFile,
         metadata: EpubMetadata,
         coverFile: java.io.File?,
     ): LibraryItemEntity = LibraryItemEntity(
         sourceId = sourceId,
         id = identity,
-        libraryId = LocalFilesCatalog.LOCAL_ROOT_ID,
+        libraryId = folderLibraryId,
         title = metadata.title?.ifBlank { null } ?: stripExtension(file.displayName),
         author = metadata.author?.ifBlank { null } ?: "",
         coverUrl = coverFile?.toURI()?.toString(),

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
@@ -166,6 +166,11 @@ class LocalFilesScanner @Inject constructor(
                     lastSeenAtEpochMs = scanStart,
                 ),
             )
+            // Retag the library_items compatibility hint at the currently-walked folder so
+            // library_items.libraryId always names a still-configured folder library. Without
+            // this, removing the "home" folder of a shared book would leave the row pointing at
+            // a deleted LibraryEntity even though the book still lives in another folder.
+            libraryItemDao.updateLibraryId(sourceId, identity, folderLibraryId)
             return Outcome.REFRESHED
         }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesSourceInstaller.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesSourceInstaller.kt
@@ -1,8 +1,6 @@
 package com.riffle.core.data.localfiles
 
 import android.net.Uri
-import com.riffle.core.database.LibraryDao
-import com.riffle.core.database.LibraryEntity
 import com.riffle.core.database.SourceDao
 import com.riffle.core.database.SourceEntity
 import com.riffle.core.domain.SourceType
@@ -16,7 +14,8 @@ import javax.inject.Singleton
  * Owns the "install a LocalFiles Source" side of the Add-Source flow. Materialises the singleton
  * LocalFiles [SourceEntity] on first use (there is at most one LocalFiles source per device — the
  * user's multi-folder model runs *inside* that source), attaches the picked SAF folder to it via
- * [LocalFilesFolderRepository], and kicks the initial [LocalFilesScanner.scan].
+ * [LocalFilesFolderRepository] (which also creates a per-folder [com.riffle.core.database.LibraryEntity]
+ * named after the folder), and kicks the initial [LocalFilesScanner.scan].
  *
  * Not part of [com.riffle.core.domain.SourceRepository.commit] because there is no
  * [com.riffle.core.domain.PendingSource] step (no credentials to authenticate, no library set to
@@ -25,7 +24,6 @@ import javax.inject.Singleton
 @Singleton
 class LocalFilesSourceInstaller @Inject constructor(
     private val sourceDao: SourceDao,
-    private val libraryDao: LibraryDao,
     private val folderRepository: LocalFilesFolderRepository,
     private val scanner: LocalFilesScanner,
     private val logger: Logger,
@@ -33,27 +31,28 @@ class LocalFilesSourceInstaller @Inject constructor(
 
     data class InstallResult(
         val sourceId: String,
+        val libraryId: String,
         val scan: LocalFilesScanner.ScanReport,
     )
 
     /**
-     * Adds [treeUri] to the LocalFiles source, creating the source row and its synthetic
-     * `local:root` library on first call. Runs a first scan of the folder and returns the
-     * outcome so callers can surface add/failure counts.
+     * Adds [treeUri] to the LocalFiles source, creating the source row on first call and always
+     * creating a fresh per-folder library. Runs a first scan of the folder and returns the outcome
+     * so callers can surface add/failure counts.
      */
     suspend fun installFolder(treeUri: Uri): InstallResult {
         logger.d(LogChannel.LocalFiles) { "installFolder start uri=$treeUri" }
         val sourceId = ensureLocalFilesSource()
         logger.d(LogChannel.LocalFiles) { "installFolder sourceId=$sourceId" }
-        folderRepository.addFolder(sourceId, treeUri)
-        logger.d(LogChannel.LocalFiles) { "installFolder folder attached, starting scan" }
+        val libraryId = folderRepository.addFolder(sourceId, treeUri)
+        logger.d(LogChannel.LocalFiles) { "installFolder folder attached libraryId=$libraryId, starting scan" }
         val report = scanner.scan(sourceId)
         logger.d(LogChannel.LocalFiles) {
             "installFolder scan done added=${report.added} refreshed=${report.refreshed} " +
                 "removed=${report.removed} failures=${report.failures.size} " +
                 "failureSample=${report.failures.take(3).joinToString { "${it.displayName}:${it.reason}" }}"
         }
-        return InstallResult(sourceId = sourceId, scan = report)
+        return InstallResult(sourceId = sourceId, libraryId = libraryId, scan = report)
     }
 
     /**
@@ -76,16 +75,6 @@ class LocalFilesSourceInstaller @Inject constructor(
             type = SourceType.LOCAL_FILES.name,
         )
         val inserted = sourceDao.upsertAsFirstIfNoActive(entity)
-        libraryDao.upsertAll(
-            listOf(
-                LibraryEntity(
-                    id = LocalFilesCatalog.LOCAL_ROOT_ID,
-                    name = "Local Files",
-                    mediaType = "book",
-                    sourceId = inserted.id,
-                ),
-            ),
-        )
         return inserted.id
     }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
@@ -101,6 +101,12 @@ internal class FakeLibraryItemDao : LibraryItemDao {
     override suspend fun listByLibraryId(sourceId: String, libraryId: String): List<LibraryItemEntity> =
         scoped(sourceId, libraryId)
 
+    override suspend fun listByIds(sourceId: String, itemIds: List<String>): List<LibraryItemEntity> {
+        val idSet = itemIds.toHashSet()
+        return roomData.values.flatMap { it.value }
+            .filter { it.sourceId == sourceId && it.id in idSet }
+    }
+
     override fun observeById(sourceId: String, itemId: String): Flow<LibraryItemEntity?> =
         MutableStateFlow(roomData.values.flatMap { it.value }.firstOrNull { it.sourceId == sourceId && it.id == itemId })
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
@@ -137,6 +137,14 @@ internal class FakeLibraryItemDao : LibraryItemDao {
             .map { ReadingProgressRow(it.id, it.readingProgress) }
 
     override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) {}
+    override suspend fun updateLibraryId(sourceId: String, itemId: String, libraryId: String) {
+        val entry = roomData.entries.firstOrNull { e ->
+            e.value.value.any { it.sourceId == sourceId && it.id == itemId }
+        } ?: return
+        entry.value.value = entry.value.value.map {
+            if (it.sourceId == sourceId && it.id == itemId) it.copy(libraryId = libraryId) else it
+        }
+    }
 
     override suspend fun updateFinishedAt(sourceId: String, itemId: String, finishedAt: Long?) {}
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -96,6 +96,11 @@ class LibraryRepositoryTest {
             roomData[sourceId]?.value = emptyList()
         }
 
+        override suspend fun deleteById(sourceId: String, libraryId: String) {
+            val flow = roomData[sourceId] ?: return
+            flow.value = flow.value.filterNot { it.id == libraryId }
+        }
+
         override suspend fun setUnsupported(sourceId: String, libraryId: String, isUnsupported: Boolean) {
             val flow = roomData[sourceId] ?: return
             flow.value = flow.value.map { if (it.id == libraryId) it.copy(isUnsupported = isUnsupported) else it }

--- a/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
@@ -24,6 +24,7 @@ internal object ThrowingLibraryItemDao : LibraryItemDao {
     override suspend fun updateMetadata(metadata: LibraryItemMetadata) = Unit
     override suspend fun getById(sourceId: String, itemId: String): LibraryItemEntity? = null
     override suspend fun listByLibraryId(sourceId: String, libraryId: String): List<LibraryItemEntity> = emptyList()
+    override suspend fun listByIds(sourceId: String, itemIds: List<String>): List<LibraryItemEntity> = emptyList()
     override fun observeById(sourceId: String, itemId: String): Flow<LibraryItemEntity?> = flowOf(null)
     override suspend fun findSourceIdForItem(itemId: String): String? = null
     override suspend fun deleteByLibraryId(sourceId: String, libraryId: String) = Unit
@@ -45,5 +46,6 @@ internal object ThrowingLibraryDao : LibraryDao {
     override suspend fun getById(sourceId: String, libraryId: String): LibraryEntity? = null
     override suspend fun upsertAll(libraries: List<LibraryEntity>) = Unit
     override suspend fun deleteBySourceId(sourceId: String) = Unit
+    override suspend fun deleteById(sourceId: String, libraryId: String) = Unit
     override suspend fun setUnsupported(sourceId: String, libraryId: String, isUnsupported: Boolean) = Unit
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
@@ -32,6 +32,7 @@ internal object ThrowingLibraryItemDao : LibraryItemDao {
     override suspend fun deleteRemovedFromLibrary(sourceId: String, libraryId: String, serverItemIds: List<String>) = Unit
     override suspend fun updateLastOpenedAt(sourceId: String, itemId: String, timestamp: Long) = Unit
     override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) = Unit
+    override suspend fun updateLibraryId(sourceId: String, itemId: String, libraryId: String) = Unit
     override suspend fun updateFinishedAt(sourceId: String, itemId: String, finishedAt: Long?) = Unit
     override suspend fun getLastOpenedAtMap(sourceId: String, libraryId: String): List<LastOpenedAtRow> = emptyList()
     override suspend fun getReadingProgressMap(sourceId: String, libraryId: String): List<ReadingProgressRow> = emptyList()

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -400,6 +400,7 @@ class ReadaloudMatchingServiceTest {
         override suspend fun deleteRemovedFromLibrary(sourceId: String, libraryId: String, serverItemIds: List<String>) = Unit
         override suspend fun updateLastOpenedAt(sourceId: String, itemId: String, timestamp: Long) = Unit
         override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) = Unit
+        override suspend fun updateLibraryId(sourceId: String, itemId: String, libraryId: String) = Unit
         override suspend fun updateFinishedAt(sourceId: String, itemId: String, finishedAt: Long?) = Unit
         override suspend fun getLastOpenedAtMap(sourceId: String, libraryId: String): List<LastOpenedAtRow> = emptyList()
         override suspend fun getReadingProgressMap(sourceId: String, libraryId: String): List<ReadingProgressRow> = emptyList()

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -389,6 +389,10 @@ class ReadaloudMatchingServiceTest {
         override suspend fun updateMetadata(metadata: com.riffle.core.database.LibraryItemMetadata) = Unit
         override suspend fun getById(sourceId: String, itemId: String): LibraryItemEntity? = byId[itemId]
         override suspend fun listByLibraryId(sourceId: String, libraryId: String): List<LibraryItemEntity> = emptyList()
+        override suspend fun listByIds(sourceId: String, itemIds: List<String>): List<LibraryItemEntity> {
+            val idSet = itemIds.toHashSet()
+            return byId.values.filter { it.id in idSet }
+        }
         override fun observeById(sourceId: String, itemId: String): Flow<LibraryItemEntity?> = flowOf(byId[itemId])
         override suspend fun findSourceIdForItem(itemId: String): String? = byId[itemId]?.sourceId
         override suspend fun deleteByLibraryId(sourceId: String, libraryId: String) = Unit

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -131,6 +131,7 @@ class SeriesIntegrationTest {
         override suspend fun getLastOpenedAtMap(sourceId: String, libraryId: String): List<LastOpenedAtRow> = emptyList()
         override suspend fun getReadingProgressMap(sourceId: String, libraryId: String): List<ReadingProgressRow> = emptyList()
         override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) {}
+        override suspend fun updateLibraryId(sourceId: String, itemId: String, libraryId: String) {}
         override suspend fun updateFinishedAt(sourceId: String, itemId: String, finishedAt: Long?) {}
         override suspend fun listMatchableBySourceType(serverType: String): List<com.riffle.core.database.MatchableItemRow> = emptyList()
         override fun observeBySource(sourceId: String): Flow<List<LibraryItemEntity>> = kotlinx.coroutines.flow.flowOf(emptyList())

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -105,6 +105,7 @@ class SeriesIntegrationTest {
         override suspend fun getById(sourceId: String, libraryId: String): LibraryEntity? = null
         override suspend fun upsertAll(libraries: List<LibraryEntity>) {}
         override suspend fun deleteBySourceId(sourceId: String) {}
+        override suspend fun deleteById(sourceId: String, libraryId: String) {}
         override suspend fun setUnsupported(sourceId: String, libraryId: String, isUnsupported: Boolean) {}
     }
 
@@ -117,6 +118,7 @@ class SeriesIntegrationTest {
         override fun observeAllBooks(sourceId: String, libraryId: String): Flow<List<LibraryItemEntity>> = MutableStateFlow(emptyList())
         override suspend fun getById(sourceId: String, itemId: String): LibraryItemEntity? = null
         override suspend fun listByLibraryId(sourceId: String, libraryId: String): List<LibraryItemEntity> = emptyList()
+        override suspend fun listByIds(sourceId: String, itemIds: List<String>): List<LibraryItemEntity> = emptyList()
         override fun observeById(sourceId: String, itemId: String): Flow<LibraryItemEntity?> = MutableStateFlow(null)
         override suspend fun findSourceIdForItem(itemId: String): String? = null
         override suspend fun upsertAll(items: List<LibraryItemEntity>) {}

--- a/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
@@ -104,6 +104,9 @@ class ServerRepositoryTest {
         override suspend fun getById(sourceId: String, libraryId: String): LibraryEntity? =
             rows[sourceId].orEmpty().firstOrNull { it.id == libraryId }
         override suspend fun deleteBySourceId(sourceId: String) { rows.remove(sourceId) }
+        override suspend fun deleteById(sourceId: String, libraryId: String) {
+            rows[sourceId]?.removeIf { it.id == libraryId }
+        }
         override suspend fun setUnsupported(sourceId: String, libraryId: String, isUnsupported: Boolean) {
             rows[sourceId]?.replaceAll { if (it.id == libraryId) it.copy(isUnsupported = isUnsupported) else it }
         }
@@ -147,6 +150,10 @@ class ServerRepositoryTest {
         override suspend fun getById(sourceId: String, itemId: String) = rows.values.flatten().firstOrNull { it.id == itemId }
         override suspend fun listByLibraryId(sourceId: String, libraryId: String) =
             rows[libraryId].orEmpty().filter { it.sourceId == sourceId }.toList()
+        override suspend fun listByIds(sourceId: String, itemIds: List<String>): List<com.riffle.core.database.LibraryItemEntity> {
+            val idSet = itemIds.toHashSet()
+            return rows.values.flatten().filter { it.sourceId == sourceId && it.id in idSet }
+        }
         override fun observeById(sourceId: String, itemId: String) = flowOf(rows.values.flatten().firstOrNull { it.id == itemId })
         override suspend fun findSourceIdForItem(itemId: String): String? = rows.values.flatten().firstOrNull { it.id == itemId }?.sourceId
         override suspend fun upsertAll(items: List<com.riffle.core.database.LibraryItemEntity>) {

--- a/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
@@ -176,6 +176,7 @@ class ServerRepositoryTest {
         override suspend fun getLastOpenedAtMap(sourceId: String, libraryId: String) = emptyList<com.riffle.core.database.LastOpenedAtRow>()
         override suspend fun getReadingProgressMap(sourceId: String, libraryId: String) = emptyList<com.riffle.core.database.ReadingProgressRow>()
         override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) {}
+        override suspend fun updateLibraryId(sourceId: String, itemId: String, libraryId: String) {}
         override suspend fun updateFinishedAt(sourceId: String, itemId: String, finishedAt: Long?) {}
         override suspend fun listMatchableBySourceType(serverType: String) = emptyList<com.riffle.core.database.MatchableItemRow>()
         override fun observeBySource(sourceId: String) = flowOf(emptyList<com.riffle.core.database.LibraryItemEntity>())

--- a/core/data/src/test/kotlin/com/riffle/core/data/chitanka/ChitankaSourceInstallerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/chitanka/ChitankaSourceInstallerTest.kt
@@ -138,6 +138,9 @@ class ChitankaSourceInstallerTest {
         override suspend fun deleteBySourceId(sourceId: String) {
             rows.removeIf { it.sourceId == sourceId }
         }
+        override suspend fun deleteById(sourceId: String, libraryId: String) {
+            rows.removeIf { it.sourceId == sourceId && it.id == libraryId }
+        }
         override suspend fun setUnsupported(sourceId: String, libraryId: String, isUnsupported: Boolean) {
             val idx = rows.indexOfFirst { it.sourceId == sourceId && it.id == libraryId }
             if (idx >= 0) rows[idx] = rows[idx].copy(isUnsupported = isUnsupported)

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalogTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalogTest.kt
@@ -6,8 +6,10 @@ import com.riffle.core.catalog.SortKey
 import com.riffle.core.catalog.abs.CatalogException
 import com.riffle.core.data.FakeLibraryItemDao
 import com.riffle.core.database.LibraryItemEntity
-import com.riffle.core.database.LocalFilesFileEntity
 import com.riffle.core.database.LocalFilesFileDao
+import com.riffle.core.database.LocalFilesFileEntity
+import com.riffle.core.database.LocalFilesFileFolderDao
+import com.riffle.core.database.LocalFilesFileFolderEntity
 import com.riffle.core.database.LocalFilesFolderDao
 import com.riffle.core.database.LocalFilesFolderEntity
 import com.riffle.core.domain.SourceType
@@ -23,30 +25,26 @@ import java.io.File
 class LocalFilesCatalogTest {
 
     private val sourceId = "src-1"
-    private val libraryId = LocalFilesCatalog.LOCAL_ROOT_ID
+    private val folderTreeUri = "content://tree/A"
+    private val libraryId = "lib-A"
 
     @Test
-    fun `listRoots returns the single synthetic local root`() = runTest {
-        val catalog = catalog()
-        val roots = catalog.listRoots()
-        assertEquals(1, roots.size)
-        assertEquals(libraryId, roots[0].id)
-        assertEquals("Local Files", roots[0].name)
-        assertEquals(SourceType.LOCAL_FILES, catalog.sourceType)
+    fun `listRoots returns one root per configured folder, named after the folder`() = runTest {
+        val folderDao = InMemoryFolderDao()
+        listOf(
+            folderRow(treeUri = "content://tree/A", displayName = "Reading Now", libraryId = "lib-A"),
+            folderRow(treeUri = "content://tree/B", displayName = "Archive", libraryId = "lib-B"),
+        ).forEach { folderDao.store[it.sourceId to it.treeUri] = it }
+        val roots = catalog(folderDao = folderDao).listRoots()
+        assertEquals(setOf("lib-A" to "Reading Now", "lib-B" to "Archive"), roots.map { it.id to it.name }.toSet())
     }
 
     @Test
-    fun `browse returns items sorted by title, paged`() = runTest {
-        val items = FakeLibraryItemDao()
-        items.emit(
-            sourceId,
-            listOf(
-                epubItem("c", "Cormac"),
-                epubItem("a", "Alpha"),
-                epubItem("b", "Bravo"),
-            ),
+    fun `browse returns items in the folder-library, sorted by title, paged`() = runTest {
+        val (fileFolderDao, folderDao, items) = twoBookFolder(
+            titles = listOf("Cormac", "Alpha", "Bravo"),
         )
-        val catalog = catalog(items = items)
+        val catalog = catalog(folderDao = folderDao, fileFolderDao = fileFolderDao, items = items)
 
         val page0 = catalog.browse(libraryId, SortKey.TITLE, page = 0, pageSize = 2)
         assertEquals(listOf("Alpha", "Bravo"), page0.map { it.title })
@@ -58,15 +56,15 @@ class LocalFilesCatalogTest {
     @Test
     fun `browse sort by ADDED_AT is descending`() = runTest {
         val items = FakeLibraryItemDao()
-        items.emit(
-            sourceId,
-            listOf(
-                epubItem("old", "Old", addedAt = 100L),
-                epubItem("new", "New", addedAt = 500L),
-                epubItem("mid", "Mid", addedAt = 250L),
-            ),
+        val bookItems = listOf(
+            epubItem("old", "Old", addedAt = 100L),
+            epubItem("new", "New", addedAt = 500L),
+            epubItem("mid", "Mid", addedAt = 250L),
         )
-        val catalog = catalog(items = items)
+        items.emit(sourceId, bookItems)
+        val folderDao = folderWith(libraryId)
+        val fileFolderDao = fileFolderWith(bookItems.map { it.id })
+        val catalog = catalog(folderDao = folderDao, fileFolderDao = fileFolderDao, items = items)
         val browsed = catalog.browse(libraryId, SortKey.ADDED_AT)
         assertEquals(listOf("New", "Mid", "Old"), browsed.map { it.title })
     }
@@ -74,15 +72,17 @@ class LocalFilesCatalogTest {
     @Test
     fun `search matches title and author case-insensitively`() = runTest {
         val items = FakeLibraryItemDao()
-        items.emit(
-            sourceId,
-            listOf(
-                epubItem("1", "The Hobbit", author = "J.R.R. Tolkien"),
-                epubItem("2", "Dune", author = "Frank Herbert"),
-                epubItem("3", "Foundation", author = "Isaac Asimov"),
-            ),
+        val bookItems = listOf(
+            epubItem("1", "The Hobbit", author = "J.R.R. Tolkien"),
+            epubItem("2", "Dune", author = "Frank Herbert"),
+            epubItem("3", "Foundation", author = "Isaac Asimov"),
         )
-        val catalog = catalog(items = items)
+        items.emit(sourceId, bookItems)
+        val catalog = catalog(
+            folderDao = folderWith(libraryId),
+            fileFolderDao = fileFolderWith(bookItems.map { it.id }),
+            items = items,
+        )
 
         assertEquals(listOf("The Hobbit"), catalog.search(libraryId, "hobbit").map { it.title })
         assertEquals(listOf("Foundation"), catalog.search(libraryId, "asimov").map { it.title })
@@ -104,7 +104,6 @@ class LocalFilesCatalogTest {
         fileDao.rows[sourceId to "item-1"] = LocalFilesFileEntity(
             sourceId = sourceId,
             sourceItemId = "item-1",
-            folderTreeUri = "content://tree/A",
             originalUri = "content://tree/A/document/1",
             copiedPath = tmp.absolutePath,
             coverPath = null,
@@ -130,7 +129,6 @@ class LocalFilesCatalogTest {
         fileDao.rows[sourceId to "item-1"] = LocalFilesFileEntity(
             sourceId = sourceId,
             sourceItemId = "item-1",
-            folderTreeUri = "content://tree/A",
             originalUri = "content://tree/A/document/1",
             copiedPath = "/tmp/x.pdf",
             coverPath = null,
@@ -161,16 +159,18 @@ class LocalFilesCatalogTest {
     @Test
     fun `listSeries aggregates library_items by seriesName and falls back to title when sequence is missing`() = runTest {
         val items = FakeLibraryItemDao()
-        items.emit(
-            sourceId,
-            listOf(
-                epubItem("a", "Book A", seriesName = "Cycle"),
-                epubItem("b", "Book B", seriesName = "Cycle"),
-                epubItem("c", "Loner", seriesName = null),
-                epubItem("d", "Other 1", seriesName = "Other"),
-            ),
+        val bookItems = listOf(
+            epubItem("a", "Book A", seriesName = "Cycle"),
+            epubItem("b", "Book B", seriesName = "Cycle"),
+            epubItem("c", "Loner", seriesName = null),
+            epubItem("d", "Other 1", seriesName = "Other"),
         )
-        val catalog = catalog(items = items)
+        items.emit(sourceId, bookItems)
+        val catalog = catalog(
+            folderDao = folderWith(libraryId),
+            fileFolderDao = fileFolderWith(bookItems.map { it.id }),
+            items = items,
+        )
 
         val series = catalog.listSeries(libraryId)
         assertEquals(listOf("Cycle", "Other"), series.map { it.name })
@@ -182,21 +182,20 @@ class LocalFilesCatalogTest {
         assertEquals(listOf("Book A", "Book B"), inCycle.map { it.title })
     }
 
-    // Regression pin: if this ever flips back to alphabetical-by-title, "Book 10" will land
-    // before "Book 2" again. LocalFilesCatalog MUST delegate to SeriesEntryOrdering; the shared
-    // ordering interprets the persisted seriesSequence as numeric when possible.
     @Test
     fun `listSeries orders entries by numeric seriesSequence, not by title`() = runTest {
         val items = FakeLibraryItemDao()
-        items.emit(
-            sourceId,
-            listOf(
-                epubItem("ten", "Book Ten", seriesName = "Cycle", seriesSequence = "10"),
-                epubItem("two", "Book Two", seriesName = "Cycle", seriesSequence = "2"),
-                epubItem("one", "Book One", seriesName = "Cycle", seriesSequence = "1"),
-            ),
+        val bookItems = listOf(
+            epubItem("ten", "Book Ten", seriesName = "Cycle", seriesSequence = "10"),
+            epubItem("two", "Book Two", seriesName = "Cycle", seriesSequence = "2"),
+            epubItem("one", "Book One", seriesName = "Cycle", seriesSequence = "1"),
         )
-        val catalog = catalog(items = items)
+        items.emit(sourceId, bookItems)
+        val catalog = catalog(
+            folderDao = folderWith(libraryId),
+            fileFolderDao = fileFolderWith(bookItems.map { it.id }),
+            items = items,
+        )
 
         val cycle = catalog.listSeries(libraryId).first()
         assertEquals(listOf("one", "two", "ten"), cycle.items.map { it.itemId })
@@ -213,19 +212,16 @@ class LocalFilesCatalogTest {
         val items = FakeLibraryItemDao().also {
             it.emit(sourceId, listOf(epubItem("a", "Only Book", seriesName = null)))
         }
-        val catalog = catalog(items = items)
+        val catalog = catalog(
+            folderDao = folderWith(libraryId),
+            fileFolderDao = fileFolderWith(listOf("a")),
+            items = items,
+        )
         assertTrue(catalog.listSeries(libraryId).isEmpty())
     }
 
     @Test
     fun `capability set excludes every non-LocalFiles surface`() {
-        // Regression pin for issue #439's promise: a LocalFiles user sees no Collections tab, no
-        // To Read tab, no Reading Sessions, no Reading Statistics, and no Listen affordance.
-        // LocalFilesCatalog does implement SeriesCapability (folder-inferred series) and
-        // OfflineBrowseCapability. If any assertion below flips green, either LocalFilesCatalog
-        // silently gained a capability it doesn't actually implement, or the marker mixins have
-        // drifted. Uses raw `is` checks — this module's JVM target (17) can't inline
-        // `Catalog.has<T>()` emitted by core:catalog (target 21).
         val catalog: com.riffle.core.catalog.Catalog = catalog()
 
         assertTrue(catalog is com.riffle.core.catalog.SeriesCapability)
@@ -241,21 +237,92 @@ class LocalFilesCatalogTest {
     @Test
     fun `RECENTLY_OPENED sort is not supported at the Catalog layer`() = runTest {
         val items = FakeLibraryItemDao().also { it.emit(sourceId, listOf(epubItem("a", "a"))) }
-        val catalog = catalog(items = items)
+        val catalog = catalog(
+            folderDao = folderWith(libraryId),
+            fileFolderDao = fileFolderWith(listOf("a")),
+            items = items,
+        )
         val ex = runCatching { catalog.browse(libraryId, SortKey.RECENTLY_OPENED) }.exceptionOrNull()
         assertTrue(ex is CatalogException.UnsupportedFormat)
     }
 
+    @Test
+    fun `books shared across two folders appear in both folders' libraries`() = runTest {
+        val items = FakeLibraryItemDao()
+        val shared = epubItem("shared", "Shared Book")
+        val onlyInA = epubItem("only-a", "A-only")
+        val onlyInB = epubItem("only-b", "B-only")
+        items.emit(sourceId, listOf(shared, onlyInA, onlyInB))
+        val folderDao = InMemoryFolderDao()
+        listOf(
+            folderRow(treeUri = "tree-a", displayName = "A", libraryId = "lib-A"),
+            folderRow(treeUri = "tree-b", displayName = "B", libraryId = "lib-B"),
+        ).forEach { folderDao.store[it.sourceId to it.treeUri] = it }
+        val fileFolderDao = InMemoryFileFolderDao()
+        listOf(
+            membership("shared", "tree-a"),
+            membership("shared", "tree-b"),
+            membership("only-a", "tree-a"),
+            membership("only-b", "tree-b"),
+        ).forEach { fileFolderDao.rows[Triple(it.sourceId, it.sourceItemId, it.folderTreeUri)] = it }
+        val catalog = catalog(folderDao = folderDao, fileFolderDao = fileFolderDao, items = items)
+        val a = catalog.browse("lib-A", SortKey.TITLE).map { it.title }.toSet()
+        val b = catalog.browse("lib-B", SortKey.TITLE).map { it.title }.toSet()
+        assertEquals(setOf("A-only", "Shared Book"), a)
+        assertEquals(setOf("B-only", "Shared Book"), b)
+    }
+
     // region helpers
+
+    private fun folderRow(treeUri: String, displayName: String, libraryId: String) =
+        LocalFilesFolderEntity(
+            sourceId = sourceId,
+            treeUri = treeUri,
+            displayName = displayName,
+            addedAtEpochMs = 0L,
+            libraryId = libraryId,
+        )
+
+    private fun membership(itemId: String, treeUri: String) = LocalFilesFileFolderEntity(
+        sourceId = sourceId,
+        sourceItemId = itemId,
+        folderTreeUri = treeUri,
+        lastSeenAtEpochMs = 0L,
+    )
+
+    private fun folderWith(libraryId: String): InMemoryFolderDao {
+        val dao = InMemoryFolderDao()
+        val row = folderRow(treeUri = folderTreeUri, displayName = "A", libraryId = libraryId)
+        dao.store[row.sourceId to row.treeUri] = row
+        return dao
+    }
+
+    private fun fileFolderWith(itemIds: List<String>): InMemoryFileFolderDao {
+        val dao = InMemoryFileFolderDao()
+        for (id in itemIds) {
+            val m = membership(id, folderTreeUri)
+            dao.rows[Triple(m.sourceId, m.sourceItemId, m.folderTreeUri)] = m
+        }
+        return dao
+    }
+
+    private fun twoBookFolder(titles: List<String>): Triple<InMemoryFileFolderDao, InMemoryFolderDao, FakeLibraryItemDao> {
+        val items = FakeLibraryItemDao()
+        val entries = titles.mapIndexed { i, t -> epubItem("id-$i", t) }
+        items.emit(sourceId, entries)
+        return Triple(fileFolderWith(entries.map { it.id }), folderWith(libraryId), items)
+    }
 
     private fun catalog(
         folderDao: LocalFilesFolderDao = InMemoryFolderDao(),
         fileDao: LocalFilesFileDao = InMemoryFileDao(),
+        fileFolderDao: LocalFilesFileFolderDao = InMemoryFileFolderDao(),
         items: FakeLibraryItemDao = FakeLibraryItemDao(),
     ) = LocalFilesCatalog(
         sourceId = sourceId,
         folderDao = folderDao,
         fileDao = fileDao,
+        fileFolderDao = fileFolderDao,
         itemDao = items,
     )
 
@@ -282,7 +349,7 @@ class LocalFilesCatalogTest {
 
     // endregion
 
-    // region in-memory DAOs (mirrors of the scanner test's fakes so this suite is self-contained)
+    // region in-memory DAOs
 
     private class InMemoryFolderDao : LocalFilesFolderDao {
         val store = mutableMapOf<Pair<String, String>, LocalFilesFolderEntity>()
@@ -293,6 +360,8 @@ class LocalFilesCatalogTest {
             store.values.filter { it.sourceId == sourceId }.sortedBy { it.addedAtEpochMs }
         override fun observeForSource(sourceId: String): Flow<List<LocalFilesFolderEntity>> =
             MutableStateFlow(store.values.filter { it.sourceId == sourceId })
+        override suspend fun getByLibraryId(sourceId: String, libraryId: String): LocalFilesFolderEntity? =
+            store.values.firstOrNull { it.sourceId == sourceId && it.libraryId == libraryId }
         override suspend fun delete(sourceId: String, treeUri: String) {
             store.remove(sourceId to treeUri)
         }
@@ -307,16 +376,34 @@ class LocalFilesCatalogTest {
             rows[sourceId to sourceItemId]
         override suspend fun forSource(sourceId: String): List<LocalFilesFileEntity> =
             rows.values.filter { it.sourceId == sourceId }
-        override suspend fun touchLastSeen(
-            sourceId: String,
-            sourceItemId: String,
-            folderTreeUri: String,
-            seenAt: Long,
-        ) { /* not exercised */ }
-        override suspend fun stale(sourceId: String, scanStart: Long): List<LocalFilesFileEntity> = emptyList()
+        override suspend fun touchLastSeen(sourceId: String, sourceItemId: String, seenAt: Long) {}
         override suspend fun delete(sourceId: String, sourceItemId: String) {
             rows.remove(sourceId to sourceItemId)
         }
+    }
+
+    private class InMemoryFileFolderDao : LocalFilesFileFolderDao {
+        val rows = mutableMapOf<Triple<String, String, String>, LocalFilesFileFolderEntity>()
+        override suspend fun upsert(entity: LocalFilesFileFolderEntity) {
+            rows[Triple(entity.sourceId, entity.sourceItemId, entity.folderTreeUri)] = entity
+        }
+        override suspend fun forFile(sourceId: String, sourceItemId: String): List<LocalFilesFileFolderEntity> =
+            rows.values.filter { it.sourceId == sourceId && it.sourceItemId == sourceItemId }
+        override suspend fun forFolder(sourceId: String, folderTreeUri: String): List<LocalFilesFileFolderEntity> =
+            rows.values.filter { it.sourceId == sourceId && it.folderTreeUri == folderTreeUri }
+        override suspend fun itemIdsInFolder(sourceId: String, folderTreeUri: String): List<String> =
+            forFolder(sourceId, folderTreeUri).map { it.sourceItemId }
+        override suspend fun stale(sourceId: String, scanStart: Long): List<LocalFilesFileFolderEntity> = emptyList()
+        override suspend fun delete(sourceId: String, sourceItemId: String, folderTreeUri: String) {
+            rows.remove(Triple(sourceId, sourceItemId, folderTreeUri))
+        }
+        override suspend fun deleteFolder(sourceId: String, folderTreeUri: String) {
+            rows.entries.removeIf { it.value.sourceId == sourceId && it.value.folderTreeUri == folderTreeUri }
+        }
+        override suspend fun deleteFile(sourceId: String, sourceItemId: String) {
+            rows.entries.removeIf { it.value.sourceId == sourceId && it.value.sourceItemId == sourceItemId }
+        }
+        override suspend fun orphanedFiles(sourceId: String): List<LocalFilesFileEntity> = emptyList()
     }
 
     // endregion

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesScannerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesScannerTest.kt
@@ -3,6 +3,8 @@ package com.riffle.core.data.localfiles
 import com.riffle.core.data.FakeLibraryItemDao
 import com.riffle.core.database.LocalFilesFileDao
 import com.riffle.core.database.LocalFilesFileEntity
+import com.riffle.core.database.LocalFilesFileFolderDao
+import com.riffle.core.database.LocalFilesFileFolderEntity
 import com.riffle.core.database.LocalFilesFolderDao
 import com.riffle.core.database.LocalFilesFolderEntity
 import com.riffle.core.domain.Clock
@@ -12,7 +14,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.ByteArrayInputStream
@@ -37,7 +38,7 @@ class LocalFilesScannerTest {
     }
 
     @Test
-    fun `single EPUB adds one library_items row plus local_files_files row`() = runTest {
+    fun `single EPUB adds one library_items row plus local_files_files row plus one membership`() = runTest {
         val h = harness().apply {
             configureFolder("f1", files = listOf(fakeEpub("Dune", "Frank Herbert", "book.epub")))
         }
@@ -49,14 +50,21 @@ class LocalFilesScannerTest {
         val item = h.libraryItems.upserted.single()
         assertEquals("Dune", item.title)
         assertEquals("Frank Herbert", item.author)
-        assertEquals(LocalFilesCatalog.LOCAL_ROOT_ID, item.libraryId)
+        // The item's libraryId names the folder-library that contains it (per-folder library model
+        // — no more synthetic "local:root" umbrella library). Folder "f1" was configured with
+        // libraryId "lib-f1".
+        assertEquals("lib-f1", item.libraryId)
         assertEquals(LocalFilesScanner.EBOOK_FORMAT_EPUB, item.ebookFormat)
-        assertNotNull(item.coverUrl) // fakeEpub embeds a cover
+        assertNotNull(item.coverUrl)
 
         assertEquals(1, h.files.rows.size)
         val row = h.files.rows.values.single()
         assertEquals(item.id, row.sourceItemId)
         assertNotNull(row.copiedPath)
+
+        // One folder-membership row anchoring this file to folder "f1".
+        assertEquals(1, h.memberships.rows.size)
+        assertEquals("f1", h.memberships.rows.values.single().folderTreeUri)
     }
 
     @Test
@@ -71,8 +79,8 @@ class LocalFilesScannerTest {
         assertEquals(1, second.refreshed)
         assertEquals(0, second.removed)
         assertEquals(1, h.files.rows.size)
-        // library_items got a single upsert during the first scan and NOT a duplicate on the second.
         assertEquals(1, h.libraryItems.upserted.size)
+        assertEquals(1, h.memberships.rows.size)
     }
 
     @Test
@@ -81,6 +89,7 @@ class LocalFilesScannerTest {
         h.configureFolder("f1", files = listOf(fakeEpub("Dune", "Herbert", "book.epub")))
         h.scanner.scan(sourceId)
         assertEquals(1, h.files.rows.size)
+        assertEquals(1, h.memberships.rows.size)
 
         h.clock.advanceMs(1000)
         h.configureFolder("f1", files = emptyList())
@@ -88,6 +97,7 @@ class LocalFilesScannerTest {
         assertEquals(0, second.added)
         assertEquals(1, second.removed)
         assertEquals(0, h.files.rows.size)
+        assertEquals(0, h.memberships.rows.size)
         assertTrue(h.copyIn.booksOnDisk.isEmpty())
     }
 
@@ -163,26 +173,22 @@ class LocalFilesScannerTest {
     @Test
     fun `folder-walk failure records a failure and preserves rows (no stale sweep on incomplete scan)`() = runTest {
         val h = harness()
-        // First scan lands one file.
         h.configureFolder("f1", files = listOf(fakeEpub("A", "B", "a.epub")))
         h.scanner.scan(sourceId)
         assertEquals(1, h.files.rows.size)
 
-        // Second scan: walker throws. A transient walker failure must NOT cascade to deletion —
-        // otherwise a DocumentsProvider hiccup wipes previously-ingested books whose lastSeenAt
-        // was never touched. Row survives; sweep runs on the next fully-clean scan.
         h.clock.advanceMs(1000)
         h.walker.throwFor("f1")
         val report = h.scanner.scan(sourceId)
         assertEquals(0, report.removed)
         assertEquals(1, report.failures.size)
         assertEquals(1, h.files.rows.size)
+        assertEquals(1, h.memberships.rows.size)
     }
 
     @Test
     fun `ingest failure suppresses the stale sweep for this pass`() = runTest {
         val h = harness()
-        // First scan: two books, both land.
         val good = fakeEpub("Good", "A", "good.epub")
         val bad = WalkedFile(
             originalUri = "content://f1/bad.epub",
@@ -195,9 +201,6 @@ class LocalFilesScannerTest {
         h.scanner.scan(sourceId)
         assertEquals(1, h.files.rows.size)
 
-        // Second scan: `bad` is a new file that throws during head-read; `good` is gone. Under the
-        // old (unsafe) behavior good's row would be pruned because its lastSeenAt wasn't touched.
-        // Correct behavior: the ingest exception suppresses the sweep entirely — good is preserved.
         h.clock.advanceMs(1000)
         h.configureFolder("f1", files = listOf(bad))
         val report = h.scanner.scan(sourceId)
@@ -209,7 +212,7 @@ class LocalFilesScannerTest {
     // --- multi-folder same file --------------------------------------------
 
     @Test
-    fun `same file in two folders resolves to one row and survives removal from one`() = runTest {
+    fun `same file in two folders resolves to one row but has two folder memberships and survives removal from one`() = runTest {
         val bytes = buildEpub(opfMetadata = """<dc:title>Shared</dc:title>""")
         fun sharedFile(uri: String) = WalkedFile(
             originalUri = uri,
@@ -222,23 +225,32 @@ class LocalFilesScannerTest {
         h.configureFolder("f1", files = listOf(sharedFile("content://f1/shared.epub")))
         h.configureFolder("f2", files = listOf(sharedFile("content://f2/shared.epub")))
         val first = h.scanner.scan(sourceId)
-        assertEquals(1, first.added)     // ← the whole point: same identity hash ⇒ one row.
-        assertEquals(1, first.refreshed) // ← touched by the second folder's scan pass.
+        assertEquals(1, first.added)     // same identity hash ⇒ one file row.
+        assertEquals(1, first.refreshed) // touched again by folder f2's walk.
         assertEquals(1, h.files.rows.size)
+        // Both folder-memberships are recorded — this is what makes the book appear in both
+        // folder libraries. Any regression collapsing memberships back to one row would fail
+        // here first.
+        assertEquals(2, h.memberships.rows.size)
+        val folders = h.memberships.rows.values.map { it.folderTreeUri }.toSet()
+        assertEquals(setOf("f1", "f2"), folders)
 
-        // Remove from f1 only; f2 still has it → row survives.
+        // Remove from f1 only; f2 still has it → file row survives, only f1's membership goes.
         h.clock.advanceMs(1000)
         h.configureFolder("f1", files = emptyList())
         val second = h.scanner.scan(sourceId)
         assertEquals(0, second.removed)
         assertEquals(1, h.files.rows.size)
+        assertEquals(1, h.memberships.rows.size)
+        assertEquals("f2", h.memberships.rows.values.single().folderTreeUri)
 
-        // Remove from f2 too → row deleted.
+        // Remove from f2 too → file row and last membership deleted.
         h.clock.advanceMs(1000)
         h.configureFolder("f2", files = emptyList())
         val third = h.scanner.scan(sourceId)
         assertEquals(1, third.removed)
         assertEquals(0, h.files.rows.size)
+        assertEquals(0, h.memberships.rows.size)
     }
 
     // --- harness ------------------------------------------------------------
@@ -249,12 +261,14 @@ class LocalFilesScannerTest {
         val libraryItems = FakeLibraryItemDao()
         val folders = InMemoryFolderDao()
         val files = InMemoryFileDao()
+        val memberships = InMemoryFileFolderDao(files)
         val walker = InMemoryWalker()
         val copyIn = InMemoryCopyIn()
         val clock = MutableClock()
         val scanner = LocalFilesScanner(
             folderDao = folders,
             fileDao = files,
+            fileFolderDao = memberships,
             libraryItemDao = libraryItems,
             walker = walker,
             copyIn = copyIn,
@@ -264,7 +278,15 @@ class LocalFilesScannerTest {
         )
 
         suspend fun configureFolder(treeUri: String, files: List<WalkedFile>) {
-            folders.upsert(LocalFilesFolderEntity("src-1", treeUri, treeUri, clock.nowMs()))
+            folders.upsert(
+                LocalFilesFolderEntity(
+                    sourceId = "src-1",
+                    treeUri = treeUri,
+                    displayName = treeUri,
+                    addedAtEpochMs = clock.nowMs(),
+                    libraryId = "lib-$treeUri",
+                ),
+            )
             walker.set(treeUri, files)
         }
     }
@@ -303,6 +325,8 @@ class LocalFilesScannerTest {
             store.values.filter { it.sourceId == sourceId }.sortedBy { it.addedAtEpochMs }
         override fun observeForSource(sourceId: String): Flow<List<LocalFilesFolderEntity>> =
             MutableStateFlow(store.values.filter { it.sourceId == sourceId })
+        override suspend fun getByLibraryId(sourceId: String, libraryId: String): LocalFilesFolderEntity? =
+            store.values.firstOrNull { it.sourceId == sourceId && it.libraryId == libraryId }
         override suspend fun delete(sourceId: String, treeUri: String) {
             store.remove(sourceId to treeUri)
         }
@@ -317,20 +341,42 @@ class LocalFilesScannerTest {
             rows[sourceId to sourceItemId]
         override suspend fun forSource(sourceId: String): List<LocalFilesFileEntity> =
             rows.values.filter { it.sourceId == sourceId }
-        override suspend fun touchLastSeen(
-            sourceId: String,
-            sourceItemId: String,
-            folderTreeUri: String,
-            seenAt: Long,
-        ) {
+        override suspend fun touchLastSeen(sourceId: String, sourceItemId: String, seenAt: Long) {
             val row = rows[sourceId to sourceItemId] ?: return
-            rows[sourceId to sourceItemId] =
-                row.copy(lastSeenAtEpochMs = seenAt, folderTreeUri = folderTreeUri)
+            rows[sourceId to sourceItemId] = row.copy(lastSeenAtEpochMs = seenAt)
         }
-        override suspend fun stale(sourceId: String, scanStart: Long): List<LocalFilesFileEntity> =
-            rows.values.filter { it.sourceId == sourceId && it.lastSeenAtEpochMs < scanStart }
         override suspend fun delete(sourceId: String, sourceItemId: String) {
             rows.remove(sourceId to sourceItemId)
+        }
+    }
+
+    private class InMemoryFileFolderDao(
+        private val fileDao: InMemoryFileDao,
+    ) : LocalFilesFileFolderDao {
+        val rows = mutableMapOf<Triple<String, String, String>, LocalFilesFileFolderEntity>()
+        override suspend fun upsert(entity: LocalFilesFileFolderEntity) {
+            rows[Triple(entity.sourceId, entity.sourceItemId, entity.folderTreeUri)] = entity
+        }
+        override suspend fun forFile(sourceId: String, sourceItemId: String): List<LocalFilesFileFolderEntity> =
+            rows.values.filter { it.sourceId == sourceId && it.sourceItemId == sourceItemId }
+        override suspend fun forFolder(sourceId: String, folderTreeUri: String): List<LocalFilesFileFolderEntity> =
+            rows.values.filter { it.sourceId == sourceId && it.folderTreeUri == folderTreeUri }
+        override suspend fun itemIdsInFolder(sourceId: String, folderTreeUri: String): List<String> =
+            forFolder(sourceId, folderTreeUri).map { it.sourceItemId }
+        override suspend fun stale(sourceId: String, scanStart: Long): List<LocalFilesFileFolderEntity> =
+            rows.values.filter { it.sourceId == sourceId && it.lastSeenAtEpochMs < scanStart }
+        override suspend fun delete(sourceId: String, sourceItemId: String, folderTreeUri: String) {
+            rows.remove(Triple(sourceId, sourceItemId, folderTreeUri))
+        }
+        override suspend fun deleteFolder(sourceId: String, folderTreeUri: String) {
+            rows.entries.removeIf { it.value.sourceId == sourceId && it.value.folderTreeUri == folderTreeUri }
+        }
+        override suspend fun deleteFile(sourceId: String, sourceItemId: String) {
+            rows.entries.removeIf { it.value.sourceId == sourceId && it.value.sourceItemId == sourceItemId }
+        }
+        override suspend fun orphanedFiles(sourceId: String): List<LocalFilesFileEntity> {
+            val liveItemIds = rows.values.filter { it.sourceId == sourceId }.map { it.sourceItemId }.toHashSet()
+            return fileDao.rows.values.filter { it.sourceId == sourceId && it.sourceItemId !in liveItemIds }
         }
     }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesSourceInstallerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesSourceInstallerTest.kt
@@ -1,14 +1,11 @@
 package com.riffle.core.data.localfiles
 
-import com.riffle.core.database.LibraryDao
-import com.riffle.core.database.LibraryEntity
 import com.riffle.core.database.SourceDao
 import com.riffle.core.database.SourceEntity
 import com.riffle.core.domain.SourceType
 import com.riffle.core.logging.NoopLogger
 import io.mockk.mockk
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -21,8 +18,7 @@ class LocalFilesSourceInstallerTest {
     @Test
     fun `ensureLocalFilesSource creates a fresh LOCAL_FILES source on first call`() = runTest {
         val sourceDao = InMemorySourceDao()
-        val libraryDao = InMemoryLibraryDao()
-        val installer = installer(sourceDao = sourceDao, libraryDao = libraryDao)
+        val installer = installer(sourceDao = sourceDao)
 
         val id = installer.ensureLocalFilesSource()
 
@@ -44,24 +40,9 @@ class LocalFilesSourceInstallerTest {
         val second = installer.ensureLocalFilesSource()
 
         assertEquals(first, second)
-        // Only one row survives — critical: any second insertion would give the CatalogRegistry
-        // two factories to disambiguate, and multi-folder-in-one-source is the intended model.
+        // Only one row survives — critical: LocalFiles is a device singleton, and any second
+        // insertion would give the CatalogRegistry two factories to disambiguate.
         assertEquals(1, sourceDao.rowsOfType(SourceType.LOCAL_FILES.name))
-    }
-
-    @Test
-    fun `ensureLocalFilesSource seeds the synthetic local root library row`() = runTest {
-        val libraryDao = InMemoryLibraryDao()
-        val installer = installer(libraryDao = libraryDao)
-
-        val sourceId = installer.ensureLocalFilesSource()
-
-        val libs = libraryDao.forSource(sourceId)
-        assertEquals(1, libs.size)
-        val lib = libs.single()
-        assertEquals(LocalFilesCatalog.LOCAL_ROOT_ID, lib.id)
-        assertEquals(sourceId, lib.sourceId)
-        assertEquals("book", lib.mediaType)
     }
 
     @Test
@@ -83,8 +64,6 @@ class LocalFilesSourceInstallerTest {
         val id = installer.ensureLocalFilesSource()
 
         val local = sourceDao.getById(id)!!
-        // Adding LocalFiles when an ABS source is already active must not knock it out of the
-        // active slot — first-source-active is a convenience, not a takeover.
         assertEquals(false, local.isActive)
         assertEquals(true, sourceDao.getById("abs-1")!!.isActive)
     }
@@ -93,13 +72,10 @@ class LocalFilesSourceInstallerTest {
 
     private fun installer(
         sourceDao: SourceDao = InMemorySourceDao(),
-        libraryDao: LibraryDao = InMemoryLibraryDao(),
     ): LocalFilesSourceInstaller = LocalFilesSourceInstaller(
         sourceDao = sourceDao,
-        libraryDao = libraryDao,
         // folderRepository + scanner are only exercised by installFolder; ensureLocalFilesSource
-        // touches neither. Relaxed mocks keep the constructor happy without needing an Android
-        // Context or the metadata-extractor chain.
+        // touches neither. Relaxed mocks keep the constructor happy.
         folderRepository = mockk(relaxed = true),
         scanner = mockk(relaxed = true),
         logger = NoopLogger,
@@ -134,30 +110,6 @@ class LocalFilesSourceInstallerTest {
         override suspend fun deleteById(id: String) { rows.remove(id) }
         override suspend fun setAbsUserId(id: String, absUserId: String) {
             rows[id]?.let { rows[id] = it.copy(absUserId = absUserId) }
-        }
-    }
-
-    private class InMemoryLibraryDao : LibraryDao {
-        val rows = mutableListOf<LibraryEntity>()
-        fun forSource(sourceId: String): List<LibraryEntity> = rows.filter { it.sourceId == sourceId }
-        override fun observeBySourceId(sourceId: String): Flow<List<LibraryEntity>> =
-            MutableStateFlow(rows.filter { it.sourceId == sourceId })
-        override suspend fun libraryIdsForSource(sourceId: String): List<String> =
-            rows.filter { it.sourceId == sourceId }.map { it.id }
-        override suspend fun getById(sourceId: String, libraryId: String): LibraryEntity? =
-            rows.firstOrNull { it.sourceId == sourceId && it.id == libraryId }
-        override suspend fun upsertAll(libraries: List<LibraryEntity>) {
-            for (lib in libraries) {
-                rows.removeIf { it.sourceId == lib.sourceId && it.id == lib.id }
-                rows.add(lib)
-            }
-        }
-        override suspend fun deleteBySourceId(sourceId: String) {
-            rows.removeIf { it.sourceId == sourceId }
-        }
-        override suspend fun setUnsupported(sourceId: String, libraryId: String, isUnsupported: Boolean) {
-            val idx = rows.indexOfFirst { it.sourceId == sourceId && it.id == libraryId }
-            if (idx >= 0) rows[idx] = rows[idx].copy(isUnsupported = isUnsupported)
         }
     }
 

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/53.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/53.json
@@ -1,0 +1,1693 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 53,
+    "identityHash": "f1b781b58017c26f20e1f548758e6fd0",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, `pageCount` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesSequence",
+            "columnName": "seriesSequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "scope"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, `originFontFamily` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedFigures",
+            "columnName": "embeddedFigures",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageHref",
+            "columnName": "imageHref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageSvg",
+            "columnName": "imageSvg",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBytes",
+            "columnName": "imageBytes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originFontFamily",
+            "columnName": "originFontFamily",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "local_files_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `treeUri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `addedAtEpochMs` INTEGER NOT NULL, `libraryId` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `treeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtEpochMs",
+            "columnName": "addedAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "treeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `originalUri` TEXT NOT NULL, `copiedPath` TEXT NOT NULL, `coverPath` TEXT, `format` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `mtimeEpochMs` INTEGER NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUri",
+            "columnName": "originalUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "copiedPath",
+            "columnName": "copiedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtimeEpochMs",
+            "columnName": "mtimeEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_files_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_file_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `folderTreeUri` TEXT NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`, `folderTreeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderTreeUri",
+            "columnName": "folderTreeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId",
+            "folderTreeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_file_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_local_files_file_folders_sourceId_folderTreeUri",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "folderTreeUri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId_folderTreeUri` ON `${TABLE_NAME}` (`sourceId`, `folderTreeUri`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f1b781b58017c26f20e1f548758e6fd0')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1919,7 +1919,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 52, true,
+            TEST_DB, 53, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -1971,6 +1971,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_49_50,
             RiffleDatabase.MIGRATION_50_51,
             RiffleDatabase.MIGRATION_51_52,
+            RiffleDatabase.MIGRATION_52_53,
         )
 
         db.query("SELECT url, username, serverType, absUserId, type FROM sources WHERE id = 's1'").use { cursor ->
@@ -2292,6 +2293,144 @@ class MigrationTest {
             assertEquals("cbz", c.getString(1))
             assertTrue("new pageCount column defaults to NULL", c.isNull(2))
         }
+        db.close()
+    }
+
+    // Library-per-folder for LocalFiles: each configured folder becomes its own Library named
+    // after the folder's displayName, and library_items rows migrate off the synthetic
+    // "local:root" library onto the per-folder library. A junction table records folder
+    // membership so a book in two folders can appear under both libraries after the next scan.
+    @Test
+    fun migration52To53_localFilesLibraryPerFolder() {
+        helper.createDatabase(TEST_DB, 52).apply {
+            execSQL(
+                "INSERT INTO sources (id, url, isActive, insecureConnectionAllowed, username, serverType, absUserId, type) " +
+                    "VALUES ('lf1', 'https://localfiles.invalid', 0, 0, '', 'AUDIOBOOKSHELF', NULL, 'LOCAL_FILES')"
+            )
+            // The synthetic root library that pre-53 LocalFiles installs seeded.
+            execSQL(
+                "INSERT INTO libraries (id, name, mediaType, sourceId, isUnsupported) " +
+                    "VALUES ('local:root', 'Local Files', 'book', 'lf1', 0)"
+            )
+            // Two configured folders on this Source.
+            execSQL(
+                "INSERT INTO local_files_folders (sourceId, treeUri, displayName, addedAtEpochMs) VALUES " +
+                    "('lf1', 'content://tree/A', 'Reading Now', 100), " +
+                    "('lf1', 'content://tree/B', 'Archive', 200)"
+            )
+            // Three files: two anchored to folder A, one to folder B. Pre-53 each file row carries
+            // a single folderTreeUri — the folder it was first ingested from.
+            execSQL(
+                "INSERT INTO local_files_files " +
+                    "(sourceId, sourceItemId, folderTreeUri, originalUri, copiedPath, coverPath, " +
+                    "format, sizeBytes, mtimeEpochMs, lastSeenAtEpochMs) VALUES " +
+                    "('lf1','fA1','content://tree/A','uriA1','/tmp/A1',NULL,'epub',1,0,10), " +
+                    "('lf1','fA2','content://tree/A','uriA2','/tmp/A2',NULL,'epub',1,0,10), " +
+                    "('lf1','fB1','content://tree/B','uriB1','/tmp/B1',NULL,'epub',1,0,10)"
+            )
+            // library_items rows for each of those files, all tagged with the synthetic root.
+            fun insertItem(id: String) = execSQL(
+                "INSERT INTO library_items " +
+                    "(sourceId, id, libraryId, title, author, coverUrl, readingProgress, " +
+                    "ebookFileIno, ebookFormat, hasAudio, audioDurationSec, description, seriesName, " +
+                    "seriesSequence, publishedYear, genres, publisher, language, lastOpenedAt, addedAt, " +
+                    "isbn, asin, finishedAt, pageCount) VALUES " +
+                    "('lf1','$id','local:root','$id-title','author',NULL,0.0,NULL,'epub',0,0.0,NULL,NULL,NULL,NULL,'',NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL)"
+            )
+            insertItem("fA1"); insertItem("fA2"); insertItem("fB1")
+            // An orphan library_items row whose sourceItemId has no corresponding local_files_files
+            // row — it should be dropped by the migration since we can't attribute it to a folder.
+            execSQL(
+                "INSERT INTO library_items " +
+                    "(sourceId, id, libraryId, title, author, coverUrl, readingProgress, " +
+                    "ebookFileIno, ebookFormat, hasAudio, audioDurationSec, description, seriesName, " +
+                    "seriesSequence, publishedYear, genres, publisher, language, lastOpenedAt, addedAt, " +
+                    "isbn, asin, finishedAt) VALUES " +
+                    "('lf1','orphan','local:root','orphan-title','author',NULL,0.0,NULL,'epub',0,0.0,NULL,NULL,NULL,NULL,'',NULL,NULL,NULL,NULL,NULL,NULL,NULL)"
+            )
+            close()
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 53, true, RiffleDatabase.MIGRATION_52_53)
+
+        // Folder A and Folder B both got a distinct per-folder libraryId of the form
+        // "local:folder:<uuid>". Names lifted from the displayName column.
+        val folderALib = db.query(
+            "SELECT libraryId FROM local_files_folders WHERE sourceId = 'lf1' AND treeUri = 'content://tree/A'",
+        ).use { c -> assertTrue(c.moveToFirst()); c.getString(0) }
+        val folderBLib = db.query(
+            "SELECT libraryId FROM local_files_folders WHERE sourceId = 'lf1' AND treeUri = 'content://tree/B'",
+        ).use { c -> assertTrue(c.moveToFirst()); c.getString(0) }
+        assertTrue(folderALib.startsWith("local:folder:"))
+        assertTrue(folderBLib.startsWith("local:folder:"))
+        assertTrue("Folders must not share the same libraryId", folderALib != folderBLib)
+
+        // A LibraryEntity now exists per folder, named after the folder's displayName.
+        db.query(
+            "SELECT name FROM libraries WHERE sourceId = 'lf1' AND id = ?",
+            arrayOf<Any>(folderALib),
+        ).use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals("Reading Now", c.getString(0))
+        }
+        db.query(
+            "SELECT name FROM libraries WHERE sourceId = 'lf1' AND id = ?",
+            arrayOf<Any>(folderBLib),
+        ).use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals("Archive", c.getString(0))
+        }
+
+        // The synthetic "local:root" library row is gone.
+        db.query("SELECT COUNT(*) FROM libraries WHERE id = 'local:root'").use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals(0, c.getInt(0))
+        }
+
+        // Membership junction has one row per pre-migration file, keyed by the file's historical
+        // folderTreeUri. Cross-folder duplicates would materialise on the next scan; this test
+        // only validates the historical backfill.
+        db.query(
+            "SELECT sourceItemId, folderTreeUri FROM local_files_file_folders " +
+                "WHERE sourceId = 'lf1' ORDER BY sourceItemId",
+        ).use { c ->
+            val rows = buildList {
+                while (c.moveToNext()) add(c.getString(0) to c.getString(1))
+            }
+            assertEquals(
+                listOf(
+                    "fA1" to "content://tree/A",
+                    "fA2" to "content://tree/A",
+                    "fB1" to "content://tree/B",
+                ),
+                rows,
+            )
+        }
+
+        // library_items rows are reassigned: fA1/fA2 → folderALib, fB1 → folderBLib.
+        db.query("SELECT id, libraryId FROM library_items WHERE sourceId = 'lf1' ORDER BY id").use { c ->
+            val rows = buildList {
+                while (c.moveToNext()) add(c.getString(0) to c.getString(1))
+            }
+            assertEquals(
+                listOf(
+                    "fA1" to folderALib,
+                    "fA2" to folderALib,
+                    "fB1" to folderBLib,
+                ),
+                rows,
+            )
+        }
+
+        // `folderTreeUri` is no longer a column on `local_files_files` — table was recreated.
+        db.query("PRAGMA table_info(local_files_files)").use { c ->
+            val columns = buildList { while (c.moveToNext()) add(c.getString(1)) }
+            assertTrue("folderTreeUri must be moved off local_files_files", "folderTreeUri" !in columns)
+            // Core columns still present, verifying the recreation copied data cleanly.
+            assertTrue("sourceItemId" in columns)
+            assertTrue("copiedPath" in columns)
+        }
+
         db.close()
     }
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryDao.kt
@@ -25,6 +25,9 @@ interface LibraryDao {
     @Query("DELETE FROM libraries WHERE sourceId = :sourceId")
     suspend fun deleteBySourceId(sourceId: String)
 
+    @Query("DELETE FROM libraries WHERE sourceId = :sourceId AND id = :libraryId")
+    suspend fun deleteById(sourceId: String, libraryId: String)
+
     @Transaction
     suspend fun replaceAllForSource(sourceId: String, libraries: List<LibraryEntity>) {
         deleteBySourceId(sourceId)

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
@@ -61,6 +61,9 @@ interface LibraryItemDao {
     @Query("SELECT * FROM library_items WHERE sourceId = :sourceId AND id = :itemId LIMIT 1")
     suspend fun getById(sourceId: String, itemId: String): LibraryItemEntity?
 
+    @Query("SELECT * FROM library_items WHERE sourceId = :sourceId AND id IN (:itemIds)")
+    suspend fun listByIds(sourceId: String, itemIds: List<String>): List<LibraryItemEntity>
+
     /** Reactive single-item read — re-emits when the row changes (e.g. readingProgress on reader close). */
     @Query("SELECT * FROM library_items WHERE sourceId = :sourceId AND id = :itemId LIMIT 1")
     fun observeById(sourceId: String, itemId: String): Flow<LibraryItemEntity?>

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
@@ -120,6 +120,15 @@ interface LibraryItemDao {
     @Query("UPDATE library_items SET readingProgress = :progress WHERE sourceId = :sourceId AND id = :itemId")
     suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float)
 
+    /**
+     * Retag a library item's [libraryId]. Used by the LocalFiles scanner so a book's compatibility
+     * hint stays pointed at some *currently-configured* folder library — otherwise removing that
+     * folder leaves the row naming a deleted [LibraryEntity]. Catalog queries for LocalFiles go
+     * through `local_files_file_folders`, so this column is authoritative only outside LocalFiles.
+     */
+    @Query("UPDATE library_items SET libraryId = :libraryId WHERE sourceId = :sourceId AND id = :itemId")
+    suspend fun updateLibraryId(sourceId: String, itemId: String, libraryId: String)
+
     @Query("UPDATE library_items SET finishedAt = :finishedAt WHERE sourceId = :sourceId AND id = :itemId")
     suspend fun updateFinishedAt(sourceId: String, itemId: String, finishedAt: Long?)
 

--- a/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFileDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFileDao.kt
@@ -18,17 +18,10 @@ interface LocalFilesFileDao {
     suspend fun forSource(sourceId: String): List<LocalFilesFileEntity>
 
     @Query(
-        "UPDATE local_files_files SET lastSeenAtEpochMs = :seenAt, folderTreeUri = :folderTreeUri " +
+        "UPDATE local_files_files SET lastSeenAtEpochMs = :seenAt " +
             "WHERE sourceId = :sourceId AND sourceItemId = :sourceItemId",
     )
-    suspend fun touchLastSeen(sourceId: String, sourceItemId: String, folderTreeUri: String, seenAt: Long)
-
-    /**
-     * Rows in this source that were not seen during the current scan. Callers hard-delete these
-     * (and their library_items rows + copied bytes) after the walk finishes.
-     */
-    @Query("SELECT * FROM local_files_files WHERE sourceId = :sourceId AND lastSeenAtEpochMs < :scanStart")
-    suspend fun stale(sourceId: String, scanStart: Long): List<LocalFilesFileEntity>
+    suspend fun touchLastSeen(sourceId: String, sourceItemId: String, seenAt: Long)
 
     @Query("DELETE FROM local_files_files WHERE sourceId = :sourceId AND sourceItemId = :sourceItemId")
     suspend fun delete(sourceId: String, sourceItemId: String)

--- a/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFileEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFileEntity.kt
@@ -5,9 +5,11 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 
 /**
- * One ingested local book file. Composite PK (sourceId, sourceItemId) where sourceItemId is a
- * content-based identity hash (see IdentityHasher), so the same file present in multiple folders
- * resolves to a single row. `lastSeenAtEpochMs` is bumped every scan; stale rows are hard-deleted.
+ * One ingested local book file, identified by its content-based hash [sourceItemId] (see
+ * IdentityHasher). Because identity is content-based, a file present in multiple monitored folders
+ * collapses to a single row; folder membership is stored on [local_files_file_folders].
+ * `lastSeenAtEpochMs` is the aggregate — the max across all folder memberships — and is refreshed
+ * every scan pass. Rows with no surviving folder memberships are hard-deleted after a clean sweep.
  */
 @Entity(
     tableName = "local_files_files",
@@ -25,7 +27,6 @@ import androidx.room.Index
 data class LocalFilesFileEntity(
     val sourceId: String,
     val sourceItemId: String,
-    val folderTreeUri: String,
     val originalUri: String,
     val copiedPath: String,
     val coverPath: String?,

--- a/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFileFolderDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFileFolderDao.kt
@@ -1,0 +1,72 @@
+package com.riffle.core.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface LocalFilesFileFolderDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: LocalFilesFileFolderEntity)
+
+    @Query(
+        "SELECT * FROM local_files_file_folders " +
+            "WHERE sourceId = :sourceId AND sourceItemId = :sourceItemId",
+    )
+    suspend fun forFile(sourceId: String, sourceItemId: String): List<LocalFilesFileFolderEntity>
+
+    /** All memberships in a given monitored folder. Used by the catalog to list a folder library. */
+    @Query(
+        "SELECT * FROM local_files_file_folders " +
+            "WHERE sourceId = :sourceId AND folderTreeUri = :folderTreeUri",
+    )
+    suspend fun forFolder(sourceId: String, folderTreeUri: String): List<LocalFilesFileFolderEntity>
+
+    /** Every file that has at least one membership in [folderTreeUri]. */
+    @Query(
+        "SELECT sourceItemId FROM local_files_file_folders " +
+            "WHERE sourceId = :sourceId AND folderTreeUri = :folderTreeUri",
+    )
+    suspend fun itemIdsInFolder(sourceId: String, folderTreeUri: String): List<String>
+
+    /** Membership rows the current scan pass didn't touch. */
+    @Query(
+        "SELECT * FROM local_files_file_folders " +
+            "WHERE sourceId = :sourceId AND lastSeenAtEpochMs < :scanStart",
+    )
+    suspend fun stale(sourceId: String, scanStart: Long): List<LocalFilesFileFolderEntity>
+
+    @Query(
+        "DELETE FROM local_files_file_folders " +
+            "WHERE sourceId = :sourceId AND sourceItemId = :sourceItemId " +
+            "AND folderTreeUri = :folderTreeUri",
+    )
+    suspend fun delete(sourceId: String, sourceItemId: String, folderTreeUri: String)
+
+    /** All memberships for a folder — used when the user removes the folder. */
+    @Query(
+        "DELETE FROM local_files_file_folders " +
+            "WHERE sourceId = :sourceId AND folderTreeUri = :folderTreeUri",
+    )
+    suspend fun deleteFolder(sourceId: String, folderTreeUri: String)
+
+    /** All memberships for a file — used when the file row is being hard-deleted. */
+    @Query(
+        "DELETE FROM local_files_file_folders " +
+            "WHERE sourceId = :sourceId AND sourceItemId = :sourceItemId",
+    )
+    suspend fun deleteFile(sourceId: String, sourceItemId: String)
+
+    /** Files that no longer have any folder membership after the sweep. */
+    @Query(
+        "SELECT f.* FROM local_files_files f " +
+            "WHERE f.sourceId = :sourceId " +
+            "AND NOT EXISTS (" +
+            "  SELECT 1 FROM local_files_file_folders m " +
+            "  WHERE m.sourceId = f.sourceId AND m.sourceItemId = f.sourceItemId" +
+            ")",
+    )
+    suspend fun orphanedFiles(sourceId: String): List<LocalFilesFileEntity>
+}

--- a/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFileFolderEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFileFolderEntity.kt
@@ -1,0 +1,36 @@
+package com.riffle.core.database
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+/**
+ * Junction row recording that a [LocalFilesFileEntity] is present in a given
+ * [LocalFilesFolderEntity]. Since a file's identity is content-based (`sourceItemId`), the same
+ * bytes can live in multiple monitored folders — each folder membership gets its own row here,
+ * and the file appears under every monitored folder's library. `lastSeenAtEpochMs` is stamped per
+ * membership so the scanner sweep runs at membership granularity: a file removed from folder A
+ * but still in folder B keeps the A-side row gone and B-side row alive.
+ */
+@Entity(
+    tableName = "local_files_file_folders",
+    primaryKeys = ["sourceId", "sourceItemId", "folderTreeUri"],
+    foreignKeys = [
+        ForeignKey(
+            entity = SourceEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["sourceId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [
+        Index("sourceId"),
+        Index("sourceId", "folderTreeUri"),
+    ],
+)
+data class LocalFilesFileFolderEntity(
+    val sourceId: String,
+    val sourceItemId: String,
+    val folderTreeUri: String,
+    val lastSeenAtEpochMs: Long,
+)

--- a/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFolderDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFolderDao.kt
@@ -18,6 +18,12 @@ interface LocalFilesFolderDao {
     @Query("SELECT * FROM local_files_folders WHERE sourceId = :sourceId ORDER BY addedAtEpochMs ASC")
     fun observeForSource(sourceId: String): Flow<List<LocalFilesFolderEntity>>
 
+    @Query(
+        "SELECT * FROM local_files_folders " +
+            "WHERE sourceId = :sourceId AND libraryId = :libraryId LIMIT 1",
+    )
+    suspend fun getByLibraryId(sourceId: String, libraryId: String): LocalFilesFolderEntity?
+
     @Query("DELETE FROM local_files_folders WHERE sourceId = :sourceId AND treeUri = :treeUri")
     suspend fun delete(sourceId: String, treeUri: String)
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFolderEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFolderEntity.kt
@@ -6,7 +6,9 @@ import androidx.room.Index
 
 /**
  * One user-picked local folder configured under a LocalFiles Source. `treeUri` is the SAF tree URI
- * the user granted persistable read permission on; scans re-walk it every time.
+ * the user granted persistable read permission on; scans re-walk it every time. `libraryId` is the
+ * stable id of the [LibraryEntity] created for this folder — each configured folder gets its own
+ * library named after the folder, and this column ties the folder row to that library.
  */
 @Entity(
     tableName = "local_files_folders",
@@ -26,4 +28,5 @@ data class LocalFilesFolderEntity(
     val treeUri: String,
     val displayName: String,
     val addedAtEpochMs: Long,
+    val libraryId: String,
 )

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -29,8 +29,9 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         AudiobookChapterCacheEntity::class,
         LocalFilesFolderEntity::class,
         LocalFilesFileEntity::class,
+        LocalFilesFileFolderEntity::class,
     ],
-    version = 52,
+    version = 53,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -54,6 +55,7 @@ abstract class RiffleDatabase : RoomDatabase() {
     abstract fun audiobookChapterCacheDao(): AudiobookChapterCacheDao
     abstract fun localFilesFolderDao(): LocalFilesFolderDao
     abstract fun localFilesFileDao(): LocalFilesFileDao
+    abstract fun localFilesFileFolderDao(): LocalFilesFileFolderDao
 
     companion object {
         val MIGRATION_1_2 = object : Migration(1, 2) {
@@ -1342,6 +1344,141 @@ abstract class RiffleDatabase : RoomDatabase() {
         val MIGRATION_51_52 = object : Migration(51, 52) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE `library_items` ADD COLUMN `pageCount` INTEGER")
+            }
+        }
+
+        // Library-per-folder for LocalFiles Sources: each configured folder becomes its own
+        // Library named after the folder (previously every folder funnelled into one synthetic
+        // "local:root" Library). Adds:
+        //   - `libraryId` to `local_files_folders` (fresh UUID per existing folder).
+        //   - A `LibraryEntity` per folder in `libraries`, named from `displayName`.
+        //   - `local_files_file_folders` junction — one row per (file, folder) membership.
+        // Reassigns every `library_items.libraryId = 'local:root'` row to its file's owning
+        // folder's new library, drops the synthetic `local:root` `LibraryEntity`, and drops
+        // `folderTreeUri` from `local_files_files` (moved to the junction).
+        val MIGRATION_52_53 = object : Migration(52, 53) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("PRAGMA foreign_keys=OFF")
+                try {
+                    // 1. Add `libraryId` to `local_files_folders`. Table recreation (not ALTER
+                    //    ADD COLUMN) because we need a per-row UUID default that varies across rows.
+                    db.execSQL(
+                        "CREATE TABLE `local_files_folders_new` (" +
+                            "`sourceId` TEXT NOT NULL, " +
+                            "`treeUri` TEXT NOT NULL, " +
+                            "`displayName` TEXT NOT NULL, " +
+                            "`addedAtEpochMs` INTEGER NOT NULL, " +
+                            "`libraryId` TEXT NOT NULL, " +
+                            "PRIMARY KEY(`sourceId`, `treeUri`), " +
+                            "FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+                    )
+                    // Collect existing folder rows so we can mint a fresh UUID per row.
+                    data class OldFolder(
+                        val sourceId: String,
+                        val treeUri: String,
+                        val displayName: String,
+                        val addedAt: Long,
+                    )
+                    val oldFolders = mutableListOf<OldFolder>()
+                    db.query("SELECT sourceId, treeUri, displayName, addedAtEpochMs FROM local_files_folders").use { c ->
+                        while (c.moveToNext()) {
+                            oldFolders += OldFolder(c.getString(0), c.getString(1), c.getString(2), c.getLong(3))
+                        }
+                    }
+                    val folderToLibraryId = mutableMapOf<Pair<String, String>, String>()
+                    for (f in oldFolders) {
+                        val newLibraryId = "local:folder:" + java.util.UUID.randomUUID().toString()
+                        folderToLibraryId[f.sourceId to f.treeUri] = newLibraryId
+                        db.execSQL(
+                            "INSERT INTO `local_files_folders_new` (sourceId, treeUri, displayName, addedAtEpochMs, libraryId) VALUES (?, ?, ?, ?, ?)",
+                            arrayOf<Any>(f.sourceId, f.treeUri, f.displayName, f.addedAt, newLibraryId),
+                        )
+                    }
+                    db.execSQL("DROP TABLE `local_files_folders`")
+                    db.execSQL("ALTER TABLE `local_files_folders_new` RENAME TO `local_files_folders`")
+                    db.execSQL(
+                        "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `local_files_folders` (`sourceId`)"
+                    )
+
+                    // 2. Create the junction table.
+                    db.execSQL(
+                        "CREATE TABLE IF NOT EXISTS `local_files_file_folders` (" +
+                            "`sourceId` TEXT NOT NULL, " +
+                            "`sourceItemId` TEXT NOT NULL, " +
+                            "`folderTreeUri` TEXT NOT NULL, " +
+                            "`lastSeenAtEpochMs` INTEGER NOT NULL, " +
+                            "PRIMARY KEY(`sourceId`, `sourceItemId`, `folderTreeUri`), " +
+                            "FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+                    )
+                    db.execSQL(
+                        "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId` ON `local_files_file_folders` (`sourceId`)"
+                    )
+                    db.execSQL(
+                        "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId_folderTreeUri` " +
+                            "ON `local_files_file_folders` (`sourceId`, `folderTreeUri`)"
+                    )
+                    // Backfill: one membership row per existing file, using the file's historical
+                    // folderTreeUri. Cross-folder duplicates (a book in two folders) will
+                    // materialise on the next scan pass.
+                    db.execSQL(
+                        "INSERT INTO `local_files_file_folders` (sourceId, sourceItemId, folderTreeUri, lastSeenAtEpochMs) " +
+                            "SELECT sourceId, sourceItemId, folderTreeUri, lastSeenAtEpochMs FROM `local_files_files`"
+                    )
+
+                    // 3. Drop `folderTreeUri` from `local_files_files` via table recreation.
+                    db.execSQL(
+                        "CREATE TABLE `local_files_files_new` (" +
+                            "`sourceId` TEXT NOT NULL, " +
+                            "`sourceItemId` TEXT NOT NULL, " +
+                            "`originalUri` TEXT NOT NULL, " +
+                            "`copiedPath` TEXT NOT NULL, " +
+                            "`coverPath` TEXT, " +
+                            "`format` TEXT NOT NULL, " +
+                            "`sizeBytes` INTEGER NOT NULL, " +
+                            "`mtimeEpochMs` INTEGER NOT NULL, " +
+                            "`lastSeenAtEpochMs` INTEGER NOT NULL, " +
+                            "PRIMARY KEY(`sourceId`, `sourceItemId`), " +
+                            "FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+                    )
+                    db.execSQL(
+                        "INSERT INTO `local_files_files_new` (sourceId, sourceItemId, originalUri, copiedPath, coverPath, format, sizeBytes, mtimeEpochMs, lastSeenAtEpochMs) " +
+                            "SELECT sourceId, sourceItemId, originalUri, copiedPath, coverPath, format, sizeBytes, mtimeEpochMs, lastSeenAtEpochMs FROM `local_files_files`"
+                    )
+                    db.execSQL("DROP TABLE `local_files_files`")
+                    db.execSQL("ALTER TABLE `local_files_files_new` RENAME TO `local_files_files`")
+                    db.execSQL(
+                        "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `local_files_files` (`sourceId`)"
+                    )
+
+                    // 4. Insert one `LibraryEntity` per folder.
+                    for (f in oldFolders) {
+                        val newLibraryId = folderToLibraryId.getValue(f.sourceId to f.treeUri)
+                        db.execSQL(
+                            "INSERT OR REPLACE INTO `libraries` (id, name, mediaType, sourceId, isUnsupported) VALUES (?, ?, 'book', ?, 0)",
+                            arrayOf<Any>(newLibraryId, f.displayName, f.sourceId),
+                        )
+                    }
+
+                    // 5. Reassign existing library_items.libraryId = 'local:root' rows to the
+                    //    per-folder library based on their file's historical folderTreeUri.
+                    for (f in oldFolders) {
+                        val newLibraryId = folderToLibraryId.getValue(f.sourceId to f.treeUri)
+                        db.execSQL(
+                            "UPDATE library_items SET libraryId = ? WHERE sourceId = ? AND libraryId = 'local:root' " +
+                                "AND id IN (SELECT sourceItemId FROM local_files_file_folders WHERE sourceId = ? AND folderTreeUri = ?)",
+                            arrayOf<Any>(newLibraryId, f.sourceId, f.sourceId, f.treeUri),
+                        )
+                    }
+                    // Any library_items row still tagged 'local:root' has no matching file — drop
+                    // it. It's an orphan we can't serve, and leaving it would violate the FK-like
+                    // invariant that a library_items row's libraryId names a real `libraries` row.
+                    db.execSQL("DELETE FROM library_items WHERE libraryId = 'local:root'")
+
+                    // 6. Drop the synthetic 'local:root' LibraryEntity across every LocalFiles Source.
+                    db.execSQL("DELETE FROM libraries WHERE id = 'local:root'")
+                } finally {
+                    db.execSQL("PRAGMA foreign_keys=ON")
+                }
             }
         }
     }

--- a/docs/superpowers/specs/2026-07-10-local-files-library-per-folder-design.md
+++ b/docs/superpowers/specs/2026-07-10-local-files-library-per-folder-design.md
@@ -1,0 +1,165 @@
+# Local Files: library-per-folder
+
+**Status:** Design approved 2026-07-10.
+
+## Goal
+
+Local Files today is already a singleton `Source` per device (`SourceType.LOCAL_FILES`), and users can attach multiple monitored folders to it. But every scanned file is written into a single synthetic library `local:root` named "Local Files", and the Add-Source picker still lets the user tap "Local files" repeatedly (each tap really just adds another folder, misleadingly labeled).
+
+This change makes the Local Files data model match the mental model:
+
+- The Local Files source is a device singleton, and the UI now enforces that — it disappears from the Add-Source picker once installed.
+- Each configured folder is its own library, named after the folder.
+- New folders are added from **inside** the expanded Local Files row in Settings via a "+ Add folder" affordance.
+- A book that lives in more than one monitored folder appears under each of those folders' libraries.
+
+## Non-goals
+
+- No changes to identity hashing / de-duplication of file bytes (`sourceItemId` remains a content hash).
+- No changes to how SAF grants, copy-in, or `CopyInService` work.
+- No changes to how other Source types (Audiobookshelf, Storyteller) model libraries.
+- No new source-picker taxonomy.
+
+## Data model
+
+### `LocalFilesFolderEntity` gains a `libraryId`
+
+Every folder row gets a stable `libraryId` at insert time: `local:folder:<uuid>`. The UUID is generated once and stored, so it's stable across SAF re-grants and folder-URI changes.
+
+```
+LocalFilesFolderEntity(
+    sourceId, treeUri, displayName, addedAtEpochMs,
+    libraryId,   // new: "local:folder:<uuid>"
+)
+```
+
+### A `LibraryEntity` per folder
+
+When a folder is added, a `LibraryEntity` is created:
+
+- `id = folder.libraryId`
+- `name = folder.displayName`
+- `sourceId = <LocalFiles source id>`
+- `mediaType = "book"`
+
+The synthetic `LOCAL_ROOT_ID = "local:root"` library is retired. `LocalFilesCatalog.LOCAL_ROOT_ID` and every write that references it go away.
+
+### New junction `local_files_file_folders`
+
+Because a book's identity is content-hashed, one `local_files_files` row can be present in multiple monitored folders simultaneously. Membership becomes its own table:
+
+```
+local_files_file_folders(
+    sourceId, sourceItemId, folderTreeUri, lastSeenAtEpochMs,
+    PK (sourceId, sourceItemId, folderTreeUri),
+    FK -> local_files_files(sourceId, sourceItemId),
+    FK -> local_files_folders(sourceId, treeUri),
+)
+```
+
+`folderTreeUri` is dropped from `LocalFilesFileEntity`. The per-membership `lastSeenAtEpochMs` replaces the file-row aggregate. `fetchFile` / `openFile` still read `copiedPath` from `local_files_files` (any folder membership suffices — the file bytes are shared).
+
+### `library_items`: one row per (file, folder)
+
+The scanner emits one `LibraryItemEntity` per (sourceItemId, libraryId) — meaning a shared book gets duplicated metadata rows, one per folder library. This keeps every existing catalog query untouched (they already scope by libraryId).
+
+The metadata duplication cost is small (a few text columns) and lets the reader's normal per-library flows work with zero changes. If shared-book duplication ever becomes a scaling problem, a later `library_items_libraries` join can replace it, but that's a bigger refactor and out of scope here.
+
+## Scanner
+
+`LocalFilesScanner.scan(sourceId)`:
+
+1. Walk each configured folder; for every classified file, build the `(sourceItemId, folderTreeUri)` membership set for this pass.
+2. Per unique `sourceItemId`:
+   - Upsert one `local_files_files` row (metadata, copied bytes, `format`, cover, mtime) — no `folderTreeUri` here.
+   - Upsert one `local_files_file_folders` row per folder that contains it, stamped `lastSeenAtEpochMs = scanStart`.
+   - Upsert one `library_items` row per folder membership, each with the folder's `libraryId`. Metadata (title, author, cover URL, series…) is identical across the duplicates.
+3. Sweep-stale (only if the whole pass ran clean, per the existing guardrail in `LocalFilesScanner.kt:59-64`):
+   - Delete every `local_files_file_folders` row with `lastSeenAt < scanStart`, and the corresponding `library_items` row for that `(sourceItemId, libraryId)`.
+   - Delete every `local_files_files` row that now has zero remaining memberships, along with its copied EPUB/PDF and cover.
+
+Add-folder and remove-folder paths run a scan afterwards to converge state. Remove-folder also deletes the folder's `LibraryEntity`; the scanner's membership sweep handles cleanup of items that only lived there.
+
+## UI
+
+### Add-Source picker
+
+The "Local files" tile is shown **only when no `SourceEntity` of type `LOCAL_FILES` exists yet**. Once one exists there is nothing left to add at the source level, so the tile disappears from the picker. The Add-Source picker query already reads the Source list — a simple predicate hides the tile.
+
+The first-time flow is unchanged: pick the tile → SAF folder picker → source installer creates the singleton source + first folder + first folder's library → scan → success screen.
+
+### Sources list, expanded Local Files row
+
+Add a **"+ Add folder"** ListItem at the top of the expanded content, above the folder list. On tap:
+
+1. Launch the SAF folder picker.
+2. On success, call a shared "attach folder to source" primitive that: (a) inserts a `LocalFilesFolderEntity` with a fresh `libraryId`, (b) inserts the folder's `LibraryEntity`, (c) runs a scan.
+3. On cancel/failure, surface the same states the first-run flow uses (cancelled banner, error retry).
+
+Folder rows below stay as they are (health warning, remove-folder confirm). Their per-row display name is now also the drawer library name.
+
+### Drawer / library selector
+
+Each folder library appears under the Local Files source with `name = folder.displayName`. No more "Local Files" umbrella library. `LibraryVisibilityStore` and `LibraryOrderStore` apply per folder library — hide/reorder work identically to Audiobookshelf/Storyteller libraries.
+
+## Migration (Room `N → N+1`)
+
+Follow AGENTS.md checklist: bump `RiffleDatabase.version`, add `MIGRATION_N_(N+1)`, build to export the schema JSON, register in `DataModule.addMigrations(...)`, extend `MigrationTest`.
+
+Migration steps (single transaction):
+
+1. `ALTER TABLE local_files_folders ADD COLUMN libraryId TEXT NOT NULL DEFAULT ''`. Then for each existing folder row, generate a UUID and `UPDATE ... SET libraryId = 'local:folder:' || <uuid>`.
+2. `CREATE TABLE local_files_file_folders` with the schema above, plus FKs and indices on `(sourceId, folderTreeUri)`.
+3. Backfill the junction: for each existing `local_files_files` row, insert one `local_files_file_folders(sourceId, sourceItemId, folderTreeUri = files.folderTreeUri, lastSeenAtEpochMs = files.lastSeenAtEpochMs)`. Cross-folder duplicates are unknowable historically and will materialize on the next scan.
+4. `CREATE TABLE local_files_files_new` without `folderTreeUri`, copy rows over minus that column, drop old, rename.
+5. Insert one `LibraryEntity(id = folder.libraryId, name = folder.displayName, sourceId, mediaType = "book")` per folder row.
+6. `UPDATE library_items SET libraryId = <folder.libraryId>` where `libraryId = 'local:root'` and the file's `folderTreeUri` maps to a folder. Delete any `library_items` row with `libraryId = 'local:root'` that has no matching file row (orphan).
+7. Delete the `LibraryEntity` with `id = 'local:root'`. Delete matching `library_visibility` and `library_order` rows.
+
+Non-DB migration:
+
+- Delete `LocalFilesCatalog.LOCAL_ROOT_ID` constant.
+- `LocalFilesCatalog.listRoots()` returns one `CatalogRoot` per configured folder, sourced from `LocalFilesFolderDao`.
+- `LocalFilesSourceInstaller.installFolder` refactors: extract a shared `addFolderToSource(sourceId, treeUri, displayName)` primitive used by both the first-install path and the Settings "+ Add folder" path. Both create the folder row + library row + run a scan.
+- The Add-Source picker's tile-visibility predicate: `sources.none { it.type == LOCAL_FILES }`.
+
+## Testing
+
+Per AGENTS.md, every behavior change needs an assertion that flips red on revert.
+
+**core:database — `MigrationTest.migrationNToN1()`:**
+- Seed a pre-N DB with one Local Files `SourceEntity`, two folder rows (folder A displayName "Reading Now", folder B displayName "Archive"), and three `local_files_files` rows: file X in folder A only, file Y in folder A only, file Z in folder B only. Seed the corresponding `library_items` rows with `libraryId = "local:root"`.
+- Run the migration.
+- Assert: (a) both folders have non-empty distinct `libraryId`s of the form `local:folder:*`; (b) two `LibraryEntity` rows exist with names "Reading Now" and "Archive"; (c) `local_files_file_folders` has three rows matching the historical `folderTreeUri`s; (d) `library_items.libraryId` for X and Y equals folder A's `libraryId`, for Z equals folder B's `libraryId`; (e) `LibraryEntity` with `id = "local:root"` no longer exists; (f) `local_files_files.folderTreeUri` column is gone. Add the migration to `migrateFullChain`.
+
+**core:data — `LocalFilesScannerTest`:**
+- Add a fixture with two folders A and B, one book present only in A, one book present in both A and B (same bytes → same identity hash), one book only in B.
+- Run `scan(sourceId)`.
+- Assert: `library_items` has four rows (A-only book × 1, shared book × 2 under both `libraryId`s, B-only book × 1); `local_files_file_folders` has four rows; `local_files_files` has three rows.
+- Second-pass regression: delete the shared book from folder A only (leave B intact), rerun `scan`. Assert the A-side `library_items` row and A-side junction row are gone; the B-side row and the `local_files_files` row survive.
+
+**core:data — `LocalFilesCatalogTest`:**
+- Given two folders, assert `listRoots()` returns two `CatalogRoot`s with the folders' display names, and `browse(rootId = folder A's libraryId, ...)` returns only A's items.
+
+**app — SettingsViewModel:**
+- With an existing Local Files source and one folder, calling the "add folder" action attaches to the existing source (no second `SourceEntity` inserted) and creates a new `LibraryEntity`.
+
+**app — Add-Source picker (JVM test on the tile-visibility predicate, extracted if necessary per the AGENTS.md rule about JVM-testable decisions):**
+- Predicate returns `true` (tile shown) when the Source list contains no LOCAL_FILES source, `false` otherwise.
+
+## Files touched (indicative)
+
+- `core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFolderEntity.kt` — add `libraryId`.
+- `core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFileEntity.kt` — remove `folderTreeUri`.
+- `core/database/src/main/kotlin/com/riffle/core/database/LocalFilesFileFolderEntity.kt` — new junction entity + DAO.
+- `core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt` — version bump, `MIGRATION_N_(N+1)`, entities list.
+- `core/database/schemas/com.riffle.core.database.RiffleDatabase/<N+1>.json` — exported by KSP.
+- `core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt` — new test + `migrateFullChain` extension.
+- `core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesSourceInstaller.kt` — extract `addFolderToSource`; drop `LOCAL_ROOT_ID` library seeding.
+- `core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt` — junction-based ingest + membership sweep.
+- `core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalog.kt` — per-folder `listRoots()`, drop `LOCAL_ROOT_ID`.
+- `core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesFolderRepository.kt` — create/delete `LibraryEntity` alongside folder rows.
+- `core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt` — register migration.
+- `app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt` — "+ Add folder" row in expanded Local Files section.
+- `app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt` — "add folder" action wired to `addFolderToSource`.
+- Add-Source picker screen — hide LOCAL_FILES tile predicate.


### PR DESCRIPTION
## Summary

- LocalFiles is a device-singleton `Source`. Adding folders is now the recurring action; the "Local files" tile disappears from the Add-Source picker once installed.
- Each monitored folder is its own `Library` named after the folder's `displayName`. The synthetic `local:root` umbrella is retired.
- A book present in multiple folders appears under every folder's library, backed by a single content-hashed `library_items` row and a new `local_files_file_folders` junction.
- New "+ Add folder" affordance inside the expanded LocalFiles row in Settings > Sources.

## Data model

- `LocalFilesFolderEntity` gains a stable `libraryId` (`local:folder:<uuid>`, generated once at folder-add time).
- New junction table `local_files_file_folders(sourceId, sourceItemId, folderTreeUri, lastSeenAtEpochMs)` — one row per (file, folder) membership; source of truth for folder scoping.
- `LocalFilesFileEntity.folderTreeUri` removed (moved to the junction).

## Migration 52 → 53

- Backfills a UUID `libraryId` on every existing folder row.
- Creates one `LibraryEntity` per folder from `displayName`.
- Backfills the junction from each file's historical `folderTreeUri` (cross-folder duplicates re-materialise on the next scan).
- Reassigns `library_items.libraryId = 'local:root'` to the per-folder library; drops orphan rows and the `local:root` library.

## Scanner + Catalog

- Scanner emits per-folder memberships; sweep runs at membership granularity. Files with no remaining memberships have their `library_items` row, `local_files_files` row, and copied bytes deleted.
- `LocalFilesCatalog.listRoots()` returns one root per folder; browse/search resolve `libraryId → folder → junction → LibraryItemDao.listByIds` (chunked to 900 to stay under SQLite's bind-var limit).

## Testing

- New regression pins: shared book across two folders survives removal from one; scanner emits per-folder memberships; catalog exposes books in every folder library that contains them.
- New `migration52To53_localFilesLibraryPerFolder` covering libraryId assignment, LibraryEntity creation, junction backfill, item reassignment, `local:root` deletion, and `folderTreeUri` column removal. Chain test extended to 53.
- New test pins the source-picker predicate hiding "Local files" when a LocalFiles source exists.
- `./gradlew test` — green.

## Test plan

- [ ] Fresh install → picker shows "Local files"; pick folder → source created, folder library shown in drawer as folder name.
- [ ] Second install attempt from the picker → "Local files" tile hidden.
- [ ] Settings > Sources > Local files → expand → "+ Add folder" → pick second folder → both appear in drawer named after their folders.
- [ ] Book present in both folders shows up under both drawer entries with a single reading position.
- [ ] Remove one folder → its library disappears; books unique to that folder are gone; shared books survive under the other library.