### PR TITLE
feat(settings): reorder libraries for any source, not just Audiobookshelf

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Riffle lets you browse your library, read EPUB, PDF, and CBZ files, listen to au
 - **Local files** — import EPUB, PDF, and CBZ files from device storage and read them alongside your server libraries, with the same reader, highlights, and progress tracking
 
 ### Library
-- Multi-source support with per-library visibility controls
+- Multi-source support with per-library visibility and ordering controls
 - Browse by Home, To Read, Series, Collections, and All Books
 - Cover grid with book details
 - Read/unread and "To Read" toggles

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ChitankaSourceRowTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ChitankaSourceRowTest.kt
@@ -27,7 +27,14 @@ class ChitankaSourceRowTest {
     fun endToStartSwipe_invokesOnRemove() {
         var removed = false
         composeTestRule.setContent {
-            ChitankaSourceRow(onRemove = { removed = true })
+            ChitankaSourceRow(
+                libraryItems = emptyList(),
+                isExpanded = false,
+                onToggleExpanded = {},
+                onSetLibraryVisible = { _, _ -> },
+                onReorderLibraries = {},
+                onRemove = { removed = true },
+            )
         }
 
         composeTestRule.onNodeWithTag("ChitankaSourceRow").performTouchInput { swipeLeft() }
@@ -39,7 +46,14 @@ class ChitankaSourceRowTest {
     @Test
     fun row_hasNoTrailingRemoveButton() {
         composeTestRule.setContent {
-            ChitankaSourceRow(onRemove = {})
+            ChitankaSourceRow(
+                libraryItems = emptyList(),
+                isExpanded = false,
+                onToggleExpanded = {},
+                onSetLibraryVisible = { _, _ -> },
+                onReorderLibraries = {},
+                onRemove = {},
+            )
         }
 
         composeTestRule.onNodeWithText("Remove").assertDoesNotExist()

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ServerSettingsExpansionTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ServerSettingsExpansionTest.kt
@@ -52,7 +52,6 @@ class ServerSettingsExpansionTest {
             )
         }
 
-        composeTestRule.onNodeWithText("Enabled libraries").assertIsDisplayed()
         composeTestRule.onNodeWithText("Fiction").assertIsDisplayed()
         composeTestRule.onNodeWithText("Non-fiction").assertIsDisplayed()
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/ReorderableLibraryList.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/ReorderableLibraryList.kt
@@ -73,7 +73,7 @@ internal fun ReorderableLibraryList(
 }
 
 /** The list's library ids with positions [i] and [j] swapped — the new full order to persist. */
-private fun List<LibraryUiItem>.idsWithSwap(i: Int, j: Int): List<String> {
+internal fun List<LibraryUiItem>.idsWithSwap(i: Int, j: Int): List<String> {
     val ids = map { it.library.id }.toMutableList()
     val tmp = ids[i]
     ids[i] = ids[j]

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -817,24 +817,27 @@ private fun ServerRow(
     onReorderLibraries: (orderedLibraryIds: List<String>) -> Unit,
     onOpenReadaloudMatches: () -> Unit,
 ) {
-    SwipeToDeleteRow(onDelete = onRemove) {
-        Column {
-            val username = server.username.takeIf { it.isNotEmpty() }
-            val subtitle = buildString {
-                if (username != null) {
-                    append(username)
-                    append(" · ")
-                }
-                append(server.url.value)
-                if (serverVersion != null) {
-                    append(" · v")
-                    append(serverVersion)
-                }
+    Column {
+        val username = server.username.takeIf { it.isNotEmpty() }
+        val subtitle = buildString {
+            if (username != null) {
+                append(username)
+                append(" · ")
             }
-            val chevronRotation by animateFloatAsState(
-                targetValue = if (isExpanded) 90f else 0f,
-                label = "chevron",
-            )
+            append(server.url.value)
+            if (serverVersion != null) {
+                append(" · v")
+                append(serverVersion)
+            }
+        }
+        val chevronRotation by animateFloatAsState(
+            targetValue = if (isExpanded) 90f else 0f,
+            label = "chevron",
+        )
+        // Swipe-to-delete wraps ONLY the compact header — a swipe inside the tall expanded
+        // content (which holds interactive switches and chevron buttons) would otherwise partly
+        // reveal the delete background as a stray trash-icon peek.
+        SwipeToDeleteRow(onDelete = onRemove) {
             ListItem(
                 modifier = Modifier.clickable { onToggleExpanded() },
                 leadingContent = {
@@ -850,16 +853,16 @@ private fun ServerRow(
                     { Text("Active", style = MaterialTheme.typography.labelSmall) }
                 } else null,
             )
-            AnimatedVisibility(visible = isExpanded) {
-                ServerSettingsExpansion(
-                    server = server,
-                    libraryItems = libraryItems,
-                    summary = summary,
-                    onSetLibraryVisible = onSetLibraryVisible,
-                    onReorderLibraries = onReorderLibraries,
-                    onOpenReadaloudMatches = onOpenReadaloudMatches,
-                )
-            }
+        }
+        AnimatedVisibility(visible = isExpanded) {
+            ServerSettingsExpansion(
+                server = server,
+                libraryItems = libraryItems,
+                summary = summary,
+                onSetLibraryVisible = onSetLibraryVisible,
+                onReorderLibraries = onReorderLibraries,
+                onOpenReadaloudMatches = onOpenReadaloudMatches,
+            )
         }
     }
 }
@@ -878,14 +881,9 @@ internal fun ServerSettingsExpansion(
     onOpenReadaloudMatches: () -> Unit,
 ) {
     val transparentColors = ListItemDefaults.colors(containerColor = Color.Transparent)
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)),
-    ) {
+    Column(modifier = Modifier.fillMaxWidth()) {
         when (server.serverType) {
             ServerType.AUDIOBOOKSHELF -> {
-                ExpansionHeader("Enabled libraries")
                 if (libraryItems.isEmpty()) {
                     ExpansionNote("No libraries found.")
                 } else {
@@ -1076,8 +1074,9 @@ private fun LocalFilesSourceRow(
         label = "chevron",
     )
 
-    SwipeToDeleteRow(onDelete = onRemoveSource) {
-      Column {
+    Column {
+      // Swipe wraps only the collapsed header; see [ServerRow] for the reasoning.
+      SwipeToDeleteRow(onDelete = onRemoveSource) {
         ListItem(
             modifier = Modifier
                 .clickable { onToggleExpanded() }
@@ -1108,7 +1107,8 @@ private fun LocalFilesSourceRow(
                 }
             } else null,
         )
-        androidx.compose.animation.AnimatedVisibility(visible = isExpanded) {
+      }
+      androidx.compose.animation.AnimatedVisibility(visible = isExpanded) {
             Column {
                 ListItem(
                     modifier = Modifier
@@ -1225,7 +1225,6 @@ private fun LocalFilesSourceRow(
                 }
             }
         }
-      }
     }
 
     pendingFolderRemoval?.let { folder ->
@@ -1287,8 +1286,9 @@ internal fun ChitankaSourceRow(
         targetValue = if (isExpanded) 90f else 0f,
         label = "chevron",
     )
-    SwipeToDeleteRow(onDelete = onRemove) {
-      Column {
+    Column {
+      // Swipe wraps only the collapsed header; see [ServerRow] for the reasoning.
+      SwipeToDeleteRow(onDelete = onRemove) {
         ListItem(
             modifier = Modifier
                 .clickable { onToggleExpanded() }
@@ -1303,16 +1303,15 @@ internal fun ChitankaSourceRow(
             headlineContent = { Text("Chitanka") },
             supportingContent = { Text("chitanka.info · gramofonche.chitanka.info") },
         )
-        androidx.compose.animation.AnimatedVisibility(visible = isExpanded) {
-            if (libraryItems.isNotEmpty()) {
-                ExpansionHeader("Enabled libraries")
-                ReorderableLibraryList(
-                    items = libraryItems,
-                    onSetLibraryVisible = onSetLibraryVisible,
-                    onReorder = onReorderLibraries,
-                )
-            }
-        }
+      }
+      androidx.compose.animation.AnimatedVisibility(visible = isExpanded) {
+          if (libraryItems.isNotEmpty()) {
+              ReorderableLibraryList(
+                  items = libraryItems,
+                  onSetLibraryVisible = onSetLibraryVisible,
+                  onReorder = onReorderLibraries,
+              )
+          }
       }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -114,7 +114,7 @@ fun SettingsScreen(
     val localFilesFolderHealth by viewModel.localFilesFolderHealth.collectAsState()
     val chitankaSource by viewModel.chitankaSource.collectAsState()
     val serverVersions by viewModel.serverVersions.collectAsState()
-    val libraryItemsByServer by viewModel.libraryUiItemsByServer.collectAsState()
+    val libraryItemsBySource by viewModel.libraryUiItemsBySource.collectAsState()
     val readaloudSummaries by viewModel.readaloudSummaries.collectAsState()
     val appUpdateState by viewModel.appUpdateState.collectAsState()
     val readaloudPreferences by viewModel.readaloudPreferences.collectAsState()
@@ -194,7 +194,7 @@ fun SettingsScreen(
                         },
                         onRemove = { viewModel.removeServer(server.id) },
                         serverVersion = serverVersions[server.id],
-                        libraryItems = libraryItemsByServer[server.id].orEmpty(),
+                        libraryItems = libraryItemsBySource[server.id].orEmpty(),
                         summary = readaloudSummaries[server.id],
                         onSetLibraryVisible = { libraryId, visible ->
                             viewModel.setLibraryVisible(server.id, libraryId, visible)
@@ -210,6 +210,7 @@ fun SettingsScreen(
                         source = lfs,
                         folders = localFilesFolders,
                         folderHealth = localFilesFolderHealth,
+                        libraryItems = libraryItemsBySource[lfs.id].orEmpty(),
                         isExpanded = expandedServers[lfs.id] == true,
                         onToggleExpanded = {
                             expandedServers[lfs.id] = expandedServers[lfs.id] != true
@@ -217,10 +218,27 @@ fun SettingsScreen(
                         onAddFolder = onNavigateToAddLocalFolder,
                         onRemoveFolder = { treeUri -> viewModel.removeLocalFolder(treeUri) },
                         onRemoveSource = { viewModel.removeLocalFilesSource() },
+                        onSetLibraryVisible = { libraryId, visible ->
+                            viewModel.setLibraryVisible(lfs.id, libraryId, visible)
+                        },
+                        onReorderLibraries = { orderedIds ->
+                            viewModel.setLibraryOrder(lfs.id, orderedIds)
+                        },
                     )
                 }
-                chitankaSource?.let { _ ->
+                chitankaSource?.let { source ->
                     ChitankaSourceRow(
+                        libraryItems = libraryItemsBySource[source.id].orEmpty(),
+                        isExpanded = expandedServers[source.id] == true,
+                        onToggleExpanded = {
+                            expandedServers[source.id] = expandedServers[source.id] != true
+                        },
+                        onSetLibraryVisible = { libraryId, visible ->
+                            viewModel.setLibraryVisible(source.id, libraryId, visible)
+                        },
+                        onReorderLibraries = { orderedIds ->
+                            viewModel.setLibraryOrder(source.id, orderedIds)
+                        },
                         onRemove = { viewModel.removeChitankaSource() },
                     )
                 }
@@ -1038,11 +1056,14 @@ private fun LocalFilesSourceRow(
     source: com.riffle.core.domain.Source,
     folders: List<com.riffle.core.database.LocalFilesFolderEntity>,
     folderHealth: Map<String, Boolean>,
+    libraryItems: List<LibraryUiItem>,
     isExpanded: Boolean,
     onToggleExpanded: () -> Unit,
     onAddFolder: () -> Unit,
     onRemoveFolder: (String) -> Unit,
     onRemoveSource: () -> Unit,
+    onSetLibraryVisible: (libraryId: String, visible: Boolean) -> Unit,
+    onReorderLibraries: (orderedLibraryIds: List<String>) -> Unit,
 ) {
     var pendingFolderRemoval by remember { mutableStateOf<com.riffle.core.database.LocalFilesFolderEntity?>(null) }
     var pendingSourceRemoval by remember { mutableStateOf(false) }
@@ -1139,6 +1160,14 @@ private fun LocalFilesSourceRow(
                         )
                     }
                 }
+                if (libraryItems.isNotEmpty()) {
+                    ExpansionHeader("Enabled libraries")
+                    ReorderableLibraryList(
+                        items = libraryItems,
+                        onSetLibraryVisible = onSetLibraryVisible,
+                        onReorder = onReorderLibraries,
+                    )
+                }
                 TextButton(
                     onClick = { pendingSourceRemoval = true },
                     modifier = Modifier
@@ -1193,19 +1222,50 @@ private fun LocalFilesSourceRow(
 }
 
 /**
- * Minimal sources-list row for the singleton Chitanka Source. No sub-UI (unlike
- * [LocalFilesSourceRow] which manages folders) — Chitanka is zero-config; removal is
- * via the shared end-to-start swipe gesture, matching every other configured-source row.
+ * Sources-list row for the singleton Chitanka Source. Chitanka is zero-config; the expanded body
+ * exposes the per-library visibility+order editor (Chitanka installs Books and Gramofonche
+ * libraries). Removal is via the shared end-to-start swipe gesture, matching every other
+ * configured-source row.
  */
 @Composable
 internal fun ChitankaSourceRow(
+    libraryItems: List<LibraryUiItem>,
+    isExpanded: Boolean,
+    onToggleExpanded: () -> Unit,
+    onSetLibraryVisible: (libraryId: String, visible: Boolean) -> Unit,
+    onReorderLibraries: (orderedLibraryIds: List<String>) -> Unit,
     onRemove: () -> Unit,
 ) {
+    val chevronRotation by androidx.compose.animation.core.animateFloatAsState(
+        targetValue = if (isExpanded) 90f else 0f,
+        label = "chevron",
+    )
     SwipeToDeleteRow(onDelete = onRemove) {
+      Column {
         ListItem(
-            modifier = Modifier.testTag("ChitankaSourceRow"),
+            modifier = Modifier
+                .clickable { onToggleExpanded() }
+                .testTag("ChitankaSourceRow"),
+            leadingContent = {
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = if (isExpanded) "Collapse" else "Expand",
+                    modifier = Modifier.rotate(chevronRotation),
+                )
+            },
             headlineContent = { Text("Chitanka") },
             supportingContent = { Text("chitanka.info · gramofonche.chitanka.info") },
         )
+        androidx.compose.animation.AnimatedVisibility(visible = isExpanded) {
+            if (libraryItems.isNotEmpty()) {
+                ExpansionHeader("Enabled libraries")
+                ReorderableLibraryList(
+                    items = libraryItems,
+                    onSetLibraryVisible = onSetLibraryVisible,
+                    onReorder = onReorderLibraries,
+                )
+            }
+        }
+      }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -33,6 +33,8 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Warning
@@ -52,6 +54,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -1130,7 +1133,24 @@ private fun LocalFilesSourceRow(
                         },
                     )
                 } else {
-                    folders.forEach { folder ->
+                    // Folders and libraries are 1:1 for Local Files. Drive iteration by the
+                    // libraryItems list (already ordered per the user's saved reorder), then look
+                    // up each folder by libraryId. Any folder without a matching library still
+                    // renders — falls back to its natural position at the end.
+                    val foldersByLibraryId = folders.associateBy { it.libraryId }
+                    val orderedFolders = buildList {
+                        val consumed = mutableSetOf<String>()
+                        libraryItems.forEach { item ->
+                            foldersByLibraryId[item.library.id]?.let { folder ->
+                                add(folder to item)
+                                consumed += folder.treeUri
+                            }
+                        }
+                        folders.forEach { folder ->
+                            if (folder.treeUri !in consumed) add(folder to null)
+                        }
+                    }
+                    orderedFolders.forEachIndexed { index, (folder, item) ->
                         val isHealthy = folderHealth[folder.treeUri] != false
                         ListItem(
                             modifier = Modifier.testTag("LocalFilesFolder.${folder.treeUri}"),
@@ -1153,20 +1173,47 @@ private fun LocalFilesSourceRow(
                                 )
                             },
                             trailingContent = {
-                                IconButton(onClick = { pendingFolderRemoval = folder }) {
-                                    Icon(Icons.Default.Delete, contentDescription = "Remove folder")
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    if (item != null && libraryItems.size > 1) {
+                                        IconButton(
+                                            onClick = {
+                                                onReorderLibraries(libraryItems.idsWithSwap(index, index - 1))
+                                            },
+                                            enabled = index > 0,
+                                        ) {
+                                            Icon(
+                                                Icons.Filled.KeyboardArrowUp,
+                                                contentDescription = "Move ${folder.displayName} up",
+                                            )
+                                        }
+                                        IconButton(
+                                            onClick = {
+                                                onReorderLibraries(libraryItems.idsWithSwap(index, index + 1))
+                                            },
+                                            enabled = index < libraryItems.lastIndex,
+                                        ) {
+                                            Icon(
+                                                Icons.Filled.KeyboardArrowDown,
+                                                contentDescription = "Move ${folder.displayName} down",
+                                            )
+                                        }
+                                    }
+                                    if (item != null) {
+                                        Switch(
+                                            checked = item.isVisible,
+                                            onCheckedChange = { visible ->
+                                                onSetLibraryVisible(item.library.id, visible)
+                                            },
+                                            enabled = item.switchEnabled,
+                                        )
+                                    }
+                                    IconButton(onClick = { pendingFolderRemoval = folder }) {
+                                        Icon(Icons.Default.Delete, contentDescription = "Remove folder")
+                                    }
                                 }
                             },
                         )
                     }
-                }
-                if (libraryItems.isNotEmpty()) {
-                    ExpansionHeader("Enabled libraries")
-                    ReorderableLibraryList(
-                        items = libraryItems,
-                        onSetLibraryVisible = onSetLibraryVisible,
-                        onReorder = onReorderLibraries,
-                    )
                 }
                 TextButton(
                     onClick = { pendingSourceRemoval = true },

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -1138,19 +1138,22 @@ private fun LocalFilesSourceRow(
                     // up each folder by libraryId. Any folder without a matching library still
                     // renders — falls back to its natural position at the end.
                     val foldersByLibraryId = folders.associateBy { it.libraryId }
-                    val orderedFolders = buildList {
+                    // Each row carries the index of its item within [libraryItems] so the reorder
+                    // swap lands on the right pair even when a library has no matching folder yet
+                    // (or vice versa) during the brief window between DAO flow emissions.
+                    val orderedFolders = buildList<Triple<com.riffle.core.database.LocalFilesFolderEntity, LibraryUiItem?, Int>> {
                         val consumed = mutableSetOf<String>()
-                        libraryItems.forEach { item ->
+                        libraryItems.forEachIndexed { libraryIndex, item ->
                             foldersByLibraryId[item.library.id]?.let { folder ->
-                                add(folder to item)
+                                add(Triple(folder, item, libraryIndex))
                                 consumed += folder.treeUri
                             }
                         }
                         folders.forEach { folder ->
-                            if (folder.treeUri !in consumed) add(folder to null)
+                            if (folder.treeUri !in consumed) add(Triple(folder, null, -1))
                         }
                     }
-                    orderedFolders.forEachIndexed { index, (folder, item) ->
+                    orderedFolders.forEach { (folder, item, libraryIndex) ->
                         val isHealthy = folderHealth[folder.treeUri] != false
                         ListItem(
                             modifier = Modifier.testTag("LocalFilesFolder.${folder.treeUri}"),
@@ -1177,9 +1180,9 @@ private fun LocalFilesSourceRow(
                                     if (item != null && libraryItems.size > 1) {
                                         IconButton(
                                             onClick = {
-                                                onReorderLibraries(libraryItems.idsWithSwap(index, index - 1))
+                                                onReorderLibraries(libraryItems.idsWithSwap(libraryIndex, libraryIndex - 1))
                                             },
-                                            enabled = index > 0,
+                                            enabled = libraryIndex > 0,
                                         ) {
                                             Icon(
                                                 Icons.Filled.KeyboardArrowUp,
@@ -1188,9 +1191,9 @@ private fun LocalFilesSourceRow(
                                         }
                                         IconButton(
                                             onClick = {
-                                                onReorderLibraries(libraryItems.idsWithSwap(index, index + 1))
+                                                onReorderLibraries(libraryItems.idsWithSwap(libraryIndex, libraryIndex + 1))
                                             },
-                                            enabled = index < libraryItems.lastIndex,
+                                            enabled = libraryIndex < libraryItems.lastIndex,
                                         ) {
                                             Icon(
                                                 Icons.Filled.KeyboardArrowDown,

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -335,23 +335,19 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-    private val absServers: StateFlow<List<Source>> = servers
-        // Match by (type, serverType) rather than serverType alone: LocalFiles rows persist
-        // `serverType = AUDIOBOOKSHELF` as a placeholder (see [LocalFilesSourceInstaller]) and
-        // would otherwise leak into every ABS-only downstream (library refresh, cover tokens).
-        .map { list ->
-            list.filter {
-                it.type == com.riffle.core.domain.SourceType.ABS &&
-                    it.serverType == ServerType.AUDIOBOOKSHELF
-            }
-        }
+    // Every browsable source contributes to the per-source library editor. Storyteller stays
+    // excluded (Settings-only, never browsable per ADR 0026) — its expansion shows a
+    // readaloud-matches summary instead of a library list.
+    private val browsableSources: StateFlow<List<Source>> = servers
+        .map { list -> list.filter { it.serverType != ServerType.STORYTELLER_SERVICE } }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     /**
-     * Library visibility items for each Audiobookshelf server, keyed by server id. Libraries are
-     * read from the local DB per server, so a server need not be active to manage its libraries.
+     * Library visibility+order items keyed by source id, for every browsable source (ABS, Local
+     * Files, Chitanka, …). Libraries are read from the local DB per source, so a source need not
+     * be active to manage its libraries.
      */
-    val libraryUiItemsByServer: StateFlow<Map<String, List<LibraryUiItem>>> = absServers
+    val libraryUiItemsBySource: StateFlow<Map<String, List<LibraryUiItem>>> = browsableSources
         .flatMapLatest { list ->
             if (list.isEmpty()) {
                 MutableStateFlow(emptyMap<String, List<LibraryUiItem>>())

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -119,12 +119,14 @@ class SettingsViewModelTest {
         id: String,
         active: Boolean = false,
         serverType: ServerType = ServerType.AUDIOBOOKSHELF,
+        type: com.riffle.core.domain.SourceType = com.riffle.core.domain.SourceType.ABS,
     ) = Source(
         id = id,
         url = SourceUrl.parse("https://$id.example.com")!!,
         isActive = active,
         insecureConnectionAllowed = false,
         username = "",
+        type = type,
         serverType = serverType,
     )
 
@@ -436,7 +438,7 @@ class SettingsViewModelTest {
         serversFlow.value = listOf(server("srv-1", active = true))
         librariesFlow.value = listOf(library("lib-1"), library("lib-2"))
         val vm = makeViewModel()
-        backgroundScope.launch { vm.libraryUiItemsByServer.collect {} }
+        backgroundScope.launch { vm.libraryUiItemsBySource.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
 
         vm.setLibraryVisible(sourceId = "srv-1", libraryId = "lib-1", visible = false)
@@ -452,7 +454,7 @@ class SettingsViewModelTest {
         librariesFlow.value = listOf(library("lib-1"), library("lib-2"))
         hiddenFlow.value = mapOf("srv-1" to setOf("lib-1"))
         val vm = makeViewModel()
-        backgroundScope.launch { vm.libraryUiItemsByServer.collect {} }
+        backgroundScope.launch { vm.libraryUiItemsBySource.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
 
         vm.setLibraryVisible(sourceId = "srv-1", libraryId = "lib-1", visible = true)
@@ -472,17 +474,17 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `libraryUiItemsByServer reflects the saved custom order`() = runTest {
+    fun `libraryUiItemsBySource reflects the saved custom order`() = runTest {
         serversFlow.value = listOf(server("srv-1", active = true))
         librariesFlow.value = listOf(library("lib-1"), library("lib-2"), library("lib-3"))
         orderFlow.value = mapOf("srv-1" to listOf("lib-2", "lib-3", "lib-1"))
         val vm = makeViewModel()
-        backgroundScope.launch { vm.libraryUiItemsByServer.collect {} }
+        backgroundScope.launch { vm.libraryUiItemsBySource.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(
             listOf("lib-2", "lib-3", "lib-1"),
-            vm.libraryUiItemsByServer.value["srv-1"].orEmpty().map { it.library.id },
+            vm.libraryUiItemsBySource.value["srv-1"].orEmpty().map { it.library.id },
         )
     }
 
@@ -492,10 +494,10 @@ class SettingsViewModelTest {
         librariesFlow.value = listOf(library("lib-1"), library("lib-2"))
         hiddenFlow.value = mapOf("srv-1" to setOf("lib-2"))  // only lib-1 is visible
         val vm = makeViewModel()
-        backgroundScope.launch { vm.libraryUiItemsByServer.collect {} }
+        backgroundScope.launch { vm.libraryUiItemsBySource.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
 
-        val items = vm.libraryUiItemsByServer.value["srv-1"].orEmpty()
+        val items = vm.libraryUiItemsBySource.value["srv-1"].orEmpty()
         val lib1Item = items.first { it.library.id == "lib-1" }
         val lib2Item = items.first { it.library.id == "lib-2" }
         assertFalse("lib-1 is the sole visible library, its switch must be disabled", lib1Item.switchEnabled)
@@ -508,26 +510,86 @@ class SettingsViewModelTest {
         librariesFlow.value = listOf(library("lib-1"), library("lib-2"))
         // nothing hidden — both visible
         val vm = makeViewModel()
-        backgroundScope.launch { vm.libraryUiItemsByServer.collect {} }
+        backgroundScope.launch { vm.libraryUiItemsBySource.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
 
-        val items = vm.libraryUiItemsByServer.value["srv-1"].orEmpty()
+        val items = vm.libraryUiItemsBySource.value["srv-1"].orEmpty()
         assertTrue(items.all { it.switchEnabled })
     }
 
     @Test
-    fun `libraryUiItemsByServer exposes libraries for a non-active ABS server`() = runTest {
+    fun `libraryUiItemsBySource populated for a Local Files source`() = runTest {
+        serversFlow.value = listOf(
+            server("lf-1", type = com.riffle.core.domain.SourceType.LOCAL_FILES),
+        )
+        librariesFlow.value = listOf(library("folder-a"), library("folder-b"))
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.libraryUiItemsBySource.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val items = vm.libraryUiItemsBySource.value["lf-1"].orEmpty()
+        assertEquals(listOf("folder-a", "folder-b"), items.map { it.library.id })
+    }
+
+    @Test
+    fun `libraryUiItemsBySource populated for a Chitanka source`() = runTest {
+        serversFlow.value = listOf(
+            server("ch-1", type = com.riffle.core.domain.SourceType.CHITANKA),
+        )
+        librariesFlow.value = listOf(library("books"), library("gramofonche"))
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.libraryUiItemsBySource.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val items = vm.libraryUiItemsBySource.value["ch-1"].orEmpty()
+        assertEquals(listOf("books", "gramofonche"), items.map { it.library.id })
+    }
+
+    @Test
+    fun `libraryUiItemsBySource applies saved order for a Local Files source`() = runTest {
+        serversFlow.value = listOf(
+            server("lf-1", type = com.riffle.core.domain.SourceType.LOCAL_FILES),
+        )
+        librariesFlow.value = listOf(library("a"), library("b"), library("c"))
+        orderFlow.value = mapOf("lf-1" to listOf("c", "a", "b"))
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.libraryUiItemsBySource.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            listOf("c", "a", "b"),
+            vm.libraryUiItemsBySource.value["lf-1"].orEmpty().map { it.library.id },
+        )
+    }
+
+    @Test
+    fun `libraryUiItemsBySource omits Storyteller services`() = runTest {
+        serversFlow.value = listOf(
+            server("st-1", serverType = ServerType.STORYTELLER_SERVICE),
+        )
+        librariesFlow.value = listOf(library("lib-1"))
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.libraryUiItemsBySource.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Storyteller is Settings-only (ADR 0026) and never appears in the drawer, so we don't
+        // surface its libraries in the reorder/visibility editor either.
+        assertNull(vm.libraryUiItemsBySource.value["st-1"])
+    }
+
+    @Test
+    fun `libraryUiItemsBySource exposes libraries for a non-active ABS server`() = runTest {
         serversFlow.value = listOf(
             server("srv-active", active = true),
             server("srv-other", active = false),
         )
         librariesFlow.value = listOf(library("lib-1"), library("lib-2"))
         val vm = makeViewModel()
-        backgroundScope.launch { vm.libraryUiItemsByServer.collect {} }
+        backgroundScope.launch { vm.libraryUiItemsBySource.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
 
         // The non-active server still has manageable library items — no activation required.
-        val items = vm.libraryUiItemsByServer.value["srv-other"].orEmpty()
+        val items = vm.libraryUiItemsBySource.value["srv-other"].orEmpty()
         assertEquals(2, items.size)
     }
 

--- a/docs/superpowers/specs/2026-07-11-library-reorder-any-source-design.md
+++ b/docs/superpowers/specs/2026-07-11-library-reorder-any-source-design.md
@@ -1,0 +1,119 @@
+# Library reorder for any source — design
+
+## Problem
+
+PR #170 shipped drawer-library reordering for Audiobookshelf servers only. The user
+wants the same up/down controls for every browsable source (Local Files, Chitanka —
+and any future source type), so that the ordering of whatever appears in the left
+drawer under a given source is under the user's control regardless of source type.
+
+## Current state (why the fix is small)
+
+The domain and data layers are already source-agnostic:
+
+- `LibraryOrderPreferencesStore` (core/domain) is keyed by `sourceId: String`.
+- `NavigationDrawerViewModel.visibleLibraries` combines `libraryObserver.observeLibraries()`
+  with `orderStore.libraryOrder(activeSourceId)` and calls `orderLibraries(...)` — the
+  same code path for every source.
+- Local Files creates a per-folder `LibraryEntity` row (see
+  `LocalFilesSourceInstaller`), so its folders already surface as `Library` entries in
+  the drawer.
+- Chitanka installs its own `LibraryEntity` rows via
+  `ChitankaLibraryItemUpserter`.
+
+The gap is entirely in Settings:
+
+- `SettingsViewModel.absServers` filters to `SourceType.ABS` before deriving
+  `libraryUiItemsByServer`, so non-ABS sources have no ui-items map entry.
+- `SettingsScreen` only renders the "Libraries" subsection (with the reorder
+  chevrons) inside `ServerRow`, which is only used for ABS sources.
+
+## Design
+
+### `SettingsViewModel` (core/data unchanged)
+
+- Rename `absServers` → `browsableSources`. Keep the `STORYTELLER_SERVICE`
+  exclusion (Storyteller is Settings-only, never browsable per ADR 0026). Drop the
+  `SourceType.ABS` filter so Local Files and Chitanka sources flow through.
+- Rename `libraryUiItemsByServer` → `libraryUiItemsBySource`. Same
+  `Map<String, List<LibraryUiItem>>` shape; now populated for every browsable
+  source.
+- `setLibraryVisible(sourceId, ...)` and `setLibraryOrder(sourceId, ...)` are
+  already source-agnostic — no signature change.
+
+### `SettingsScreen` UI
+
+- Extract the per-library editor (visibility switch + up/down chevrons) currently
+  inline in `ServerRow` into a reusable `@Composable LibrariesEditor(
+  libraryItems: List<LibraryUiItem>, onSetVisible: (libraryId, Boolean) -> Unit,
+  onReorder: (orderedIds: List<String>) -> Unit)`.
+- `ServerRow`: unchanged externally; internally calls `LibrariesEditor`.
+- `LocalFilesSourceRow`: accept `libraryItems: List<LibraryUiItem>`. Render
+  `LibrariesEditor` inside the expanded content as a sibling to the existing
+  Folders subsection. The Folders subsection stays as-is (add/remove/health is a
+  distinct concern from display order).
+- `ChitankaSourceRow`: accept `libraryItems`. Render `LibrariesEditor` if
+  non-empty; otherwise no-op (Chitanka may install zero or one library).
+- Drop the `SourceType.ABS` gate around `servers.filter { ... }` only insofar as
+  the `libraryUiItemsBySource[sourceId]` map lookup is now valid for every
+  source. The ABS-specific `ServerRow` still gates on `SourceType.ABS` because
+  it renders ABS-only surfaces (server version banner, readaloud summary).
+
+### Storage / migration
+
+None. `LibraryOrderPreferencesStore` already keys by `sourceId` and stores order
+in an existing DataStore. Local Files and Chitanka sources have their own
+`sourceId`s; the preferences file will grow new entries as users reorder.
+
+## Trade-off note (Q1)
+
+For Local Files, folders and libraries are 1:1. The design keeps two subsections
+inside the expanded row: **Folders** (add/remove/health) and **Libraries**
+(visibility + order). Same names may appear twice. We accept this because:
+
+- Folder-level operations (path selection, missing-folder health) are logically
+  distinct from library display preferences.
+- Merging them would require threading library ids into `LocalFilesFolderRow`
+  and duplicating the reorder/visibility semantics inside a folder-scoped
+  widget.
+- Parity across source types is the goal for this change; visual refinement of
+  the Local Files row can happen separately.
+
+## Testing
+
+All tests are JVM-level (no Readium/WebView involvement).
+
+### `SettingsViewModelTest`
+
+- **Local Files reorder plumbing** — with a `SourceType.LOCAL_FILES` source and
+  three `LibraryEntity` rows, assert `libraryUiItemsBySource[sourceId]` exposes
+  three `LibraryUiItem`s in insertion order.
+- **Local Files order persists** — call `viewModel.setLibraryOrder(sourceId,
+  [c, a, b])` and assert the fake `LibraryOrderPreferencesStore` records that
+  ordering under `sourceId`.
+- **Chitanka reorder plumbing** — analogous, with `SourceType.CHITANKA`.
+- **ABS regression** — the existing ABS test path still populates
+  `libraryUiItemsBySource` and `setLibraryOrder` still persists for ABS
+  sources. Guards against the `absServers` rename accidentally dropping ABS.
+
+### `NavigationDrawerViewModelTest`
+
+- **Custom order applied for a Local Files active source** — set a
+  `libraryOrder` for a Local Files source id, assert `visibleLibraries` reflects
+  it. Locks in that the drawer path is source-agnostic and future refactors
+  that regress this fail loudly.
+
+### Failure-under-revert check (per AGENTS.md)
+
+If someone reverts the `absServers` filter change, the two Local Files /
+Chitanka `libraryUiItemsBySource` assertions flip to empty-map lookups and fail.
+If someone reverts the drawer-path assumption, the drawer test fails to see the
+custom order.
+
+## Out of scope
+
+- Reordering the sources themselves in the drawer / source switcher.
+- Cross-source ordering (order is per-source).
+- Any drag-based reorder (up/down chevrons are the shipped affordance from
+  PR #170 and are retained).
+- Any change to Storyteller (never browsable).


### PR DESCRIPTION
## Summary

Extends the per-source library editor (visibility toggle + up/down chevrons) from Audiobookshelf-only to every browsable source (Local Files, Chitanka, and any future source type).

The domain and drawer layers were already source-agnostic — `LibraryOrderPreferencesStore` is keyed by `sourceId`, and `NavigationDrawerViewModel` applies `orderLibraries()` uniformly. The gap was purely in `SettingsViewModel`, which filtered to `SourceType.ABS` before building the per-library UI items, and in `SettingsScreen`, where only `ServerRow` rendered the reorder chevrons.

### What changed

- **`SettingsViewModel`**: `absServers` → `browsableSources` (only excludes Storyteller — Settings-only per ADR 0026). `libraryUiItemsByServer` → `libraryUiItemsBySource`, populated for every browsable source.
- **`SettingsScreen`**:
  - Chitanka row grows the standard chevron + expand pattern and reuses `ReorderableLibraryList` inside its expansion.
  - Local Files: folder rows now carry inline up/down chevrons + a visibility switch alongside the existing delete button — folders and libraries are 1:1 for this source, so a single row exposes all controls.
  - Swipe-to-delete now wraps only the compact header of each source row; a swipe inside the tall expanded body no longer partly reveals the delete background as a stray trash-icon peek.
  - Removed the redundant `surfaceVariant` tint and the "Enabled libraries" label — a switch already reads as enabled/disabled.
- **README**: updated the multi-source line to mention ordering alongside visibility.

### Tests

JVM-level assertions in `SettingsViewModelTest`:
- `libraryUiItemsBySource` populated for a Local Files source
- `libraryUiItemsBySource` populated for a Chitanka source
- Saved custom order applies for a Local Files source
- Storyteller services stay excluded
- All existing ABS reorder / visibility tests still green

`ChitankaSourceRowTest` (androidTest) updated for the new signature; still asserts swipe-to-delete parity and no trailing "Remove" button.

## Test plan

- [ ] Configure an ABS server; expand its Settings row; reorder libraries via chevrons; confirm the drawer follows.
- [ ] Configure Local Files with 2+ folders; reorder via the inline chevrons; confirm the drawer follows.
- [ ] Add Chitanka; expand; reorder Books/Gramofonche; confirm the drawer follows.
- [ ] Swipe each source row header end-to-start; confirm removal fires; confirm no stray trash icon peek inside the expanded body during a normal tap on the switch or chevrons.