### PR TITLE
fix(chitanka): parse book annotations from /book/ pages

### DIFF
--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
@@ -238,7 +238,13 @@ class ChitankaCatalog(
                     val textHtml = runCatching { http.getString(textUrl) }.getOrNull()
                     if (textHtml != null) {
                         val enriched = ChitankaScraper.parseDetailPage(textHtml, textUrl)
-                        return ROOT_BOOKS to enriched.copy(url = url)  // keep the original id
+                        // The /text/ surface has no book-anno block — preserve the /book/
+                        // annotation (and cover) if the enrichment came back empty.
+                        return ROOT_BOOKS to enriched.copy(
+                            url = url,  // keep the original id
+                            description = enriched.description.ifEmpty { bookDetail.description },
+                            coverUrl = enriched.coverUrl ?: bookDetail.coverUrl,
+                        )
                     }
                 }
                 ROOT_BOOKS to bookDetail

--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraper.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraper.kt
@@ -134,15 +134,21 @@ internal object ChitankaScraper {
             .map { it.text().trim() }
             .filter { it.isNotEmpty() }
 
-        // Description: try meta[name=description], then book-card popover, then wiki intro.
+        // Description: try meta[name=description], then the book-anno block (present on /book/
+        // pages as `div.text-content.book-anno` — the canonical chitanka annotation), then the
+        // book-card popover, then the wiki intro.
         val genericMetaPrefix = "Универсална библиотека"
         val metaDesc = doc.selectFirst("meta[name=description]")?.attr("content")?.trim().orEmpty()
+        val bookAnnoDesc = doc.select("div.text-content.book-anno p")
+            .joinToString("\n\n") { it.text().trim() }
+            .trim()
         val popoverHtml = doc.selectFirst("h4.book-title .popover-trigger")?.attr("data-content").orEmpty()
         val popoverDesc = if (popoverHtml.isNotEmpty() && !popoverHtml.contains("blockquote")) {
             Jsoup.parse(popoverHtml).selectFirst("p")?.text()?.trim().orEmpty()
         } else ""
         val description = when {
             metaDesc.isNotEmpty() && !metaDesc.startsWith(genericMetaPrefix) -> metaDesc
+            bookAnnoDesc.isNotEmpty() -> bookAnnoDesc
             popoverDesc.isNotEmpty() -> popoverDesc
             else -> doc.selectFirst("section[data-mw-section-id=0] p")?.text()?.trim().orEmpty()
         }

--- a/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraperTest.kt
+++ b/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraperTest.kt
@@ -55,6 +55,32 @@ class ChitankaScraperTest {
     }
 
     @Test
+    fun `detail page extracts description from book-anno block on book pages`() {
+        // Mirrors chitanka's /book/ HTML: generic meta description, real annotation in
+        // div.text-content.book-anno. Regression for missing book summaries in the app.
+        val html = """
+            <html><head>
+              <meta name="description" content="Универсална библиотека за книги и текстове.">
+            </head><body>
+              <h1><a class="selflink" itemprop="name">Пример</a></h1>
+              <div class="media-body">
+                <div class="text-content book-anno">
+                  <p id="p-1">Първи абзац от анотацията.</p>
+                  <p id="p-2">Втори абзац.</p>
+                </div>
+              </div>
+            </body></html>
+        """.trimIndent()
+
+        val d = ChitankaScraper.parseDetailPage(html, "https://chitanka.info/book/3000-primer")
+
+        assertEquals(
+            "Първи абзац от анотацията.\n\nВтори абзац.",
+            d.description,
+        )
+    }
+
+    @Test
     fun `toAbsolute resolves relative and preserves absolute urls`() {
         assertEquals(
             "https://chitanka.info/book/1",


### PR DESCRIPTION
## Summary

Chitanka book detail pages showed no summary in the app. Two bugs:

1. **Scraper never matched the real annotation.** `parseDetailPage`'s description path checked `meta[name=description]` (site-wide generic on every page), then `h4.book-title .popover-trigger[data-content]` — but the popover actually lives in a sibling `.bookcat` div, not inside `h4.book-title`, so this selector never fired. Fallback to `section[data-mw-section-id=0] p` was a MediaWiki idiom chitanka doesn't use. Verified against live `/book/3000` etc.: the real annotation lives in `<div class="text-content book-anno">`. Added that selector, joining the paragraphs.

2. **`/book/` → `/text/` canonicalization clobbered the description.** `ChitankaCatalog.resolveItem` fetches `/book/` to parse `bookDetail`, then re-fetches the linked `/text/` page for genre labels and returns the enriched detail with `bookDetail.description` silently dropped (the `/text/` surface has no `book-anno` block). Now preserves `bookDetail.description` and `bookDetail.coverUrl` when the enriched values come back empty.

Regression test in `ChitankaScraperTest` covers the scraper path with an inline HTML fixture mirroring chitanka's actual `/book/` markup (generic meta + book-anno block).

## Test plan

- [x] `./gradlew :core:catalog-chitanka:test` green
- [ ] Manual verify: open a Chitanka book (e.g. `/book/3000`) in the app — summary should now render