### PR TITLE
feat(reader): CBZ thumbnail navigation row

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/cbz/CbzThumbnailStripTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/cbz/CbzThumbnailStripTest.kt
@@ -1,0 +1,56 @@
+package com.riffle.app.feature.reader.cbz
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression pin: the CBZ nav row is a thumbnail strip, not a Material Slider.
+ * If someone reverts to `Slider`, the `cbz_thumb_*` semantics nodes disappear
+ * and both assertions below flip red.
+ */
+@RunWith(AndroidJUnit4::class)
+class CbzThumbnailStripTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun renders_thumbnails_and_tap_routes_to_onSeek() {
+        val source = FakeCbzImageSource(pageCount = 12)
+        var lastSeek = -1
+
+        composeTestRule.setContent {
+            CbzThumbnailStrip(
+                currentPage = 0,
+                pageCount = source.pageCount,
+                imageSource = source,
+                onSeek = { lastSeek = it },
+            )
+        }
+
+        composeTestRule.onNodeWithTag("cbz_thumbnail_strip").assertExists()
+        composeTestRule.onNodeWithTag("cbz_thumb_0").assertExists()
+
+        // 40dp thumbs at a start-aligned LazyRow — index 5 sits well inside the initial
+        // viewport on the ~320dp+ harness screen.
+        composeTestRule.onNodeWithTag("cbz_thumb_5").performClick()
+
+        assertEquals(5, lastSeek)
+    }
+}
+
+/**
+ * Returns an empty byte array — image decode fails, produceState resolves to null,
+ * and the AsyncImage never renders. The tagged `Box` behind it stays composed, which
+ * is all the test needs to assert click routing.
+ */
+private class FakeCbzImageSource(override val pageCount: Int) : CbzImageSource {
+    override fun imageBytes(pageIndex: Int): ByteArray = ByteArray(0)
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -7,14 +7,22 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CircularProgressIndicator
@@ -22,7 +30,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -47,8 +54,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import coil.compose.AsyncImage
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
+import coil.size.Size as CoilSize
 import com.riffle.app.feature.reader.VolumeNavEvent
 import com.riffle.app.feature.reader.rememberImmersiveModeState
 import kotlinx.coroutines.Dispatchers
@@ -141,9 +150,10 @@ fun CbzReaderScreen(
                 exit = slideOutVertically { it },
                 modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth(),
             ) {
-                CbzScrubber(
+                CbzThumbnailStrip(
                     currentPage = currentPage,
                     pageCount = ready.pageCount,
+                    imageSource = ready.imageSource,
                     onSeek = { viewModel.jumpToPage(it) },
                 )
             }
@@ -274,30 +284,87 @@ private fun CbzPage(
 }
 
 @Composable
-private fun CbzScrubber(
+internal fun CbzThumbnailStrip(
     currentPage: Int,
     pageCount: Int,
+    imageSource: CbzImageSource,
     onSeek: (Int) -> Unit,
 ) {
-    Row(
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(currentPage) {
+        val viewport = listState.layoutInfo.viewportEndOffset - listState.layoutInfo.viewportStartOffset
+        // Centre the current thumb: item width ~= 40dp, and viewport is in px. If layout hasn't happened
+        // yet (viewport == 0) fall back to scrollToItem with a small leading offset so the animation
+        // becomes meaningful once measured.
+        val leading = if (viewport > 0) -(viewport / 2) else 0
+        listState.animateScrollToItem(currentPage, scrollOffset = leading)
+    }
+
+    Column(
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.9f))
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
+            .padding(vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
             text = "${currentPage + 1} / $pageCount",
             color = MaterialTheme.colorScheme.onSurface,
         )
-        Slider(
-            value = currentPage.toFloat(),
-            onValueChange = { onSeek(it.toInt()) },
-            valueRange = 0f..(pageCount - 1).coerceAtLeast(1).toFloat(),
-            steps = (pageCount - 2).coerceAtLeast(0),
-            modifier = Modifier.weight(1f).testTag("cbz_scrubber"),
-        )
+        LazyRow(
+            state = listState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 4.dp)
+                .testTag("cbz_thumbnail_strip"),
+            contentPadding = PaddingValues(horizontal = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            items(pageCount) { index ->
+                CbzThumbnail(
+                    imageSource = imageSource,
+                    pageIndex = index,
+                    isCurrent = index == currentPage,
+                    onClick = { onSeek(index) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CbzThumbnail(
+    imageSource: CbzImageSource,
+    pageIndex: Int,
+    isCurrent: Boolean,
+    onClick: () -> Unit,
+) {
+    val context = LocalContext.current
+    val bytes by produceState<ByteArray?>(initialValue = null, key1 = pageIndex, key2 = imageSource) {
+        value = withContext(Dispatchers.IO) { runCatching { imageSource.imageBytes(pageIndex) }.getOrNull() }
+    }
+    val borderColor = if (isCurrent) MaterialTheme.colorScheme.primary else Color.Transparent
+    Box(
+        modifier = Modifier
+            .size(width = 40.dp, height = 56.dp)
+            .background(Color(0xFF1A1A1A), RoundedCornerShape(2.dp))
+            .border(width = 2.dp, color = borderColor, shape = RoundedCornerShape(2.dp))
+            .clickable { onClick() }
+            .testTag("cbz_thumb_$pageIndex"),
+    ) {
+        val currentBytes = bytes
+        if (currentBytes != null) {
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(currentBytes)
+                    .size(CoilSize(120, 168))
+                    .crossfade(false)
+                    .build(),
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
     }
 }
 

--- a/docs/superpowers/specs/2026-07-11-cbz-thumbnail-nav-row-design.md
+++ b/docs/superpowers/specs/2026-07-11-cbz-thumbnail-nav-row-design.md
@@ -1,0 +1,67 @@
+# CBZ thumbnail navigation row — design
+
+## Problem
+
+The CBZ reader's bottom navigation row is a Material `Slider` (`CbzScrubber` in `app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt`). It gives a linear seek position but no visual context for where you are in the comic. Users want a scrollable thumbnail strip instead — the same "slide across pages" affordance a physical comic gives you when you fan the edges.
+
+Slide-to-turn on the page canvas already works (the reader uses `HorizontalPager`). This change is only about the nav row.
+
+## Scope
+
+- Replace `CbzScrubber` with `CbzThumbnailStrip`, a horizontally-scrollable `LazyRow` of page thumbnails.
+- Tap a thumbnail → jump to that page (existing `viewModel.jumpToPage`).
+- Current page is visually marked; strip auto-centers on the current page as it changes.
+- Page swipe on the canvas is unchanged.
+
+Out of scope: dragging a finger across the strip as a live scrubber, long-press previews, pinch-zoom of the strip, chapter markers, preloading all thumbnails eagerly.
+
+## Design
+
+### Component: `CbzThumbnailStrip`
+
+- `LazyRow` with one item per page, `contentPadding = 12dp horizontal`, `spacedBy(4dp)`.
+- Each item ≈ 40dp × 56dp (comic ~2:3 aspect).
+- Current page: 2dp border in `MaterialTheme.colorScheme.primary`.
+- A "N / total" label sits above the row (kept from today's UI) so page count remains readable at a glance.
+- Container: ~72dp tall (thumb + label + padding), same `surface.copy(alpha = 0.9f)` background as today so it reads over dark comic pages.
+- Tap → `onSeek(pageIndex)` → `viewModel.jumpToPage(pageIndex)`.
+- `LaunchedEffect(currentPage) { listState.animateScrollToItem(currentPage, scrollOffset = -centeringOffsetPx) }` keeps the current thumb centered when the page changes via swipe / volume keys / resume.
+
+### Thumbnail decoding
+
+- Reuse `CbzImageSource.imageBytes(pageIndex)` — the existing decode path used by `CbzPage`.
+- Load via Coil `AsyncImage` per item; Coil's memory + disk caches absorb repeat scrolls.
+- Downsample with `ImageRequest.size(Size(120, 168))` so 100+ pages don't hold full-res bitmaps.
+- Placeholder while decoding: flat dark box, no spinner (spinners across dozens of tiles are visually noisy).
+- Off-screen items are recycled by `LazyRow`; there is no separate preload pass.
+
+### ViewModel
+
+No changes. `currentPage` flow and `jumpToPage(Int)` already cover reads and writes.
+
+### Test tags
+
+- `LazyRow` → `cbz_thumbnail_strip` (replaces today's `cbz_scrubber`).
+- Each item → `cbz_thumb_$index`.
+
+## Testing
+
+Compose UI + Coil don't unit-test cleanly at the JVM level, so verification is instrumentation:
+
+- New `CbzReaderScreenTest` under `app/src/androidTest/kotlin/com/riffle/app/feature/reader/cbz/`:
+  - Launches `CbzReaderScreen` with a fake `CbzImageSource` returning solid-color bitmaps for N pages.
+  - Reveals the nav row (screen starts non-immersive) and clicks `cbz_thumb_5`.
+  - Asserts the pager settles on page 5 (assert on `cbz_pager` current page via a semantics probe, or via a page-index label rendered in the fake).
+
+Test runs via `make harness-test`. This is the regression assertion for the swap: if someone reverts to the `Slider`, the test fails because `cbz_thumb_5` no longer exists.
+
+## Files touched
+
+- `app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt` — replace `CbzScrubber` with `CbzThumbnailStrip`; remove `Slider` import.
+- `app/src/androidTest/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreenTest.kt` — new file.
+
+## Non-goals / decisions locked in
+
+- Not adding drag-scrub semantics — Option A only (tap-to-jump, free scroll of the strip).
+- Keeping the "N / total" label above the strip.
+- Thumbnail size is 40dp × 56dp; page numbers under each thumb are not shown (label above is enough).


### PR DESCRIPTION
## Summary
Replace the CBZ reader's bottom `Slider` scrubber with a horizontally-scrollable thumbnail strip. Tap a thumbnail to jump; the strip auto-centres on the current page as it changes. Swipe-to-turn on the page canvas is unchanged (`HorizontalPager`).

Thumbnails decode via the existing `CbzImageSource` off the UI thread and downsample through Coil (120×168 px) so a 100-page comic doesn't hold full-res bitmaps. Off-screen tiles are recycled by `LazyRow`.

Spec: `docs/superpowers/specs/2026-07-11-cbz-thumbnail-nav-row-design.md`

## Notes on validation
- `./gradlew :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin checkRiffleLogTags checkNoServerReferences` all green.
- Instrumentation test `CbzThumbnailStripTest` was authored as the regression pin but **not executed in this workspace** — the base `Harness_Medium_Phone` AVD isn't installed on this machine, so `make harness-test-class CLASS=…CbzThumbnailStripTest` couldn't clone it. Please run it locally (or rely on CI) before merging.

## Test plan
- [ ] Run `make harness-test-class CLASS=com.riffle.app.feature.reader.cbz.CbzThumbnailStripTest` on a machine with the phone harness AVD.
- [ ] Open a CBZ book on an AVD/device: bottom nav row shows a horizontal strip of page thumbnails instead of a slider; tapping a thumb jumps to that page; the current thumb has a primary-color border and auto-centres as pages turn.
- [ ] Swipe left/right on the page still turns pages.