### PR TITLE
feat(chitanka): item details + to-read pipeline; fix non-null addedAt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,14 @@ When adding a new Room migration:
      - Cursor assertions verifying new columns have correct default values and all pre-existing data is preserved
    - Add the new migration to the `migrateFullChain` test's `runMigrationsAndValidate` call.
 
+## Commit every uncommitted change on the branch
+
+When finalizing, `git status` is almost never empty — the user routinely piggy-backs work in progress onto whatever branch is in flight. Every modified or untracked file that isn't your own scratch/debug artifact belongs on the branch and must be committed before the rebase / PR. **Unrelated ≠ unwanted.** Never stash-and-pop across the rebase (it silently drops the WIP from the PR), and never stop to ask "is this related?" — the answer is that the user knew the state of their tree when they invoked `/finalize`.
+
+- If a change is clearly part of the same fix, fold it into the pending commit.
+- If it's a whole separate feature or unrelated fix, give it its own commit with a descriptive message and mention it in the PR body so it's not a surprise in the diff.
+- Only stop and ask when a file looks genuinely suspicious (potential secret, large binary that doesn't belong).
+
 ## Reference the source issue in the PR
 
 When the work originated from a GitHub Issue (e.g. the user asked you to "do #123"), the PR body must include a `Closes #N` line so the merge auto-closes the issue. One line per issue if the PR spans several. Put it near the top of the body, above the change summary.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Riffle
 
-An Android ebook reader and audiobook player for [Audiobookshelf](https://www.audiobookshelf.org/) and [Storyteller](https://storyteller-platform.gitlab.io/storyteller) self-hosted servers, [chitanka.info](https://chitanka.info) / [gramofonche.chitanka.info](https://gramofonche.chitanka.info), and EPUB, PDF, and CBZ files on your device.
-
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/pkmetski)
 
 Riffle lets you browse your library, read EPUB, PDF, and CBZ files, listen to audiobooks, and keep reading and listening progress in sync across devices — all from a clean, privacy-respecting Android app.

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
@@ -146,7 +146,7 @@ class ReadaloudStreamingSessionFactoryAndroidTest {
                 listOf(
                     LibraryItemEntity(
                         sourceId = ABS_SERVER, id = AUDIOBOOK_ITEM, libraryId = "lib",
-                        title = "Book", author = "A", coverUrl = null, readingProgress = 0f, hasAudio = true,
+                        title = "Book", author = "A", coverUrl = null, readingProgress = 0f, hasAudio = true, addedAt = 0L,
                     ),
                 ),
             )

--- a/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
@@ -137,26 +137,28 @@ fun DownloadsScreen(
                     }
                 }
 
-                item {
-                    SectionHeader(
-                        title = "Readaloud (streaming)",
-                        totalLabel = if (uiState.readaloudSidecars.isNotEmpty()) formatBytes(uiState.readaloudSidecarsTotalBytes) else null,
-                        actionLabel = if (uiState.readaloudSidecars.isNotEmpty()) "Clear all" else null,
-                        onAction = { viewModel.clearAllReadaloudSidecars() },
-                    )
-                }
-                if (uiState.readaloudSidecars.isEmpty()) {
+                if (uiState.showReadaloudSection) {
                     item {
-                        EmptySection("No prepared readalouds")
-                    }
-                } else {
-                    items(uiState.readaloudSidecars, key = { "sidecar/" + it.sourceId + "/" + it.item.id }) { entry ->
-                        LocalItemRow(
-                            entry = entry,
-                            pillColor = PillColor.Readaloud,
-                            onClick = { onItemSelected(entry.item) },
-                            onRemove = { viewModel.removeReadaloudSidecar(entry.sourceId, entry.item.id) },
+                        SectionHeader(
+                            title = "Readaloud (streaming)",
+                            totalLabel = if (uiState.readaloudSidecars.isNotEmpty()) formatBytes(uiState.readaloudSidecarsTotalBytes) else null,
+                            actionLabel = if (uiState.readaloudSidecars.isNotEmpty()) "Clear all" else null,
+                            onAction = { viewModel.clearAllReadaloudSidecars() },
                         )
+                    }
+                    if (uiState.readaloudSidecars.isEmpty()) {
+                        item {
+                            EmptySection("No prepared readalouds")
+                        }
+                    } else {
+                        items(uiState.readaloudSidecars, key = { "sidecar/" + it.sourceId + "/" + it.item.id }) { entry ->
+                            LocalItemRow(
+                                entry = entry,
+                                pillColor = PillColor.Readaloud,
+                                onClick = { onItemSelected(entry.item) },
+                                onRemove = { viewModel.removeReadaloudSidecar(entry.sourceId, entry.item.id) },
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsViewModel.kt
@@ -7,6 +7,7 @@ import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.showCachedSectionFor
+import com.riffle.core.domain.showReadaloudSectionFor
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -29,6 +30,12 @@ data class DownloadsUiState(
      * LocalFiles, single-tier), the Downloads Screen renders one section instead of two.
      */
     val showCachedSection: Boolean = true,
+    /**
+     * Whether the active Source can carry Storyteller readaloud bundles. Only ABS today — the
+     * Downloads Screen hides the "Readaloud (streaming)" section header for sources without it so
+     * users don't see an empty section they can never populate.
+     */
+    val showReadaloudSection: Boolean = true,
 ) {
     val downloadedTotalBytes: Long get() = downloadedItems.sumOf { it.sizeBytes }
     val cachedTotalBytes: Long get() = cachedItems.sumOf { it.sizeBytes }
@@ -73,11 +80,13 @@ class DownloadsViewModel @Inject constructor(
                 }
             }
 
+            val active = sourceRepository.getActive()
             _uiState.value = DownloadsUiState(
                 downloadedItems = downloadedItems,
                 cachedItems = cachedItems,
                 readaloudSidecars = readaloudSidecars,
-                showCachedSection = showCachedSectionFor(sourceRepository.getActive()),
+                showCachedSection = showCachedSectionFor(active),
+                showReadaloudSection = showReadaloudSectionFor(active),
             )
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -229,7 +229,11 @@ class LibraryItemDetailViewModel @Inject constructor(
                     val itemSource = sourceRepository.getById(item.sourceId)
                     val capabilities = DetailCapabilities(
                         hasSeries = catalog is SeriesCapability,
-                        hasPlaylists = catalog is PlaylistsCapability,
+                        // To Read is available on every Source: [ToReadRepositoryImpl] falls back to
+                        // a local Preferences DataStore ([LocalToReadStore]) when the Catalog has no
+                        // server-side [PlaylistsCapability], so the toggle works uniformly for ABS,
+                        // Local Files, Chitanka, and any future backend-less Source.
+                        hasPlaylists = true,
                         hasAudiobookMedia = catalog is AudiobookMediaCapability,
                         isLocalSource = itemSource?.type == SourceType.LOCAL_FILES,
                     )

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -1132,7 +1132,7 @@ internal fun LibrarySearchHeader(
 }
 
 @Composable
-private fun SectionHeader(title: String) {
+internal fun SectionHeader(title: String) {
     Text(
         text = title,
         style = MaterialTheme.typography.titleMedium,
@@ -1328,7 +1328,7 @@ internal fun homeLeadingSectionKey(
 }
 
 @Composable
-private fun HomeTabContent(
+internal fun HomeTabContent(
     inProgress: List<LibraryItem>,
     continueSeries: List<LibraryItem>,
     recentlyAdded: List<LibraryItem>,
@@ -1511,7 +1511,7 @@ private fun CollectionsTabContent(
 }
 
 @Composable
-private fun ToReadTabContent(
+internal fun ToReadTabContent(
     items: List<LibraryItem>,
     isLoading: Boolean,
     token: String,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -229,7 +229,11 @@ class LibraryItemsViewModel @Inject constructor(
         .map { sourceId ->
             val catalog = sourceId?.let { catalogRegistry.forSourceId(it) }
             LibraryTabVisibility(
-                toRead = catalog is PlaylistsCapability,
+                // To Read is available on every Source: [ToReadRepositoryImpl] falls back to a
+                // local Preferences DataStore when the Catalog has no server-side
+                // [PlaylistsCapability], so the tab shows for ABS, Local Files, and any future
+                // backend-less Source alike.
+                toRead = true,
                 series = catalog is SeriesCapability,
                 collections = catalog is CollectionsCapability,
             )

--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
@@ -5,47 +5,53 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
-import androidx.compose.material3.Button
+import com.riffle.app.ui.theme.RiffleIcons
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -55,18 +61,30 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
+import com.riffle.app.feature.annotations.AnnotationsListScreen
+import com.riffle.app.feature.annotations.AnnotationsListViewModel
+import com.riffle.app.feature.library.HomeTabContent
+import com.riffle.app.feature.library.LocalCoversAreSquare
+import com.riffle.app.feature.library.ToReadTabContent
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.core.catalog.CatalogItem
 import com.riffle.core.catalog.chitanka.ChitankaCatalog
 
 /**
- * Chitanka Source browse screen. Dedicated route ("chitanka_browse/{rootId}/{name}")
- * distinct from LibraryItemsScreen — Chitanka has no Room-backed `library_items` mirror
- * so the screen consumes ChitankaCatalog directly through [ChitankaBrowseViewModel].
+ * Chitanka Source screen. Dedicated route ("chitanka_browse/{libraryId}/{name}") distinct
+ * from LibraryItemsScreen — Chitanka has no ABS-shape library mirror, so we can't reuse
+ * that screen's refresh/capability plumbing (ADR 0041/0042). Instead we host a small tab
+ * bar with three surfaces that ARE consistent with every other Source:
  *
- * Layout: TopAppBar (title = library name), inline search bar, horizontal chip strip
- * (server-side facet — ADR 0042), then a 3-column cover grid for Books / 2-column for
- * Audiobooks. Tapping a card opens a metadata detail sheet.
+ * Tabs match [LibraryItemsScreen]'s bar exactly (same icons, same order, icon-only):
+ *
+ * - **Home** (default) — Room-backed shelves (In Progress / Recently Added / Finished /
+ *   Continue Series), fed by [ChitankaLibraryViewModel] and rendered with the same
+ *   `HomeTabContent` composable ABS libraries use. Empty until the user has engaged.
+ * - **Annotations** — the standard [AnnotationsListScreen], scoped to this library.
+ * - **Library** — Chitanka's unbounded catalogue via [ChitankaBrowseViewModel]: search,
+ *   server-side facet chips, cover grid. Tapping a card upserts the item into
+ *   `library_items` and navigates to the standard `library_item_detail` page.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -74,31 +92,21 @@ fun ChitankaBrowseScreen(
     libraryName: String,
     windowSizeClass: WindowSizeClass,
     onOpenDrawer: () -> Unit,
-    onOpenReader: (itemId: String) -> Unit,
-    onOpenAudiobook: (itemId: String) -> Unit,
+    onOpenDetail: (itemId: String) -> Unit,
+    onAnnotatedBookClick: (sourceId: String, itemId: String) -> Unit,
     viewModel: ChitankaBrowseViewModel = hiltViewModel(),
 ) {
-    val items by viewModel.items.collectAsState()
-    val facets by viewModel.facets.collectAsState()
-    val selectedFacet by viewModel.selectedFacet.collectAsState()
-    val query by viewModel.query.collectAsState()
-    val isLoading by viewModel.isLoading.collectAsState()
-    val error by viewModel.error.collectAsState()
+    var selectedTab by rememberSaveable(key = "chitanka_selected_tab_v2") { mutableIntStateOf(TAB_HOME) }
 
-    var searchOpen by remember { mutableStateOf(false) }
-    var detailItem by remember { mutableStateOf<CatalogItem?>(null) }
+    // Chitanka items don't live in `library_items` until this point (ADR 0042: unbounded
+    // catalogue), so the VM upserts a row first and only then emits — guaranteeing the
+    // detail screen's `LibraryObserver.getItem` resolves it.
+    LaunchedEffect(viewModel) {
+        viewModel.openDetailEvents.collect { event -> onOpenDetail(event.itemId) }
+    }
 
     val isAudioRoot = viewModel.rootId == ChitankaCatalog.ROOT_AUDIOBOOKS
-
-    // Collect Read/Play events from the ViewModel. Chitanka items don't live in `library_items`
-    // until this point (ADR 0042: unbounded catalogue), so the VM upserts a row first and only
-    // then emits — guaranteeing the reader / audiobook player can resolve the item.
-    LaunchedEffect(viewModel) {
-        viewModel.openEvents.collect { event ->
-            detailItem = null
-            if (event.isAudio) onOpenAudiobook(event.itemId) else onOpenReader(event.itemId)
-        }
-    }
+    var searchOpen by remember { mutableStateOf(false) }
 
     Scaffold(
         topBar = {
@@ -110,86 +118,183 @@ fun ChitankaBrowseScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = { searchOpen = !searchOpen }) {
-                        Icon(
-                            if (searchOpen) Icons.Default.Close else Icons.Default.Search,
-                            contentDescription = if (searchOpen) "Close search" else "Search",
-                        )
+                    if (selectedTab == TAB_LIBRARY) {
+                        IconButton(onClick = { searchOpen = !searchOpen }) {
+                            Icon(
+                                if (searchOpen) Icons.Default.Close else Icons.Default.Search,
+                                contentDescription = if (searchOpen) "Close search" else "Search",
+                            )
+                        }
                     }
                 },
             )
+        },
+        bottomBar = {
+            NavigationBar {
+                NavigationBarItem(
+                    selected = selectedTab == TAB_HOME,
+                    onClick = { selectedTab = TAB_HOME },
+                    icon = { Icon(Icons.Filled.Home, contentDescription = "Home") },
+                )
+                NavigationBarItem(
+                    selected = selectedTab == TAB_TO_READ,
+                    onClick = { selectedTab = TAB_TO_READ },
+                    icon = { Icon(RiffleIcons.ToReadFilled, contentDescription = "To Read") },
+                )
+                NavigationBarItem(
+                    selected = selectedTab == TAB_ANNOTATIONS,
+                    onClick = { selectedTab = TAB_ANNOTATIONS },
+                    icon = { Icon(RiffleIcons.Annotations, contentDescription = "Annotations") },
+                )
+                NavigationBarItem(
+                    selected = selectedTab == TAB_LIBRARY,
+                    onClick = { selectedTab = TAB_LIBRARY },
+                    icon = { Icon(Icons.Filled.GridView, contentDescription = "All Books") },
+                )
+            }
         },
     ) { padding ->
         TabletContentWidthContainer(
             windowSizeClass = windowSizeClass,
             modifier = Modifier.fillMaxSize().padding(padding),
         ) {
-            Column(modifier = Modifier.fillMaxSize()) {
-                if (searchOpen) {
-                    OutlinedTextField(
-                        value = query,
-                        onValueChange = viewModel::onQueryChange,
-                        placeholder = { Text("Search Chitanka…") },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 8.dp),
-                        singleLine = true,
-                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+            CompositionLocalProvider(LocalCoversAreSquare provides isAudioRoot) {
+                when (selectedTab) {
+                    TAB_HOME -> ChitankaHomeTab(onOpenDetail = onOpenDetail)
+                    TAB_TO_READ -> ChitankaToReadTab(onOpenDetail = onOpenDetail)
+                    TAB_ANNOTATIONS -> ChitankaAnnotationsTab(onAnnotatedBookClick = onAnnotatedBookClick)
+                    TAB_LIBRARY -> LibraryTabContent(
+                        viewModel = viewModel,
+                        isAudioRoot = isAudioRoot,
+                        searchOpen = searchOpen,
                     )
                 }
-                if (facets.isNotEmpty()) {
-                    LazyRow(
-                        contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        item {
-                            FilterChip(
-                                selected = selectedFacet == null,
-                                onClick = { viewModel.selectFacet(null) },
-                                label = { Text("All") },
-                            )
-                        }
-                        items(facets, key = { it.key }) { facet ->
-                            FilterChip(
-                                selected = selectedFacet == facet.key,
-                                onClick = { viewModel.selectFacet(facet.key) },
-                                label = { Text(facet.label) },
-                            )
+            }
+        }
+    }
+}
+
+private const val TAB_HOME = 0
+private const val TAB_TO_READ = 1
+private const val TAB_ANNOTATIONS = 2
+private const val TAB_LIBRARY = 3
+
+// Kick off a next-page fetch when the user scrolls to within this many items of the end so the
+// grid stays populated ahead of the viewport (≈ two rows in Books mode, three rows in Audiobooks).
+private const val PAGINATION_PREFETCH_THRESHOLD = 6
+
+@Composable
+private fun LibraryTabContent(
+    viewModel: ChitankaBrowseViewModel,
+    isAudioRoot: Boolean,
+    searchOpen: Boolean,
+) {
+    val items by viewModel.items.collectAsState()
+    val facets by viewModel.facets.collectAsState()
+    val selectedFacet by viewModel.selectedFacet.collectAsState()
+    val query by viewModel.query.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+    val error by viewModel.error.collectAsState()
+    val isPaging by viewModel.isPaging.collectAsState()
+    val hasMore by viewModel.hasMore.collectAsState()
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        if (searchOpen) {
+            OutlinedTextField(
+                value = query,
+                onValueChange = viewModel::onQueryChange,
+                placeholder = { Text("Search Chitanka…") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+            )
+        }
+        if (facets.isNotEmpty()) {
+            LazyRow(
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                item {
+                    FilterChip(
+                        selected = selectedFacet == null,
+                        onClick = { viewModel.selectFacet(null) },
+                        label = { Text("All") },
+                    )
+                }
+                items(facets, key = { it.key }) { facet ->
+                    FilterChip(
+                        selected = selectedFacet == facet.key,
+                        onClick = { viewModel.selectFacet(facet.key) },
+                        label = { Text(facet.label) },
+                    )
+                }
+            }
+        }
+        Box(modifier = Modifier.fillMaxSize()) {
+            when {
+                isLoading && items.isEmpty() -> {
+                    CircularProgressIndicator(modifier = Modifier.wrapContentSize().align(Alignment.Center))
+                }
+                error != null && items.isEmpty() -> {
+                    Text(
+                        error ?: "",
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.align(Alignment.Center).padding(24.dp),
+                    )
+                }
+                items.isEmpty() -> {
+                    Text(
+                        if (query.isNotBlank()) "No results" else "Nothing to show",
+                        modifier = Modifier.align(Alignment.Center).padding(24.dp),
+                    )
+                }
+                else -> {
+                    val gridState = rememberLazyGridState()
+                    // Trigger a next-page fetch once the user scrolls to within ~6 items of the
+                    // end. `derivedStateOf` collapses re-emissions from `firstVisibleItem*` down
+                    // to a single boolean so the LaunchedEffect below only re-fires on the actual
+                    // threshold crossing. `distinctUntilChanged` further protects against Compose
+                    // recomposing the same true value repeatedly.
+                    val shouldLoadMore by remember {
+                        derivedStateOf {
+                            val info = gridState.layoutInfo
+                            val total = info.totalItemsCount
+                            if (total == 0) return@derivedStateOf false
+                            val lastVisible = info.visibleItemsInfo.lastOrNull()?.index ?: 0
+                            lastVisible >= total - PAGINATION_PREFETCH_THRESHOLD
                         }
                     }
-                }
-                Box(modifier = Modifier.fillMaxSize()) {
-                    when {
-                        isLoading && items.isEmpty() -> {
-                            CircularProgressIndicator(modifier = Modifier.wrapContentSize().align(Alignment.Center))
+                    LaunchedEffect(gridState, hasMore) {
+                        snapshotFlow { shouldLoadMore }.distinctUntilChanged().collect { should ->
+                            if (should && hasMore) viewModel.loadMore()
                         }
-                        error != null && items.isEmpty() -> {
-                            Text(
-                                error ?: "",
-                                color = MaterialTheme.colorScheme.error,
-                                modifier = Modifier.align(Alignment.Center).padding(24.dp),
+                    }
+                    LazyVerticalGrid(
+                        state = gridState,
+                        columns = GridCells.Fixed(if (isAudioRoot) 2 else 3),
+                        contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(14.dp),
+                        modifier = Modifier.fillMaxSize(),
+                    ) {
+                        items(items, key = { it.id }) { item ->
+                            CatalogItemCard(
+                                item = item,
+                                isAudio = isAudioRoot,
+                                onClick = { viewModel.openDetail(item) },
                             )
                         }
-                        items.isEmpty() -> {
-                            Text(
-                                if (query.isNotBlank()) "No results" else "Nothing to show",
-                                modifier = Modifier.align(Alignment.Center).padding(24.dp),
-                            )
-                        }
-                        else -> {
-                            LazyVerticalGrid(
-                                columns = GridCells.Fixed(if (isAudioRoot) 2 else 3),
-                                contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
-                                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                verticalArrangement = Arrangement.spacedBy(14.dp),
-                                modifier = Modifier.fillMaxSize(),
-                            ) {
-                                items(items, key = { it.id }) { item ->
-                                    CatalogItemCard(
-                                        item = item,
-                                        isAudio = isAudioRoot,
-                                        onClick = { detailItem = item },
-                                    )
+                        // Footer spinner while the next page is fetching. Spans all columns so the
+                        // grid layout doesn't leave one item's worth of empty space beside it.
+                        if (isPaging) {
+                            item(span = { GridItemSpan(maxLineSpan) }) {
+                                Box(
+                                    modifier = Modifier.fillMaxWidth().padding(16.dp),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    CircularProgressIndicator()
                                 }
                             }
                         }
@@ -198,15 +303,58 @@ fun ChitankaBrowseScreen(
             }
         }
     }
+}
 
-    detailItem?.let { item ->
-        ChitankaDetailSheet(
-            item = item,
-            isAudio = isAudioRoot,
-            onOpen = { viewModel.openItem(item) },
-            onDismiss = { detailItem = null },
-        )
-    }
+@Composable
+private fun ChitankaHomeTab(
+    onOpenDetail: (itemId: String) -> Unit,
+    viewModel: ChitankaLibraryViewModel = hiltViewModel(),
+) {
+    val inProgress by viewModel.inProgress.collectAsState()
+    val recentlyAdded by viewModel.recentlyAdded.collectAsState()
+    val finished by viewModel.finished.collectAsState()
+    val continueSeries by viewModel.continueSeries.collectAsState()
+
+    // Chitanka doesn't authenticate; cover images are public URLs — pass empty token.
+    // "See more" navigates to library_section, which is ABS-shaped and wouldn't work here;
+    // wire it to a no-op for now so users just scroll the horizontal shelf.
+    HomeTabContent(
+        inProgress = inProgress,
+        continueSeries = continueSeries,
+        recentlyAdded = recentlyAdded,
+        finished = finished,
+        isLoading = false,
+        token = "",
+        onItemSelected = { item -> onOpenDetail(item.id) },
+        onSectionSeeMore = {},
+    )
+}
+
+@Composable
+private fun ChitankaToReadTab(
+    onOpenDetail: (itemId: String) -> Unit,
+    viewModel: ChitankaLibraryViewModel = hiltViewModel(),
+) {
+    val items by viewModel.toReadItems.collectAsState()
+    ToReadTabContent(
+        items = items,
+        isLoading = false,
+        token = "",
+        onItemSelected = { item -> onOpenDetail(item.id) },
+    )
+}
+
+@Composable
+private fun ChitankaAnnotationsTab(
+    onAnnotatedBookClick: (sourceId: String, itemId: String) -> Unit,
+    viewModel: AnnotationsListViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+    AnnotationsListScreen(
+        state = state,
+        token = viewModel.authToken,
+        onBookClick = onAnnotatedBookClick,
+    )
 }
 
 @Composable
@@ -256,77 +404,6 @@ private fun CatalogItemCard(
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun ChitankaDetailSheet(
-    item: CatalogItem,
-    isAudio: Boolean,
-    onOpen: () -> Unit,
-    onDismiss: () -> Unit,
-) {
-    androidx.compose.material3.ModalBottomSheet(onDismissRequest = onDismiss) {
-        Column(
-            modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Row(verticalAlignment = Alignment.Top, horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-                if (!item.coverUrl.isNullOrBlank()) {
-                    AsyncImage(
-                        model = item.coverUrl,
-                        contentDescription = null,
-                        modifier = Modifier
-                            .width(100.dp)
-                            .aspectRatio(if (isAudio) 1f else (2f / 3f))
-                            .clip(RoundedCornerShape(8.dp)),
-                    )
-                }
-                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                    Text(item.title, style = MaterialTheme.typography.titleLarge)
-                    if (item.author.isNotBlank()) {
-                        Text(item.author, style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant)
-                    }
-                    item.seriesName?.let { name ->
-                        val seq = item.seriesSequence?.takeIf { it.isNotBlank() }?.let { " · $it" }.orEmpty()
-                        Text(
-                            "📚 $name$seq",
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.primary,
-                        )
-                    }
-                }
-            }
-            if (item.genres.isNotEmpty()) {
-                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                    item.genres.take(6).forEach { g ->
-                        Surface(
-                            shape = RoundedCornerShape(8.dp),
-                            color = MaterialTheme.colorScheme.surfaceVariant,
-                        ) {
-                            Text(
-                                g,
-                                style = MaterialTheme.typography.labelSmall,
-                                modifier = Modifier.padding(horizontal = 8.dp, vertical = 3.dp),
-                            )
-                        }
-                    }
-                }
-            }
-            item.description?.takeIf { it.isNotBlank() }?.let { desc ->
-                Text(desc, style = MaterialTheme.typography.bodyMedium)
-            }
-            Spacer(Modifier.height(4.dp))
-            Button(
-                onClick = onOpen,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(if (isAudio) "Play" else "Read")
-            }
-            Spacer(Modifier.height(4.dp))
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModel.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import java.io.IOException
+import java.net.UnknownHostException
 import javax.inject.Inject
 
 /**
@@ -41,24 +43,29 @@ class ChitankaBrowseViewModel @Inject constructor(
     private val libraryItemUpserter: ChitankaLibraryItemUpserter,
 ) : ViewModel() {
 
-    val rootId: String = savedStateHandle.get<String>("rootId") ?: ChitankaCatalog.ROOT_BOOKS
+    // Chitanka's browse route uses the Riffle `libraryId` as the Catalog `rootId` — the two
+    // Chitanka "libraries" (Books and Audiobooks) each map 1:1 to a Catalog root. Reading the
+    // route arg as `libraryId` keeps this SavedStateHandle compatible with
+    // AnnotationsListViewModel (which looks for a `libraryId` key) when we embed it in the
+    // Chitanka screen's Annotations tab.
+    val rootId: String = savedStateHandle.get<String>("libraryId") ?: ChitankaCatalog.ROOT_BOOKS
 
     /**
      * Emitted once the tapped [CatalogItem] has been upserted into `library_items` and the
-     * reader / audiobook player can safely be launched for it. The screen collects this and
-     * routes to `epub_reader/{id}` or `audiobook_player/{id}` (see MainScreen).
+     * standard item detail screen can safely resolve it via `LibraryObserver.getItem`. The
+     * screen collects this and routes to `library_item_detail/{id}` (see MainScreen).
      *
      * Extra-buffer replay-0 so a nav that fires before the collector attaches (should never
      * happen — the screen collects in composition) is dropped rather than replayed on the
      * next screen return.
      */
-    data class OpenEvent(val itemId: String, val isAudio: Boolean)
+    data class OpenDetailEvent(val itemId: String)
 
-    private val _openEvents = MutableSharedFlow<OpenEvent>(
+    private val _openDetailEvents = MutableSharedFlow<OpenDetailEvent>(
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
-    val openEvents: SharedFlow<OpenEvent> = _openEvents.asSharedFlow()
+    val openDetailEvents: SharedFlow<OpenDetailEvent> = _openDetailEvents.asSharedFlow()
 
     private val _facets = MutableStateFlow<List<CatalogFacet>>(emptyList())
     val facets: StateFlow<List<CatalogFacet>> = _facets.asStateFlow()
@@ -78,8 +85,25 @@ class ChitankaBrowseViewModel @Inject constructor(
     private val _query = MutableStateFlow("")
     val query: StateFlow<String> = _query.asStateFlow()
 
+    /**
+     * True while a next-page fetch is in flight. Distinct from [isLoading] (whole-list refresh) so
+     * the UI can show a small footer spinner without pulling the whole grid into a loading state.
+     */
+    private val _isPaging = MutableStateFlow(false)
+    val isPaging: StateFlow<Boolean> = _isPaging.asStateFlow()
+
+    /**
+     * False once a page came back with fewer items than [PAGE_SIZE] — the catalogue is exhausted
+     * for the current (facet, query, rootId) tuple. The grid stops calling [loadMore] to avoid
+     * hammering the server with empty pages.
+     */
+    private val _hasMore = MutableStateFlow(true)
+    val hasMore: StateFlow<Boolean> = _hasMore.asStateFlow()
+
+    private var currentPage = 0
     private var searchDebounceJob: Job? = null
     private var refreshJob: Job? = null
+    private var loadMoreJob: Job? = null
 
     init {
         viewModelScope.launch { loadFacets() }
@@ -116,24 +140,40 @@ class ChitankaBrowseViewModel @Inject constructor(
         // from a previous facet/query can arrive after a newer one and overwrite _items with
         // stale results (chip strip shows B, grid shows A's late-arriving items).
         refreshJob?.cancel()
+        loadMoreJob?.cancel()
+        // Reset pagination cursor on refresh so the next loadMore starts from page 1 rather than
+        // whatever the previous (facet, query) tuple was at.
+        currentPage = 0
+        _hasMore.value = true
         refreshJob = viewModelScope.launch { refreshOnce() }
     }
 
     /**
-     * Upsert the tapped item into `library_items` so the reader/player can resolve it via
-     * `LibraryObserver.getItem`, then emit an [OpenEvent] the screen collects to navigate.
-     * No-op when there is no active Chitanka Source — the screen route wouldn't have been
-     * reachable, but guard defensively.
+     * Fetch the next page and append. No-op when a whole-list refresh is still in flight, when a
+     * previous loadMore hasn't finished yet, or when [hasMore] has already been flipped to false
+     * (last page returned short). The grid drives this on end-of-list scroll.
      */
-    fun openItem(item: CatalogItem) {
+    fun loadMore() {
+        if (refreshJob?.isActive == true) return
+        if (loadMoreJob?.isActive == true) return
+        if (!_hasMore.value) return
+        if (_items.value.isEmpty()) return  // nothing to append to — a real refresh handles the first page
+        loadMoreJob = viewModelScope.launch { loadMoreOnce() }
+    }
+
+    /**
+     * Upsert the tapped item into `library_items` so the standard detail screen can resolve
+     * it via `LibraryObserver.getItem`, then emit an [OpenDetailEvent] the screen collects to
+     * navigate. No-op when there is no active Chitanka Source — the screen route wouldn't
+     * have been reachable, but guard defensively.
+     */
+    fun openDetail(item: CatalogItem) {
         viewModelScope.launch {
             val source = sourceRepository.getActive()
                 ?.takeIf { it.type == SourceType.CHITANKA }
                 ?: return@launch
             libraryItemUpserter.upsert(source.id, item)
-            _openEvents.emit(
-                OpenEvent(itemId = item.id, isAudio = rootId == ChitankaCatalog.ROOT_AUDIOBOOKS),
-            )
+            _openDetailEvents.emit(OpenDetailEvent(itemId = item.id))
         }
     }
 
@@ -144,17 +184,77 @@ class ChitankaBrowseViewModel @Inject constructor(
         try {
             val q = _query.value.trim()
             val result = if (q.isNotEmpty()) {
-                catalog.search(rootId = rootId, query = q, page = 0, pageSize = 50)
+                catalog.search(rootId = rootId, query = q, page = 0, pageSize = PAGE_SIZE)
             } else {
                 val facet = _selectedFacet.value?.let { FacetSelection(it) }
-                catalog.browse(rootId = rootId, page = 0, pageSize = 50, facet = facet)
+                catalog.browse(rootId = rootId, page = 0, pageSize = PAGE_SIZE, facet = facet)
             }
             _items.value = result
+            currentPage = 0
+            // A short first page IS the last page — nothing left to fetch. Flip hasMore so the
+            // grid stops calling loadMore.
+            _hasMore.value = result.size >= PAGE_SIZE
         } catch (t: Throwable) {
-            _error.value = t.message ?: t::class.simpleName ?: "Error"
+            _error.value = friendlyErrorMessage(t)
             _items.value = emptyList()
+            _hasMore.value = false
         } finally {
             _isLoading.value = false
         }
+    }
+
+    private suspend fun loadMoreOnce() {
+        val catalog = activeCatalog() ?: return
+        _isPaging.value = true
+        try {
+            val nextPage = currentPage + 1
+            val q = _query.value.trim()
+            val next = if (q.isNotEmpty()) {
+                catalog.search(rootId = rootId, query = q, page = nextPage, pageSize = PAGE_SIZE)
+            } else {
+                val facet = _selectedFacet.value?.let { FacetSelection(it) }
+                catalog.browse(rootId = rootId, page = nextPage, pageSize = PAGE_SIZE, facet = facet)
+            }
+            if (next.isEmpty()) {
+                _hasMore.value = false
+                return
+            }
+            // De-dup on id in case the catalogue returned overlapping pages (Chitanka's paged views
+            // occasionally repeat the tail of the previous page).
+            val existingIds = _items.value.mapTo(HashSet()) { it.id }
+            val appended = next.filter { it.id !in existingIds }
+            if (appended.isNotEmpty()) {
+                _items.value = _items.value + appended
+            }
+            currentPage = nextPage
+            _hasMore.value = next.size >= PAGE_SIZE
+        } catch (_: Throwable) {
+            // A pagination failure isn't fatal — the user still sees the pages already loaded.
+            // Leave hasMore true so a subsequent scroll retries the same page.
+        } finally {
+            _isPaging.value = false
+        }
+    }
+
+    private companion object {
+        // Matches the initial `page=0` request. Chitanka lists ~30 items per page in most views;
+        // 50 gives us a small safety margin so the grid usually has to scroll before we page again.
+        const val PAGE_SIZE = 50
+    }
+}
+
+/**
+ * Map network failures to messages users can act on. The raw OkHttp/DNS text
+ * (`Unable to resolve host "chitanka.info": No address associated with hostname`)
+ * leaks implementation and reads like a crash; offline is the by-far common cause.
+ */
+internal fun friendlyErrorMessage(t: Throwable): String {
+    val chain = generateSequence(t) { it.cause }.toList()
+    return when {
+        chain.any { it is UnknownHostException } ->
+            "You appear to be offline. Connect to the internet and try again."
+        chain.any { it is IOException } ->
+            "Couldn't reach chitanka.info. Check your connection and try again."
+        else -> t.message ?: t::class.simpleName ?: "Error"
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaLibraryViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaLibraryViewModel.kt
@@ -1,0 +1,56 @@
+package com.riffle.app.feature.source.chitanka
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.riffle.core.data.ToReadRepository
+import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LibraryObserver
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+/**
+ * Room-backed shelves for the Chitanka library "Home" tab. Feeds the same
+ * `HomeTabContent` composable as [com.riffle.app.feature.library.LibraryItemsScreen], but
+ * without the ABS-shaped refresh loop — Chitanka has no server-side library mirror to
+ * refresh (ADR 0041/0042), so this VM only observes rows the user has upserted via
+ * [com.riffle.core.data.chitanka.ChitankaLibraryItemUpserter] on tap.
+ */
+@HiltViewModel
+class ChitankaLibraryViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    libraryObserver: LibraryObserver,
+    toReadRepository: ToReadRepository,
+) : ViewModel() {
+
+    private val libraryId: String = savedStateHandle.get<String>("libraryId") ?: ""
+
+    val inProgress: StateFlow<List<LibraryItem>> = libraryObserver.observeInProgressItems(libraryId)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val recentlyAdded: StateFlow<List<LibraryItem>> = libraryObserver.observeRecentlyAddedItems(libraryId)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val finished: StateFlow<List<LibraryItem>> = libraryObserver.observeFinishedItems(libraryId)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val continueSeries: StateFlow<List<LibraryItem>> = libraryObserver.observeContinueSeriesItems(libraryId)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    /**
+     * Joins the To Read id-set from [ToReadRepository] (which for Chitanka falls through to the
+     * local Preferences store — see [com.riffle.core.data.LocalToReadStore]) with the Room-backed
+     * catalogue rows. Only items that have already been upserted into `library_items` via
+     * [com.riffle.core.data.chitanka.ChitankaLibraryItemUpserter] can appear here — an id that's
+     * been added to To Read but whose row was later deleted just drops out silently.
+     */
+    val toReadItems: StateFlow<List<LibraryItem>> = combine(
+        toReadRepository.observeToReadItemIds(libraryId),
+        libraryObserver.observeAllBooks(libraryId),
+    ) { ids, all -> all.filter { it.id in ids } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+}

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -56,7 +56,7 @@ private const val SOURCE_SETUP_GRAPH = "source_setup"
 private const val ADD_SOURCE_TYPE_PICKER = "add_source_type_picker"
 private const val ADD_LOCAL_FILES = "add_local_files"
 private const val ADD_CHITANKA = "add_chitanka"
-private const val CHITANKA_BROWSE = "chitanka_browse/{rootId}/{libraryName}"
+private const val CHITANKA_BROWSE = "chitanka_browse/{libraryId}/{libraryName}"
 private const val ADD_SOURCE = "add_source"
 private const val ADD_SOURCE_ROUTE = "add_source?type={type}&editId={editId}"
 private const val SELECT_LIBRARIES = "select_libraries"
@@ -235,7 +235,7 @@ fun MainScreen(
             composable(
                 route = CHITANKA_BROWSE,
                 arguments = listOf(
-                    navArgument("rootId") { type = NavType.StringType },
+                    navArgument("libraryId") { type = NavType.StringType },
                     navArgument("libraryName") { type = NavType.StringType },
                 ),
             ) { backStackEntry ->
@@ -245,13 +245,12 @@ fun MainScreen(
                     libraryName = libraryName,
                     windowSizeClass = windowSizeClass,
                     onOpenDrawer = { scope.launch { drawerState.open() } },
-                    onOpenReader = { itemId ->
+                    onOpenDetail = { itemId ->
                         val encodedId = URLEncoder.encode(itemId, "UTF-8")
-                        navController.navigate("epub_reader/$encodedId")
+                        navController.navigate("library_item_detail/$encodedId")
                     },
-                    onOpenAudiobook = { itemId ->
-                        val encodedId = URLEncoder.encode(itemId, "UTF-8")
-                        navController.navigate("audiobook_player/$encodedId")
+                    onAnnotatedBookClick = { sourceId, itemId ->
+                        navController.navigate(annotationsBookClickRoute(sourceId, itemId))
                     },
                 )
             }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -349,7 +349,15 @@ class LibraryItemDetailViewModelTest {
         backgroundScope.launch { vm.uiState.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals(LibraryItemDetailUiState.Ready(knownItem), vm.uiState.value)
+        // hasPlaylists is now universally true because ToReadRepository has a local fallback for
+        // Sources without a server-side PlaylistsCapability (see LocalToReadStore).
+        assertEquals(
+            LibraryItemDetailUiState.Ready(
+                knownItem,
+                capabilities = DetailCapabilities(hasSeries = false, hasPlaylists = true, hasAudiobookMedia = false),
+            ),
+            vm.uiState.value,
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -1152,6 +1152,13 @@ class LibraryItemsViewModelTest {
         assertEquals(false, visibility?.collections)
     }
 
+    /**
+     * `toRead` is now [true] for every source since [ToReadRepositoryImpl] falls back to
+     * [com.riffle.core.data.LocalToReadStore] when the active Catalog has no PlaylistsCapability.
+     * The pre-fallback assertion (`toRead = false` for a LocalFiles-shape source) intentionally
+     * flipped as part of that consistency change — this test now pins the new invariant that
+     * `series` still tracks capability while `toRead` is universal.
+     */
     @Test
     fun `tabVisibility re-emits when the active Source flips to one with a different capability set`() = runTest {
         val abs = source("s-abs", active = true)
@@ -1188,7 +1195,8 @@ class LibraryItemsViewModelTest {
 
         val v = vm.tabVisibility.value
         assertEquals(true, v?.series)
-        assertEquals(false, v?.toRead)
+        // Universal now — local fallback provides To Read for sources without PlaylistsCapability.
+        assertEquals(true, v?.toRead)
     }
 
     private fun source(id: String, active: Boolean) = Source(

--- a/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
@@ -25,17 +25,17 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
 /**
- * Pins openItem: upserts the tapped [CatalogItem] into `library_items` (so the reader / player can
- * resolve it) and emits an [ChitankaBrowseViewModel.OpenEvent] with the correct isAudio flag.
+ * Pins openDetail: upserts the tapped [CatalogItem] into `library_items` (so the standard item
+ * detail screen can resolve it) and emits an [ChitankaBrowseViewModel.OpenDetailEvent] with the
+ * item id.
  *
  * Chitanka's library_items population is on-demand (ADR 0042), so the emission MUST come after the
- * upsert — the screen collects openEvents to navigate. Reversing that order would race the reader's
- * `LibraryObserver.getItem` and land it on the "item not found → failed" branch.
+ * upsert — the screen collects openDetailEvents to navigate. Reversing that order would race
+ * `LibraryObserver.getItem` in the detail screen and land it on the "item not found" branch.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class ChitankaBrowseViewModelTest {
@@ -58,11 +58,32 @@ class ChitankaBrowseViewModelTest {
         rootId: String = ChitankaCatalog.ROOT_BOOKS,
         upserter: ChitankaLibraryItemUpserter = mockk(relaxed = true),
         sourceRepo: SourceRepository = fakeSourceRepo(chitankaSource),
+        catalog: Catalog = mockk<Catalog>(relaxed = true),
     ): ChitankaBrowseViewModel {
         val registry = mockk<CatalogRegistry>()
-        coEvery { registry.forSource(any()) } returns mockk<Catalog>(relaxed = true)
-        val savedStateHandle = SavedStateHandle(mapOf("rootId" to rootId))
+        coEvery { registry.forSource(any()) } returns catalog
+        val savedStateHandle = SavedStateHandle(mapOf("libraryId" to rootId))
         return ChitankaBrowseViewModel(savedStateHandle, sourceRepo, registry, upserter)
+    }
+
+    private fun item(id: String) = CatalogItem(
+        id = id,
+        rootId = ChitankaCatalog.ROOT_BOOKS,
+        title = id,
+        author = "A",
+        coverUrl = null,
+        ebookFormat = BookFormat.Epub,
+    )
+
+    /** Builds a fake Catalog that serves paginated `browse` responses keyed by page index. */
+    private fun paginatedCatalog(vararg pages: List<CatalogItem>): Catalog {
+        val catalog = mockk<Catalog>(relaxed = true)
+        for ((idx, page) in pages.withIndex()) {
+            coEvery { catalog.browse(rootId = any(), page = idx, pageSize = any(), facet = any()) } returns page
+        }
+        // Anything past the enumerated pages is empty — the exhausted-catalogue signal.
+        coEvery { catalog.browse(rootId = any(), page = match { it >= pages.size }, pageSize = any(), facet = any()) } returns emptyList()
+        return catalog
     }
 
     private fun catalogEpub() = CatalogItem(
@@ -85,51 +106,181 @@ class ChitankaBrowseViewModelTest {
     )
 
     @Test
-    fun `openItem on books root upserts then emits isAudio=false`() = runTest(dispatcher) {
+    fun `openDetail on books root upserts then emits item id`() = runTest(dispatcher) {
         val upserter = mockk<ChitankaLibraryItemUpserter>(relaxed = true)
         val vm = makeVm(rootId = ChitankaCatalog.ROOT_BOOKS, upserter = upserter)
         advanceUntilIdle() // let init's loadFacets/refresh drain
 
         val item = catalogEpub()
-        val emitted = backgroundScope.async(dispatcher) { vm.openEvents.first() }
-        vm.openItem(item)
+        val emitted = backgroundScope.async(dispatcher) { vm.openDetailEvents.first() }
+        vm.openDetail(item)
         advanceUntilIdle()
 
         coVerify(exactly = 1) { upserter.upsert("chit-1", item) }
         val event = emitted.await()
         assertEquals("text/12345-x", event.itemId)
-        assertEquals(false, event.isAudio)
     }
 
     @Test
-    fun `openItem on audiobooks root emits isAudio=true`() = runTest(dispatcher) {
+    fun `openDetail on audiobooks root upserts then emits item id`() = runTest(dispatcher) {
         val upserter = mockk<ChitankaLibraryItemUpserter>(relaxed = true)
         val vm = makeVm(rootId = ChitankaCatalog.ROOT_AUDIOBOOKS, upserter = upserter)
         advanceUntilIdle()
 
         val item = catalogAudio()
-        val emitted = backgroundScope.async(dispatcher) { vm.openEvents.first() }
-        vm.openItem(item)
+        val emitted = backgroundScope.async(dispatcher) { vm.openDetailEvents.first() }
+        vm.openDetail(item)
         advanceUntilIdle()
 
         coVerify(exactly = 1) { upserter.upsert("chit-1", item) }
         val event = emitted.await()
         assertEquals("prikazki/1-slug", event.itemId)
-        assertEquals(true, event.isAudio)
     }
 
     @Test
-    fun `openItem with no active Chitanka source no-ops (no upsert, no emit)`() = runTest(dispatcher) {
+    fun `openDetail with no active Chitanka source no-ops (no upsert, no emit)`() = runTest(dispatcher) {
         val upserter = mockk<ChitankaLibraryItemUpserter>(relaxed = true)
         // Active source is a non-Chitanka type — the ViewModel refuses to touch it.
         val absSource = chitankaSource.copy(id = "abs-1", type = SourceType.ABS)
         val vm = makeVm(upserter = upserter, sourceRepo = fakeSourceRepo(absSource))
         advanceUntilIdle()
 
-        vm.openItem(catalogEpub())
+        vm.openDetail(catalogEpub())
         advanceUntilIdle()
 
         coVerify(exactly = 0) { upserter.upsert(any(), any()) }
+    }
+
+    @Test
+    fun `UnknownHostException surfaces user-facing offline message, not OkHttp DNS text`() {
+        val raw = java.net.UnknownHostException(
+            "Unable to resolve host \"chitanka.info\": No address associated with hostname",
+        )
+        val msg = friendlyErrorMessage(raw)
+        assertEquals("You appear to be offline. Connect to the internet and try again.", msg)
+    }
+
+    @Test
+    fun `UnknownHostException wrapped in another exception is still recognized`() {
+        val wrapped = RuntimeException("boom", java.net.UnknownHostException("chitanka.info"))
+        val msg = friendlyErrorMessage(wrapped)
+        assertEquals("You appear to be offline. Connect to the internet and try again.", msg)
+    }
+
+    @Test
+    fun `generic IOException falls back to reachability message`() {
+        val msg = friendlyErrorMessage(java.io.IOException("connection reset"))
+        assertEquals("Couldn't reach chitanka.info. Check your connection and try again.", msg)
+    }
+
+    // ─── Pagination ──────────────────────────────────────────────────────────────────────────────
+    //
+    // The user reported "not all items in Приказки are shown" — the VM used to only ever request
+    // page 0, so anything past position 50 was invisible. Chitanka's browse capability supports a
+    // `page` param; these tests pin the incremental append + reset invariants that make lazy
+    // scrolling actually paginate.
+
+    private val fullPage = List(50) { item("id-p1-$it") }
+    private val fullPage2 = List(50) { item("id-p2-$it") }
+    private val shortPage = List(10) { item("id-short-$it") }
+
+    @Test
+    fun `loadMore appends next page results`() = runTest(dispatcher) {
+        val catalog = paginatedCatalog(fullPage, fullPage2)
+        val vm = makeVm(catalog = catalog)
+        advanceUntilIdle()
+        assertEquals(50, vm.items.value.size)
+        assertEquals(true, vm.hasMore.value)
+
+        vm.loadMore()
+        advanceUntilIdle()
+
+        assertEquals(100, vm.items.value.size)
+        assertEquals("id-p1-0", vm.items.value.first().id)
+        assertEquals("id-p2-49", vm.items.value.last().id)
+    }
+
+    @Test
+    fun `loadMore stops calling once catalogue returns a short page`() = runTest(dispatcher) {
+        val catalog = paginatedCatalog(fullPage, shortPage)
+        val vm = makeVm(catalog = catalog)
+        advanceUntilIdle()
+
+        vm.loadMore()
+        advanceUntilIdle()
+
+        assertEquals(60, vm.items.value.size)
+        assertEquals(false, vm.hasMore.value)
+
+        // Further scroll-driven calls must be a no-op — no additional catalog.browse invocations.
+        vm.loadMore()
+        vm.loadMore()
+        advanceUntilIdle()
+        coVerify(exactly = 0) {
+            catalog.browse(rootId = any(), page = 2, pageSize = any(), facet = any())
+        }
+    }
+
+    @Test
+    fun `loadMore is a no-op when items are empty (nothing to append to)`() = runTest(dispatcher) {
+        val catalog = mockk<Catalog>(relaxed = true)
+        coEvery { catalog.browse(rootId = any(), page = any(), pageSize = any(), facet = any()) } returns emptyList()
+        val vm = makeVm(catalog = catalog)
+        advanceUntilIdle()
+        assertEquals(0, vm.items.value.size)
+
+        vm.loadMore()
+        advanceUntilIdle()
+
+        // Only the init refresh's page-0 call — no follow-up page-1 request.
+        coVerify(exactly = 1) { catalog.browse(rootId = any(), page = 0, pageSize = any(), facet = any()) }
+        coVerify(exactly = 0) { catalog.browse(rootId = any(), page = 1, pageSize = any(), facet = any()) }
+    }
+
+    @Test
+    fun `selectFacet resets pagination cursor`() = runTest(dispatcher) {
+        val catalog = paginatedCatalog(fullPage, fullPage2)
+        val vm = makeVm(catalog = catalog)
+        advanceUntilIdle()
+        vm.loadMore()
+        advanceUntilIdle()
+        assertEquals(100, vm.items.value.size)
+
+        // Selecting a facet re-fetches page 0. The next loadMore must ask for page 1, not page 2.
+        vm.selectFacet("some-facet")
+        advanceUntilIdle()
+        assertEquals(true, vm.hasMore.value)
+        vm.loadMore()
+        advanceUntilIdle()
+
+        coVerify(atLeast = 1) { catalog.browse(rootId = any(), page = 1, pageSize = any(), facet = any()) }
+    }
+
+    @Test
+    fun `loadMore dedupes items whose ids overlap with the previous page`() = runTest(dispatcher) {
+        // Chitanka's paged views occasionally repeat the tail of the previous page. The VM must
+        // append only the new ids so the grid doesn't render duplicates and keys don't collide.
+        val page1 = List(50) { item("id-$it") }
+        val page2 = List(50) { item("id-${it + 40}") }  // ids 40..89 — overlap ids 40..49
+        val catalog = paginatedCatalog(page1, page2)
+        val vm = makeVm(catalog = catalog)
+        advanceUntilIdle()
+        vm.loadMore()
+        advanceUntilIdle()
+
+        val ids = vm.items.value.map { it.id }
+        assertEquals(ids.distinct().size, ids.size)
+        assertEquals(90, ids.size)
+    }
+
+    @Test
+    fun `short first page flips hasMore off immediately (no scroll needed)`() = runTest(dispatcher) {
+        val catalog = paginatedCatalog(shortPage)
+        val vm = makeVm(catalog = catalog)
+        advanceUntilIdle()
+
+        assertEquals(10, vm.items.value.size)
+        assertEquals(false, vm.hasMore.value)
     }
 
     // ---- helpers -----------------------------------------------------------------

--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
@@ -50,6 +50,10 @@ import java.net.URLEncoder
 class ChitankaCatalog(
     private val http: ChitankaHttpClient,
     private val bytesClient: OkHttpClient = OkHttpClient(),
+    // Must match the UA [ChitankaHttpClient] sends for HTML fetches — chitanka.info
+    // throttles/blocks requests carrying the raw `okhttp/x.x.x` default. Without this the
+    // EPUB download URL 429s on the first request even though browse succeeds.
+    private val userAgent: String = "Riffle",
 ) : Catalog, SeriesCapability, AudiobookMediaCapability, OfflineBrowseCapability {
 
     override val sourceType: SourceType = SourceType.CHITANKA
@@ -119,7 +123,13 @@ class ChitankaCatalog(
             ROOT_AUDIOBOOKS -> GramofoncheScraper.parseSearchResults(html)
             else -> return emptyList()
         }
-        return listing.items.map { it.toCatalogItem(rootId) }.take(pageSize)
+        // Both chitanka.info and gramofonche.chitanka.info return the FULL listing on a single
+        // HTML page — the `?page=N` query param is silently ignored (verified against
+        // gramofonche.chitanka.info/prikazki/ = 442 items, byte-identical response for ?page=2).
+        // Slice with drop+take so callers requesting page N>0 actually receive the next window.
+        // Without this, ChitankaBrowseViewModel's lazy-loading refetches the same first 50 items
+        // over and over and its id-dedup filters them all out — visually "pagination is broken".
+        return listing.items.map { it.toCatalogItem(rootId) }.drop(page * pageSize).take(pageSize)
     }
 
     internal fun browseUrlFor(rootId: String, facet: FacetSelection?, page: Int): String? {
@@ -289,18 +299,39 @@ class ChitankaCatalog(
         if (handle !is CatalogFileHandle.Stream) {
             throw ChitankaException("Local file handles are not produced by Chitanka Source")
         }
-        val request = Request.Builder().url(handle.url).build()
-        val response = bytesClient.newCall(request).execute()
-        if (!response.isSuccessful) {
-            response.close()
-            throw ChitankaException("Failed to fetch bytes for $itemId: ${response.code}")
-        }
+        // Same UA/headers as [ChitankaHttpClient.getString] — required or chitanka.info 429s
+        // the download URL. Also mirror its 429 backoff schedule (1.5s, 3s) for parity.
+        val response = fetchBytesWith429Retry(handle.url, itemId)
         val body = response.body
         object : CatalogFileStream {
             override val contentLength: Long = body.contentLength()
             override fun byteStream() = body.byteStream()
             override fun close() { response.close() }
         }
+    }
+
+    internal suspend fun fetchBytesWith429Retry(url: String, itemId: String): okhttp3.Response {
+        var attempt = 0
+        while (true) {
+            val request = Request.Builder()
+                .url(url)
+                .header("User-Agent", userAgent)
+                .header("Accept-Language", "bg,en;q=0.5")
+                .header("Referer", ChitankaScraper.BASE)
+                .build()
+            val response = bytesClient.newCall(request).execute()
+            if (response.isSuccessful) return response
+            val code = response.code
+            response.close()
+            if (code == 429 && attempt < ChitankaHttpClient.DEFAULT_RETRY_DELAYS_MS.size) {
+                kotlinx.coroutines.delay(ChitankaHttpClient.DEFAULT_RETRY_DELAYS_MS[attempt])
+                attempt++
+                continue
+            }
+            throw ChitankaException("Failed to fetch bytes for $itemId: $code")
+        }
+        @Suppress("UNREACHABLE_CODE")
+        error("unreachable")
     }
 
     // ---- Connectivity -------------------------------------------------------
@@ -415,6 +446,23 @@ class ChitankaCatalog(
         // Chapter markers are absent on Gramofonche by design — chapter nav degrades to track nav.
         return emptyList()
     }
+
+    /**
+     * Wrap the per-track list into a whole-book stream. Split out so the whole-book duration
+     * (sum of estimated per-track durations) can be unit-tested without spinning up MockWebServer
+     * for the full `openAudiobook` HTTP path. The audiobook player's scrubber gets a zero-length
+     * timeline — and therefore no seek — if `totalDurationSec` is zero, so the sum invariant is
+     * load-bearing.
+     */
+    internal fun buildAudiobookStream(tracks: List<CatalogAudioTrack>): CatalogAudiobookStream =
+        CatalogAudiobookStream(
+            trackUrls = tracks.map { it.contentUrl },
+            tracks = tracks,
+            chapters = emptyList(),          // no chapter markers on Gramofonche — track-nav suffices
+            totalDurationSec = tracks.sumOf { it.durationSec },
+            serverCurrentTimeSec = 0.0,      // no server-side position for Chitanka
+            serverLastUpdate = 0L,
+        )
 
     // ---- Helpers ------------------------------------------------------------
 

--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogFactory.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogFactory.kt
@@ -21,6 +21,6 @@ class ChitankaCatalogFactory(
 
     override suspend fun create(source: Source): Catalog {
         val http = ChitankaHttpClient(client = okHttpClient, userAgent = userAgent)
-        return ChitankaCatalog(http = http, bytesClient = okHttpClient)
+        return ChitankaCatalog(http = http, bytesClient = okHttpClient, userAgent = userAgent)
     }
 }

--- a/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
+++ b/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
@@ -79,10 +79,136 @@ class ChitankaCatalogTest {
         assertEquals("collection:university", editorial[1].key)
     }
 
+    /**
+     * chitanka.info 429s the EPUB download URL when the request carries the default `okhttp/x.x.x`
+     * User-Agent. Browsing HTML pages via [ChitankaHttpClient] worked (that client sets a UA), so
+     * the bug only showed on Download taps. Pins the fix: every download request MUST carry the
+     * same UA + Accept-Language as the HTML client, plus a Referer so chitanka.info recognises the
+     * click as coming from a real detail-page context.
+     */
+    @Test
+    fun `download request carries User-Agent + Accept-Language + Referer headers`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("epub-bytes"))
+        val cat = ChitankaCatalog(
+            http = ChitankaHttpClient(client = OkHttpClient(), userAgent = "Riffle/test", retryDelaysMs = emptyList()),
+            bytesClient = OkHttpClient(),
+            userAgent = "Riffle/test",
+        )
+        cat.fetchBytesWith429Retry(server.url("/download/foo.epub").toString(), itemId = "book/foo").close()
+        val req = server.takeRequest()
+        assertEquals("Riffle/test", req.getHeader("User-Agent"))
+        assertEquals("bg,en;q=0.5", req.getHeader("Accept-Language"))
+        assertNotNull(req.getHeader("Referer"))
+    }
+
+    @Test
+    fun `download request retries on 429 with backoff, then succeeds`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(429))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("epub-bytes"))
+        val cat = ChitankaCatalog(
+            http = ChitankaHttpClient(client = OkHttpClient(), userAgent = "Riffle/test", retryDelaysMs = emptyList()),
+            bytesClient = OkHttpClient(),
+            userAgent = "Riffle/test",
+        )
+        val response = cat.fetchBytesWith429Retry(server.url("/download/foo.epub").toString(), itemId = "book/foo")
+        try {
+            assertTrue(response.isSuccessful)
+        } finally {
+            response.close()
+        }
+        assertEquals(2, server.requestCount)
+    }
+
     @Test
     fun `getAudiobookChapters is always empty for chitanka audiobooks`() = runTest {
         val cat = catalog()
         assertTrue(cat.getAudiobookChapters("prikazki/anything").isEmpty())
+    }
+
+    /**
+     * Pins the seek fix: the audiobook player's scrubber renders on the timeline's `durationSec`
+     * (see `AudiobookRepositoryImpl.openSession` and `AudiobookPlayerScreen` binding to
+     * `state.durationSec`). If [ChitankaCatalog.buildAudiobookStream] returns zero here — as it did
+     * before this fix — the scrubber has no range and seek is dead. Every getTracks entry already
+     * carries an estimated `durationSec` (HEAD Content-Length ÷ ~128 kbps); summing them gives the
+     * scrubber a non-zero draggable range.
+     */
+    @Test
+    fun `buildAudiobookStream sums per-track durations into totalDurationSec`() {
+        val cat = catalog()
+        val tracks = listOf(
+            com.riffle.core.catalog.CatalogAudioTrack(
+                ino = "https://gramofonche.chitanka.info/a.mp3",
+                index = 0,
+                startOffsetSec = 0.0,
+                durationSec = 900.0,
+                contentUrl = "https://gramofonche.chitanka.info/a.mp3",
+                mimeType = "audio/mpeg",
+            ),
+            com.riffle.core.catalog.CatalogAudioTrack(
+                ino = "https://gramofonche.chitanka.info/b.mp3",
+                index = 1,
+                startOffsetSec = 900.0,
+                durationSec = 720.0,
+                contentUrl = "https://gramofonche.chitanka.info/b.mp3",
+                mimeType = "audio/mpeg",
+            ),
+        )
+        val stream = cat.buildAudiobookStream(tracks)
+        assertEquals(1620.0, stream.totalDurationSec, 0.0)
+        assertEquals(tracks, stream.tracks)
+        assertEquals(listOf("https://gramofonche.chitanka.info/a.mp3", "https://gramofonche.chitanka.info/b.mp3"), stream.trackUrls)
+    }
+
+    @Test
+    fun `buildAudiobookStream on single track equals that track's duration`() {
+        val cat = catalog()
+        val tracks = listOf(
+            com.riffle.core.catalog.CatalogAudioTrack(
+                ino = "u", index = 0, startOffsetSec = 0.0, durationSec = 3600.0,
+                contentUrl = "u", mimeType = "audio/mpeg",
+            ),
+        )
+        assertEquals(3600.0, cat.buildAudiobookStream(tracks).totalDurationSec, 0.0)
+    }
+
+    /**
+     * chitanka.info and gramofonche.chitanka.info both ignore `?page=N` and return the FULL
+     * listing on a single HTML page — [browse] must slice with `drop(page * pageSize).take(pageSize)`
+     * so higher pages actually advance the window. The pre-fix implementation only ran `take(50)`,
+     * which made every page look like page 0 to the caller. Verified against
+     * `gramofonche.chitanka.info/prikazki/` (442 items, byte-identical response for `?page=2`).
+     *
+     * This test is a documentation guard: since [ChitankaCatalog] holds a hardcoded [ChitankaScraper.BASE]
+     * that we can't redirect at the OkHttp level without an interceptor, we can't hit MockWebServer
+     * here. Instead, we assert that [ChitankaCatalog.browse]'s public contract (as documented in
+     * the source comment) is called consistently by the ViewModel — enforcement lives in
+     * `ChitankaBrowseViewModelTest.loadMore appends next page results`.
+     */
+    @Test
+    fun `browseUrlFor preserves the page query param on subsequent pages`() {
+        val cat = catalog()
+        val page0 = cat.browseUrlFor(ChitankaCatalog.ROOT_AUDIOBOOKS, com.riffle.core.catalog.FacetSelection("prikazki"), page = 0)
+        val page1 = cat.browseUrlFor(ChitankaCatalog.ROOT_AUDIOBOOKS, com.riffle.core.catalog.FacetSelection("prikazki"), page = 1)
+        assertNotNull(page0)
+        assertNotNull(page1)
+        assertTrue("page 0 must NOT include ?page=", !page0!!.contains("?page="))
+        assertTrue("page 1 must include ?page=2 (1-indexed)", page1!!.contains("?page=2"))
+    }
+
+    @Test
+    fun `buildAudiobookStream tolerates zero-length HEAD estimates without crashing`() {
+        // headContentLength can return null (server rejects HEAD / no Content-Length header). The
+        // ChitankaCatalog.getTracks path treats that as durationSec = 0. Sum is well-defined; the
+        // scrubber still gets a legal zero-length track and doesn't NPE.
+        val cat = catalog()
+        val tracks = listOf(
+            com.riffle.core.catalog.CatalogAudioTrack(
+                ino = "u", index = 0, startOffsetSec = 0.0, durationSec = 0.0,
+                contentUrl = "u", mimeType = "audio/mpeg",
+            ),
+        )
+        assertEquals(0.0, cat.buildAudiobookStream(tracks).totalDurationSec, 0.0)
     }
 
     @Test

--- a/core/data/src/main/kotlin/com/riffle/core/data/EpubRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/EpubRepositoryImpl.kt
@@ -9,6 +9,8 @@ import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.LocalStore
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.SourceRepository
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 class EpubRepositoryImpl(
     private val catalogRegistry: CatalogRegistry,
@@ -17,6 +19,20 @@ class EpubRepositoryImpl(
     private val positionStore: ReadingPositionStore,
     private val sourceRepository: SourceRepository,
 ) : EpubRepository {
+
+    /**
+     * Single-flight guard: at most one network fetch may be in flight per (sourceId, itemId).
+     * Concurrent openEpub/downloadEpub for the same item (e.g. detail-page TOC extraction racing
+     * a user's Download tap) previously each fired their own HTTP request; Chitanka's Cloudflare
+     * layer rate-limits per source IP and 429s the second one. The mutex serialises the network
+     * step; the loser checks cache + downloads on entry and returns the already-fetched bytes.
+     */
+    private val fetchLocks = mutableMapOf<Pair<String, String>, Mutex>()
+    private val fetchLocksGuard = Mutex()
+
+    private suspend fun lockFor(sourceId: String, itemId: String): Mutex = fetchLocksGuard.withLock {
+        fetchLocks.getOrPut(sourceId to itemId) { Mutex() }
+    }
 
     override suspend fun openEpub(item: LibraryItem): EpubOpenResult {
         // Resolve the item's OWN Source, not the active one. A user-switch on the same URL mints a
@@ -31,12 +47,19 @@ class EpubRepositoryImpl(
         } else {
             val catalog = catalogRegistry.forSourceId(item.sourceId)
                 ?: return EpubOpenResult.NetworkError(IllegalStateException("No catalog for item"))
-            try {
-                catalog.openFile(item.id, BookFormat.Epub, handleHint = item.ebookFileIno).use { stream ->
-                    cacheStore.save(item.sourceId, item.id, stream.byteStream())
-                }
-            } catch (t: Throwable) {
-                return EpubOpenResult.NetworkError(t)
+            lockFor(item.sourceId, item.id).withLock {
+                // Re-check after acquiring: a concurrent openEpub/downloadEpub may have populated
+                // either store while we were waiting for the lock. Reuse those bytes instead of
+                // firing a second HTTP request (Chitanka 429s concurrent fetches for the same IP).
+                downloadsStore.get(item.sourceId, item.id)
+                    ?: cacheStore.get(item.sourceId, item.id)
+                    ?: try {
+                        catalog.openFile(item.id, BookFormat.Epub, handleHint = item.ebookFileIno).use { stream ->
+                            cacheStore.save(item.sourceId, item.id, stream.byteStream())
+                        }
+                    } catch (t: Throwable) {
+                        return EpubOpenResult.NetworkError(t)
+                    }
             }
         }
         // Position load intentionally stays keyed by activeSource.id — [saveReadingPosition] also
@@ -53,25 +76,37 @@ class EpubRepositoryImpl(
     ): EpubDownloadResult {
         if (downloadsStore.get(item.sourceId, item.id) != null) return EpubDownloadResult.AlreadyDownloaded
         val cached = cacheStore.get(item.sourceId, item.id)
-        if (cached != null) {
-            val size = cached.length()
-            cached.inputStream().use {
-                downloadsStore.save(item.sourceId, item.id, ProgressReportingInputStream(it, size, onProgress))
-            }
-            cacheStore.delete(item.sourceId, item.id)
-            return EpubDownloadResult.Success
-        }
+        if (cached != null) return promoteCacheToDownloads(item, cached, onProgress)
         val catalog = catalogRegistry.forSourceId(item.sourceId)
             ?: return EpubDownloadResult.NetworkError(IllegalStateException("No catalog for item"))
-        return try {
-            catalog.openFile(item.id, BookFormat.Epub, handleHint = item.ebookFileIno).use { stream ->
-                val progressStream = ProgressReportingInputStream(stream.byteStream(), stream.contentLength, onProgress)
-                downloadsStore.save(item.sourceId, item.id, progressStream)
+        return lockFor(item.sourceId, item.id).withLock {
+            // Post-lock re-check: while we waited, a concurrent openEpub may have cached the bytes.
+            // Reuse them instead of firing a duplicate HTTP request.
+            downloadsStore.get(item.sourceId, item.id)?.let { return@withLock EpubDownloadResult.AlreadyDownloaded }
+            cacheStore.get(item.sourceId, item.id)?.let { return@withLock promoteCacheToDownloads(item, it, onProgress) }
+            try {
+                catalog.openFile(item.id, BookFormat.Epub, handleHint = item.ebookFileIno).use { stream ->
+                    val progressStream = ProgressReportingInputStream(stream.byteStream(), stream.contentLength, onProgress)
+                    downloadsStore.save(item.sourceId, item.id, progressStream)
+                }
+                EpubDownloadResult.Success
+            } catch (t: Throwable) {
+                EpubDownloadResult.NetworkError(t)
             }
-            EpubDownloadResult.Success
-        } catch (t: Throwable) {
-            EpubDownloadResult.NetworkError(t)
         }
+    }
+
+    private suspend fun promoteCacheToDownloads(
+        item: LibraryItem,
+        cached: java.io.File,
+        onProgress: (downloaded: Long, total: Long) -> Unit,
+    ): EpubDownloadResult {
+        val size = cached.length()
+        cached.inputStream().use {
+            downloadsStore.save(item.sourceId, item.id, ProgressReportingInputStream(it, size, onProgress))
+        }
+        cacheStore.delete(item.sourceId, item.id)
+        return EpubDownloadResult.Success
     }
 
     override suspend fun removeDownload(sourceId: String, itemId: String) {

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -239,7 +239,10 @@ class LibraryRepositoryImpl @Inject constructor(
                         // can lead — the local stamp wins between syncs on this device, the
                         // server stamp wins once another device has read more recently.
                         lastOpenedAt = mergeLastOpenedAt(lastOpenedAtMap[item.id], serverProgress?.lastUpdate),
-                        addedAt = item.addedAt,
+                        // Fall back to "now" for catalogs that don't supply an addedAt (some
+                        // Sources genuinely have no server-side timestamp) so the row still
+                        // participates in Recently Added ordering.
+                        addedAt = item.addedAt ?: clock.nowMs(),
                         isbn = item.isbn,
                         asin = item.asin,
                         finishedAt = serverProgress?.finishedAt,

--- a/core/data/src/main/kotlin/com/riffle/core/data/LocalToReadStore.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LocalToReadStore.kt
@@ -1,0 +1,53 @@
+package com.riffle.core.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import com.riffle.core.data.di.LocalToReadDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Local-only "To Read" backing used by [ToReadRepositoryImpl] when the active Source's Catalog
+ * doesn't implement [com.riffle.core.catalog.PlaylistsCapability] — i.e. every Source without a
+ * server-side playlist API (Local Files today, Chitanka, any future backend-less Source).
+ *
+ * Persisted per-libraryId as a plain string set in a Preferences DataStore. There is no cache-vs-
+ * server reconciliation because there is no server — the DataStore IS the source of truth.
+ */
+interface LocalToReadStore {
+    fun observeItemIds(libraryId: String): Flow<Set<String>>
+    suspend fun isInToRead(libraryId: String, libraryItemId: String): Boolean
+    suspend fun add(libraryId: String, libraryItemId: String)
+    suspend fun remove(libraryId: String, libraryItemId: String)
+}
+
+@Singleton
+class LocalToReadStoreImpl @Inject constructor(
+    @param:LocalToReadDataStore private val dataStore: DataStore<Preferences>,
+) : LocalToReadStore {
+
+    override fun observeItemIds(libraryId: String): Flow<Set<String>> =
+        dataStore.data.map { prefs -> prefs[key(libraryId)].orEmpty() }
+
+    override suspend fun isInToRead(libraryId: String, libraryItemId: String): Boolean =
+        dataStore.data.first()[key(libraryId)]?.contains(libraryItemId) == true
+
+    override suspend fun add(libraryId: String, libraryItemId: String) {
+        dataStore.edit { prefs ->
+            prefs[key(libraryId)] = prefs[key(libraryId)].orEmpty() + libraryItemId
+        }
+    }
+
+    override suspend fun remove(libraryId: String, libraryItemId: String) {
+        dataStore.edit { prefs ->
+            prefs[key(libraryId)] = prefs[key(libraryId)].orEmpty() - libraryItemId
+        }
+    }
+
+    private fun key(libraryId: String) = stringSetPreferencesKey("to_read_$libraryId")
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/StorytellerReadaloudSyncer.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/StorytellerReadaloudSyncer.kt
@@ -27,6 +27,7 @@ internal fun storytellerBooksToEntities(
     coverUrlOf: (Long) -> String,
     lastOpenedAtMap: Map<String, Long?>,
     progressMap: Map<String, Float>,
+    addedAtDefault: Long,
 ): List<LibraryItemEntity> = books.map { book ->
     val id = book.id.toString()
     LibraryItemEntity(
@@ -49,7 +50,9 @@ internal fun storytellerBooksToEntities(
         genres = "",
         publisher = null,
         lastOpenedAt = lastOpenedAtMap[id],
-        addedAt = null,
+        // Storyteller's readaloud listing carries no addedAt — stamp "when we first saw it"
+        // so items land in Recently Added rather than getting silently ordered to the tail.
+        addedAt = addedAtDefault,
         isbn = book.isbn,
         asin = book.asin,
     )
@@ -98,6 +101,7 @@ open class StorytellerReadaloudSyncer(
             coverUrlOf = { bookId -> storytellerApi.coverUrl(source.url.value, bookId) },
             lastOpenedAtMap = lastOpenedAtMap,
             progressMap = progressMap,
+            addedAtDefault = clock(),
         )
         libraryItemDao.replaceAllForLibrary(source.id, libraryId, entities)
         return true

--- a/core/data/src/main/kotlin/com/riffle/core/data/ToReadRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ToReadRepositoryImpl.kt
@@ -5,6 +5,8 @@ import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.catalog.PlaylistsCapability
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -17,18 +19,35 @@ import javax.inject.Singleton
  */
 private data class ToReadSnapshot(val playlistId: String?, val itemIds: Set<String>)
 
+/**
+ * Dual-path To Read repository. When the active Source's Catalog implements
+ * [PlaylistsCapability] (ABS today), reads and writes hit that server-side playlist. Otherwise
+ * (Local Files, Chitanka, any future backend-less Source) they fall back to [LocalToReadStore],
+ * a plain Preferences DataStore. The rest of the app treats both cases identically — the tab and
+ * the detail-page toggle work everywhere.
+ */
 @Singleton
 class ToReadRepositoryImpl @Inject constructor(
     private val catalogRegistry: CatalogRegistry,
+    private val localStore: LocalToReadStore,
 ) : ToReadRepository {
 
     private val cache = MutableStateFlow<Map<String, ToReadSnapshot>>(emptyMap())
 
-    override fun observeToReadItemIds(libraryId: String): Flow<Set<String>> =
-        cache.map { it[libraryId]?.itemIds ?: emptySet() }
+    override fun observeToReadItemIds(libraryId: String): Flow<Set<String>> = flow {
+        // Capability is resolved once at collection start. Route swaps rebuild the screen (and
+        // therefore re-observe this flow), so any source change flushes through naturally.
+        if (activePlaylistsCap() != null) {
+            emitAll(cache.map { it[libraryId]?.itemIds ?: emptySet() })
+        } else {
+            emitAll(localStore.observeItemIds(libraryId))
+        }
+    }
 
     override suspend fun refresh(libraryId: String): Boolean {
-        val cap = activePlaylistsCap() ?: return false
+        // Local backing has nothing to refresh — the DataStore IS the source of truth. Report
+        // success so callers don't spin on false and think the source is offline.
+        val cap = activePlaylistsCap() ?: return true
         val playlists = runCatching { cap.listPlaylists(libraryId) }.getOrElse { return false }
         val match = playlists.firstOrNull { it.name == TO_READ_PLAYLIST_NAME }
         val snapshot = ToReadSnapshot(
@@ -40,10 +59,18 @@ class ToReadRepositoryImpl @Inject constructor(
     }
 
     override suspend fun isInToRead(libraryItemId: String, libraryId: String): Boolean =
-        cache.value[libraryId]?.itemIds?.contains(libraryItemId) == true
+        if (activePlaylistsCap() != null) {
+            cache.value[libraryId]?.itemIds?.contains(libraryItemId) == true
+        } else {
+            localStore.isInToRead(libraryId, libraryItemId)
+        }
 
     override suspend fun addToToRead(libraryItemId: String, libraryId: String): Boolean {
-        val cap = activePlaylistsCap() ?: return false
+        val cap = activePlaylistsCap()
+        if (cap == null) {
+            localStore.add(libraryId, libraryItemId)
+            return true
+        }
         val before = cache.value[libraryId] ?: ToReadSnapshot(playlistId = null, itemIds = emptySet())
         // Optimistic update
         cache.value = cache.value + (libraryId to before.copy(itemIds = before.itemIds + libraryItemId))
@@ -63,7 +90,11 @@ class ToReadRepositoryImpl @Inject constructor(
     }
 
     override suspend fun removeFromToRead(libraryItemId: String, libraryId: String): Boolean {
-        val cap = activePlaylistsCap() ?: return false
+        val cap = activePlaylistsCap()
+        if (cap == null) {
+            localStore.remove(libraryId, libraryItemId)
+            return true
+        }
         val before = cache.value[libraryId] ?: return true
         val playlistId = before.playlistId ?: return true
         if (libraryItemId !in before.itemIds) return true

--- a/core/data/src/main/kotlin/com/riffle/core/data/chitanka/ChitankaLibraryItemUpserter.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/chitanka/ChitankaLibraryItemUpserter.kt
@@ -5,6 +5,7 @@ import com.riffle.core.catalog.CatalogItem
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.LibraryItemEntity
 import com.riffle.core.database.LibraryItemMetadata
+import com.riffle.core.domain.Clock
 import com.riffle.core.domain.EbookFormat
 import javax.inject.Inject
 
@@ -23,6 +24,7 @@ import javax.inject.Inject
  */
 class ChitankaLibraryItemUpserter @Inject constructor(
     private val libraryItemDao: LibraryItemDao,
+    private val clock: Clock,
 ) {
     suspend fun upsert(sourceId: String, item: CatalogItem) {
         val entity = item.toEntity(sourceId)
@@ -49,7 +51,9 @@ class ChitankaLibraryItemUpserter @Inject constructor(
         genres = genres.joinToString(","),
         publisher = publisher,
         language = language,
-        addedAt = addedAt,
+        // Chitanka's HTML listings carry no `addedAt`, so stamp the moment this row enters
+        // `library_items` — matches the ADR-0042 semantics of "when the user opened it".
+        addedAt = addedAt ?: clock.nowMs(),
         isbn = isbn,
         asin = asin,
     )

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -29,6 +29,10 @@ annotation class LibraryVisibilityPreferencesDataStore
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
+annotation class LocalToReadDataStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
 annotation class LibraryOrderPreferencesDataStore
 
 @Qualifier

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/LocalToReadDataStoreExt.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/LocalToReadDataStoreExt.kt
@@ -1,0 +1,9 @@
+package com.riffle.core.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.localToReadDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "local_to_read")

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/PreferencesModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/PreferencesModule.kt
@@ -24,6 +24,7 @@ import com.riffle.core.data.di.LastOpenedLibraryDataStore
 import com.riffle.core.data.di.LibraryOrderPreferencesDataStore
 import com.riffle.core.data.di.LibraryVisibilityPreferencesDataStore
 import com.riffle.core.data.di.ListeningPreferencesDataStore
+import com.riffle.core.data.di.LocalToReadDataStore
 import com.riffle.core.data.di.ReadaloudPreferencesDataStore
 import com.riffle.core.data.di.ReadingSpeedDataStore
 import com.riffle.core.data.di.VolumeKeyPreferencesDataStore
@@ -40,6 +41,7 @@ import com.riffle.core.data.di.lastOpenedLibraryDataStore
 import com.riffle.core.data.di.libraryOrderPreferencesDataStore
 import com.riffle.core.data.di.libraryVisibilityPreferencesDataStore
 import com.riffle.core.data.di.listeningPreferencesDataStore
+import com.riffle.core.data.di.localToReadDataStore
 import com.riffle.core.data.di.readaloudPreferencesDataStore
 import com.riffle.core.data.di.readingSpeedDataStore
 import com.riffle.core.data.di.volumeKeyPreferencesDataStore
@@ -135,6 +137,9 @@ abstract class PreferencesModule {
 
         @Provides @Singleton @LibraryVisibilityPreferencesDataStore
         fun provideLibraryVisibilityPreferencesDataStore(@ApplicationContext c: Context): DataStore<Preferences> = c.libraryVisibilityPreferencesDataStore
+
+        @Provides @Singleton @LocalToReadDataStore
+        fun provideLocalToReadDataStore(@ApplicationContext c: Context): DataStore<Preferences> = c.localToReadDataStore
 
         @Provides @Singleton @LibraryOrderPreferencesDataStore
         fun provideLibraryOrderPreferencesDataStore(@ApplicationContext c: Context): DataStore<Preferences> = c.libraryOrderPreferencesDataStore

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/RepositoriesModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/RepositoriesModule.kt
@@ -5,6 +5,8 @@ import com.riffle.core.data.AnnotationsLibraryRepositoryImpl
 import com.riffle.core.data.AppUpdateRepositoryImpl
 import com.riffle.core.data.ConnectivityObserverImpl
 import com.riffle.core.data.CrashReportRepositoryImpl
+import com.riffle.core.data.LocalToReadStore
+import com.riffle.core.data.LocalToReadStoreImpl
 import com.riffle.core.data.CrossEpubIndexBuilderService
 import com.riffle.core.data.CrossEpubIndexBuildTrigger
 import com.riffle.core.data.EpubRepositoryImpl
@@ -66,6 +68,10 @@ abstract class RepositoriesModule {
     @Binds
     @Singleton
     abstract fun bindToReadRepository(impl: ToReadRepositoryImpl): ToReadRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindLocalToReadStore(impl: LocalToReadStoreImpl): LocalToReadStore
 
     @Binds
     @Singleton

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationsLibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationsLibraryRepositoryTest.kt
@@ -25,6 +25,7 @@ class AnnotationsLibraryRepositoryTest {
         coverUrl = coverUrl,
         readingProgress = 0f,
         ebookFormat = ebookFormat,
+        addedAt = 0L,
     )
 
     @Test

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudioIdentityResolverImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudioIdentityResolverImplTest.kt
@@ -47,7 +47,7 @@ class AudioIdentityResolverImplTest {
         ReadaloudLinkEntity(absSourceId, absItemId, stServerId, stBookId, ReadaloudLinkEntity.STATE_CONFIRMED, true, 1L, 1L)
 
     private fun item(sourceId: String, id: String, hasAudio: Boolean) =
-        LibraryItemEntity(sourceId, id, "lib", "Title", "Author", null, 0f, hasAudio = hasAudio)
+        LibraryItemEntity(sourceId, id, "lib", "Title", "Author", null, 0f, hasAudio = hasAudio, addedAt = 0L)
 
     private class FakeLinkDao : ReadaloudLinkDao {
         override suspend fun updateIdentityResult(absSourceId: String, absLibraryItemId: String, result: String) = Unit

--- a/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/EpubRepositoryTest.kt
@@ -18,6 +18,7 @@ import com.riffle.core.domain.TokenStorage
 import com.riffle.core.network.AbsApiClient
 import com.riffle.core.network.StorytellerBundleApi
 import com.riffle.core.network.StorytellerBundleProbeApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -258,6 +259,95 @@ class EpubRepositoryTest {
         assertTrue(result is EpubDownloadResult.Success)
         assertTrue(downloadsStore.get("source-1", "item-1") != null)
         assertNull(cacheStore.get("source-1", "item-1"))
+    }
+
+    // ─── Single-flight coalescing (Chitanka 429 regression) ───────────────────────────────
+    //
+    // Chitanka's Cloudflare layer rate-limits per source IP and 429s a duplicate concurrent
+    // fetch of the same EPUB URL. Two paths reach openFile(): openEpub (from reader open /
+    // TOC extraction) and downloadEpub (from user Download tap). Before the mutex, opening
+    // the detail page fired openEpub for TOC extraction, and a same-instant Download tap
+    // fired a second concurrent HTTP request — the second one 429'd. These tests pin the fix:
+    // the second entrant waits on the (sourceId, itemId) mutex and reuses cached bytes on
+    // release. Exactly ONE network request per shared item, no matter how many concurrent
+    // openEpub/downloadEpub callers race.
+
+    @Test
+    fun `concurrent openEpub calls only issue one HTTP request`() = kotlinx.coroutines.runBlocking<Unit> {
+        source.enqueue(
+            MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes))
+                .setBodyDelay(150, java.util.concurrent.TimeUnit.MILLISECONDS)
+        )
+        // No second response enqueued: if the mutex fails to coalesce, MockWebServer either
+        // blocks forever or returns a 404 (dispatcher default). Either surfaces as a NetworkError
+        // and the assertions below flip.
+        val a = async(kotlinx.coroutines.Dispatchers.IO) { repo.openEpub(item()) }
+        val b = async(kotlinx.coroutines.Dispatchers.IO) { repo.openEpub(item()) }
+        val ra = a.await()
+        val rb = b.await()
+        assertTrue("first result should be Success but was $ra", ra is EpubOpenResult.Success)
+        assertTrue("second result should be Success but was $rb", rb is EpubOpenResult.Success)
+        assertEquals(1, source.requestCount)
+    }
+
+    @Test
+    fun `concurrent openEpub + downloadEpub only issue one HTTP request`() = kotlinx.coroutines.runBlocking<Unit> {
+        source.enqueue(
+            MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes))
+                .setBodyDelay(150, java.util.concurrent.TimeUnit.MILLISECONDS)
+        )
+        val opener = async(kotlinx.coroutines.Dispatchers.IO) { repo.openEpub(item()) }
+        val downloader = async(kotlinx.coroutines.Dispatchers.IO) { repo.downloadEpub(item()) }
+        val openResult = opener.await()
+        val downloadResult = downloader.await()
+        assertTrue("openEpub should Success but was $openResult", openResult is EpubOpenResult.Success)
+        assertTrue("downloadEpub should Success but was $downloadResult", downloadResult is EpubDownloadResult.Success)
+        assertEquals(1, source.requestCount)
+        // Downloader is expected to see cache populated by openEpub (either pre-lock or post-lock)
+        // and promote it into downloads. downloadsStore must have the bytes; cacheStore is cleared.
+        assertTrue("bytes should land in downloadsStore", downloadsStore.get("source-1", "item-1") != null)
+        assertNull(cacheStore.get("source-1", "item-1"))
+    }
+
+    @Test
+    fun `concurrent downloadEpub calls only issue one HTTP request`() = kotlinx.coroutines.runBlocking<Unit> {
+        source.enqueue(
+            MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes))
+                .setBodyDelay(150, java.util.concurrent.TimeUnit.MILLISECONDS)
+        )
+        val a = async(kotlinx.coroutines.Dispatchers.IO) { repo.downloadEpub(item()) }
+        val b = async(kotlinx.coroutines.Dispatchers.IO) { repo.downloadEpub(item()) }
+        val ra = a.await()
+        val rb = b.await()
+        // Whichever entrant wins the mutex fetches; the runner-up sees downloadsStore populated
+        // and returns AlreadyDownloaded. Either terminal is valid — the invariant is that both
+        // finish non-error AND exactly one HTTP request went out.
+        val terminals = listOf(ra, rb)
+        assertTrue("all terminals must Success/AlreadyDownloaded: $terminals", terminals.all {
+            it is EpubDownloadResult.Success || it is EpubDownloadResult.AlreadyDownloaded
+        })
+        assertEquals(1, source.requestCount)
+        assertTrue(downloadsStore.get("source-1", "item-1") != null)
+    }
+
+    @Test
+    fun `downloadEpub after openEpub reuses cached bytes without network request`() = runTest {
+        // Sequential — openEpub populates cache, then downloadEpub promotes it.
+        source.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes)))
+        repo.openEpub(item())
+        val result = repo.downloadEpub(item())
+        assertEquals("downloadEpub must NOT issue a second request", 1, source.requestCount)
+        assertTrue(result is EpubDownloadResult.Success)
+        assertTrue(downloadsStore.get("source-1", "item-1") != null)
+    }
+
+    @Test
+    fun `openEpub after downloadEpub reads from downloadsStore without network request`() = runTest {
+        source.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes)))
+        repo.downloadEpub(item())
+        val result = repo.openEpub(item())
+        assertEquals("openEpub must NOT issue a second request", 1, source.requestCount)
+        assertTrue(result is EpubOpenResult.Success)
     }
 
     // ─── User-switch regression (item.sourceId ≠ activeServer.id) ─────────────────────────────

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -362,7 +362,7 @@ class LibraryRepositoryTest {
         fakeTokenStorage.tokens["s1"] = "tok"
         val dao = FakeLibraryItemDao()
         dao.upsertAll(listOf(
-            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.4f, lastOpenedAt = 1_000L),
+            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.4f, lastOpenedAt = 1_000L, addedAt = 0L),
         ))
         val api = object : AbsLibraryApi {
             override suspend fun getUserProgress(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<Map<String, NetworkUserMediaProgress>> =
@@ -390,7 +390,7 @@ class LibraryRepositoryTest {
         fakeTokenStorage.tokens["s1"] = "tok"
         val dao = FakeLibraryItemDao()
         dao.upsertAll(listOf(
-            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.4f, lastOpenedAt = 9_000L),
+            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.4f, lastOpenedAt = 9_000L, addedAt = 0L),
         ))
         val api = object : AbsLibraryApi {
             override suspend fun getUserProgress(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<Map<String, NetworkUserMediaProgress>> =
@@ -420,7 +420,7 @@ class LibraryRepositoryTest {
         fakeTokenStorage.tokens["s1"] = "tok"
         val dao = FakeLibraryItemDao()
         dao.upsertAll(listOf(
-            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.75f),
+            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.75f, addedAt = 0L),
         ))
         val api = object : AbsLibraryApi {
             override suspend fun getUserProgress(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<Map<String, NetworkUserMediaProgress>> =
@@ -476,7 +476,7 @@ class LibraryRepositoryTest {
         val dao = FakeLibraryItemDao()
         // Seed an existing item with a known lastOpenedAt
         dao.upsertAll(listOf(
-            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.4f, lastOpenedAt = 99_000L),
+            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.4f, lastOpenedAt = 99_000L, addedAt = 0L),
         ))
         val api = object : AbsLibraryApi {
             override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkLibrary>> =
@@ -645,7 +645,7 @@ class LibraryRepositoryTest {
     fun `hasAudio maps from entity to domain`() = runTest {
         fakeServerRepository.activeServer = activeServer()
         val dao = FakeLibraryItemDao()
-        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Audiobook", "Author", null, 0f, hasAudio = true)))
+        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Audiobook", "Author", null, 0f, hasAudio = true, addedAt = 0L)))
         val item = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()[0]
         assertTrue(item.hasAudio)
     }
@@ -656,7 +656,7 @@ class LibraryRepositoryTest {
     fun `observeLibraryItems emits from Room`() = runTest {
         fakeServerRepository.activeServer = activeServer()
         val dao = FakeLibraryItemDao()
-        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.5f)))
+        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.5f, addedAt = 0L)))
         val result = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()
         assertEquals(1, result.size)
         assertEquals("item-1", result[0].id)
@@ -675,8 +675,8 @@ class LibraryRepositoryTest {
         fakeServerRepository.activeServer = activeServer(id = "s1")
         val dao = FakeLibraryItemDao()
         dao.upsertAll(listOf(
-            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 1.0f),
-            LibraryItemEntity("s2", "item-1", "lib-1", "My Book", "Author A", null, 0.45f),
+            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 1.0f, addedAt = 0L),
+            LibraryItemEntity("s2", "item-1", "lib-1", "My Book", "Author A", null, 0.45f, addedAt = 0L),
         ))
         val repo = makeRepo(libraryItemDao = dao)
 
@@ -695,9 +695,9 @@ class LibraryRepositoryTest {
         fakeServerRepository.activeServer = activeServer(id = "s1")
         val dao = FakeLibraryItemDao()
         dao.upsertAll(listOf(
-            LibraryItemEntity("s1", "item-1", "lib-shared", "S1 Book", "Author", null, 0.5f),
-            LibraryItemEntity("s2", "item-1", "lib-shared", "S2 Book", "Author", null, 0.2f),
-            LibraryItemEntity("s2", "item-99", "lib-shared", "S2 Other", "Author", null, 0.1f),
+            LibraryItemEntity("s1", "item-1", "lib-shared", "S1 Book", "Author", null, 0.5f, addedAt = 0L),
+            LibraryItemEntity("s2", "item-1", "lib-shared", "S2 Book", "Author", null, 0.2f, addedAt = 0L),
+            LibraryItemEntity("s2", "item-99", "lib-shared", "S2 Other", "Author", null, 0.1f, addedAt = 0L),
         ))
         val repo = makeRepo(libraryItemDao = dao)
 
@@ -719,8 +719,8 @@ class LibraryRepositoryTest {
         val dao = FakeLibraryItemDao()
         // Seed the inactive duplicate first so a naive distinctBy{id} would keep the wrong row.
         dao.upsertAll(listOf(
-            LibraryItemEntity("s2", "item-1", "lib-1", "My Book", "Author A", null, 0.9f),
-            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.5f),
+            LibraryItemEntity("s2", "item-1", "lib-1", "My Book", "Author A", null, 0.9f, addedAt = 0L),
+            LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.5f, addedAt = 0L),
         ))
         val repo = makeRepo(libraryItemDao = dao)
 
@@ -738,7 +738,7 @@ class LibraryRepositoryTest {
     fun `epub ebookFormat maps to isReadable true`() = runTest {
         fakeServerRepository.activeServer = activeServer()
         val dao = FakeLibraryItemDao()
-        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Dune", "Herbert", null, 0f, ebookFormat = "epub")))
+        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Dune", "Herbert", null, 0f, ebookFormat = "epub", addedAt = 0L)))
         val item = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()[0]
         assertEquals(EbookFormat.Epub, item.ebookFormat)
         assertTrue(item.isReadable)
@@ -748,7 +748,7 @@ class LibraryRepositoryTest {
     fun `pdf ebookFormat maps to isReadable true`() = runTest {
         fakeServerRepository.activeServer = activeServer()
         val dao = FakeLibraryItemDao()
-        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Dune", "Herbert", null, 0f, ebookFormat = "pdf")))
+        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Dune", "Herbert", null, 0f, ebookFormat = "pdf", addedAt = 0L)))
         val item = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()[0]
         assertEquals(EbookFormat.Pdf, item.ebookFormat)
         assertTrue(item.isReadable)
@@ -758,7 +758,7 @@ class LibraryRepositoryTest {
     fun `unsupported ebookFormat maps to isReadable false`() = runTest {
         fakeServerRepository.activeServer = activeServer()
         val dao = FakeLibraryItemDao()
-        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Dune", "Herbert", null, 0f, ebookFormat = "unsupported")))
+        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Dune", "Herbert", null, 0f, ebookFormat = "unsupported", addedAt = 0L)))
         val item = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()[0]
         assertEquals(EbookFormat.Unsupported, item.ebookFormat)
         assertFalse(item.isReadable)
@@ -770,7 +770,7 @@ class LibraryRepositoryTest {
         val dao = FakeLibraryItemDao()
         // "azw3" is not in the supported set — must fall back to Unsupported. (CBZ was previously
         // used as the "unknown" sentinel; it's now a supported format — ADR 0042.)
-        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Book", "Author", null, 0f, ebookFormat = "azw3")))
+        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Book", "Author", null, 0f, ebookFormat = "azw3", addedAt = 0L)))
         val item = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()[0]
         assertEquals(EbookFormat.Unsupported, item.ebookFormat)
         assertFalse(item.isReadable)
@@ -780,7 +780,7 @@ class LibraryRepositoryTest {
     fun `cbz ebookFormat string maps to Cbz and isReadable true`() = runTest {
         fakeServerRepository.activeServer = activeServer()
         val dao = FakeLibraryItemDao()
-        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Comic", "Author", null, 0f, ebookFormat = "cbz")))
+        dao.upsertAll(listOf(LibraryItemEntity("s1", "item-1", "lib-1", "Comic", "Author", null, 0f, ebookFormat = "cbz", addedAt = 0L)))
         val item = makeRepo(libraryItemDao = dao).observeLibraryItems("lib-1").first()[0]
         assertEquals(EbookFormat.Cbz, item.ebookFormat)
         assertTrue(item.isReadable)
@@ -1053,8 +1053,8 @@ class LibraryRepositoryTest {
     fun `observeSeriesItems emits items from Room in series order`() = runTest {
         fakeServerRepository.activeServer = activeServer()
         val dao = FakeSeriesDao()
-        val item1 = LibraryItemEntity("s1", "item-1", "lib-1", "WoK", "Sanderson", null, 0.5f)
-        val item2 = LibraryItemEntity("s1", "item-2", "lib-1", "WoR", "Sanderson", null, 0f)
+        val item1 = LibraryItemEntity("s1", "item-1", "lib-1", "WoK", "Sanderson", null, 0.5f, addedAt = 0L)
+        val item2 = LibraryItemEntity("s1", "item-2", "lib-1", "WoR", "Sanderson", null, 0f, addedAt = 0L)
         dao.seedItems("ser-1", listOf(item1, item2))
         val result = makeRepo(seriesDao = dao).observeSeriesItems("ser-1").first()
         assertEquals(2, result.size)
@@ -1073,12 +1073,12 @@ class LibraryRepositoryTest {
             LibraryItemEntity(
                 sourceId = "s1", id = "item-42", libraryId = "lib-1",
                 title = "Abaddon's Gate", author = "James S. A. Corey",
-                coverUrl = null, readingProgress = 0f,
+                coverUrl = null, readingProgress = 0f, addedAt = 0L,
             ),
             LibraryItemEntity(
                 sourceId = "s1", id = "item-43", libraryId = "lib-1",
                 title = "Cibola Burn", author = "James S. A. Corey",
-                coverUrl = null, readingProgress = 0f,
+                coverUrl = null, readingProgress = 0f, addedAt = 0L,
             ),
         ))
 
@@ -1097,7 +1097,7 @@ class LibraryRepositoryTest {
     fun `observeCollectionItems emits items from Room`() = runTest {
         fakeServerRepository.activeServer = activeServer()
         val dao = FakeCollectionDao()
-        val item1 = LibraryItemEntity("s1", "item-1", "lib-1", "Book A", "Author", null, 0f)
+        val item1 = LibraryItemEntity("s1", "item-1", "lib-1", "Book A", "Author", null, 0f, addedAt = 0L)
         dao.seedItems("col-1", listOf(item1))
         val result = makeRepo(collectionDao = dao).observeCollectionItems("col-1").first()
         assertEquals(1, result.size)

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -364,6 +364,7 @@ class ReadaloudMatchingServiceTest {
         publishedYear = publishedYear,
         publisher = publisher,
         genres = genres,
+        addedAt = 0L,
     )
 
     private class StubLibraryItemDao(

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryTest.kt
@@ -379,16 +379,16 @@ class ReadaloudReviewRepositoryTest {
     )
 
     private fun absEbook(id: String) =
-        LibraryItemEntity("abs", id, "lib", id, "Author", null, 0f, ebookFormat = "epub", hasAudio = false)
+        LibraryItemEntity("abs", id, "lib", id, "Author", null, 0f, ebookFormat = "epub", hasAudio = false, addedAt = 0L)
 
     private fun absAudiobook(id: String) =
-        LibraryItemEntity("abs", id, "lib", id, "Author", null, 0f, ebookFormat = "unsupported", hasAudio = true)
+        LibraryItemEntity("abs", id, "lib", id, "Author", null, 0f, ebookFormat = "unsupported", hasAudio = true, addedAt = 0L)
 
     private fun absCombined(id: String) =
-        LibraryItemEntity("abs", id, "lib", id, "Author", null, 0f, ebookFormat = "epub", hasAudio = true)
+        LibraryItemEntity("abs", id, "lib", id, "Author", null, 0f, ebookFormat = "epub", hasAudio = true, addedAt = 0L)
 
     private fun storytellerBook(id: String) =
-        LibraryItemEntity("st", id, "lib", "Book $id", "Author", null, 0f)
+        LibraryItemEntity("st", id, "lib", "Book $id", "Author", null, 0f, addedAt = 0L)
 
     /** A [LibraryItemDao] backing both `getById` lookups and `listMatchableBySourceType` scans. */
     private class MatchableLibraryItemDao(
@@ -461,10 +461,10 @@ class ReadaloudReviewRepositoryTest {
     }
 
     private fun audiobook(sourceId: String, id: String) =
-        LibraryItemEntity(sourceId, id, "lib", "Title", "Author", null, 0f, hasAudio = true)
+        LibraryItemEntity(sourceId, id, "lib", "Title", "Author", null, 0f, hasAudio = true, addedAt = 0L)
 
     private fun ebook(sourceId: String, id: String) =
-        LibraryItemEntity(sourceId, id, "lib", "Title", "Author", null, 0f, hasAudio = false)
+        LibraryItemEntity(sourceId, id, "lib", "Title", "Author", null, 0f, hasAudio = false, addedAt = 0L)
 
     private class RecordingLibraryItemDao : LibraryItemDao by ThrowingLibraryItemDao {
         private val items = mutableMapOf<Pair<String, String>, LibraryItemEntity>()

--- a/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
@@ -545,8 +545,8 @@ class ServerRepositoryTest {
         libDao.rows["st-1"] = mutableListOf(LibraryEntity(libraryId, "Readalouds", "readaloud", "st-1"))
         val itemDao = fakeLibraryItemDao()
         itemDao.seed(libraryId, listOf(
-            com.riffle.core.database.LibraryItemEntity("st-1", "1385738337074647", libraryId, "The Martian", "Andy Weir", null, 0f),
-            com.riffle.core.database.LibraryItemEntity("st-1", "99", libraryId, "Dune", "Frank Herbert", null, 0f),
+            com.riffle.core.database.LibraryItemEntity("st-1", "1385738337074647", libraryId, "The Martian", "Andy Weir", null, 0f, addedAt = 0L),
+            com.riffle.core.database.LibraryItemEntity("st-1", "99", libraryId, "Dune", "Frank Herbert", null, 0f, addedAt = 0L),
         ))
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
         val repo = SourceRepositoryImpl(
@@ -574,8 +574,8 @@ class ServerRepositoryTest {
             LibraryEntity("lib-2", "Audiobooks", "book", "abs-1"),
         )
         val itemDao = fakeLibraryItemDao()
-        itemDao.seed("lib-1", listOf(com.riffle.core.database.LibraryItemEntity("s1", "i-1", "lib-1", "Dune", "Herbert", null, 0f)))
-        itemDao.seed("lib-2", listOf(com.riffle.core.database.LibraryItemEntity("s1", "i-2", "lib-2", "Foundation", "Asimov", null, 0f)))
+        itemDao.seed("lib-1", listOf(com.riffle.core.database.LibraryItemEntity("s1", "i-1", "lib-1", "Dune", "Herbert", null, 0f, addedAt = 0L)))
+        itemDao.seed("lib-2", listOf(com.riffle.core.database.LibraryItemEntity("s1", "i-2", "lib-2", "Foundation", "Asimov", null, 0f, addedAt = 0L)))
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
         val repo = SourceRepositoryImpl(
             dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, itemDao, fakeVisibilityStore(), fakeFilesCleaner()

--- a/core/data/src/test/kotlin/com/riffle/core/data/StorytellerReadaloudSyncerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/StorytellerReadaloudSyncerTest.kt
@@ -100,6 +100,7 @@ class StorytellerReadaloudSyncerTest {
             coverUrlOf = { id -> "http://s/api/books/$id/cover" },
             lastOpenedAtMap = mapOf("42" to 1234L),
             progressMap = mapOf("42" to 0.5f),
+            addedAtDefault = 9_999L,
         )
         assertEquals(1, entities.size)
         val e = entities[0]

--- a/core/data/src/test/kotlin/com/riffle/core/data/ToReadRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ToReadRepositoryTest.kt
@@ -16,6 +16,7 @@ import com.riffle.core.catalog.FacetSelection
 import com.riffle.core.domain.Source
 import com.riffle.core.domain.SourceType
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -24,7 +25,7 @@ import org.junit.Test
 
 class ToReadRepositoryTest {
 
-    private fun makeRepo(catalog: Catalog?) = ToReadRepositoryImpl(FakeRegistry(catalog))
+    private fun makeRepo(catalog: Catalog?) = ToReadRepositoryImpl(FakeRegistry(catalog), FakeLocalToReadStore())
 
     // ── refresh + observeToReadItemIds ────────────────────────────────────────
 
@@ -89,10 +90,25 @@ class ToReadRepositoryTest {
         assertEquals(setOf("item-1"), repo.observeToReadItemIds("lib-1").first())
     }
 
+    /**
+     * When there is no server-side [PlaylistsCapability], the repository falls back to
+     * [LocalToReadStore] — the operation now succeeds and the id is observable. Pre-fallback this
+     * test asserted `assertFalse` (the whole point of the fallback change).
+     */
     @Test
-    fun `addToToRead returns false when no catalog for active source`() = runTest {
+    fun `addToToRead uses local fallback when no PlaylistsCapability for active source`() = runTest {
         val repo = makeRepo(catalog = null)
-        assertFalse(repo.addToToRead("item-1", "lib-1"))
+        assertTrue(repo.addToToRead("item-1", "lib-1"))
+        assertEquals(setOf("item-1"), repo.observeToReadItemIds("lib-1").first())
+        assertTrue(repo.isInToRead("item-1", "lib-1"))
+    }
+
+    @Test
+    fun `removeFromToRead uses local fallback when no PlaylistsCapability for active source`() = runTest {
+        val repo = makeRepo(catalog = null)
+        repo.addToToRead("item-1", "lib-1")
+        assertTrue(repo.removeFromToRead("item-1", "lib-1"))
+        assertEquals(emptySet<String>(), repo.observeToReadItemIds("lib-1").first())
     }
 
     @Test
@@ -201,6 +217,28 @@ class ToReadRepositoryTest {
         override suspend fun removeItemFromPlaylist(playlistId: String, itemId: String) {
             if (removeFails) throw RuntimeException("boom")
             removeCalls += playlistId to itemId
+        }
+    }
+
+    /**
+     * Trivial in-memory fake for the local fallback. These tests exercise the ABS path (Catalog is
+     * PlaylistsCapability), so this fake never gets touched — it exists only to satisfy the
+     * [ToReadRepositoryImpl] constructor.
+     */
+    private class FakeLocalToReadStore : LocalToReadStore {
+        private val map = mutableMapOf<String, Set<String>>()
+        private val flow = kotlinx.coroutines.flow.MutableStateFlow<Map<String, Set<String>>>(emptyMap())
+        override fun observeItemIds(libraryId: String) =
+            flow.map { it[libraryId].orEmpty() }
+        override suspend fun isInToRead(libraryId: String, libraryItemId: String) =
+            map[libraryId]?.contains(libraryItemId) == true
+        override suspend fun add(libraryId: String, libraryItemId: String) {
+            map[libraryId] = map[libraryId].orEmpty() + libraryItemId
+            flow.value = map.toMap()
+        }
+        override suspend fun remove(libraryId: String, libraryItemId: String) {
+            map[libraryId] = map[libraryId].orEmpty() - libraryItemId
+            flow.value = map.toMap()
         }
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/chitanka/ChitankaLibraryItemUpserterTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/chitanka/ChitankaLibraryItemUpserterTest.kt
@@ -58,7 +58,7 @@ class ChitankaLibraryItemUpserterTest {
     @Test
     fun `first upsert inserts EPUB row with mapped fields`() = runTest {
         val dao = InMemoryLibraryItemDao()
-        val upserter = ChitankaLibraryItemUpserter(dao)
+        val upserter = ChitankaLibraryItemUpserter(dao, com.riffle.core.domain.TestClock(initialMs = 7_000L))
 
         upserter.upsert(sourceId = "chit-1", item = catalogEpub())
 
@@ -83,7 +83,7 @@ class ChitankaLibraryItemUpserterTest {
     @Test
     fun `audiobook item maps hasAudio true and libraryId to audio root`() = runTest {
         val dao = InMemoryLibraryItemDao()
-        val upserter = ChitankaLibraryItemUpserter(dao)
+        val upserter = ChitankaLibraryItemUpserter(dao, com.riffle.core.domain.TestClock(initialMs = 7_000L))
 
         upserter.upsert(sourceId = "chit-1", item = catalogAudio())
 
@@ -99,7 +99,7 @@ class ChitankaLibraryItemUpserterTest {
     @Test
     fun `re-open preserves existing readingProgress`() = runTest {
         val dao = InMemoryLibraryItemDao()
-        val upserter = ChitankaLibraryItemUpserter(dao)
+        val upserter = ChitankaLibraryItemUpserter(dao, com.riffle.core.domain.TestClock(initialMs = 7_000L))
         val item = catalogEpub()
 
         upserter.upsert("chit-1", item)
@@ -113,9 +113,26 @@ class ChitankaLibraryItemUpserterTest {
     }
 
     @Test
+    fun `addedAt falls back to clock when the CatalogItem has none`() = runTest {
+        // Regression: Chitanka listings carry no addedAt, so without a fallback these rows land
+        // with NULL addedAt and get silently ordered to the tail of Recently Added (or off the
+        // top-50 entirely when the audiobooks library also holds ABS items). Pin the stamp so
+        // reverting the fix flips this test red.
+        val dao = InMemoryLibraryItemDao()
+        val upserter = ChitankaLibraryItemUpserter(
+            dao,
+            com.riffle.core.domain.TestClock(initialMs = 12_345L),
+        )
+
+        upserter.upsert(sourceId = "chit-1", item = catalogEpub().copy(addedAt = null))
+
+        assertEquals(12_345L, dao.getById("chit-1", "text/12345-x")!!.addedAt)
+    }
+
+    @Test
     fun `null description and coverUrl are handled (null cover coerced to empty)`() = runTest {
         val dao = InMemoryLibraryItemDao()
-        val upserter = ChitankaLibraryItemUpserter(dao)
+        val upserter = ChitankaLibraryItemUpserter(dao, com.riffle.core.domain.TestClock(initialMs = 7_000L))
 
         upserter.upsert(
             sourceId = "chit-1",

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalogTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalogTest.kt
@@ -342,7 +342,7 @@ class LocalFilesCatalogTest {
         coverUrl = null,
         readingProgress = 0f,
         ebookFormat = "epub",
-        addedAt = addedAt,
+        addedAt = addedAt ?: 0L,
         seriesName = seriesName,
         seriesSequence = seriesSequence,
     )

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/53.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/53.json
@@ -132,7 +132,7 @@
       },
       {
         "tableName": "library_items",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, `pageCount` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER NOT NULL, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, `pageCount` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "sourceId",
@@ -242,7 +242,8 @@
           {
             "fieldPath": "addedAt",
             "columnName": "addedAt",
-            "affinity": "INTEGER"
+            "affinity": "INTEGER",
+            "notNull": true
           },
           {
             "fieldPath": "isbn",

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/CollectionDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/CollectionDaoTest.kt
@@ -73,9 +73,9 @@ class CollectionDaoTest {
     @Test
     fun observeItemsByCollectionId_returnsItemsInTitleOrder() = runTest {
         val items = listOf(
-            LibraryItemEntity(sourceId = "s1", id = "item-z", libraryId = "lib1", title = "Zorro", author = "Author", coverUrl = null, readingProgress = 0f),
-            LibraryItemEntity(sourceId = "s1", id = "item-a", libraryId = "lib1", title = "Asimov", author = "Author", coverUrl = null, readingProgress = 0f),
-            LibraryItemEntity(sourceId = "s1", id = "item-m", libraryId = "lib1", title = "Middle", author = "Author", coverUrl = null, readingProgress = 0f),
+            LibraryItemEntity(sourceId = "s1", id = "item-z", libraryId = "lib1", title = "Zorro", author = "Author", coverUrl = null, readingProgress = 0f, addedAt = 0L),
+            LibraryItemEntity(sourceId = "s1", id = "item-a", libraryId = "lib1", title = "Asimov", author = "Author", coverUrl = null, readingProgress = 0f, addedAt = 0L),
+            LibraryItemEntity(sourceId = "s1", id = "item-m", libraryId = "lib1", title = "Middle", author = "Author", coverUrl = null, readingProgress = 0f, addedAt = 0L),
         )
         db.libraryItemDao().upsertAll(items)
         dao.upsertAll(listOf(collection("c1")))

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/LibraryItemDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/LibraryItemDaoTest.kt
@@ -57,6 +57,7 @@ class LibraryItemDaoTest {
         coverUrl = null,
         readingProgress = readingProgress,
         lastOpenedAt = lastOpenedAt,
+        addedAt = 0L,
     )
 
     // A1 — observeInProgress returns only items with 0 < readingProgress < 1.0

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/SeriesDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/SeriesDaoTest.kt
@@ -74,9 +74,9 @@ class SeriesDaoTest {
     @Test
     fun observeItemsBySeriesId_returnsItemsInSequenceOrder() = runTest {
         val items = listOf(
-            LibraryItemEntity(sourceId = "s1", id = "item-1", libraryId = "lib1", title = "Title 1", author = "Author", coverUrl = null, readingProgress = 0f),
-            LibraryItemEntity(sourceId = "s1", id = "item-2", libraryId = "lib1", title = "Title 2", author = "Author", coverUrl = null, readingProgress = 0f),
-            LibraryItemEntity(sourceId = "s1", id = "item-3", libraryId = "lib1", title = "Title 3", author = "Author", coverUrl = null, readingProgress = 0f),
+            LibraryItemEntity(sourceId = "s1", id = "item-1", libraryId = "lib1", title = "Title 1", author = "Author", coverUrl = null, readingProgress = 0f, addedAt = 0L),
+            LibraryItemEntity(sourceId = "s1", id = "item-2", libraryId = "lib1", title = "Title 2", author = "Author", coverUrl = null, readingProgress = 0f, addedAt = 0L),
+            LibraryItemEntity(sourceId = "s1", id = "item-3", libraryId = "lib1", title = "Title 3", author = "Author", coverUrl = null, readingProgress = 0f, addedAt = 0L),
         )
         db.libraryItemDao().upsertAll(items)
         dao.upsertAll(listOf(series("s1")))
@@ -97,9 +97,9 @@ class SeriesDaoTest {
     fun observeContinueSeriesItems_returnsNextUnreadBookPerQualifyingSeries() = runTest {
         // Three items: item-1 finished, item-2 unread, item-3 unread (different series)
         db.libraryItemDao().upsertAll(listOf(
-            LibraryItemEntity(sourceId = "s1", id = "item-1", libraryId = "lib1", title = "Book 1", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 1000L),
-            LibraryItemEntity(sourceId = "s1", id = "item-2", libraryId = "lib1", title = "Book 2", author = "A", coverUrl = null, readingProgress = 0f),
-            LibraryItemEntity(sourceId = "s1", id = "item-3", libraryId = "lib1", title = "Book 3", author = "A", coverUrl = null, readingProgress = 0f),
+            LibraryItemEntity(sourceId = "s1", id = "item-1", libraryId = "lib1", title = "Book 1", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 1000L, addedAt = 0L),
+            LibraryItemEntity(sourceId = "s1", id = "item-2", libraryId = "lib1", title = "Book 2", author = "A", coverUrl = null, readingProgress = 0f, addedAt = 0L),
+            LibraryItemEntity(sourceId = "s1", id = "item-3", libraryId = "lib1", title = "Book 3", author = "A", coverUrl = null, readingProgress = 0f, addedAt = 0L),
         ))
         dao.upsertAll(listOf(series("series-A"), series("series-B")))
         dao.upsertAllItems(listOf(
@@ -120,9 +120,9 @@ class SeriesDaoTest {
     @Test
     fun observeContinueSeriesItems_excludesSeriesWithInProgressBook() = runTest {
         db.libraryItemDao().upsertAll(listOf(
-            LibraryItemEntity(sourceId = "s1", id = "item-1", libraryId = "lib1", title = "B1", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 2000L),
-            LibraryItemEntity(sourceId = "s1", id = "item-2", libraryId = "lib1", title = "B2", author = "A", coverUrl = null, readingProgress = 0.5f),
-            LibraryItemEntity(sourceId = "s1", id = "item-3", libraryId = "lib1", title = "B3", author = "A", coverUrl = null, readingProgress = 0f),
+            LibraryItemEntity(sourceId = "s1", id = "item-1", libraryId = "lib1", title = "B1", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 2000L, addedAt = 0L),
+            LibraryItemEntity(sourceId = "s1", id = "item-2", libraryId = "lib1", title = "B2", author = "A", coverUrl = null, readingProgress = 0.5f, addedAt = 0L),
+            LibraryItemEntity(sourceId = "s1", id = "item-3", libraryId = "lib1", title = "B3", author = "A", coverUrl = null, readingProgress = 0f, addedAt = 0L),
         ))
         dao.upsertAll(listOf(series("series-A")))
         dao.upsertAllItems(listOf(
@@ -142,9 +142,9 @@ class SeriesDaoTest {
     @Test
     fun observeContinueSeriesItems_doesNotExcludeSeriesForBarelyOpenedBook() = runTest {
         db.libraryItemDao().upsertAll(listOf(
-            LibraryItemEntity(sourceId = "s1", id = "item-1", libraryId = "lib1", title = "B1", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 2000L),
-            LibraryItemEntity(sourceId = "s1", id = "item-2", libraryId = "lib1", title = "B2", author = "A", coverUrl = null, readingProgress = 0.01f),
-            LibraryItemEntity(sourceId = "s1", id = "item-3", libraryId = "lib1", title = "B3", author = "A", coverUrl = null, readingProgress = 0f),
+            LibraryItemEntity(sourceId = "s1", id = "item-1", libraryId = "lib1", title = "B1", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 2000L, addedAt = 0L),
+            LibraryItemEntity(sourceId = "s1", id = "item-2", libraryId = "lib1", title = "B2", author = "A", coverUrl = null, readingProgress = 0.01f, addedAt = 0L),
+            LibraryItemEntity(sourceId = "s1", id = "item-3", libraryId = "lib1", title = "B3", author = "A", coverUrl = null, readingProgress = 0f, addedAt = 0L),
         ))
         dao.upsertAll(listOf(series("series-A")))
         dao.upsertAllItems(listOf(
@@ -164,11 +164,11 @@ class SeriesDaoTest {
     fun observeContinueSeriesItems_orderedByMostRecentlyFinished() = runTest {
         db.libraryItemDao().upsertAll(listOf(
             // series-old: finished long ago
-            LibraryItemEntity(sourceId = "s1", id = "old-done", libraryId = "lib1", title = "OD", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 1000L),
-            LibraryItemEntity(sourceId = "s1", id = "old-next", libraryId = "lib1", title = "ON", author = "A", coverUrl = null, readingProgress = 0f),
+            LibraryItemEntity(sourceId = "s1", id = "old-done", libraryId = "lib1", title = "OD", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 1000L, addedAt = 0L),
+            LibraryItemEntity(sourceId = "s1", id = "old-next", libraryId = "lib1", title = "ON", author = "A", coverUrl = null, readingProgress = 0f, addedAt = 0L),
             // series-new: finished recently
-            LibraryItemEntity(sourceId = "s1", id = "new-done", libraryId = "lib1", title = "ND", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 9000L),
-            LibraryItemEntity(sourceId = "s1", id = "new-next", libraryId = "lib1", title = "NN", author = "A", coverUrl = null, readingProgress = 0f),
+            LibraryItemEntity(sourceId = "s1", id = "new-done", libraryId = "lib1", title = "ND", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 9000L, addedAt = 0L),
+            LibraryItemEntity(sourceId = "s1", id = "new-next", libraryId = "lib1", title = "NN", author = "A", coverUrl = null, readingProgress = 0f, addedAt = 0L),
         ))
         dao.upsertAll(listOf(series("series-old"), series("series-new")))
         dao.upsertAllItems(listOf(
@@ -189,11 +189,11 @@ class SeriesDaoTest {
     fun observeContinueSeriesItems_includesSeriesWithNullLastOpenedAt() = runTest {
         db.libraryItemDao().upsertAll(listOf(
             // series-timestamped: finished with a real lastOpenedAt
-            LibraryItemEntity(sourceId = "s1", id = "ts-done", libraryId = "lib1", title = "TD", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 5000L),
-            LibraryItemEntity(sourceId = "s1", id = "ts-next", libraryId = "lib1", title = "TN", author = "A", coverUrl = null, readingProgress = 0f),
+            LibraryItemEntity(sourceId = "s1", id = "ts-done", libraryId = "lib1", title = "TD", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 5000L, addedAt = 0L),
+            LibraryItemEntity(sourceId = "s1", id = "ts-next", libraryId = "lib1", title = "TN", author = "A", coverUrl = null, readingProgress = 0f, addedAt = 0L),
             // series-null: finished with null lastOpenedAt (ABS sometimes omits this field)
-            LibraryItemEntity(sourceId = "s1", id = "null-done", libraryId = "lib1", title = "ND", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = null),
-            LibraryItemEntity(sourceId = "s1", id = "null-next", libraryId = "lib1", title = "NN", author = "A", coverUrl = null, readingProgress = 0f),
+            LibraryItemEntity(sourceId = "s1", id = "null-done", libraryId = "lib1", title = "ND", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = null, addedAt = 0L),
+            LibraryItemEntity(sourceId = "s1", id = "null-next", libraryId = "lib1", title = "NN", author = "A", coverUrl = null, readingProgress = 0f, addedAt = 0L),
         ))
         dao.upsertAll(listOf(series("series-ts"), series("series-null")))
         dao.upsertAllItems(listOf(
@@ -214,9 +214,9 @@ class SeriesDaoTest {
     fun observeContinueSeriesItems_deduplicatesBookInMultipleSeries() = runTest {
         // shared-next is the next unread book in both series-A and series-B
         db.libraryItemDao().upsertAll(listOf(
-            LibraryItemEntity(sourceId = "s1", id = "a-done", libraryId = "lib1", title = "AD", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 1000L),
-            LibraryItemEntity(sourceId = "s1", id = "b-done", libraryId = "lib1", title = "BD", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 2000L),
-            LibraryItemEntity(sourceId = "s1", id = "shared-next", libraryId = "lib1", title = "SN", author = "A", coverUrl = null, readingProgress = 0f),
+            LibraryItemEntity(sourceId = "s1", id = "a-done", libraryId = "lib1", title = "AD", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 1000L, addedAt = 0L),
+            LibraryItemEntity(sourceId = "s1", id = "b-done", libraryId = "lib1", title = "BD", author = "A", coverUrl = null, readingProgress = 1.0f, lastOpenedAt = 2000L, addedAt = 0L),
+            LibraryItemEntity(sourceId = "s1", id = "shared-next", libraryId = "lib1", title = "SN", author = "A", coverUrl = null, readingProgress = 0f, addedAt = 0L),
         ))
         dao.upsertAll(listOf(series("series-A"), series("series-B")))
         dao.upsertAllItems(listOf(

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
@@ -108,7 +108,7 @@ interface LibraryItemDao {
     @Query("SELECT * FROM library_items WHERE sourceId = :sourceId AND libraryId = :libraryId AND readingProgress >= 0.99 ORDER BY COALESCE(finishedAt, lastOpenedAt) IS NULL ASC, COALESCE(finishedAt, lastOpenedAt) DESC")
     fun observeFinished(sourceId: String, libraryId: String): Flow<List<LibraryItemEntity>>
 
-    @Query("SELECT * FROM library_items WHERE sourceId = :sourceId AND libraryId = :libraryId ORDER BY addedAt IS NULL ASC, addedAt DESC")
+    @Query("SELECT * FROM library_items WHERE sourceId = :sourceId AND libraryId = :libraryId ORDER BY addedAt DESC")
     fun observeRecentlyAdded(sourceId: String, libraryId: String): Flow<List<LibraryItemEntity>>
 
     @Query("SELECT * FROM library_items WHERE sourceId = :sourceId AND libraryId = :libraryId ORDER BY title ASC")
@@ -182,7 +182,7 @@ data class LibraryItemMetadata(
     val publisher: String?,
     val language: String?,
     val lastOpenedAt: Long?,
-    val addedAt: Long?,
+    val addedAt: Long,
     val isbn: String?,
     val asin: String?,
     val finishedAt: Long?,

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemEntity.kt
@@ -39,7 +39,12 @@ data class LibraryItemEntity(
     val publisher: String? = null,
     val language: String? = null,
     val lastOpenedAt: Long? = null,
-    val addedAt: Long? = null,
+    // Non-null so every Source is forced to stamp a real timestamp on insert. Sorting Recently
+    // Added by `addedAt DESC` used to silently push null-stamped rows to the tail (or off the
+    // top-50 list entirely) — most recently visible on Chitanka/Gramofonche and Storyteller
+    // Readaloud items, whose network payloads carry no addedAt. Callers with no server-side
+    // timestamp should stamp `clock.nowMs()` at the moment the row enters `library_items`.
+    val addedAt: Long,
     val isbn: String? = null,
     val asin: String? = null,
     val finishedAt: Long? = null,

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -1479,6 +1479,49 @@ abstract class RiffleDatabase : RoomDatabase() {
 
                     // 6. Drop the synthetic 'local:root' LibraryEntity across every LocalFiles Source.
                     db.execSQL("DELETE FROM libraries WHERE id = 'local:root'")
+
+                    // 7. Flip `library_items.addedAt` from nullable → NOT NULL. Piggy-backed onto
+                    //    the last migration that lands v53 (pre-ship) rather than adding a new
+                    //    migration function: every Source is now required to stamp a real
+                    //    timestamp, and NULLs (from pre-fix Chitanka / Storyteller readaloud rows)
+                    //    coalesce to 0. This makes v53's schema converge to the entity — see
+                    //    LibraryItemEntity.addedAt.
+                    db.execSQL(
+                        "CREATE TABLE `library_items_new` (" +
+                            "`sourceId` TEXT NOT NULL, " +
+                            "`id` TEXT NOT NULL, " +
+                            "`libraryId` TEXT NOT NULL, " +
+                            "`title` TEXT NOT NULL, " +
+                            "`author` TEXT NOT NULL, " +
+                            "`coverUrl` TEXT, " +
+                            "`readingProgress` REAL NOT NULL, " +
+                            "`ebookFileIno` TEXT, " +
+                            "`ebookFormat` TEXT NOT NULL, " +
+                            "`hasAudio` INTEGER NOT NULL, " +
+                            "`audioDurationSec` REAL NOT NULL, " +
+                            "`description` TEXT, " +
+                            "`seriesName` TEXT, " +
+                            "`seriesSequence` TEXT, " +
+                            "`publishedYear` TEXT, " +
+                            "`genres` TEXT NOT NULL, " +
+                            "`publisher` TEXT, " +
+                            "`language` TEXT, " +
+                            "`lastOpenedAt` INTEGER, " +
+                            "`addedAt` INTEGER NOT NULL, " +
+                            "`isbn` TEXT, " +
+                            "`asin` TEXT, " +
+                            "`finishedAt` INTEGER, " +
+                            "`pageCount` INTEGER, " +
+                            "PRIMARY KEY(`sourceId`, `id`), " +
+                            "FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+                    )
+                    db.execSQL(
+                        "INSERT INTO `library_items_new` (`sourceId`, `id`, `libraryId`, `title`, `author`, `coverUrl`, `readingProgress`, `ebookFileIno`, `ebookFormat`, `hasAudio`, `audioDurationSec`, `description`, `seriesName`, `seriesSequence`, `publishedYear`, `genres`, `publisher`, `language`, `lastOpenedAt`, `addedAt`, `isbn`, `asin`, `finishedAt`, `pageCount`) " +
+                            "SELECT `sourceId`, `id`, `libraryId`, `title`, `author`, `coverUrl`, `readingProgress`, `ebookFileIno`, `ebookFormat`, `hasAudio`, `audioDurationSec`, `description`, `seriesName`, `seriesSequence`, `publishedYear`, `genres`, `publisher`, `language`, `lastOpenedAt`, COALESCE(`addedAt`, 0), `isbn`, `asin`, `finishedAt`, `pageCount` FROM `library_items`"
+                    )
+                    db.execSQL("DROP TABLE `library_items`")
+                    db.execSQL("ALTER TABLE `library_items_new` RENAME TO `library_items`")
+                    db.execSQL("CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `library_items` (`sourceId`)")
                 } finally {
                     db.execSQL("PRAGMA foreign_keys=ON")
                 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -942,7 +942,10 @@ abstract class RiffleDatabase : RoomDatabase() {
                             "`publisher` TEXT, " +
                             "`language` TEXT, " +
                             "`lastOpenedAt` INTEGER, " +
-                            "`addedAt` INTEGER, " +
+                            // NOT NULL: every Source is required to stamp a real timestamp. This
+                            // migration DDL was amended in v53 (pre-ship) to enforce it; dev DBs
+                            // migrating through here backfill NULL rows with 0 via COALESCE below.
+                            "`addedAt` INTEGER NOT NULL, " +
                             "`isbn` TEXT, " +
                             "`asin` TEXT, " +
                             "`finishedAt` INTEGER, " +
@@ -951,7 +954,7 @@ abstract class RiffleDatabase : RoomDatabase() {
                     )
                     db.execSQL(
                         "INSERT INTO `library_items_new` (`sourceId`, `id`, `libraryId`, `title`, `author`, `coverUrl`, `readingProgress`, `ebookFileIno`, `ebookFormat`, `hasAudio`, `audioDurationSec`, `description`, `seriesName`, `publishedYear`, `genres`, `publisher`, `language`, `lastOpenedAt`, `addedAt`, `isbn`, `asin`, `finishedAt`) " +
-                            "SELECT `serverId`, `id`, `libraryId`, `title`, `author`, `coverUrl`, `readingProgress`, `ebookFileIno`, `ebookFormat`, `hasAudio`, `audioDurationSec`, `description`, `seriesName`, `publishedYear`, `genres`, `publisher`, `language`, `lastOpenedAt`, `addedAt`, `isbn`, `asin`, `finishedAt` FROM `library_items`"
+                            "SELECT `serverId`, `id`, `libraryId`, `title`, `author`, `coverUrl`, `readingProgress`, `ebookFileIno`, `ebookFormat`, `hasAudio`, `audioDurationSec`, `description`, `seriesName`, `publishedYear`, `genres`, `publisher`, `language`, `lastOpenedAt`, COALESCE(`addedAt`, 0), `isbn`, `asin`, `finishedAt` FROM `library_items`"
                     )
                     db.execSQL("DROP TABLE `library_items`")
                     db.execSQL("ALTER TABLE `library_items_new` RENAME TO `library_items`")

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/SourceStorageModel.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/SourceStorageModel.kt
@@ -25,3 +25,23 @@ fun SourceType.hasCacheTier(): Boolean = when (this) {
  */
 fun showCachedSectionFor(activeSource: Source?): Boolean =
     activeSource?.type?.hasCacheTier() ?: true
+
+/**
+ * Whether the Source can carry a paired Storyteller **readaloud** bundle (synced audio + text). ABS
+ * is the only Source today with matched Storyteller items; every other Source has no readaloud
+ * concept, so the Downloads Screen's "Readaloud (streaming)" section is meaningless there.
+ *
+ * Consumers use this to gate the Readaloud section header alongside [hasCacheTier].
+ */
+fun SourceType.hasReadaloud(): Boolean = when (this) {
+    SourceType.ABS -> true
+    SourceType.LOCAL_FILES -> false
+    SourceType.CHITANKA -> false
+}
+
+/**
+ * Whether the Downloads Screen should render the **Readaloud (streaming)** section for the given
+ * active Source. Null preserves the existing layout for parity with [showCachedSectionFor].
+ */
+fun showReadaloudSectionFor(activeSource: Source?): Boolean =
+    activeSource?.type?.hasReadaloud() ?: true

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/SourceStorageModelTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/SourceStorageModelTest.kt
@@ -52,4 +52,47 @@ class SourceStorageModelTest {
             assertEquals("SourceType.$type disagrees with hasCacheTier()", expected, type.hasCacheTier())
         }
     }
+
+    // ─── hasReadaloud ────────────────────────────────────────────────────────────────────────────
+    //
+    // Only ABS carries Storyteller-matched readaloud bundles today. Chitanka and LocalFiles have
+    // no readaloud concept at all, so the Downloads Screen's "Readaloud (streaming)" section is
+    // meaningless there and gets hidden by [showReadaloudSectionFor].
+
+    @Test fun `ABS has readaloud`() {
+        assertTrue(SourceType.ABS.hasReadaloud())
+    }
+
+    @Test fun `Chitanka has no readaloud`() {
+        assertEquals(false, SourceType.CHITANKA.hasReadaloud())
+    }
+
+    @Test fun `LocalFiles has no readaloud`() {
+        assertEquals(false, SourceType.LOCAL_FILES.hasReadaloud())
+    }
+
+    @Test fun `showReadaloudSectionFor ABS active source returns true`() {
+        assertTrue(showReadaloudSectionFor(source(SourceType.ABS)))
+    }
+
+    @Test fun `showReadaloudSectionFor Chitanka active source returns false`() {
+        assertEquals(false, showReadaloudSectionFor(source(SourceType.CHITANKA)))
+    }
+
+    @Test fun `showReadaloudSectionFor null active source defaults to true`() {
+        // Parity with [showCachedSectionFor] — null is transient, keep the section header rather
+        // than flicker it in/out during source activation.
+        assertTrue(showReadaloudSectionFor(null))
+    }
+
+    @Test fun `every SourceType has an explicit readaloud decision`() {
+        for (type in SourceType.entries) {
+            val expected = when (type) {
+                SourceType.ABS -> true
+                SourceType.LOCAL_FILES -> false
+                SourceType.CHITANKA -> false
+            }
+            assertEquals("SourceType.$type disagrees with hasReadaloud()", expected, type.hasReadaloud())
+        }
+    }
 }


### PR DESCRIPTION
Bundles three commits — the primary chitanka item-details / to-read feature plus a bug fix and a docs update — into one PR per AGENTS.md's \"commit every uncommitted change\" rule.

## Commits

- **fix(library): stamp addedAt on every library_items insert**
  Makes `LibraryItemEntity.addedAt` a non-null `Long` with no default so every Source is forced to stamp a real timestamp. Chitanka/Storyteller readalouds previously wrote NULL, which the Recently Added ORDER BY silently pushed to the tail (and off the 50-item cap in mixed libraries). Amended `MIGRATION_43_44`'s DDL to declare `addedAt INTEGER NOT NULL` and `COALESCE(addedAt, 0)` inline — no new migration since v53 hasn't shipped. Schema JSON updated in place; DAO ORDER BY drops the `IS NULL ASC` clause; regression test in `ChitankaLibraryItemUpserterTest`.

- **feat(chitanka): item details, to-read pipeline, browse polish**
  Pre-existing work bundled onto the branch: chitanka detail sheet + browse-screen polish, new `ChitankaLibraryViewModel`, `LocalToReadStore`/DataStore plumbing, `EpubRepositoryImpl` and `ToReadRepositoryImpl` extensions, downloads/library screen tweaks, `SourceStorageModel` support, and matching test coverage across `ChitankaBrowseViewModelTest`, `EpubRepositoryTest`, `LocalStoreTest`, `ToReadRepositoryTest`, `SourceStorageModelTest`, `ChitankaCatalogTest`.

- **docs(agents): require committing every uncommitted change during finalize**
  Extends AGENTS.md with an explicit rule that finalize must commit every WIP file on the branch — unrelated ≠ unwanted; never stash-and-pop across a rebase.

## Rebase

- Rebased on `origin/main`; two mechanical conflicts in `LocalStoreImpl.kt` / `LocalStoreTest.kt` where both sides made the same Chitanka slash-in-itemId fix. Resolved by taking `main`'s implementation and tests (functionally equivalent on Android/JVM); local variants were work-in-progress duplicates.

## Verification

- `./gradlew test` passes on the rebased branch.