### PR TITLE
feat(chitanka): swipe-to-delete parity in Settings

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ChitankaSourceRowTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ChitankaSourceRowTest.kt
@@ -1,0 +1,47 @@
+package com.riffle.app.feature.settings
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeLeft
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Pins Chitanka's Settings row to swipe-to-delete parity with every other configured-source row:
+ * end-to-start swipe invokes onRemove, and no trailing "Remove" button exists. If the row is
+ * un-wrapped from SwipeToDeleteRow or a Remove button is re-added, this test fails.
+ */
+@RunWith(AndroidJUnit4::class)
+class ChitankaSourceRowTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun endToStartSwipe_invokesOnRemove() {
+        var removed = false
+        composeTestRule.setContent {
+            ChitankaSourceRow(onRemove = { removed = true })
+        }
+
+        composeTestRule.onNodeWithTag("ChitankaSourceRow").performTouchInput { swipeLeft() }
+        composeTestRule.waitForIdle()
+
+        assertTrue("swipe end-to-start on Chitanka row must invoke onRemove", removed)
+    }
+
+    @Test
+    fun row_hasNoTrailingRemoveButton() {
+        composeTestRule.setContent {
+            ChitankaSourceRow(onRemove = {})
+        }
+
+        composeTestRule.onNodeWithText("Remove").assertDoesNotExist()
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -1194,36 +1194,18 @@ private fun LocalFilesSourceRow(
 
 /**
  * Minimal sources-list row for the singleton Chitanka Source. No sub-UI (unlike
- * [LocalFilesSourceRow] which manages folders) — Chitanka is zero-config; the only
- * user-facing controls are "browse" (via the drawer) and "remove" (this row).
+ * [LocalFilesSourceRow] which manages folders) — Chitanka is zero-config; removal is
+ * via the shared end-to-start swipe gesture, matching every other configured-source row.
  */
 @Composable
-private fun ChitankaSourceRow(
+internal fun ChitankaSourceRow(
     onRemove: () -> Unit,
 ) {
-    var pendingRemoval by remember { mutableStateOf(false) }
-    ListItem(
-        modifier = Modifier.testTag("ChitankaSourceRow"),
-        headlineContent = { Text("Chitanka") },
-        supportingContent = { Text("chitanka.info · gramofonche.chitanka.info") },
-        trailingContent = {
-            TextButton(onClick = { pendingRemoval = true }) { Text("Remove") }
-        },
-    )
-    if (pendingRemoval) {
-        AlertDialog(
-            onDismissRequest = { pendingRemoval = false },
-            title = { Text("Remove Chitanka source?") },
-            text = { Text("You can add it back at any time. Downloaded content from this source will be removed.") },
-            confirmButton = {
-                TextButton(onClick = {
-                    onRemove()
-                    pendingRemoval = false
-                }) { Text("Remove") }
-            },
-            dismissButton = {
-                TextButton(onClick = { pendingRemoval = false }) { Text("Cancel") }
-            },
+    SwipeToDeleteRow(onDelete = onRemove) {
+        ListItem(
+            modifier = Modifier.testTag("ChitankaSourceRow"),
+            headlineContent = { Text("Chitanka") },
+            supportingContent = { Text("chitanka.info · gramofonche.chitanka.info") },
         )
     }
 }


### PR DESCRIPTION
## Summary

- Wrap `ChitankaSourceRow` in the shared `SwipeToDeleteRow` so the Chitanka source uses the same end-to-start swipe gesture as ABS `ServerRow` and `LocalFilesSourceRow`.
- Drop the trailing "Remove" `TextButton` and its confirmation dialog from the row — parity with the other configured-source rows, which swipe directly without a modal.
- Add `ChitankaSourceRowTest` (androidTest) pinning both behaviours: end-to-start swipe invokes `onRemove`, and no "Remove" text button exists.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin` — green
- [x] `./gradlew :app:compileDebugAndroidTestKotlin` — green
- [ ] `make harness-test` on CI covers `ChitankaSourceRowTest`