### PR TITLE
fix(chitanka): audiobook total duration + open-book ENOENT for slash-bearing item ids

### DIFF
--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
@@ -402,14 +402,7 @@ class ChitankaCatalog(
     override suspend fun openAudiobook(itemId: String, deviceLabel: String): CatalogAudiobookStream? {
         val tracks = getTracks(itemId)
         if (tracks.isEmpty()) return null
-        return CatalogAudiobookStream(
-            trackUrls = tracks.map { it.contentUrl },
-            tracks = tracks,
-            chapters = emptyList(),          // no chapter markers on Gramofonche — track-nav suffices
-            totalDurationSec = 0.0,          // unknown until playback begins
-            serverCurrentTimeSec = 0.0,      // no server-side position for Chitanka
-            serverLastUpdate = 0L,
-        )
+        return buildAudiobookStream(tracks)
     }
 
     override suspend fun getAudiobookChapters(itemId: String): List<CatalogAudiobookChapter> {
@@ -472,6 +465,22 @@ class ChitankaCatalog(
             CatalogFacet(key = "pesnicki", label = "Песнички", sortOrder = 2),
             CatalogFacet(key = "zagolemi", label = "За по-големи", sortOrder = 3),
         )
+
+        /**
+         * Assembles a Gramofonche audiobook stream from its per-track spans. The total duration
+         * is the sum of track durations — leaving it at 0 makes the player's timeline math
+         * collapse (AbsolutePositionPlayer falls back to ExoPlayer's per-track duration, so the
+         * UI shows 0 until the current track resolves and never reflects the whole book).
+         */
+        internal fun buildAudiobookStream(tracks: List<CatalogAudioTrack>): CatalogAudiobookStream =
+            CatalogAudiobookStream(
+                trackUrls = tracks.map { it.contentUrl },
+                tracks = tracks,
+                chapters = emptyList(),
+                totalDurationSec = tracks.sumOf { it.durationSec },
+                serverCurrentTimeSec = 0.0,
+                serverLastUpdate = 0L,
+            )
     }
 }
 

--- a/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
+++ b/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
@@ -1,6 +1,7 @@
 package com.riffle.core.catalog.chitanka
 
 import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.CatalogAudioTrack
 import com.riffle.core.catalog.CatalogFacet
 import com.riffle.core.catalog.FacetSelection
 import kotlinx.coroutines.test.runTest
@@ -89,6 +90,35 @@ class ChitankaCatalogTest {
         val url = "https://gramofonche.chitanka.info/prikazki/foo/track-1.mp3"
         val cat = catalog()
         assertEquals(url, cat.buildStreamUrl("prikazki/foo", url))
+    }
+
+    @Test
+    fun `buildAudiobookStream totalDurationSec sums per-track durations`() {
+        // Regression: openAudiobook used to hardcode totalDurationSec = 0.0, which collapsed the
+        // audiobook player's timeline math (AbsolutePositionPlayer falls back to ExoPlayer's
+        // per-track duration when the total is 0) and left the UI's total time stuck at 0.
+        val tracks = listOf(
+            CatalogAudioTrack(
+                ino = "https://gramofonche.chitanka.info/prikazki/foo/a.mp3",
+                index = 0,
+                startOffsetSec = 0.0,
+                durationSec = 1200.0,
+                contentUrl = "https://gramofonche.chitanka.info/prikazki/foo/a.mp3",
+                mimeType = "audio/mpeg",
+            ),
+            CatalogAudioTrack(
+                ino = "https://gramofonche.chitanka.info/prikazki/foo/b.mp3",
+                index = 1,
+                startOffsetSec = 1200.0,
+                durationSec = 900.5,
+                contentUrl = "https://gramofonche.chitanka.info/prikazki/foo/b.mp3",
+                mimeType = "audio/mpeg",
+            ),
+        )
+        val stream = ChitankaCatalog.buildAudiobookStream(tracks)
+        assertEquals(2100.5, stream.totalDurationSec, 1e-9)
+        assertEquals(tracks.map { it.contentUrl }, stream.trackUrls)
+        assertTrue(stream.chapters.isEmpty())
     }
 
     @Test

--- a/core/data/src/main/kotlin/com/riffle/core/data/LocalStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LocalStoreImpl.kt
@@ -56,10 +56,20 @@ class LocalStoreImpl(
         dir.listFiles()
             ?.filter { it.isDirectory }
             ?.flatMap { serverDir ->
-                serverDir.listFiles()
-                    ?.filter { it.name.endsWith(extension) }
-                    ?.map { StoredItemRef(sourceId = serverDir.name, itemId = it.name.removeSuffix(extension)) }
-                    ?: emptyList()
+                // Chitanka item ids contain '/' (e.g. "book/12018-…"), which puts saved files inside
+                // nested subdirectories of serverDir. Walk the whole tree so those items list, then
+                // rebuild the item id from the relative path.
+                val prefix = serverDir.absolutePath + File.separator
+                serverDir.walkTopDown()
+                    .filter { it.isFile && it.name.endsWith(extension) }
+                    .map { file ->
+                        val relative = file.absolutePath.removePrefix(prefix)
+                        StoredItemRef(
+                            sourceId = serverDir.name,
+                            itemId = relative.removeSuffix(extension),
+                        )
+                    }
+                    .toList()
             }
             ?: emptyList()
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/LocalStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LocalStoreImpl.kt
@@ -26,6 +26,10 @@ class LocalStoreImpl(
             val serverDir = dir.resolve(sourceId).also { it.mkdirs() }
             val dest = serverDir.resolve("$itemId$extension")
             val tmp = serverDir.resolve("$itemId$extension.tmp")
+            // Item ids may contain '/' (e.g. Chitanka's "book/12018-…", "prikazki/…"), which lands
+            // dest/tmp inside a nested subdirectory of serverDir. Create it before opening the stream,
+            // otherwise the tmp write fails ENOENT ("No such file or directory").
+            tmp.parentFile?.mkdirs()
             try {
                 tmp.outputStream().use { out -> stream.copyTo(out) }
                 tmp.renameTo(dest)

--- a/core/data/src/test/kotlin/com/riffle/core/data/LocalStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LocalStoreTest.kt
@@ -99,4 +99,17 @@ class LocalStoreTest {
     fun `listItems returns empty list when store is empty`() {
         assertTrue(store.listItems().isEmpty())
     }
+
+    @Test
+    fun `save creates nested parent directories for slash-bearing item ids`() = runTest {
+        // Regression: Chitanka item ids are "book/12018-…", "prikazki/…", etc. The write path
+        // used to only mkdirs the serverDir, so the tmp file inside the nested "book/" folder
+        // failed ENOENT and the reader surfaced "Network error: … open failed: ENOENT".
+        val bytes = "epub-content".toByteArray()
+        val file = store.save("source-1", "book/12018-kniga", bytes.inputStream())
+        assertTrue(file.exists())
+        val result = store.get("source-1", "book/12018-kniga")
+        assertNotNull(result)
+        assertArrayEquals(bytes, result!!.readBytes())
+    }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/LocalStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LocalStoreTest.kt
@@ -101,6 +101,18 @@ class LocalStoreTest {
     }
 
     @Test
+    fun `listItems descends into nested directories to surface slash-bearing item ids`() = runTest {
+        // Companion to the nested-save fix: without a recursive walk, cached Chitanka items are
+        // silently invisible to the Downloads/Cache screens (DownloadsRepositoryImpl.getCachedItems
+        // flat-maps listItems) even though they exist on disk.
+        store.save("source-1", "book/12018-kniga", "a".toByteArray().inputStream())
+        store.save("source-1", "flat-item", "b".toByteArray().inputStream())
+        val refs = store.listItems()
+        assertTrue(refs.contains(StoredItemRef("source-1", "book/12018-kniga")))
+        assertTrue(refs.contains(StoredItemRef("source-1", "flat-item")))
+    }
+
+    @Test
     fun `save creates nested parent directories for slash-bearing item ids`() = runTest {
         // Regression: Chitanka item ids are "book/12018-…", "prikazki/…", etc. The write path
         // used to only mkdirs the serverDir, so the tmp file inside the nested "book/" folder


### PR DESCRIPTION
## Summary

Two fixes for opening Chitanka items:

- **Audiobook total time stuck at 0.** `ChitankaCatalog.openAudiobook` hardcoded `totalDurationSec = 0.0`. Since Gramofonche exposes no per-track duration, `getTracks` estimates per-track from HEAD `Content-Length`; the total should be their sum. Extracted `Companion.buildAudiobookStream(tracks)` so the assembly is a pure, unit-testable function.
- **Opening a Chitanka book failed with `open failed: ENOENT`.** Chitanka item ids are shaped like `book/12018-…`, `prikazki/…`, `text/…` — paths with real slashes. `LocalStoreImpl.save()` only `mkdirs`'d the serverDir, so the tmp write inside the nested subdirectory failed. `listItems()` had the same shape mismatch: it enumerated the top-level `book` folder as a candidate and rejected it for lacking `.epub`, so cached Chitanka items were silently invisible to Downloads/Cache screens. Both fixed — `save()` creates the nested parent, `listItems()` walks the tree.

Each fix has a regression test that flips red on revert.

## Test plan

- [x] `:core:catalog-chitanka:test` green — new test `buildAudiobookStream totalDurationSec sums per-track durations` asserts sum, not 0.
- [x] `:core:data:testDebugUnitTest` green — new tests `save creates nested parent directories for slash-bearing item ids` and `listItems descends into nested directories to surface slash-bearing item ids`.
- [ ] Manually verified: opening a Chitanka book no longer surfaces the ENOENT toast; audiobook total time reads correctly (per user report — playback works).