### PR TITLE
feat(source): enforce single-instance rule for credential-less sources

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerScreen.kt
@@ -53,12 +53,17 @@ data class SourceTypeCard(
 )
 
 /**
- * The cards shown by [SourceTypePickerScreen]. When [hasLocalFilesSource] is true the "Local
- * files" card is omitted — LocalFiles is a device singleton, so a second install would attach to
- * the existing row, which the picker's "add source" framing hides. Adding another folder to that
- * existing source is a dedicated action in Settings.
+ * The cards shown by [SourceTypePickerScreen]. Source types that require no login (LocalFiles,
+ * Chitanka) are device singletons: their tile is omitted once one already exists. For LocalFiles,
+ * adding another folder is a dedicated action in Settings; for Chitanka there is nothing more to
+ * configure. Rule of thumb: any credential-less source type is one-per-device — a duplicate row
+ * would have no distinguishing configuration and would be either a silent no-op or a confusing
+ * duplicate library entry.
  */
-internal fun sourceTypeCards(hasLocalFilesSource: Boolean = false): List<SourceTypeCard> = buildList {
+internal fun sourceTypeCards(
+    hasLocalFilesSource: Boolean = false,
+    hasChitankaSource: Boolean = false,
+): List<SourceTypeCard> = buildList {
     add(
         SourceTypeCard(
             type = SourceTypeChoice.Audiobookshelf,
@@ -79,15 +84,17 @@ internal fun sourceTypeCards(hasLocalFilesSource: Boolean = false): List<SourceT
             ),
         )
     }
-    add(
-        SourceTypeCard(
-            type = SourceTypeChoice.Chitanka,
-            title = "Chitanka",
-            subtitle = "Browse Bulgarian ebooks (chitanka.info) and audiobooks (gramofonche).",
-            enabled = true,
-            comingSoon = false,
-        ),
-    )
+    if (!hasChitankaSource) {
+        add(
+            SourceTypeCard(
+                type = SourceTypeChoice.Chitanka,
+                title = "Chitanka",
+                subtitle = "Browse Bulgarian ebooks (chitanka.info) and audiobooks (gramofonche).",
+                enabled = true,
+                comingSoon = false,
+            ),
+        )
+    }
 }
 
 private fun testTagFor(type: SourceTypeChoice): String = when (type) {
@@ -105,6 +112,7 @@ fun SourceTypePickerScreen(
     onPickLocalFiles: () -> Unit,
     onPickChitanka: () -> Unit,
     hasLocalFilesSource: Boolean = false,
+    hasChitankaSource: Boolean = false,
 ) {
     Scaffold(
         topBar = {
@@ -126,7 +134,10 @@ fun SourceTypePickerScreen(
                 modifier = Modifier.fillMaxSize().padding(24.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                sourceTypeCards(hasLocalFilesSource = hasLocalFilesSource).forEach { card ->
+                sourceTypeCards(
+                    hasLocalFilesSource = hasLocalFilesSource,
+                    hasChitankaSource = hasChitankaSource,
+                ).forEach { card ->
                     SourceTypeCardRow(
                         card = card,
                         onClick = when (card.type) {

--- a/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerViewModel.kt
@@ -12,20 +12,29 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
 /**
- * Backs [SourceTypePickerScreen] with the "is LocalFiles already installed?" flag. LocalFiles is a
- * device singleton — one row max — so after the first install the picker hides its tile and points
- * the user at the Settings folder-management row to add another folder to that existing source.
+ * Backs [SourceTypePickerScreen] with "is X already installed?" flags for the credential-less
+ * source types (LocalFiles, Chitanka). Both are device singletons — one row max each — so after
+ * the first install the picker hides that tile. For LocalFiles, adding another folder is a
+ * dedicated action in Settings; for Chitanka there's nothing more to configure.
+ *
+ * The rule "at most one instance" applies to every source type that requires no login: without
+ * credentials there's nothing to disambiguate a second row from the first, so a duplicate would
+ * be either a silent no-op or a confusing duplicate library entry.
  */
 @HiltViewModel
 class SourceTypePickerViewModel @Inject constructor(
     sourceRepository: SourceRepository,
 ) : ViewModel() {
 
-    // Default to true (tile hidden) so a user who already has a LocalFiles source doesn't see
-    // the tile flash into view for a frame before the flow's first emission removes it. First-run
-    // users on a fresh device see the ABS card immediately and the LocalFiles card fades in on
+    // Default to true (tile hidden) so a user who already has these sources doesn't see the
+    // tile flash into view for a frame before the flow's first emission removes it. First-run
+    // users on a fresh device see the ABS card immediately and the singleton cards fade in on
     // the first emission — a less-jarring order than "tile appears, then vanishes".
     val hasLocalFilesSource: StateFlow<Boolean> = sourceRepository.observeAll()
         .map { sources -> sources.any { it.type == SourceType.LOCAL_FILES } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), initialValue = true)
+
+    val hasChitankaSource: StateFlow<Boolean> = sourceRepository.observeAll()
+        .map { sources -> sources.any { it.type == SourceType.CHITANKA } }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), initialValue = true)
 }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -205,6 +205,7 @@ fun MainScreen(
                 val pickerViewModel: com.riffle.app.feature.server.SourceTypePickerViewModel =
                     androidx.hilt.navigation.compose.hiltViewModel()
                 val hasLocalFilesSource by pickerViewModel.hasLocalFilesSource.collectAsState()
+                val hasChitankaSource by pickerViewModel.hasChitankaSource.collectAsState()
                 com.riffle.app.feature.server.SourceTypePickerScreen(
                     windowSizeClass = windowSizeClass,
                     onNavigateBack = {
@@ -228,6 +229,7 @@ fun MainScreen(
                         }
                     },
                     hasLocalFilesSource = hasLocalFilesSource,
+                    hasChitankaSource = hasChitankaSource,
                 )
             }
             composable(

--- a/app/src/test/kotlin/com/riffle/app/feature/server/SourceTypePickerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/server/SourceTypePickerTest.kt
@@ -57,4 +57,23 @@ class SourceTypePickerTest {
         assertTrue(cards.none { it.type is SourceTypeChoice.LocalFiles })
         assertTrue(cards.any { it.type is SourceTypeChoice.Audiobookshelf })
     }
+
+    // Chitanka is a device singleton — no credentials to disambiguate a second row from the
+    // first, so a duplicate would be either a silent no-op or a confusing duplicate library
+    // entry. If this predicate ever flips, the picker will start offering to add duplicates.
+    @Test
+    fun `Chitanka card is hidden once a Chitanka source exists`() {
+        val cards = sourceTypeCards(hasChitankaSource = true)
+        assertTrue(cards.none { it.type is SourceTypeChoice.Chitanka })
+        assertTrue(cards.any { it.type is SourceTypeChoice.Audiobookshelf })
+        assertTrue(cards.any { it.type is SourceTypeChoice.LocalFiles })
+    }
+
+    // Both credential-less singletons already installed: only ABS remains addable.
+    @Test
+    fun `only ABS remains when both credential-less singletons are installed`() {
+        val cards = sourceTypeCards(hasLocalFilesSource = true, hasChitankaSource = true)
+        assertEquals(1, cards.size)
+        assertEquals(SourceTypeChoice.Audiobookshelf, cards[0].type)
+    }
 }


### PR DESCRIPTION
## Summary

Credential-less source types (LocalFiles, Chitanka) are device singletons: without login there's nothing to disambiguate a second row from the first, so a duplicate would be a silent no-op or a confusing duplicate library entry. LocalFiles already had this UI-side hide; extend the same rule to Chitanka.

## Changes

- `SourceTypePickerViewModel` exposes `hasChitankaSource` mirroring `hasLocalFilesSource`.
- `SourceTypePickerScreen.sourceTypeCards(...)` omits the Chitanka tile when `hasChitankaSource = true`.
- `MainScreen` wires the new flag through.
- Doc comments generalize the rule to "any credential-less source type is one-per-device."
- Regression tests pin the Chitanka tile-hide predicate and the "both singletons installed → only ABS remains" case.

Data-layer idempotency in \`ChitankaSourceInstaller.install()\` was already in place (getByType early-return); this PR closes the UI-side loophole that was still letting users tap through the tile after Chitanka was installed.

## Test plan

- [x] \`./gradlew :app:testDebugUnitTest --tests SourceTypePickerTest\` — green