### PR TITLE
feat(chitanka): wire Read/Play buttons in detail sheet to reader + audiobook player

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -39,6 +40,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -72,6 +74,8 @@ fun ChitankaBrowseScreen(
     libraryName: String,
     windowSizeClass: WindowSizeClass,
     onOpenDrawer: () -> Unit,
+    onOpenReader: (itemId: String) -> Unit,
+    onOpenAudiobook: (itemId: String) -> Unit,
     viewModel: ChitankaBrowseViewModel = hiltViewModel(),
 ) {
     val items by viewModel.items.collectAsState()
@@ -85,6 +89,16 @@ fun ChitankaBrowseScreen(
     var detailItem by remember { mutableStateOf<CatalogItem?>(null) }
 
     val isAudioRoot = viewModel.rootId == ChitankaCatalog.ROOT_AUDIOBOOKS
+
+    // Collect Read/Play events from the ViewModel. Chitanka items don't live in `library_items`
+    // until this point (ADR 0042: unbounded catalogue), so the VM upserts a row first and only
+    // then emits — guaranteeing the reader / audiobook player can resolve the item.
+    LaunchedEffect(viewModel) {
+        viewModel.openEvents.collect { event ->
+            detailItem = null
+            if (event.isAudio) onOpenAudiobook(event.itemId) else onOpenReader(event.itemId)
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -189,6 +203,7 @@ fun ChitankaBrowseScreen(
         ChitankaDetailSheet(
             item = item,
             isAudio = isAudioRoot,
+            onOpen = { viewModel.openItem(item) },
             onDismiss = { detailItem = null },
         )
     }
@@ -250,6 +265,7 @@ private fun CatalogItemCard(
 private fun ChitankaDetailSheet(
     item: CatalogItem,
     isAudio: Boolean,
+    onOpen: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     androidx.compose.material3.ModalBottomSheet(onDismissRequest = onDismiss) {
@@ -304,14 +320,13 @@ private fun ChitankaDetailSheet(
                 Text(desc, style = MaterialTheme.typography.bodyMedium)
             }
             Spacer(Modifier.height(4.dp))
-            Text(
-                if (isAudio)
-                    "Playback and download for Chitanka audiobooks will land in a follow-up (see PR)."
-                else
-                    "Reader and download integration for Chitanka books will land in a follow-up.",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
+            Button(
+                onClick = onOpen,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(if (isAudio) "Play" else "Read")
+            }
+            Spacer(Modifier.height(4.dp))
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModel.kt
@@ -8,13 +8,18 @@ import com.riffle.core.catalog.CatalogItem
 import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.catalog.FacetSelection
 import com.riffle.core.catalog.chitanka.ChitankaCatalog
+import com.riffle.core.data.chitanka.ChitankaLibraryItemUpserter
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.SourceType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -33,9 +38,27 @@ class ChitankaBrowseViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val sourceRepository: SourceRepository,
     private val catalogRegistry: CatalogRegistry,
+    private val libraryItemUpserter: ChitankaLibraryItemUpserter,
 ) : ViewModel() {
 
     val rootId: String = savedStateHandle.get<String>("rootId") ?: ChitankaCatalog.ROOT_BOOKS
+
+    /**
+     * Emitted once the tapped [CatalogItem] has been upserted into `library_items` and the
+     * reader / audiobook player can safely be launched for it. The screen collects this and
+     * routes to `epub_reader/{id}` or `audiobook_player/{id}` (see MainScreen).
+     *
+     * Extra-buffer replay-0 so a nav that fires before the collector attaches (should never
+     * happen — the screen collects in composition) is dropped rather than replayed on the
+     * next screen return.
+     */
+    data class OpenEvent(val itemId: String, val isAudio: Boolean)
+
+    private val _openEvents = MutableSharedFlow<OpenEvent>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    val openEvents: SharedFlow<OpenEvent> = _openEvents.asSharedFlow()
 
     private val _facets = MutableStateFlow<List<CatalogFacet>>(emptyList())
     val facets: StateFlow<List<CatalogFacet>> = _facets.asStateFlow()
@@ -94,6 +117,24 @@ class ChitankaBrowseViewModel @Inject constructor(
         // stale results (chip strip shows B, grid shows A's late-arriving items).
         refreshJob?.cancel()
         refreshJob = viewModelScope.launch { refreshOnce() }
+    }
+
+    /**
+     * Upsert the tapped item into `library_items` so the reader/player can resolve it via
+     * `LibraryObserver.getItem`, then emit an [OpenEvent] the screen collects to navigate.
+     * No-op when there is no active Chitanka Source — the screen route wouldn't have been
+     * reachable, but guard defensively.
+     */
+    fun openItem(item: CatalogItem) {
+        viewModelScope.launch {
+            val source = sourceRepository.getActive()
+                ?.takeIf { it.type == SourceType.CHITANKA }
+                ?: return@launch
+            libraryItemUpserter.upsert(source.id, item)
+            _openEvents.emit(
+                OpenEvent(itemId = item.id, isAudio = rootId == ChitankaCatalog.ROOT_AUDIOBOOKS),
+            )
+        }
     }
 
     private suspend fun refreshOnce() {

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -243,6 +243,14 @@ fun MainScreen(
                     libraryName = libraryName,
                     windowSizeClass = windowSizeClass,
                     onOpenDrawer = { scope.launch { drawerState.open() } },
+                    onOpenReader = { itemId ->
+                        val encodedId = URLEncoder.encode(itemId, "UTF-8")
+                        navController.navigate("epub_reader/$encodedId")
+                    },
+                    onOpenAudiobook = { itemId ->
+                        val encodedId = URLEncoder.encode(itemId, "UTF-8")
+                        navController.navigate("audiobook_player/$encodedId")
+                    },
                 )
             }
             composable(ADD_CHITANKA) {

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookResumeResolverTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookResumeResolverTest.kt
@@ -151,6 +151,29 @@ class AudiobookResumeResolverTest {
     }
 
     @Test
+    fun `zeroed session (Chitanka fresh open) → resumeSec=0, resumeStamp=0, no crash`() = runTest {
+        // Chitanka's openAudiobook returns a stream with serverCurrentTimeSec=0, serverLastUpdate=0,
+        // totalDurationSec=0 (unknown until ExoPlayer resolves each track). A fresh open has no local
+        // row either. Pin: the resolver returns (0.0, 0L) — the reconciler picks InSync (0 !> 0),
+        // audiobookResumeSec short-circuits on durationSec<=0 (no bogus fraction*0 fallback), and
+        // audiobookStartSec no-ops on durationSec<=0 (no finished-book rewind on a zero-duration).
+        val store = FakePositionStore(loadedSec = null, loadedTs = 0L)
+        val resolver = AudiobookResumeResolver(store, FakeClock(0L))
+
+        val result = resolver.resolve(
+            sourceId = "chit-1",
+            itemId = "prikazki/some-tale",
+            session = session(duration = 0.0, serverCurrentTimeSec = 0.0, serverLastUpdate = 0L),
+            readingProgressFraction = 0f,
+            startAtSec = -1.0,
+        )
+
+        assertEquals(0.0, result.resumeSec, 0.0001)
+        assertEquals(0L, result.resumeStamp)
+        assertTrue("zeroed session must not write back to store", store.saves.isEmpty())
+    }
+
+    @Test
     fun `empty sourceId → no store IO, defaults from session`() = runTest {
         val store = FakePositionStore(loadedSec = 999.0, loadedTs = 99_999L)
         val resolver = AudiobookResumeResolver(store, FakeClock(0L))

--- a/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
@@ -1,0 +1,155 @@
+package com.riffle.app.feature.source.chitanka
+
+import androidx.lifecycle.SavedStateHandle
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogItem
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.chitanka.ChitankaCatalog
+import com.riffle.core.data.chitanka.ChitankaLibraryItemUpserter
+import com.riffle.core.domain.Source
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.SourceType
+import com.riffle.core.domain.SourceUrl
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pins openItem: upserts the tapped [CatalogItem] into `library_items` (so the reader / player can
+ * resolve it) and emits an [ChitankaBrowseViewModel.OpenEvent] with the correct isAudio flag.
+ *
+ * Chitanka's library_items population is on-demand (ADR 0042), so the emission MUST come after the
+ * upsert — the screen collects openEvents to navigate. Reversing that order would race the reader's
+ * `LibraryObserver.getItem` and land it on the "item not found → failed" branch.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ChitankaBrowseViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before fun setUp() { Dispatchers.setMain(dispatcher) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    private val chitankaSource = Source(
+        id = "chit-1",
+        url = SourceUrl.parse("https://chitanka.info")!!,
+        isActive = true,
+        insecureConnectionAllowed = false,
+        username = "",
+        type = SourceType.CHITANKA,
+    )
+
+    private fun makeVm(
+        rootId: String = ChitankaCatalog.ROOT_BOOKS,
+        upserter: ChitankaLibraryItemUpserter = mockk(relaxed = true),
+        sourceRepo: SourceRepository = fakeSourceRepo(chitankaSource),
+    ): ChitankaBrowseViewModel {
+        val registry = mockk<CatalogRegistry>()
+        coEvery { registry.forSource(any()) } returns mockk<Catalog>(relaxed = true)
+        val savedStateHandle = SavedStateHandle(mapOf("rootId" to rootId))
+        return ChitankaBrowseViewModel(savedStateHandle, sourceRepo, registry, upserter)
+    }
+
+    private fun catalogEpub() = CatalogItem(
+        id = "text/12345-x",
+        rootId = ChitankaCatalog.ROOT_BOOKS,
+        title = "T",
+        author = "A",
+        coverUrl = null,
+        ebookFormat = BookFormat.Epub,
+    )
+
+    private fun catalogAudio() = CatalogItem(
+        id = "prikazki/1-slug",
+        rootId = ChitankaCatalog.ROOT_AUDIOBOOKS,
+        title = "T",
+        author = "A",
+        coverUrl = null,
+        ebookFormat = BookFormat.Audiobook,
+        hasAudio = true,
+    )
+
+    @Test
+    fun `openItem on books root upserts then emits isAudio=false`() = runTest(dispatcher) {
+        val upserter = mockk<ChitankaLibraryItemUpserter>(relaxed = true)
+        val vm = makeVm(rootId = ChitankaCatalog.ROOT_BOOKS, upserter = upserter)
+        advanceUntilIdle() // let init's loadFacets/refresh drain
+
+        val item = catalogEpub()
+        val emitted = backgroundScope.async(dispatcher) { vm.openEvents.first() }
+        vm.openItem(item)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { upserter.upsert("chit-1", item) }
+        val event = emitted.await()
+        assertEquals("text/12345-x", event.itemId)
+        assertEquals(false, event.isAudio)
+    }
+
+    @Test
+    fun `openItem on audiobooks root emits isAudio=true`() = runTest(dispatcher) {
+        val upserter = mockk<ChitankaLibraryItemUpserter>(relaxed = true)
+        val vm = makeVm(rootId = ChitankaCatalog.ROOT_AUDIOBOOKS, upserter = upserter)
+        advanceUntilIdle()
+
+        val item = catalogAudio()
+        val emitted = backgroundScope.async(dispatcher) { vm.openEvents.first() }
+        vm.openItem(item)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { upserter.upsert("chit-1", item) }
+        val event = emitted.await()
+        assertEquals("prikazki/1-slug", event.itemId)
+        assertEquals(true, event.isAudio)
+    }
+
+    @Test
+    fun `openItem with no active Chitanka source no-ops (no upsert, no emit)`() = runTest(dispatcher) {
+        val upserter = mockk<ChitankaLibraryItemUpserter>(relaxed = true)
+        // Active source is a non-Chitanka type — the ViewModel refuses to touch it.
+        val absSource = chitankaSource.copy(id = "abs-1", type = SourceType.ABS)
+        val vm = makeVm(upserter = upserter, sourceRepo = fakeSourceRepo(absSource))
+        advanceUntilIdle()
+
+        vm.openItem(catalogEpub())
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { upserter.upsert(any(), any()) }
+    }
+
+    // ---- helpers -----------------------------------------------------------------
+
+    private fun fakeSourceRepo(active: Source?): SourceRepository = object : SourceRepository {
+        override fun observeAll() = kotlinx.coroutines.flow.flowOf(listOfNotNull(active))
+        override suspend fun getActive(): Source? = active
+        override suspend fun authenticate(
+            url: SourceUrl,
+            username: String,
+            password: String,
+            insecureAllowed: Boolean,
+            serverType: com.riffle.core.domain.ServerType,
+        ) = throw UnsupportedOperationException()
+        override suspend fun commit(
+            pending: com.riffle.core.domain.PendingSource,
+            hiddenLibraryIds: Set<String>,
+        ) = throw UnsupportedOperationException()
+        override suspend fun setActive(sourceId: String) { }
+        override suspend fun remove(sourceId: String) { }
+        override suspend fun getSourceVersion(sourceId: String): String? = null
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/chitanka/ChitankaLibraryItemUpserter.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/chitanka/ChitankaLibraryItemUpserter.kt
@@ -1,0 +1,64 @@
+package com.riffle.core.data.chitanka
+
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.CatalogItem
+import com.riffle.core.database.LibraryItemDao
+import com.riffle.core.database.LibraryItemEntity
+import com.riffle.core.database.LibraryItemMetadata
+import com.riffle.core.domain.EbookFormat
+import javax.inject.Inject
+
+/**
+ * Bridges a browsed [CatalogItem] into the local `library_items` cache when the user opens it.
+ *
+ * Chitanka is an unbounded remote catalogue (ADR 0042) — [LibraryRepositoryImpl.refreshLibraryItems]
+ * intentionally does NOT populate `library_items` for it. But the reader and the audiobook player
+ * both resolve the item via `LibraryObserver.getItem(itemId)`, so opening a Chitanka item requires
+ * a row to exist. This upserter is the on-demand hop: called from
+ * [com.riffle.app.feature.source.chitanka.ChitankaBrowseViewModel] just before navigation.
+ *
+ * Uses the same insert-or-ignore + updateMetadata pattern as
+ * [com.riffle.core.database.LibraryItemDao.replaceAllForLibrary] so a re-open preserves the local
+ * `readingProgress` value.
+ */
+class ChitankaLibraryItemUpserter @Inject constructor(
+    private val libraryItemDao: LibraryItemDao,
+) {
+    suspend fun upsert(sourceId: String, item: CatalogItem) {
+        val entity = item.toEntity(sourceId)
+        libraryItemDao.insertOrIgnore(listOf(entity))
+        libraryItemDao.updateMetadata(LibraryItemMetadata.from(entity))
+    }
+
+    private fun CatalogItem.toEntity(sourceId: String): LibraryItemEntity = LibraryItemEntity(
+        sourceId = sourceId,
+        id = id,
+        libraryId = rootId,
+        title = title,
+        author = author,
+        coverUrl = coverUrl ?: "",
+        readingProgress = readingProgress ?: 0f,
+        ebookFileIno = ebookFileIno,
+        ebookFormat = ebookFormat.toEbookFormat().toStorageString(),
+        hasAudio = hasAudio,
+        audioDurationSec = audioDurationSec,
+        description = description,
+        seriesName = seriesName,
+        seriesSequence = seriesSequence,
+        publishedYear = publishedYear,
+        genres = genres.joinToString(","),
+        publisher = publisher,
+        language = language,
+        addedAt = addedAt,
+        isbn = isbn,
+        asin = asin,
+    )
+
+    private fun BookFormat.toEbookFormat(): EbookFormat = when (this) {
+        BookFormat.Epub -> EbookFormat.Epub
+        BookFormat.Pdf -> EbookFormat.Pdf
+        BookFormat.Cbz -> EbookFormat.Cbz
+        BookFormat.Audiobook -> EbookFormat.Unsupported
+        BookFormat.Unsupported -> EbookFormat.Unsupported
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/chitanka/ChitankaLibraryItemUpserterTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/chitanka/ChitankaLibraryItemUpserterTest.kt
@@ -1,0 +1,204 @@
+package com.riffle.core.data.chitanka
+
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.CatalogItem
+import com.riffle.core.catalog.chitanka.ChitankaCatalog
+import com.riffle.core.database.LibraryItemDao
+import com.riffle.core.database.LibraryItemEntity
+import com.riffle.core.database.LibraryItemMetadata
+import com.riffle.core.database.LastOpenedAtRow
+import com.riffle.core.database.MatchableItemRow
+import com.riffle.core.database.ReadingProgressRow
+import com.riffle.core.domain.EbookFormat
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the contract for on-demand insertion of a browsed Chitanka [CatalogItem] into `library_items`.
+ *
+ * Chitanka does NOT populate library_items via refresh (ADR 0042: unbounded catalogue), so the
+ * reader / audiobook player can only resolve an item once this upserter has run. The tests here
+ * pin the field mapping (CatalogItem → LibraryItemEntity) and the re-open behaviour (existing row
+ * keeps its readingProgress, mirroring [LibraryItemDao.replaceAllForLibrary]).
+ */
+class ChitankaLibraryItemUpserterTest {
+
+    private fun catalogEpub(id: String = "text/12345-x") = CatalogItem(
+        id = id,
+        rootId = ChitankaCatalog.ROOT_BOOKS,
+        title = "Под игото",
+        author = "Иван Вазов",
+        coverUrl = "https://chitanka.info/cover.jpg",
+        ebookFormat = BookFormat.Epub,
+        hasAudio = false,
+        description = "desc",
+        seriesName = "series-x",
+        seriesSequence = "2",
+        publishedYear = "1889",
+        genres = listOf("роман", "класика"),
+        language = "Bulgarian",
+    )
+
+    private fun catalogAudio(id: String = "prikazki/1-slug") = CatalogItem(
+        id = id,
+        rootId = ChitankaCatalog.ROOT_AUDIOBOOKS,
+        title = "Три прасенца",
+        author = "нар. приказка",
+        coverUrl = null,
+        ebookFormat = BookFormat.Audiobook,
+        hasAudio = true,
+        language = "Bulgarian",
+    )
+
+    @Test
+    fun `first upsert inserts EPUB row with mapped fields`() = runTest {
+        val dao = InMemoryLibraryItemDao()
+        val upserter = ChitankaLibraryItemUpserter(dao)
+
+        upserter.upsert(sourceId = "chit-1", item = catalogEpub())
+
+        val row = dao.getById("chit-1", "text/12345-x")
+        assertNotNull("row must exist", row)
+        assertEquals("chit-1", row!!.sourceId)
+        assertEquals("text/12345-x", row.id)
+        assertEquals(ChitankaCatalog.ROOT_BOOKS, row.libraryId)
+        assertEquals("Под игото", row.title)
+        assertEquals("Иван Вазов", row.author)
+        assertEquals("https://chitanka.info/cover.jpg", row.coverUrl)
+        assertEquals(0f, row.readingProgress, 0.0001f)
+        assertEquals(EbookFormat.Epub.toStorageString(), row.ebookFormat)
+        assertEquals(false, row.hasAudio)
+        assertEquals("роман,класика", row.genres)
+        assertEquals("series-x", row.seriesName)
+        assertEquals("2", row.seriesSequence)
+        assertEquals("1889", row.publishedYear)
+        assertEquals("Bulgarian", row.language)
+    }
+
+    @Test
+    fun `audiobook item maps hasAudio true and libraryId to audio root`() = runTest {
+        val dao = InMemoryLibraryItemDao()
+        val upserter = ChitankaLibraryItemUpserter(dao)
+
+        upserter.upsert(sourceId = "chit-1", item = catalogAudio())
+
+        val row = dao.getById("chit-1", "prikazki/1-slug")
+        assertNotNull(row)
+        assertEquals(true, row!!.hasAudio)
+        assertEquals(ChitankaCatalog.ROOT_AUDIOBOOKS, row.libraryId)
+        // BookFormat.Audiobook maps to unsupported ebookFormat (the audiobook path is what runs).
+        assertEquals(EbookFormat.Unsupported.toStorageString(), row.ebookFormat)
+        assertEquals("", row.coverUrl)
+    }
+
+    @Test
+    fun `re-open preserves existing readingProgress`() = runTest {
+        val dao = InMemoryLibraryItemDao()
+        val upserter = ChitankaLibraryItemUpserter(dao)
+        val item = catalogEpub()
+
+        upserter.upsert("chit-1", item)
+        // Simulate reader progress persisted after the first open.
+        dao.updateReadingProgress("chit-1", item.id, 0.42f)
+
+        upserter.upsert("chit-1", item)
+
+        val row = dao.getById("chit-1", item.id)!!
+        assertEquals("second upsert must not overwrite locally-tracked progress", 0.42f, row.readingProgress, 0.0001f)
+    }
+
+    @Test
+    fun `null description and coverUrl are handled (null cover coerced to empty)`() = runTest {
+        val dao = InMemoryLibraryItemDao()
+        val upserter = ChitankaLibraryItemUpserter(dao)
+
+        upserter.upsert(
+            sourceId = "chit-1",
+            item = catalogEpub().copy(coverUrl = null, description = null),
+        )
+
+        val row = dao.getById("chit-1", "text/12345-x")!!
+        assertEquals("", row.coverUrl)
+        assertNull(row.description)
+    }
+
+    // ---- Test double ------------------------------------------------------------------
+
+    private class InMemoryLibraryItemDao : LibraryItemDao {
+        private val rows = mutableMapOf<Pair<String, String>, LibraryItemEntity>()
+
+        override fun observeByLibraryId(sourceId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+        override suspend fun listByLibraryId(sourceId: String, libraryId: String): List<LibraryItemEntity> = emptyList()
+        override fun observeBySource(sourceId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+        override fun observeUngroupedByLibraryId(sourceId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+
+        override suspend fun upsertAll(items: List<LibraryItemEntity>) {
+            items.forEach { rows[it.sourceId to it.id] = it }
+        }
+
+        override suspend fun insertOrIgnore(items: List<LibraryItemEntity>) {
+            items.forEach { rows.putIfAbsent(it.sourceId to it.id, it) }
+        }
+
+        override suspend fun updateMetadata(metadata: LibraryItemMetadata) {
+            val existing = rows[metadata.sourceId to metadata.id] ?: return
+            rows[metadata.sourceId to metadata.id] = existing.copy(
+                libraryId = metadata.libraryId,
+                title = metadata.title,
+                author = metadata.author,
+                coverUrl = metadata.coverUrl,
+                ebookFileIno = metadata.ebookFileIno,
+                ebookFormat = metadata.ebookFormat,
+                hasAudio = metadata.hasAudio,
+                audioDurationSec = metadata.audioDurationSec,
+                description = metadata.description,
+                seriesName = metadata.seriesName,
+                publishedYear = metadata.publishedYear,
+                genres = metadata.genres,
+                publisher = metadata.publisher,
+                language = metadata.language,
+                lastOpenedAt = metadata.lastOpenedAt,
+                addedAt = metadata.addedAt,
+                isbn = metadata.isbn,
+                asin = metadata.asin,
+                finishedAt = metadata.finishedAt,
+                // readingProgress intentionally NOT copied — updateMetadata excludes it (Room @Update).
+            )
+        }
+
+        override suspend fun deleteRemovedFromLibrary(sourceId: String, libraryId: String, serverItemIds: List<String>) {
+            rows.entries.removeAll { it.value.libraryId == libraryId && it.value.sourceId == sourceId && it.value.id !in serverItemIds }
+        }
+
+        override suspend fun getById(sourceId: String, itemId: String): LibraryItemEntity? = rows[sourceId to itemId]
+        override suspend fun listByIds(sourceId: String, itemIds: List<String>): List<LibraryItemEntity> =
+            itemIds.mapNotNull { rows[sourceId to it] }
+
+        override fun observeById(sourceId: String, itemId: String): Flow<LibraryItemEntity?> = flowOf(rows[sourceId to itemId])
+        override suspend fun findSourceIdForItem(itemId: String): String? = rows.values.firstOrNull { it.id == itemId }?.sourceId
+        override suspend fun deleteByLibraryId(sourceId: String, libraryId: String) {
+            rows.entries.removeAll { it.value.libraryId == libraryId && it.value.sourceId == sourceId }
+        }
+
+        override suspend fun deleteById(sourceId: String, itemId: String) { rows.remove(sourceId to itemId) }
+        override fun observeInProgress(sourceId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+        override fun observeFinished(sourceId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+        override fun observeRecentlyAdded(sourceId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+        override fun observeAllBooks(sourceId: String, libraryId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
+        override suspend fun updateLastOpenedAt(sourceId: String, itemId: String, timestamp: Long) { }
+        override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) {
+            val row = rows[sourceId to itemId] ?: return
+            rows[sourceId to itemId] = row.copy(readingProgress = progress)
+        }
+        override suspend fun updateLibraryId(sourceId: String, itemId: String, libraryId: String) { }
+        override suspend fun updateFinishedAt(sourceId: String, itemId: String, finishedAt: Long?) { }
+        override suspend fun getLastOpenedAtMap(sourceId: String, libraryId: String): List<LastOpenedAtRow> = emptyList()
+        override suspend fun getReadingProgressMap(sourceId: String, libraryId: String): List<ReadingProgressRow> = emptyList()
+        override suspend fun listMatchableBySourceType(serverType: String): List<MatchableItemRow> = emptyList()
+    }
+}


### PR DESCRIPTION
Closes #494

Chitanka items don't live in `library_items` (ADR 0042 unbounded catalogue), so `LibraryObserver.getItem(itemId)` returns null for a fresh browse — the reader / audiobook player would land on their "item not found → failed" branch. The `ChitankaDetailSheet` also had no actionable button, just a "follow-up" placeholder.

## What changed

1. **`ChitankaLibraryItemUpserter`** (`core:data`) — on-demand hop that upserts a browsed `CatalogItem` into `library_items` for the active Chitanka Source, using the same insert-or-ignore + `updateMetadata` pattern as `LibraryItemDao.replaceAllForLibrary` so a re-open preserves the local `readingProgress`.

2. **`ChitankaBrowseViewModel.openItem(item)`** — coroutine that runs the upsert then emits an `OpenEvent(itemId, isAudio)` on a `SharedFlow`. Emission is strictly after the upsert so the reader's `getItem` can't race.

3. **`ChitankaBrowseScreen`** — Read / Play `Button` in the detail sheet (replacing the follow-up placeholder), `onOpenReader` / `onOpenAudiobook` callback surface, and a `LaunchedEffect` that dismisses the sheet and navigates on each `OpenEvent`. `MainScreen` routes to `epub_reader/{id}` or `audiobook_player/{id}` respectively — the existing EPUB open path (`EpubRepositoryImpl.openEpub` → `catalog.openFile` → `LocalStore.save`) handles download-then-open through Chitanka's `CatalogFileHandle.Stream`.

## Audiobook player tolerates zeroed session

Chitanka's `openAudiobook` returns `serverCurrentTimeSec = 0`, `serverLastUpdate = 0L`, empty `chapters`, `totalDurationSec = 0.0`. Verified the resolver handles it cleanly: reconciler picks `InSync` (0 !> 0), `audiobookResumeSec` short-circuits on `durationSec <= 0`, `audiobookStartSec` no-ops on `durationSec <= 0` → resume = `(0.0, 0L)`, no store IO, no crash. ExoPlayer fills real per-track durations once metadata resolves.

## Tests

- `ChitankaLibraryItemUpserterTest` — field mapping (EPUB + audiobook roots), re-open preserves `readingProgress`, null cover coerces to empty.
- `ChitankaBrowseViewModelTest` — `openItem` upserts then emits, `isAudio` reflects `rootId`, no-op when active source is not Chitanka.
- `AudiobookResumeResolverTest.zeroed session (Chitanka fresh open)` — resume = `(0.0, 0L)`, no store IO.

## Test plan
- [ ] `./gradlew test` — all suites green
- [ ] AVD: add Chitanka source → Books → tap item → Read → reader loads
- [ ] AVD: Audiobooks → tap item → Play → first MP3 track streams
- [ ] Re-open a Chitanka book with tracked progress → progress preserved