### PR TITLE
fix(chitanka): gramofonche chapters + description + generic library entry route

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -606,14 +606,10 @@ fun SettingsScreen(
                         supportingContent = { Text("The app has not crashed since installation") },
                     )
                 } else {
-                    Text(
-                        text = "All reports",
-                        style = MaterialTheme.typography.labelMedium,
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
-                    )
                     ListItem(
-                        headlineContent = { Text("${crashReports.size} crash report${if (crashReports.size == 1) "" else "s"}") },
+                        headlineContent = {
+                            Text("${crashReports.size} crash report${if (crashReports.size == 1) "" else "s"}")
+                        },
                         supportingContent = { Text("Newest first") },
                         trailingContent = {
                             Row {
@@ -636,7 +632,7 @@ fun SettingsScreen(
                                     }
                                     context.startActivity(Intent.createChooser(intent, "Share crash reports"))
                                 }) {
-                                    Text("Share")
+                                    Text("Share all")
                                 }
                                 TextButton(onClick = {
                                     viewModel.clearCrashReports()
@@ -646,12 +642,6 @@ fun SettingsScreen(
                                 }
                             }
                         },
-                    )
-                    Text(
-                        text = "Individual reports",
-                        style = MaterialTheme.typography.labelMedium,
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
                     )
                     crashReports.forEach { item ->
                         val timestamp = DateFormat.getDateTimeInstance().format(Date(item.timestampMillis))

--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModel.kt
@@ -166,13 +166,21 @@ class ChitankaBrowseViewModel @Inject constructor(
      * it via `LibraryObserver.getItem`, then emit an [OpenDetailEvent] the screen collects to
      * navigate. No-op when there is no active Chitanka Source — the screen route wouldn't
      * have been reachable, but guard defensively.
+     *
+     * Listing [CatalogItem]s carry only the columns that the search-results HTML exposes
+     * (`ChitankaBookSummary.toCatalogItem` sets description/series/year/genres to null). The
+     * detail page is where the annotation, series, year and genres live, so fetch it via
+     * [Catalog.getItem] first and upsert the enriched item — otherwise the item-detail screen
+     * reads a DB row with description = null and renders no summary. Falls back to the listing
+     * item if the detail fetch fails (offline, transient 429) so navigation still happens.
      */
     fun openDetail(item: CatalogItem) {
         viewModelScope.launch {
             val source = sourceRepository.getActive()
                 ?.takeIf { it.type == SourceType.CHITANKA }
                 ?: return@launch
-            libraryItemUpserter.upsert(source.id, item)
+            val enriched = runCatching { activeCatalog()?.getItem(item.id) }.getOrNull() ?: item
+            libraryItemUpserter.upsert(source.id, enriched)
             _openDetailEvents.emit(OpenDetailEvent(itemId = item.id))
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -92,6 +92,24 @@ internal fun seriesDetailRoute(libraryId: String, seriesId: String, seriesName: 
 internal fun collectionDetailRoute(libraryId: String, collectionId: String, collectionName: String): String =
     "collection_detail/$libraryId/${URLEncoder.encode(collectionId, "UTF-8")}/${URLEncoder.encode(collectionName, "UTF-8")}"
 
+/**
+ * Dispatches to the correct library entry point for [sourceType]:
+ *   - Room-mirrored catalogues (ABS, LocalFiles, …) → `library_items/…`
+ *   - Unbounded catalogues (Chitanka today; future OPDS/Gutenberg) → `chitanka_browse/…`,
+ *     the remote-browse screen that talks to `Catalog.browse` on demand instead of reading a
+ *     pre-populated Room mirror.
+ *
+ * Keeps the dispatch decision in one place so callers don't need to enumerate [SourceType]s
+ * themselves — [SourceType.isUnboundedCatalog] is the only knob a new Source needs to flip.
+ * A null [sourceType] (activeServer hasn't resolved yet on cold start) falls back to
+ * `library_items`; the drawer will correct on the next selection.
+ */
+internal fun libraryEntryRoute(sourceType: com.riffle.core.domain.SourceType?, libraryId: String, libraryName: String): String {
+    val encoded = URLEncoder.encode(libraryName, "UTF-8")
+    return if (sourceType?.isUnboundedCatalog == true) "chitanka_browse/$libraryId/$encoded"
+    else "library_items/$libraryId/$encoded"
+}
+
 @Composable
 fun MainScreen(
     windowSizeClass: WindowSizeClass,
@@ -146,8 +164,7 @@ fun MainScreen(
 
     LaunchedEffect(Unit) {
         viewModel.redirectToLibrary.collect { library ->
-            val encoded = URLEncoder.encode(library.name, "UTF-8")
-            navController.navigateAsRoot("library_items/${library.id}/$encoded")
+            navController.navigateAsRoot(libraryEntryRoute(activeServer?.type, library.id, library.name))
             viewModel.setActiveLibrary(library.id)
         }
     }
@@ -170,11 +187,7 @@ fun MainScreen(
         onLibrarySelected = { library ->
             viewModel.setActiveLibrary(library.id)
             scope.launch { drawerState.close() }
-            val encoded = URLEncoder.encode(library.name, "UTF-8")
-            val isChitanka = activeServer?.type == com.riffle.core.domain.SourceType.CHITANKA
-            val route = if (isChitanka) "chitanka_browse/${library.id}/$encoded"
-            else "library_items/${library.id}/$encoded"
-            navController.navigateAsRoot(route)
+            navController.navigateAsRoot(libraryEntryRoute(activeServer?.type, library.id, library.name))
         },
         onDownloadsSelected = {
             scope.launch { drawerState.close() }
@@ -193,17 +206,7 @@ fun MainScreen(
                     },
                     onNavigateToLibrary = { libraryId, libraryName ->
                         viewModel.setActiveLibrary(libraryId)
-                        val encoded = URLEncoder.encode(libraryName, "UTF-8")
-                        // Mirror the drawer's dispatch (see onLibrarySelected above): Chitanka
-                        // libraries route to the dedicated browse screen because the standard
-                        // library_items screen assumes a Room-mirrored catalogue which Chitanka
-                        // does not populate (ADR 0042). Without this, cold-launching into HOME
-                        // with an active Chitanka source materialises its browse results into
-                        // library_items and shows them in the ABS-shaped grid.
-                        val isChitanka = activeServer?.type == com.riffle.core.domain.SourceType.CHITANKA
-                        val route = if (isChitanka) "chitanka_browse/$libraryId/$encoded"
-                        else "library_items/$libraryId/$encoded"
-                        navController.navigateAsRoot(route)
+                        navController.navigateAsRoot(libraryEntryRoute(activeServer?.type, libraryId, libraryName))
                     },
                 )
             }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -78,6 +78,20 @@ private const val CBZ_READER = "cbz_reader/{itemId}"
 private const val ANNOTATION_SEARCH = "annotation_search/{libraryId}?query={query}"
 private const val AUDIOBOOK_PLAYER = "audiobook_player/{itemId}?startAtSec={startAtSec}"
 
+/**
+ * URL-encodes each path segment in a series-detail route. seriesId is encoded because chitanka
+ * series ids contain slashes (`serie/foo` per ADR 0042) and would otherwise splay across the
+ * fixed [SERIES_DETAIL] template's `{seriesId}` slot, producing the "destination cannot be
+ * found in the navigation graph" crash. Nav Compose auto-decodes path arguments so the receiver
+ * (SeriesDetailViewModel) sees the original id.
+ */
+internal fun seriesDetailRoute(libraryId: String, seriesId: String, seriesName: String): String =
+    "series_detail/$libraryId/${URLEncoder.encode(seriesId, "UTF-8")}/${URLEncoder.encode(seriesName, "UTF-8")}"
+
+/** Same reasoning as [seriesDetailRoute] but for collection ids. */
+internal fun collectionDetailRoute(libraryId: String, collectionId: String, collectionName: String): String =
+    "collection_detail/$libraryId/${URLEncoder.encode(collectionId, "UTF-8")}/${URLEncoder.encode(collectionName, "UTF-8")}"
+
 @Composable
 fun MainScreen(
     windowSizeClass: WindowSizeClass,
@@ -422,12 +436,10 @@ fun MainScreen(
                     onOpenDrawer = { scope.launch { drawerState.open() } },
                     backEnabled = !drawerState.isOpen,
                     onSeriesSelected = { series ->
-                        val encodedName = URLEncoder.encode(series.name, "UTF-8")
-                        navController.navigate("series_detail/$libraryId/${series.id}/$encodedName")
+                        navController.navigate(seriesDetailRoute(libraryId, series.id, series.name))
                     },
                     onCollectionSelected = { collection ->
-                        val encodedName = URLEncoder.encode(collection.name, "UTF-8")
-                        navController.navigate("collection_detail/$libraryId/${collection.id}/$encodedName")
+                        navController.navigate(collectionDetailRoute(libraryId, collection.id, collection.name))
                     },
                     onItemSelected = { item ->
                         val encodedId = URLEncoder.encode(item.id, "UTF-8")
@@ -555,8 +567,7 @@ fun MainScreen(
                         navController.navigate("filtered_books/$libraryId/${facet.name}/$encoded")
                     },
                     onNavigateToSeries = { libraryId, seriesId, seriesName ->
-                        val encodedName = URLEncoder.encode(seriesName, "UTF-8")
-                        navController.navigate("series_detail/$libraryId/$seriesId/$encodedName")
+                        navController.navigate(seriesDetailRoute(libraryId, seriesId, seriesName))
                     },
                 )
             }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -1,6 +1,7 @@
 package com.riffle.app.navigation
 
 import androidx.activity.compose.BackHandler
+import com.riffle.core.domain.SourceType
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
@@ -104,7 +105,7 @@ internal fun collectionDetailRoute(libraryId: String, collectionId: String, coll
  * A null [sourceType] (activeServer hasn't resolved yet on cold start) falls back to
  * `library_items`; the drawer will correct on the next selection.
  */
-internal fun libraryEntryRoute(sourceType: com.riffle.core.domain.SourceType?, libraryId: String, libraryName: String): String {
+internal fun libraryEntryRoute(sourceType: SourceType?, libraryId: String, libraryName: String): String {
     val encoded = URLEncoder.encode(libraryName, "UTF-8")
     return if (sourceType?.isUnboundedCatalog == true) "chitanka_browse/$libraryId/$encoded"
     else "library_items/$libraryId/$encoded"

--- a/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
@@ -58,7 +58,13 @@ class ChitankaBrowseViewModelTest {
         rootId: String = ChitankaCatalog.ROOT_BOOKS,
         upserter: ChitankaLibraryItemUpserter = mockk(relaxed = true),
         sourceRepo: SourceRepository = fakeSourceRepo(chitankaSource),
-        catalog: Catalog = mockk<Catalog>(relaxed = true),
+        catalog: Catalog = mockk<Catalog>(relaxed = true).also {
+            // Relaxed mocks return a stub CatalogItem instead of null for `getItem`, which breaks
+            // the openDetail enrichment fallback in tests that don't explicitly stub it. Pin to
+            // null so the fallback lands on the listing item as it does at runtime for legacy
+            // sources without detail-page metadata.
+            coEvery { it.getItem(any()) } returns null
+        },
     ): ChitankaBrowseViewModel {
         val registry = mockk<CatalogRegistry>()
         coEvery { registry.forSource(any()) } returns catalog
@@ -135,6 +141,53 @@ class ChitankaBrowseViewModelTest {
         coVerify(exactly = 1) { upserter.upsert("chit-1", item) }
         val event = emitted.await()
         assertEquals("prikazki/1-slug", event.itemId)
+    }
+
+    @Test
+    fun `openDetail upserts the detail-enriched item so description reaches the DB row`() = runTest(dispatcher) {
+        // Regression: listing CatalogItems have description=null (ChitankaScraper.parseSearchResults
+        // never fills it). Before the enrichment call the upserter wrote null into `library_items`
+        // and the detail screen — which reads the DB via LibraryObserver.getItem — showed no summary
+        // even though ChitankaScraper.parseDetailPage would have surfaced one. If this ever regresses,
+        // gramofonche AND chitanka book summaries silently disappear from the details screen.
+        val upserter = mockk<ChitankaLibraryItemUpserter>(relaxed = true)
+        val listingItem = catalogEpub()  // description = null
+        val enrichedItem = listingItem.copy(
+            description = "Роман на Иван Вазов…",
+            publishedYear = "1889",
+        )
+        val catalog = mockk<Catalog>(relaxed = true)
+        coEvery { catalog.getItem(listingItem.id) } returns enrichedItem
+
+        val vm = makeVm(rootId = ChitankaCatalog.ROOT_BOOKS, upserter = upserter, catalog = catalog)
+        advanceUntilIdle()
+
+        val emitted = backgroundScope.async(dispatcher) { vm.openDetailEvents.first() }
+        vm.openDetail(listingItem)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { upserter.upsert("chit-1", enrichedItem) }
+        assertEquals(listingItem.id, emitted.await().itemId)
+    }
+
+    @Test
+    fun `openDetail falls back to the listing item when catalog getItem throws`() = runTest(dispatcher) {
+        // Offline / transient 429 on the detail page must not swallow the tap — the user still sees
+        // the detail screen, just without the enriched fields, and can retry from there.
+        val upserter = mockk<ChitankaLibraryItemUpserter>(relaxed = true)
+        val listingItem = catalogEpub()
+        val catalog = mockk<Catalog>(relaxed = true)
+        coEvery { catalog.getItem(listingItem.id) } throws java.io.IOException("boom")
+
+        val vm = makeVm(rootId = ChitankaCatalog.ROOT_BOOKS, upserter = upserter, catalog = catalog)
+        advanceUntilIdle()
+
+        val emitted = backgroundScope.async(dispatcher) { vm.openDetailEvents.first() }
+        vm.openDetail(listingItem)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { upserter.upsert("chit-1", listingItem) }
+        assertEquals(listingItem.id, emitted.await().itemId)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/navigation/DetailRouteEncodingTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/DetailRouteEncodingTest.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.navigation
 
+import com.riffle.core.domain.SourceType
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -46,6 +47,61 @@ class DetailRouteEncodingTest {
         assertEquals(4, segments.size)
         assertEquals("collection_detail", segments[0])
         assertEquals("collection%2Fsome%2Fnested%2Fid", segments[2])
+    }
+
+    // ─── libraryEntryRoute: generic dispatch driven by SourceType.isUnboundedCatalog ────────────
+    //
+    // Regression: cold-launching into a Chitanka library materialised the
+    // library_items screen (which only ever shows the handful of already-opened rows) instead of
+    // the remote-browse screen, presenting as "library only shows 1 item". Fixed by centralising
+    // the dispatch and driving it off SourceType.isUnboundedCatalog rather than an enum
+    // comparison at every call site — a new unbounded Source (OPDS, Gutenberg) only has to flip
+    // the flag on its enum entry.
+
+    @Test
+    fun `libraryEntryRoute for a Room-mirrored source lands on library_items`() {
+        val route = libraryEntryRoute(SourceType.ABS, "lib-1", "Fiction")
+        assertEquals("library_items/lib-1/Fiction", route)
+    }
+
+    @Test
+    fun `libraryEntryRoute for LOCAL_FILES lands on library_items`() {
+        val route = libraryEntryRoute(SourceType.LOCAL_FILES, "lib-1", "Downloads")
+        assertEquals("library_items/lib-1/Downloads", route)
+    }
+
+    @Test
+    fun `libraryEntryRoute for an unbounded catalogue lands on the remote-browse screen`() {
+        val route = libraryEntryRoute(SourceType.CHITANKA, "books", "Chitanka")
+        assertEquals("chitanka_browse/books/Chitanka", route)
+    }
+
+    @Test
+    fun `libraryEntryRoute encodes the library name`() {
+        val route = libraryEntryRoute(SourceType.ABS, "lib-1", "Български")
+        // The encoded segment must not contain literal Cyrillic — nav route templates only match
+        // path-safe strings.
+        assertEquals(
+            "library_items/lib-1/%D0%91%D1%8A%D0%BB%D0%B3%D0%B0%D1%80%D1%81%D0%BA%D0%B8",
+            route,
+        )
+    }
+
+    @Test
+    fun `libraryEntryRoute with null source type falls back to library_items`() {
+        // activeServer hasn't resolved yet on cold start — take the safer bounded UX; the drawer
+        // will correct on the next selection once the source resolves.
+        val route = libraryEntryRoute(null, "lib-1", "Fiction")
+        assertEquals("library_items/lib-1/Fiction", route)
+    }
+
+    @Test
+    fun `SourceType isUnboundedCatalog flag is set exactly for CHITANKA`() {
+        // The flag is what the dispatch keys on — if a future source gets the flag by accident,
+        // the whole entry point would silently switch to remote-browse.
+        assertEquals(false, SourceType.ABS.isUnboundedCatalog)
+        assertEquals(false, SourceType.LOCAL_FILES.isUnboundedCatalog)
+        assertEquals(true, SourceType.CHITANKA.isUnboundedCatalog)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/navigation/DetailRouteEncodingTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/DetailRouteEncodingTest.kt
@@ -1,0 +1,61 @@
+package com.riffle.app.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Regression: chitanka series/collection ids contain slashes (`serie/foo`, per ADR 0042) so the
+ * id MUST be URL-encoded before being spliced into the fixed `series_detail/{libraryId}/{seriesId}/
+ * {seriesName}` template. Without encoding the extra `/` slots break the route match and
+ * NavController throws `IllegalArgumentException: destination cannot be found in the navigation
+ * graph` on tap (see the AVD-5556 crash on "Австралийски квартет" -> `serie/the-australian-quartet`).
+ *
+ * These tests would flip red if either route builder stopped URL-encoding the id — pinning the
+ * fix at the JVM level without needing a NavController.
+ */
+class DetailRouteEncodingTest {
+
+    @Test
+    fun `seriesDetailRoute encodes slashes in the seriesId path segment`() {
+        val route = seriesDetailRoute(
+            libraryId = "books",
+            seriesId = "serie/the-australian-quartet",
+            seriesName = "Австралийски квартет",
+        )
+        // 4 path segments (series_detail + 3 args): id's slash is encoded to %2F so it doesn't
+        // splay into extra segments; the Cyrillic name is UTF-8 percent-encoded.
+        val segments = route.split("/")
+        assertEquals(4, segments.size)
+        assertEquals("series_detail", segments[0])
+        assertEquals("books", segments[1])
+        assertEquals("serie%2Fthe-australian-quartet", segments[2])
+        assertEquals(
+            "%D0%90%D0%B2%D1%81%D1%82%D1%80%D0%B0%D0%BB%D0%B8%D0%B9%D1%81%D0%BA%D0%B8+%D0%BA%D0%B2%D0%B0%D1%80%D1%82%D0%B5%D1%82",
+            segments[3],
+        )
+    }
+
+    @Test
+    fun `collectionDetailRoute encodes slashes in the collectionId path segment`() {
+        val route = collectionDetailRoute(
+            libraryId = "books",
+            collectionId = "collection/some/nested/id",
+            collectionName = "Училищна програма",
+        )
+        val segments = route.split("/")
+        assertEquals(4, segments.size)
+        assertEquals("collection_detail", segments[0])
+        assertEquals("collection%2Fsome%2Fnested%2Fid", segments[2])
+    }
+
+    @Test
+    fun `slash-free ids pass through unchanged (except URL-safe reencoding)`() {
+        // ABS series ids are UUIDs with no reserved characters — encoding is a no-op for them.
+        val route = seriesDetailRoute(
+            libraryId = "lib-1",
+            seriesId = "b3e5d5f0-1234",
+            seriesName = "Foo",
+        )
+        assertEquals("series_detail/lib-1/b3e5d5f0-1234/Foo", route)
+    }
+}

--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
@@ -396,12 +396,23 @@ class ChitankaCatalog(
     override suspend fun getTracks(itemId: String): List<CatalogAudioTrack> {
         val (root, detail) = resolveItem(itemId) ?: return emptyList()
         if (root != ROOT_AUDIOBOOKS) return emptyList()
-        // Gramofonche exposes no per-track duration metadata, so estimate from Content-Length
-        // via HEAD + the site's uniform ~128 kbps MP3 encoding. This isn't perfectly accurate
-        // but gives non-zero startOffsetSec / durationSec so the audiobook player's global
-        // timeline math (AudiobookTracks#trackAt / #absoluteSec) resolves the correct track
-        // across a multi-file book — with zeros, the resolver collapses every playback position
-        // onto the last track's timeline and multi-track resume/scrubbing/chapter-nav break.
+        return tracksFor(detail)
+    }
+
+    /**
+     * Turn a resolved [ChitankaDetail] into per-track spans. Split out so the caller can share a
+     * single detail-page fetch between tracks and chapter titles instead of hitting the network
+     * twice per audiobook open — [openAudiobook] and [getAudiobookChapters] both need the
+     * download list plus HEAD-estimated durations.
+     *
+     * Gramofonche exposes no per-track duration metadata, so estimate from Content-Length via
+     * HEAD + the site's uniform ~128 kbps MP3 encoding. This isn't perfectly accurate but gives
+     * non-zero startOffsetSec / durationSec so the audiobook player's global timeline math
+     * (AudiobookTracks#trackAt / #absoluteSec) resolves the correct track across a multi-file
+     * book — with zeros, the resolver collapses every playback position onto the last track's
+     * timeline and multi-track resume/scrubbing/chapter-nav break.
+     */
+    private suspend fun tracksFor(detail: ChitankaDetail): List<CatalogAudioTrack> {
         val durationsSec = coroutineScope {
             detail.downloads.map { d ->
                 async(Dispatchers.IO) {
@@ -437,10 +448,11 @@ class ChitankaCatalog(
     }
 
     override suspend fun openAudiobook(itemId: String, deviceLabel: String): CatalogAudiobookStream? {
-        val tracks = getTracks(itemId)
+        val (root, detail) = resolveItem(itemId) ?: return null
+        if (root != ROOT_AUDIOBOOKS) return null
+        val tracks = tracksFor(detail)
         if (tracks.isEmpty()) return null
-        val trackTitles = resolveItem(itemId)?.second?.downloads?.map { it.title }.orEmpty()
-        return buildAudiobookStream(tracks, trackTitles)
+        return buildAudiobookStream(tracks, detail.downloads.map { it.title })
     }
 
     override suspend fun getAudiobookChapters(itemId: String): List<CatalogAudiobookChapter> {
@@ -451,31 +463,11 @@ class ChitankaCatalog(
         // transient network failure fall back to an empty list so the drawer degrades gracefully
         // rather than propagating the exception up the ViewModel.
         return runCatching {
-            val tracks = getTracks(itemId)
-            val detail = resolveItem(itemId)?.second ?: return@runCatching emptyList()
-            synthesizeChaptersFromTracks(tracks, detail.downloads.map { it.title })
+            val (root, detail) = resolveItem(itemId) ?: return@runCatching emptyList()
+            if (root != ROOT_AUDIOBOOKS) return@runCatching emptyList()
+            synthesizeChaptersFromTracks(tracksFor(detail), detail.downloads.map { it.title })
         }.getOrElse { emptyList() }
     }
-
-    /**
-     * Wrap the per-track list into a whole-book stream. Split out so the whole-book duration
-     * (sum of estimated per-track durations) can be unit-tested without spinning up MockWebServer
-     * for the full `openAudiobook` HTTP path. The audiobook player's scrubber gets a zero-length
-     * timeline — and therefore no seek — if `totalDurationSec` is zero, so the sum invariant is
-     * load-bearing.
-     */
-    internal fun buildAudiobookStream(
-        tracks: List<CatalogAudioTrack>,
-        trackTitles: List<String> = emptyList(),
-    ): CatalogAudiobookStream =
-        CatalogAudiobookStream(
-            trackUrls = tracks.map { it.contentUrl },
-            tracks = tracks,
-            chapters = synthesizeChaptersFromTracks(tracks, trackTitles),
-            totalDurationSec = tracks.sumOf { it.durationSec },
-            serverCurrentTimeSec = 0.0,      // no server-side position for Chitanka
-            serverLastUpdate = 0L,
-        )
 
     // ---- Helpers ------------------------------------------------------------
 

--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
@@ -439,12 +439,22 @@ class ChitankaCatalog(
     override suspend fun openAudiobook(itemId: String, deviceLabel: String): CatalogAudiobookStream? {
         val tracks = getTracks(itemId)
         if (tracks.isEmpty()) return null
-        return buildAudiobookStream(tracks)
+        val trackTitles = resolveItem(itemId)?.second?.downloads?.map { it.title }.orEmpty()
+        return buildAudiobookStream(tracks, trackTitles)
     }
 
     override suspend fun getAudiobookChapters(itemId: String): List<CatalogAudiobookChapter> {
-        // Chapter markers are absent on Gramofonche by design — chapter nav degrades to track nav.
-        return emptyList()
+        // Gramofonche has no explicit chapter markers, but each MP3 in a multi-track book is a
+        // discrete story/segment with its own title in the anchor text — mirror the ABS-upload
+        // behaviour of the reference `chitanka-to-audiobookshelf` (each file becomes one chapter)
+        // so the player's chapter drawer shows the track list instead of a blank sheet. On a
+        // transient network failure fall back to an empty list so the drawer degrades gracefully
+        // rather than propagating the exception up the ViewModel.
+        return runCatching {
+            val tracks = getTracks(itemId)
+            val detail = resolveItem(itemId)?.second ?: return@runCatching emptyList()
+            synthesizeChaptersFromTracks(tracks, detail.downloads.map { it.title })
+        }.getOrElse { emptyList() }
     }
 
     /**
@@ -454,11 +464,14 @@ class ChitankaCatalog(
      * timeline — and therefore no seek — if `totalDurationSec` is zero, so the sum invariant is
      * load-bearing.
      */
-    internal fun buildAudiobookStream(tracks: List<CatalogAudioTrack>): CatalogAudiobookStream =
+    internal fun buildAudiobookStream(
+        tracks: List<CatalogAudioTrack>,
+        trackTitles: List<String> = emptyList(),
+    ): CatalogAudiobookStream =
         CatalogAudiobookStream(
             trackUrls = tracks.map { it.contentUrl },
             tracks = tracks,
-            chapters = emptyList(),          // no chapter markers on Gramofonche — track-nav suffices
+            chapters = synthesizeChaptersFromTracks(tracks, trackTitles),
             totalDurationSec = tracks.sumOf { it.durationSec },
             serverCurrentTimeSec = 0.0,      // no server-side position for Chitanka
             serverLastUpdate = 0L,
@@ -526,15 +539,38 @@ class ChitankaCatalog(
          * collapse (AbsolutePositionPlayer falls back to ExoPlayer's per-track duration, so the
          * UI shows 0 until the current track resolves and never reflects the whole book).
          */
-        internal fun buildAudiobookStream(tracks: List<CatalogAudioTrack>): CatalogAudiobookStream =
+        internal fun buildAudiobookStream(
+            tracks: List<CatalogAudioTrack>,
+            trackTitles: List<String> = emptyList(),
+        ): CatalogAudiobookStream =
             CatalogAudiobookStream(
                 trackUrls = tracks.map { it.contentUrl },
                 tracks = tracks,
-                chapters = emptyList(),
+                chapters = synthesizeChaptersFromTracks(tracks, trackTitles),
                 totalDurationSec = tracks.sumOf { it.durationSec },
                 serverCurrentTimeSec = 0.0,
                 serverLastUpdate = 0L,
             )
+
+        /**
+         * Turn the per-track spans into chapter markers, one per MP3 file. Titles come from the
+         * anchor text on the detail page (e.g. "Клан-недоклан", "Щъркел и лисица" for the 14-story
+         * 14-малки БГ приказки disc); a track without a title falls back to "Track N" so the
+         * chapter drawer never renders a blank row. Empty input → empty output.
+         */
+        internal fun synthesizeChaptersFromTracks(
+            tracks: List<CatalogAudioTrack>,
+            trackTitles: List<String>,
+        ): List<CatalogAudiobookChapter> = tracks.mapIndexed { i, t ->
+            val fallback = "Track ${i + 1}"
+            val title = trackTitles.getOrNull(i)?.takeIf { it.isNotEmpty() } ?: fallback
+            CatalogAudiobookChapter(
+                index = i,
+                startSec = t.startOffsetSec,
+                endSec = t.startOffsetSec + t.durationSec,
+                title = title,
+            )
+        }
     }
 }
 

--- a/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
+++ b/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
@@ -222,7 +222,7 @@ class ChitankaCatalogTest {
                 mimeType = "audio/mpeg",
             ),
         )
-        val stream = cat.buildAudiobookStream(tracks)
+        val stream = ChitankaCatalog.buildAudiobookStream(tracks)
         assertEquals(1620.0, stream.totalDurationSec, 0.0)
         assertEquals(tracks, stream.tracks)
         assertEquals(listOf("https://gramofonche.chitanka.info/a.mp3", "https://gramofonche.chitanka.info/b.mp3"), stream.trackUrls)
@@ -237,7 +237,7 @@ class ChitankaCatalogTest {
                 contentUrl = "u", mimeType = "audio/mpeg",
             ),
         )
-        assertEquals(3600.0, cat.buildAudiobookStream(tracks).totalDurationSec, 0.0)
+        assertEquals(3600.0, ChitankaCatalog.buildAudiobookStream(tracks).totalDurationSec, 0.0)
     }
 
     /**
@@ -276,7 +276,7 @@ class ChitankaCatalogTest {
                 contentUrl = "u", mimeType = "audio/mpeg",
             ),
         )
-        assertEquals(0.0, cat.buildAudiobookStream(tracks).totalDurationSec, 0.0)
+        assertEquals(0.0, ChitankaCatalog.buildAudiobookStream(tracks).totalDurationSec, 0.0)
     }
 
     @Test

--- a/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
+++ b/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
@@ -120,9 +120,77 @@ class ChitankaCatalogTest {
     }
 
     @Test
-    fun `getAudiobookChapters is always empty for chitanka audiobooks`() = runTest {
+    fun `getAudiobookChapters returns empty when the detail page fails to resolve`() = runTest {
+        // No MockWebServer wired for the real gramofonche host, so resolveItem returns null and
+        // the catalog falls back to an empty chapter list — the audiobook player's chapter drawer
+        // stays empty rather than crashing.
         val cat = catalog()
         assertTrue(cat.getAudiobookChapters("prikazki/anything").isEmpty())
+    }
+
+    @Test
+    fun `synthesizeChaptersFromTracks yields one chapter per track with cumulative timing`() {
+        // Gramofonche multi-file books (e.g. `/prikazki/14-malki-bg-prikazki--cd750-kanev-balkanton/`
+        // has 14 stories) should render each MP3 as a separate chapter in the player, mirroring
+        // Audiobookshelf's default multi-file chapter synthesis. Titles come from the anchor text
+        // of each MP3 link.
+        val tracks = listOf(
+            CatalogAudioTrack(
+                ino = "a", index = 0, startOffsetSec = 0.0, durationSec = 900.0,
+                contentUrl = "a", mimeType = "audio/mpeg",
+            ),
+            CatalogAudioTrack(
+                ino = "b", index = 1, startOffsetSec = 900.0, durationSec = 720.5,
+                contentUrl = "b", mimeType = "audio/mpeg",
+            ),
+        )
+        val chapters = ChitankaCatalog.synthesizeChaptersFromTracks(
+            tracks,
+            listOf("Клан-недоклан", "Щъркел и лисица"),
+        )
+        assertEquals(2, chapters.size)
+        assertEquals(0, chapters[0].index)
+        assertEquals(0.0, chapters[0].startSec, 0.0)
+        assertEquals(900.0, chapters[0].endSec, 0.0)
+        assertEquals("Клан-недоклан", chapters[0].title)
+        assertEquals(1, chapters[1].index)
+        assertEquals(900.0, chapters[1].startSec, 0.0)
+        assertEquals(1620.5, chapters[1].endSec, 1e-9)
+        assertEquals("Щъркел и лисица", chapters[1].title)
+    }
+
+    @Test
+    fun `synthesizeChaptersFromTracks falls back to Track N when title is missing`() {
+        // A track without a title in the source anchor (or the titles list too short) still needs a
+        // non-blank chapter row so the drawer doesn't render an empty entry.
+        val tracks = listOf(
+            CatalogAudioTrack(
+                ino = "a", index = 0, startOffsetSec = 0.0, durationSec = 600.0,
+                contentUrl = "a", mimeType = "audio/mpeg",
+            ),
+        )
+        val chapters = ChitankaCatalog.synthesizeChaptersFromTracks(tracks, emptyList())
+        assertEquals("Track 1", chapters[0].title)
+    }
+
+    @Test
+    fun `buildAudiobookStream populates chapters from track titles`() {
+        // Regression: openAudiobook used to hardcode chapters = emptyList(), so the chapter drawer
+        // never showed the per-story track list for multi-file gramofonche books.
+        val tracks = listOf(
+            CatalogAudioTrack(
+                ino = "a", index = 0, startOffsetSec = 0.0, durationSec = 900.0,
+                contentUrl = "a", mimeType = "audio/mpeg",
+            ),
+            CatalogAudioTrack(
+                ino = "b", index = 1, startOffsetSec = 900.0, durationSec = 720.0,
+                contentUrl = "b", mimeType = "audio/mpeg",
+            ),
+        )
+        val stream = ChitankaCatalog.buildAudiobookStream(tracks, listOf("Клан-недоклан", "Щъркел и лисица"))
+        assertEquals(2, stream.chapters.size)
+        assertEquals("Клан-недоклан", stream.chapters[0].title)
+        assertEquals("Щъркел и лисица", stream.chapters[1].title)
     }
 
     /**
@@ -244,7 +312,10 @@ class ChitankaCatalogTest {
         val stream = ChitankaCatalog.buildAudiobookStream(tracks)
         assertEquals(2100.5, stream.totalDurationSec, 1e-9)
         assertEquals(tracks.map { it.contentUrl }, stream.trackUrls)
-        assertTrue(stream.chapters.isEmpty())
+        // Without explicit titles, chapters still fill in with "Track N" placeholders — one per
+        // track — so the chapter drawer never renders blank.
+        assertEquals(2, stream.chapters.size)
+        assertEquals(listOf("Track 1", "Track 2"), stream.chapters.map { it.title })
     }
 
     @Test

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/SourceType.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/SourceType.kt
@@ -1,7 +1,16 @@
 package com.riffle.core.domain
 
-enum class SourceType {
+enum class SourceType(
+    /**
+     * True when this Source's catalogue is too large to Room-mirror — the library screen must
+     * browse it remotely on demand rather than reading from `library_items`. `library_items` for
+     * these Sources only holds the handful of rows the user has already opened (ADR 0042). UI
+     * routing keys off this flag instead of enumerating the type set so a future unbounded Source
+     * (OPDS, Gutenberg, …) inherits the remote-browse UX without touching MainScreen.
+     */
+    val isUnboundedCatalog: Boolean = false,
+) {
     ABS,
     LOCAL_FILES,
-    CHITANKA,
+    CHITANKA(isUnboundedCatalog = true),
 }


### PR DESCRIPTION
## Summary

Three interlocking fixes plus one small cleanup on the Chitanka Source path.

### 1. Gramofonche chapters + description enrichment (`25d785880` / `115270e38`)

- Multi-file Gramofonche audiobooks used to render an empty chapter drawer. `getAudiobookChapters` was hard-coded to `emptyList()` even though each MP3 link on a detail page is a discrete story with its own anchor-text title (e.g. 14 stories on `/prikazki/14-malki-bg-prikazki--cd750-kanev-balkanton/`). Now synthesises one chapter per track — `title` from the anchor text (falling back to `Track N`), with cumulative `startSec`/`endSec` from the estimated durations. Mirrors the reference `chitanka-to-audiobookshelf` behaviour of one-file-per-ABS-chapter.
- Chitanka listing `CatalogItem`s carry only cover/title/authors — description, series, year, genres, language are only produced by `ChitankaScraper.parseDetailPage`. `ChitankaBrowseViewModel.openDetail` was upserting the listing item verbatim, so the details screen (which reads DB via `LibraryObserver.getItem`) never saw any summary — including the chitanka book annotations that #508 taught the scraper to parse. `openDetail` now fetches `catalog.getItem(item.id)` first and upserts the detail-enriched item; falls back to the listing item on offline / 429.
- Follow-up refactor collapses the double-fetch: `openAudiobook` + `getAudiobookChapters` each used to resolve the detail page twice (once via `getTracks` for spans, again to reach the track titles). Introduced `tracksFor(detail)` so each call site resolves once. Also deleted the duplicate instance `buildAudiobookStream`; the companion is now the single implementation.

### 2. Detail-route encoding (`e4bade734`)

`series_detail/…` and `collection_detail/…` route templates broke on any id that contained a slash (chitanka series ids look like `serie/foo` per ADR 0042 — the raw slash split across the fixed `{seriesId}` slot and Compose Nav threw "destination cannot be found in the navigation graph"). Extracted `seriesDetailRoute` / `collectionDetailRoute` helpers that URL-encode the id before concatenating; call sites updated. Nav Compose auto-decodes, so receivers see the original id.

### 3. Generic library entry-route dispatch (`108479d89`)

Cold-launching into a Chitanka library dropped the user on `library_items` — which only ever shows the handful of already-opened rows (ADR 0042) — presenting as "library won't load past 1 item". The `redirectToLibrary` `LaunchedEffect` in `MainScreen` was unconditionally routing to `library_items/…`; the drawer + Home tile each had an inline `activeServer?.type == CHITANKA` check that would break the same way if a future unbounded Source (OPDS, Gutenberg, …) came along.

Fix generically:
- Added `SourceType.isUnboundedCatalog: Boolean` — data on the enum. Only CHITANKA sets it today; new unbounded Sources flip the flag and inherit the same UX.
- Extracted `libraryEntryRoute(sourceType, libraryId, libraryName)` in `MainScreen` — single dispatch site driven by the flag.
- Replaced all three inline enum-type checks with the helper.

### 4. Settings Diagnostics cleanup (`08f08007e`)

The Diagnostics crash-report section rendered two headers ("All reports" + "Individual reports") that presented the same list twice. Collapsed to a single header row that hosts Share all / Clear as trailing actions, followed directly by the per-crash rows. Renamed the bulk button to "Share all" to disambiguate from the per-item Share.

## Test plan

- [x] `./gradlew test` green.
- Regression tests added:
  - `ChitankaCatalogTest.synthesizeChaptersFromTracks yields one chapter per track with cumulative timing` (Bulgarian titles).
  - `ChitankaCatalogTest.synthesizeChaptersFromTracks falls back to Track N when title is missing`.
  - `ChitankaCatalogTest.buildAudiobookStream populates chapters from track titles`.
  - `ChitankaBrowseViewModelTest.openDetail upserts the detail-enriched item so description reaches the DB row`.
  - `ChitankaBrowseViewModelTest.openDetail falls back to the listing item when catalog getItem throws`.
  - `DetailRouteEncodingTest` — series id URL-encoding + `libraryEntryRoute` dispatch table (ABS + LOCAL_FILES → `library_items`; CHITANKA → `chitanka_browse`; null → `library_items`; `isUnboundedCatalog` exact set).
- [ ] Manual repro on `emulator-5556`: (a) verify multi-file Gramofonche book renders per-story chapters, (b) verify chitanka book detail shows its summary, (c) verify Chitanka drawer cold-start lands on the browse screen not `library_items`.

## Follow-ups (deferred)

- Route name `chitanka_browse/…` is still Chitanka-branded even though the dispatch is generic. Cosmetic rename ("remote_browse/…") deferred to a follow-up.