### PR TITLE
feat(source): favicon fetch + monogram fallback in switcher and adder

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Download
@@ -47,6 +48,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.riffle.app.BuildConfig
+import com.riffle.app.ui.source.SourceIcon
 import com.riffle.core.domain.Library
 import com.riffle.core.domain.Source
 import com.riffle.core.domain.SourceType
@@ -199,6 +201,9 @@ private fun DrawerHeader(
         .onSizeChanged { headerWidth = with(density) { it.width.toDp() } }
     ) {
         ListItem(
+            leadingContent = activeServer?.let { server ->
+                { SourceRowIcon(server = server) }
+            },
             headlineContent = {
                 val name = activeServer?.let(::sourceDisplayName) ?: "No source"
                 val username = activeServer
@@ -278,9 +283,10 @@ private fun DrawerHeader(
                             }
                         }
                     },
-                    leadingIcon = {
+                    leadingIcon = { SourceRowIcon(server = server) },
+                    trailingIcon = {
                         if (server.isActive) {
-                            Icon(Icons.Default.Check, contentDescription = null)
+                            Icon(Icons.Default.Check, contentDescription = "Active source")
                         } else {
                             Spacer(modifier = Modifier.size(24.dp))
                         }
@@ -292,6 +298,24 @@ private fun DrawerHeader(
                 )
             }
         }
+    }
+}
+
+/**
+ * Leading icon for a source row in the switcher. Network sources render their server's favicon
+ * via [SourceIcon] (bundled monogram fallback); LocalFiles keeps its Material Folder treatment
+ * unchanged — the switcher had no monogram concept for LocalFiles before this change.
+ */
+@Composable
+private fun SourceRowIcon(server: Source) {
+    if (server.type == SourceType.LOCAL_FILES) {
+        Icon(
+            imageVector = Icons.Default.Folder,
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+        )
+    } else {
+        SourceIcon(source = server, size = 24.dp)
     }
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerScreen.kt
@@ -13,9 +13,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.Folder
-import androidx.compose.material.icons.filled.MenuBook
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -31,12 +29,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.disabled
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.riffle.app.ui.TabletContentWidthContainer
+import com.riffle.app.ui.source.SourceTypeIcon
+import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.SourceType
 
 sealed interface SourceTypeChoice {
     data object Audiobookshelf : SourceTypeChoice
@@ -88,12 +88,6 @@ internal fun sourceTypeCards(hasLocalFilesSource: Boolean = false): List<SourceT
             comingSoon = false,
         ),
     )
-}
-
-private fun iconFor(type: SourceTypeChoice): ImageVector = when (type) {
-    SourceTypeChoice.Audiobookshelf -> Icons.Default.Cloud
-    SourceTypeChoice.LocalFiles -> Icons.Default.Folder
-    SourceTypeChoice.Chitanka -> Icons.Default.MenuBook
 }
 
 private fun testTagFor(type: SourceTypeChoice): String = when (type) {
@@ -171,12 +165,28 @@ private fun SourceTypeCardRow(card: SourceTypeCard, onClick: (() -> Unit)?) {
             horizontalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             val contentAlpha = if (card.enabled) 1f else 0.5f
-            Icon(
-                imageVector = iconFor(card.type),
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.size(40.dp).alpha(contentAlpha),
-            )
+            val iconModifier = Modifier.size(40.dp).alpha(contentAlpha)
+            when (card.type) {
+                // LocalFiles intentionally keeps its Material Folder icon — see
+                // SourceIconResolver: LOCAL_FILES has no monogram drawable.
+                SourceTypeChoice.LocalFiles -> Icon(
+                    imageVector = Icons.Default.Folder,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = iconModifier,
+                )
+                SourceTypeChoice.Audiobookshelf -> SourceTypeIcon(
+                    type = SourceType.ABS,
+                    serverType = ServerType.AUDIOBOOKSHELF,
+                    modifier = iconModifier,
+                    size = 40.dp,
+                )
+                SourceTypeChoice.Chitanka -> SourceTypeIcon(
+                    type = SourceType.CHITANKA,
+                    modifier = iconModifier,
+                    size = 40.dp,
+                )
+            }
             Column(
                 modifier = Modifier.weight(1f).alpha(contentAlpha),
             ) {

--- a/app/src/main/kotlin/com/riffle/app/ui/source/SourceIcon.kt
+++ b/app/src/main/kotlin/com/riffle/app/ui/source/SourceIcon.kt
@@ -1,0 +1,91 @@
+package com.riffle.app.ui.source
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil.compose.SubcomposeAsyncImage
+import coil.request.ImageRequest
+import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.Source
+import com.riffle.core.domain.SourceType
+
+/**
+ * Renders the icon for a configured [Source] in the source switcher: fetches the server's
+ * favicon via Coil (using the app-scope [coil.ImageLoader] with its disk cache) and falls back
+ * to the bundled monogram drawable while loading or on any error / decode failure.
+ *
+ * Do not call this for [SourceType.LOCAL_FILES]; the caller keeps its existing Material Folder
+ * treatment. See [SourceIconResolver.fallbackDrawableFor].
+ */
+@Composable
+fun SourceIcon(
+    source: Source,
+    modifier: Modifier = Modifier,
+    size: Dp = 40.dp,
+) {
+    val fallbackRes = SourceIconResolver.fallbackDrawableFor(source)
+    val faviconUrl = SourceIconResolver.faviconUrlFor(source)
+    if (faviconUrl == null) {
+        SourceIconMonogram(fallbackRes = fallbackRes, modifier = modifier, size = size)
+    } else {
+        val shape = RoundedCornerShape(8.dp)
+        SubcomposeAsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(faviconUrl)
+                .crossfade(true)
+                .build(),
+            contentDescription = null,
+            contentScale = ContentScale.Fit,
+            modifier = modifier.size(size).clip(shape),
+            loading = { SourceIconMonogram(fallbackRes = fallbackRes, size = size) },
+            error = { SourceIconMonogram(fallbackRes = fallbackRes, size = size) },
+        )
+    }
+}
+
+/**
+ * Renders the icon for a source picked by type in the "add source" flow, where no [Source] with
+ * a base URL exists yet — always the bundled monogram. Not defined for [SourceType.LOCAL_FILES];
+ * the caller keeps its existing Material Folder treatment there.
+ */
+@Composable
+fun SourceTypeIcon(
+    type: SourceType,
+    serverType: ServerType = ServerType.AUDIOBOOKSHELF,
+    modifier: Modifier = Modifier,
+    size: Dp = 40.dp,
+) {
+    val fallbackRes = SourceIconResolver.fallbackDrawableFor(type, serverType)
+    SourceIconMonogram(fallbackRes = fallbackRes, modifier = modifier, size = size)
+}
+
+@Composable
+private fun SourceIconMonogram(
+    fallbackRes: Int,
+    modifier: Modifier = Modifier,
+    size: Dp = 40.dp,
+) {
+    // Clip to a slightly-rounded rect so the fallback monogram and any fetched favicon share the
+    // same silhouette in the switcher (favicons in the wild are rectangular of varying aspect).
+    Box(
+        modifier = modifier
+            .size(size)
+            .clip(RoundedCornerShape(8.dp))
+    ) {
+        Image(
+            painter = painterResource(id = fallbackRes),
+            contentDescription = null,
+            contentScale = ContentScale.Fit,
+            modifier = Modifier.size(size),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/ui/source/SourceIconResolver.kt
+++ b/app/src/main/kotlin/com/riffle/app/ui/source/SourceIconResolver.kt
@@ -1,0 +1,64 @@
+package com.riffle.app.ui.source
+
+import androidx.annotation.DrawableRes
+import com.riffle.app.R
+import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.Source
+import com.riffle.core.domain.SourceType
+
+/**
+ * Chooses the icon for a network-backed source: a favicon URL to fetch at runtime, plus a bundled
+ * monogram drawable to use as the fallback when the fetch fails (or as the primary when no base
+ * URL is known yet, i.e. in the "add source" type picker).
+ *
+ * Chitanka's favicon is served as `.ico`, which Coil's default decoders can't handle, so we skip
+ * the fetch and always show the bundled Ч monogram.
+ *
+ * LocalFiles is intentionally excluded — see call sites — because the existing Material Folder
+ * treatment for local files is left as-is.
+ */
+object SourceIconResolver {
+
+    /**
+     * The URL to attempt for the source's favicon, or null when we don't try (LocalFiles,
+     * Chitanka). Callers should always pair the returned URL with [fallbackDrawableFor] so a
+     * fetch/decode failure falls back to the monogram.
+     */
+    fun faviconUrlFor(source: Source): String? = when (source.type) {
+        SourceType.LOCAL_FILES -> null
+        SourceType.CHITANKA -> null
+        SourceType.ABS -> when (source.serverType) {
+            // ABS bundles /Logo.png at the web root as its PWA icon — a known PNG path we can
+            // decode without a bespoke ICO decoder.
+            ServerType.AUDIOBOOKSHELF -> "${source.url.value}/Logo.png"
+            // Storyteller is Next.js; the /apple-touch-icon.png convention gives us a large PNG
+            // when the deployment ships one, and the bundled monogram covers the miss.
+            ServerType.STORYTELLER_SERVICE -> "${source.url.value}/apple-touch-icon.png"
+        }
+    }
+
+    /**
+     * Fallback drawable for a configured [Source]. Not defined for [SourceType.LOCAL_FILES] —
+     * that surface keeps the Material Folder icon at its call sites, unchanged.
+     */
+    @DrawableRes
+    fun fallbackDrawableFor(source: Source): Int =
+        fallbackDrawableFor(source.type, source.serverType)
+
+    /**
+     * Fallback drawable for a source picked by type (no configured [Source] yet). Not defined
+     * for [SourceType.LOCAL_FILES] — throws to catch callers that forgot the LocalFiles branch.
+     */
+    @DrawableRes
+    fun fallbackDrawableFor(type: SourceType, serverType: ServerType = ServerType.AUDIOBOOKSHELF): Int =
+        when (type) {
+            SourceType.LOCAL_FILES -> error(
+                "SourceIconResolver has no drawable for LOCAL_FILES — render Icons.Default.Folder at the call site."
+            )
+            SourceType.CHITANKA -> R.drawable.ic_source_chitanka
+            SourceType.ABS -> when (serverType) {
+                ServerType.AUDIOBOOKSHELF -> R.drawable.ic_source_audiobookshelf
+                ServerType.STORYTELLER_SERVICE -> R.drawable.ic_source_storyteller
+            }
+        }
+}

--- a/app/src/main/res/drawable/ic_source_audiobookshelf.xml
+++ b/app/src/main/res/drawable/ic_source_audiobookshelf.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Monogram fallback for Audiobookshelf sources when the server's favicon can't be
+  fetched or decoded. Uses "A" on the app's primary color as a source-type marker,
+  not the Audiobookshelf trademark.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="40dp"
+    android:height="40dp"
+    android:viewportWidth="40"
+    android:viewportHeight="40">
+    <path
+        android:pathData="M6,6h28a4,4 0 0 1 4,4v20a4,4 0 0 1 -4,4h-28a4,4 0 0 1 -4,-4v-20a4,4 0 0 1 4,-4z"
+        android:fillColor="#1E88E5" />
+    <path
+        android:pathData="M14.4,28L16.6,22.6H23.4L25.6,28H28.4L21.8,12H18.2L11.6,28ZM17.5,20.4L19.9,14.7H20.1L22.5,20.4Z"
+        android:fillColor="#FFFFFF" />
+</vector>

--- a/app/src/main/res/drawable/ic_source_chitanka.xml
+++ b/app/src/main/res/drawable/ic_source_chitanka.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Monogram fallback for Chitanka sources. Uses "Ч" (Cyrillic Che, first letter of
+  "Читанка") on a deep green as a source-type marker, not the Chitanka trademark.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="40dp"
+    android:height="40dp"
+    android:viewportWidth="40"
+    android:viewportHeight="40">
+    <path
+        android:pathData="M6,6h28a4,4 0 0 1 4,4v20a4,4 0 0 1 -4,4h-28a4,4 0 0 1 -4,-4v-20a4,4 0 0 1 4,-4z"
+        android:fillColor="#2A9D8F" />
+    <path
+        android:pathData="M14,12h2.7v6.4c0,1.5 1.1,2.3 2.9,2.3c1.4,0 2.6,-0.4 3.7,-0.9V12H26v16h-2.7v-5.6c-1.2,0.5 -2.5,0.8 -4,0.8c-3.4,0 -5.3,-1.7 -5.3,-4.6z"
+        android:fillColor="#FFFFFF" />
+</vector>

--- a/app/src/main/res/drawable/ic_source_storyteller.xml
+++ b/app/src/main/res/drawable/ic_source_storyteller.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Monogram fallback for Storyteller sources. Uses "S" on a warm accent as a
+  source-type marker, not the Storyteller trademark.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="40dp"
+    android:height="40dp"
+    android:viewportWidth="40"
+    android:viewportHeight="40">
+    <path
+        android:pathData="M6,6h28a4,4 0 0 1 4,4v20a4,4 0 0 1 -4,4h-28a4,4 0 0 1 -4,-4v-20a4,4 0 0 1 4,-4z"
+        android:fillColor="#F4A261" />
+    <path
+        android:pathData="M20,12c-3.6,0 -6.3,2 -6.3,4.8c0,2.4 1.5,3.8 4.7,4.5l1.9,0.4c2.3,0.5 3.1,1.1 3.1,2.3c0,1.4 -1.4,2.4 -3.4,2.4c-2.1,0 -3.6,-1 -3.9,-2.6h-2.8c0.2,3 2.7,4.8 6.6,4.8c3.9,0 6.4,-1.9 6.4,-5c0,-2.5 -1.5,-3.9 -5,-4.6l-1.7,-0.4c-2.1,-0.5 -3,-1.1 -3,-2.3c0,-1.4 1.3,-2.3 3.2,-2.3c1.9,0 3.2,0.9 3.5,2.3h2.7C25.9,13.7 23.4,12 20,12Z"
+        android:fillColor="#FFFFFF" />
+</vector>

--- a/app/src/test/kotlin/com/riffle/app/ui/source/SourceIconResolverTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/ui/source/SourceIconResolverTest.kt
@@ -1,0 +1,130 @@
+package com.riffle.app.ui.source
+
+import com.riffle.app.R
+import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.Source
+import com.riffle.core.domain.SourceType
+import com.riffle.core.domain.SourceUrl
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * Guards the wiring between Source type/serverType and the favicon URL + fallback drawable used
+ * by the source switcher + add-source picker. A regression on any of these branches would flip
+ * the icon back to the placeholder-only state that shipped before this feature.
+ */
+class SourceIconResolverTest {
+
+    private fun source(
+        type: SourceType,
+        serverType: ServerType = ServerType.AUDIOBOOKSHELF,
+        url: String = "https://example.com",
+    ): Source = Source(
+        id = "id",
+        url = SourceUrl.parse(url) ?: error("invalid test URL: $url"),
+        isActive = true,
+        insecureConnectionAllowed = false,
+        username = "",
+        type = type,
+        serverType = serverType,
+    )
+
+    // ---- faviconUrlFor ------------------------------------------------------
+
+    @Test
+    fun `favicon URL for Audiobookshelf uses Logo dot png at the server base URL`() {
+        val url = SourceIconResolver.faviconUrlFor(
+            source(type = SourceType.ABS, serverType = ServerType.AUDIOBOOKSHELF, url = "https://abs.example.com")
+        )
+        assertEquals("https://abs.example.com/Logo.png", url)
+    }
+
+    @Test
+    fun `favicon URL for Storyteller uses apple-touch-icon dot png at the service base URL`() {
+        val url = SourceIconResolver.faviconUrlFor(
+            source(
+                type = SourceType.ABS,
+                serverType = ServerType.STORYTELLER_SERVICE,
+                url = "https://storyteller.example.com",
+            )
+        )
+        assertEquals("https://storyteller.example.com/apple-touch-icon.png", url)
+    }
+
+    @Test
+    fun `favicon URL for Chitanka is null so Coil never attempts to decode the ICO`() {
+        val url = SourceIconResolver.faviconUrlFor(source(type = SourceType.CHITANKA))
+        assertNull(url)
+    }
+
+    @Test
+    fun `favicon URL for LocalFiles is null - no network origin`() {
+        val url = SourceIconResolver.faviconUrlFor(
+            source(type = SourceType.LOCAL_FILES, url = "https://localfiles.invalid"),
+        )
+        assertNull(url)
+    }
+
+    @Test
+    fun `favicon URL preserves the trailing-slash-stripping done by SourceUrl_parse`() {
+        // SourceUrl.parse strips one trailing slash; the favicon URL must therefore not have a
+        // double slash before the path segment.
+        val url = SourceIconResolver.faviconUrlFor(
+            source(type = SourceType.ABS, url = "https://abs.example.com/"),
+        )
+        assertEquals("https://abs.example.com/Logo.png", url)
+    }
+
+    // ---- fallbackDrawableFor (by Source) ------------------------------------
+
+    @Test
+    fun `fallback drawable for Audiobookshelf source is the ABS monogram`() {
+        val res = SourceIconResolver.fallbackDrawableFor(
+            source(type = SourceType.ABS, serverType = ServerType.AUDIOBOOKSHELF),
+        )
+        assertEquals(R.drawable.ic_source_audiobookshelf, res)
+    }
+
+    @Test
+    fun `fallback drawable for Storyteller source is the Storyteller monogram`() {
+        val res = SourceIconResolver.fallbackDrawableFor(
+            source(type = SourceType.ABS, serverType = ServerType.STORYTELLER_SERVICE),
+        )
+        assertEquals(R.drawable.ic_source_storyteller, res)
+    }
+
+    @Test
+    fun `fallback drawable for Chitanka source is the Chitanka monogram`() {
+        val res = SourceIconResolver.fallbackDrawableFor(source(type = SourceType.CHITANKA))
+        assertEquals(R.drawable.ic_source_chitanka, res)
+    }
+
+    @Test
+    fun `fallback drawable for LocalFiles source throws to catch callers that forgot the branch`() {
+        assertThrows(IllegalStateException::class.java) {
+            SourceIconResolver.fallbackDrawableFor(source(type = SourceType.LOCAL_FILES))
+        }
+    }
+
+    // ---- fallbackDrawableFor (by type + serverType) -------------------------
+
+    @Test
+    fun `type-only lookup returns ABS monogram for ABS+Audiobookshelf`() {
+        val res = SourceIconResolver.fallbackDrawableFor(SourceType.ABS, ServerType.AUDIOBOOKSHELF)
+        assertEquals(R.drawable.ic_source_audiobookshelf, res)
+    }
+
+    @Test
+    fun `type-only lookup returns Storyteller monogram for ABS+Storyteller`() {
+        val res = SourceIconResolver.fallbackDrawableFor(SourceType.ABS, ServerType.STORYTELLER_SERVICE)
+        assertEquals(R.drawable.ic_source_storyteller, res)
+    }
+
+    @Test
+    fun `type-only lookup returns Chitanka monogram for CHITANKA regardless of serverType`() {
+        val res = SourceIconResolver.fallbackDrawableFor(SourceType.CHITANKA)
+        assertEquals(R.drawable.ic_source_chitanka, res)
+    }
+}


### PR DESCRIPTION
## Summary

Adds per-source icons to both source surfaces:

- **Source switcher** (drawer active-source header + dropdown rows): renders the server's favicon at runtime via Coil (piggybacking on the app-scope `ImageLoader` and its 100 MB disk cache) and falls back to a bundled monogram vector while loading or on any error / decode failure. The `Check` "active" indicator moved from leading → trailing to make room for the icon.
- **Add-source picker** (`SourceTypePickerScreen`): shows the same bundled monogram set for Audiobookshelf and Chitanka. Local files keeps `Icons.Default.Folder`, unchanged.

Favicon URLs picked per source type (`SourceIconResolver`):

- Audiobookshelf → `<baseUrl>/Logo.png` (ABS bundles this as its PWA icon)
- Storyteller → `<baseUrl>/apple-touch-icon.png` (Next.js convention)
- Chitanka → skipped; its favicon is `.ico` (Coil's default decoders can't handle ICO), so we always show the Ч monogram
- LocalFiles → no favicon, no monogram; unchanged Material Folder

Monogram drawables are letter marks on brand-neutral color chips (A, S, Ч), not the projects' actual logos — same pattern Gmail/Discord use for account avatars, no trademark concern.

### Known limitation

The favicon fetch goes through the Coil `ImageLoader`'s own `OkHttpClient`, which does not carry the per-source `insecureConnectionAllowed` TLS handling used by the API clients. Users of self-hosted ABS behind a self-signed cert will always fall back to the monogram rather than see their real favicon — a degraded but non-crashing outcome. Wiring the insecure client through Coil is a follow-up if there's demand.

## Test plan

- [x] JVM unit tests: `SourceIconResolverTest` (11 tests) pin favicon URL derivation for every ABS + Storyteller + Chitanka + LocalFiles branch and the fallback drawable selection. Would flip red if any branch were reverted.
- [x] `./gradlew test` green.
- [x] `./gradlew :app:lintDebug` green.
- [ ] Visual verification on device (drawer opens, monogram shows first, favicon fades in for reachable ABS servers, Local files still shows Material Folder). *Depends on installing the APK on-device.*