### PR TITLE
feat(settings): swipe-to-delete on all configured sources

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/settings/SwipeToDeleteRowTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/settings/SwipeToDeleteRowTest.kt
@@ -1,0 +1,77 @@
+package com.riffle.app.feature.settings
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeLeft
+import androidx.compose.ui.test.swipeRight
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Pins the swipe-to-delete gesture on every configured-source row in Settings. If someone
+ * un-wraps `LocalFilesSourceRow` or `ServerRow` from `SwipeToDeleteRow`, or drops the
+ * end-to-start dismiss handling, this test fails.
+ */
+@RunWith(AndroidJUnit4::class)
+class SwipeToDeleteRowTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun endToStartSwipe_invokesOnDelete() {
+        var deleted = false
+        composeTestRule.setContent {
+            SwipeToDeleteRow(onDelete = { deleted = true }) {
+                Text(
+                    text = "Source row",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(72.dp)
+                        .background(Color.LightGray)
+                        .testTag("row"),
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("row").performTouchInput { swipeLeft() }
+        composeTestRule.waitForIdle()
+
+        assertTrue("swipe end-to-start should trigger onDelete", deleted)
+    }
+
+    @Test
+    fun startToEndSwipe_doesNotInvokeOnDelete() {
+        var deleted = false
+        composeTestRule.setContent {
+            SwipeToDeleteRow(onDelete = { deleted = true }) {
+                Text(
+                    text = "Source row",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(72.dp)
+                        .background(Color.LightGray)
+                        .testTag("row"),
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag("row").performTouchInput { swipeRight() }
+        composeTestRule.waitForIdle()
+
+        assertTrue("swipe start-to-end must not trigger onDelete", !deleted)
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -51,12 +51,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
-import androidx.compose.material3.SwipeToDismissBox
-import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -790,15 +787,7 @@ private fun ServerRow(
     onReorderLibraries: (orderedLibraryIds: List<String>) -> Unit,
     onOpenReadaloudMatches: () -> Unit,
 ) {
-    val dismissState = rememberSwipeToDismissBoxState(
-        confirmValueChange = { value ->
-            if (value == SwipeToDismissBoxValue.EndToStart) {
-                onRemove()
-                true
-            } else false
-        }
-    )
-    SwipeToDismissBox(state = dismissState, backgroundContent = {}) {
+    SwipeToDeleteRow(onDelete = onRemove) {
         Column {
             val username = server.username.takeIf { it.isNotEmpty() }
             val subtitle = buildString {
@@ -1053,7 +1042,8 @@ private fun LocalFilesSourceRow(
         label = "chevron",
     )
 
-    Column {
+    SwipeToDeleteRow(onDelete = onRemoveSource) {
+      Column {
         ListItem(
             modifier = Modifier
                 .clickable { onToggleExpanded() }
@@ -1134,6 +1124,7 @@ private fun LocalFilesSourceRow(
                 }
             }
         }
+      }
     }
 
     pendingFolderRemoval?.let { folder ->

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SwipeToDeleteRow.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SwipeToDeleteRow.kt
@@ -1,0 +1,63 @@
+package com.riffle.app.feature.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SwipeToDismissBox
+import androidx.compose.material3.SwipeToDismissBoxValue
+import androidx.compose.material3.rememberSwipeToDismissBoxState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Row wrapper that reveals a red delete affordance when swiped end-to-start and invokes
+ * [onDelete] on a full swipe. Used by every configured-source row in Settings so the delete
+ * gesture behaves the same everywhere.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun SwipeToDeleteRow(
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val dismissState = rememberSwipeToDismissBoxState(
+        confirmValueChange = { value ->
+            if (value == SwipeToDismissBoxValue.EndToStart) {
+                onDelete()
+                true
+            } else {
+                false
+            }
+        },
+    )
+    SwipeToDismissBox(
+        state = dismissState,
+        modifier = modifier,
+        enableDismissFromStartToEnd = false,
+        backgroundContent = {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.errorContainer)
+                    .padding(horizontal = 24.dp),
+                contentAlignment = Alignment.CenterEnd,
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = "Delete",
+                    tint = MaterialTheme.colorScheme.onErrorContainer,
+                )
+            }
+        },
+        content = { content() },
+    )
+}


### PR DESCRIPTION
## Summary

- Extracts the ad-hoc `SwipeToDismissBox` from `ServerRow` (ABS servers) into a reusable `SwipeToDeleteRow` composable with a red `errorContainer` background and trailing trash icon.
- Applies the wrapper to `LocalFilesSourceRow` so Local Files also supports swipe-to-delete (previously only reachable via the "Remove Local Files source" text button + confirm dialog, which is unchanged).
- ABS and Local Files now share the same end-to-start swipe gesture; a full swipe invokes the existing `onRemove` / `onRemoveSource` handlers (no confirm dialog on the swipe path — same behavior ABS already had).
- Storyteller service and WebDAV annotation-sync target are out of scope.

## Test plan

- [ ] `SwipeToDeleteRowTest.endToStartSwipe_invokesOnDelete` — instrumentation test in `app` that fails if the wrapper stops firing `onDelete` on end-to-start swipe. Pins the wiring for both `ServerRow` and `LocalFilesSourceRow`.
- [ ] `SwipeToDeleteRowTest.startToEndSwipe_doesNotInvokeOnDelete` — ensures the opposite swipe direction remains a no-op.
- [ ] Manual: swipe an ABS server row → source removed, red delete affordance visible during swipe.
- [ ] Manual: swipe the Local Files row → source removed, red delete affordance visible during swipe.