### PR TITLE
fix(library): hide download buttons on LocalFiles item details

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -1164,10 +1164,13 @@ private fun ActionRow(
                 onToggle = onToggleToRead,
             )
         }
+        // LocalFiles items live on the device already — nothing to download — so every download
+        // affordance below (ebook, audiobook, readaloud bundle) is suppressed for that Source type.
+        val showDownloadAffordances = !capabilities.isLocalSource
         // The base DownloadButton manages the ABS EPUB, so it only applies to a readable item. A
         // matched ABS item additionally gets the ReadaloudDownloadButton below, which fetches the
         // Storyteller synced bundle (ADR 0023/0026) for audio + highlight.
-        if (item.isReadable) {
+        if (showDownloadAffordances && item.isReadable) {
             DownloadButton(
                 state = downloadState,
                 onDownload = onDownload,
@@ -1176,7 +1179,7 @@ private fun ActionRow(
         }
         // A listenable item gets its own download control: the ABS audiobook tracks for offline play
         // (ADR 0029). Disabled offline when not yet downloaded (can't fetch).
-        if (item.isListenable && audiobookDownloadState != null) {
+        if (showDownloadAffordances && item.isListenable && audiobookDownloadState != null) {
             val audioOfflineBlocked = isOffline && audiobookDownloadState == DownloadState.NotDownloaded
             val audioButton: @Composable () -> Unit = {
                 DownloadButton(
@@ -1196,7 +1199,7 @@ private fun ActionRow(
                 audioButton()
             }
         }
-        if (readaloudDownloadState != null) {
+        if (showDownloadAffordances && readaloudDownloadState != null) {
             val readaloudOfflineBlocked = isOffline && readaloudDownloadState == DownloadState.NotDownloaded
             val readaloudButton: @Composable () -> Unit = {
                 ReadaloudDownloadButton(

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -24,6 +24,7 @@ import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.catalog.PlaylistsCapability
 import com.riffle.core.catalog.SeriesCapability
 import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.SourceType
 import com.riffle.core.domain.TocEntry
 import com.riffle.core.domain.TokenStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -69,6 +70,11 @@ data class DetailCapabilities(
     val hasSeries: Boolean,
     val hasPlaylists: Boolean,
     val hasAudiobookMedia: Boolean,
+    // True when the item lives on a LocalFiles Source — the file is already on device, so the
+    // download affordances (ebook, audiobook, readaloud bundle) have nothing to fetch and are
+    // hidden. Sourced from SourceType, not a Catalog capability: "already local" is a property of
+    // where the item comes from, not of what its Catalog implements.
+    val isLocalSource: Boolean = false,
 ) {
     companion object {
         /** Every capability present — matches the ABS shape used by the majority of items. */
@@ -220,10 +226,12 @@ class LibraryItemDetailViewModel @Inject constructor(
                     // versa. Raw `is` checks (see LibraryItemsViewModel.tabVisibility for the
                     // JVM-target rationale).
                     val catalog = catalogRegistry.forSourceId(item.sourceId)
+                    val itemSource = sourceRepository.getById(item.sourceId)
                     val capabilities = DetailCapabilities(
                         hasSeries = catalog is SeriesCapability,
                         hasPlaylists = catalog is PlaylistsCapability,
                         hasAudiobookMedia = catalog is AudiobookMediaCapability,
+                        isLocalSource = itemSource?.type == SourceType.LOCAL_FILES,
                     )
                     LibraryItemDetailUiState.Ready(
                         item = item,

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -851,4 +851,77 @@ class LibraryItemDetailViewModelTest {
         val after = vm.uiState.value as Ready
         assertFalse(after.isCachedOrDownloaded)
     }
+
+    // Regression for "LocalFiles item shows a Download button." A LocalFiles item lives on the
+    // device already — its DownloadButton would either be a no-op or, worse, wire "Remove" to the
+    // user's original file. The Ready-state capability flag drives the UI's suppression of every
+    // download affordance (ebook / audiobook / readaloud bundle) for LocalFiles Sources.
+    @Test
+    fun `capabilities isLocalSource is true when the item's Source is LOCAL_FILES`() = runTest {
+        val localItem = knownItem.copy(sourceId = "local-source")
+        val localSource = Source(
+            id = "local-source",
+            url = SourceUrl.parse("http://local")!!,
+            isActive = true,
+            insecureConnectionAllowed = false,
+            username = "",
+            type = com.riffle.core.domain.SourceType.LOCAL_FILES,
+        )
+        val sourceRepo = object : SourceRepository {
+            override fun observeAll(): Flow<List<Source>> = MutableStateFlow(listOf(localSource))
+            override suspend fun getActive(): Source? = localSource
+            override suspend fun getById(sourceId: String): Source? =
+                localSource.takeIf { it.id == sourceId }
+            override suspend fun authenticate(url: SourceUrl, username: String, password: String, insecureAllowed: Boolean, serverType: com.riffle.core.domain.ServerType): AuthenticateResult =
+                AuthenticateResult.WrongCredentials()
+            override suspend fun commit(pending: PendingSource, hiddenLibraryIds: Set<String>): CommitSourceResult =
+                CommitSourceResult.Failure(IOException())
+            override suspend fun setActive(sourceId: String) {}
+            override suspend fun remove(sourceId: String) {}
+            override suspend fun getSourceVersion(sourceId: String): String? = null
+        }
+        val vm = makeVm(fakeRepo(localItem), sourceRepository = sourceRepo)
+        backgroundScope.launch { vm.uiState.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val ready = vm.uiState.value as Ready
+        assertTrue(
+            "LocalFiles item must flag isLocalSource so the detail screen hides download buttons",
+            ready.capabilities.isLocalSource,
+        )
+    }
+
+    // Companion to the LOCAL_FILES test: an ABS item must NOT flag isLocalSource, or the download
+    // buttons would disappear from the majority-shape flow.
+    @Test
+    fun `capabilities isLocalSource is false when the item's Source is ABS`() = runTest {
+        val absItem = knownItem.copy(sourceId = "abs-source")
+        val absSource = Source(
+            id = "abs-source",
+            url = SourceUrl.parse("https://example.com")!!,
+            isActive = true,
+            insecureConnectionAllowed = false,
+            username = "u",
+            type = com.riffle.core.domain.SourceType.ABS,
+        )
+        val sourceRepo = object : SourceRepository {
+            override fun observeAll(): Flow<List<Source>> = MutableStateFlow(listOf(absSource))
+            override suspend fun getActive(): Source? = absSource
+            override suspend fun getById(sourceId: String): Source? =
+                absSource.takeIf { it.id == sourceId }
+            override suspend fun authenticate(url: SourceUrl, username: String, password: String, insecureAllowed: Boolean, serverType: com.riffle.core.domain.ServerType): AuthenticateResult =
+                AuthenticateResult.WrongCredentials()
+            override suspend fun commit(pending: PendingSource, hiddenLibraryIds: Set<String>): CommitSourceResult =
+                CommitSourceResult.Failure(IOException())
+            override suspend fun setActive(sourceId: String) {}
+            override suspend fun remove(sourceId: String) {}
+            override suspend fun getSourceVersion(sourceId: String): String? = null
+        }
+        val vm = makeVm(fakeRepo(absItem), sourceRepository = sourceRepo)
+        backgroundScope.launch { vm.uiState.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val ready = vm.uiState.value as Ready
+        assertFalse(ready.capabilities.isLocalSource)
+    }
 }


### PR DESCRIPTION
## Summary

For a LocalFiles Source the ebook / audiobook / readaloud-bundle download buttons on the item-detail screen have nothing to fetch — the file is already on the device — and the "Downloaded" state would wire the affordance to the user's original file. Hide them.

- Add `DetailCapabilities.isLocalSource`, populated in `LibraryItemDetailViewModel` from `sourceRepository.getById(item.sourceId)?.type == SourceType.LOCAL_FILES` (keyed off the item's OWN Source, not the active one, matching the existing capability lookup pattern).
- `ActionRow` gates all three download blocks on `!capabilities.isLocalSource`. ABS and Chitanka behaviour is unchanged.

## Test plan

- [x] `LibraryItemDetailViewModelTest.capabilities_isLocalSource_is_true_when_the_item's_Source_is_LOCAL_FILES` — pins the flag to `true` for a LOCAL_FILES source.
- [x] `LibraryItemDetailViewModelTest.capabilities_isLocalSource_is_false_when_the_item's_Source_is_ABS` — guards against accidentally hiding the buttons in the ABS majority-shape flow.
- [x] `./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.library.LibraryItemDetail*"` green locally.