### PR TITLE
fix(local-files): generalize scan empty-state so new formats aren't forgotten

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/AddLocalFilesScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/AddLocalFilesScreen.kt
@@ -36,6 +36,13 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.riffle.app.ui.TabletContentWidthContainer
 
 /**
+ * Copy shown when a scan completes but no files were classifiable. Deliberately format-agnostic
+ * — the scanner's supported set is owned by `FileClassifier.Kind`, and naming EPUB/PDF/CBZ here
+ * would silently go stale the next time a format is added.
+ */
+internal const val EMPTY_SCAN_MESSAGE: String = "No supported books were found in that folder."
+
+/**
  * Entry point for the Add-Source LocalFiles flow. Auto-launches the SAF folder picker on first
  * frame; on cancel offers a retry / back path; on success surfaces the scan report before
  * handing back to the caller. No form fields — LocalFiles has no credentials to supply.
@@ -132,7 +139,7 @@ private fun SuccessView(added: Int, failures: Int, onDone: () -> Unit) {
             )
         } else if (added == 0) {
             Text(
-                "No supported books were found in that folder.",
+                EMPTY_SCAN_MESSAGE,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/AddLocalFilesScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/AddLocalFilesScreen.kt
@@ -132,7 +132,7 @@ private fun SuccessView(added: Int, failures: Int, onDone: () -> Unit) {
             )
         } else if (added == 0) {
             Text(
-                "No EPUBs or PDFs were found in that folder.",
+                "No supported books were found in that folder.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )

--- a/app/src/test/kotlin/com/riffle/app/feature/source/localfiles/EmptyScanMessageTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/localfiles/EmptyScanMessageTest.kt
@@ -1,0 +1,29 @@
+package com.riffle.app.feature.source.localfiles
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+/**
+ * Pins the empty-state scan copy against re-specialization. The message used to name EPUB and
+ * PDF explicitly, so when CBZ support landed the string silently went stale. If someone reverts
+ * to naming individual formats, both assertions below flip red.
+ */
+class EmptyScanMessageTest {
+
+    @Test
+    fun `message stays format-agnostic`() {
+        assertEquals("No supported books were found in that folder.", EMPTY_SCAN_MESSAGE)
+    }
+
+    @Test
+    fun `message names no specific format`() {
+        val lower = EMPTY_SCAN_MESSAGE.lowercase()
+        for (token in listOf("epub", "pdf", "cbz", "cbr", "mobi", "azw")) {
+            assertFalse(
+                "EMPTY_SCAN_MESSAGE must not name specific formats (found '$token'): $EMPTY_SCAN_MESSAGE",
+                lower.contains(token),
+            )
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt
@@ -22,8 +22,8 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 /**
- * Walks the LocalFiles Source's configured folders, classifies EPUB/PDF files by extension +
- * magic bytes, computes a content-identity hash, and idempotently upserts:
+ * Walks the LocalFiles Source's configured folders, classifies supported book files (see
+ * [FileClassifier.Kind]) by extension + magic bytes, computes a content-identity hash, and idempotently upserts:
  *   - a `library_items` row per unique file (title/author/…, cover URL where extractable), with
  *     `libraryId` set to whichever folder-library currently contains it (if a file lives in
  *     several folders, the row's libraryId names any one of them — folder-scoped browsing goes


### PR DESCRIPTION
## Summary

The Local Files scan completion screen said "No EPUBs or PDFs were found in that folder." — a copy string that named the two originally-supported formats. When CBZ support landed later, `FileClassifier.Kind`, `LocalFilesScanner`, and the ebook-format enum were all updated, but the empty-state message silently went stale.

Fix the immediate bug and make the pattern harder to repeat:

- Reword the message to "No supported books were found in that folder." — format-agnostic, so future format additions don't require chasing this string.
- Extract it to `internal const val EMPTY_SCAN_MESSAGE` with a KDoc pointing at `FileClassifier.Kind` as the single source of truth.
- Refresh the `LocalFilesScanner` KDoc that also named "EPUB/PDF" explicitly.
- Add `EmptyScanMessageTest` — pins the exact copy and asserts the message names no known format token (`epub`, `pdf`, `cbz`, `cbr`, `mobi`, `azw`). If someone re-specializes it, both assertions flip red.

The scanner itself was already CBZ-aware end-to-end (`SafFolderWalker` is format-agnostic, `FileClassifier` accepts `.cbz`, and `LocalFilesScanner.ingest` builds items via `buildCbzItem`) — only the user-facing copy and a stale KDoc had drifted.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests EmptyScanMessageTest` passes locally.
- [x] Reverting the copy back to the old wording flips both new assertions red.