### PR TITLE
fix(chitanka): stop gramofonche detail parser swallowing metadata into author/narrator

### DIFF
--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraper.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraper.kt
@@ -3,7 +3,19 @@ package com.riffle.core.catalog.chitanka
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
+import org.jsoup.nodes.TextNode
 import java.net.URI
+
+/**
+ * Returns the element's text with `<br>` treated as a line break. Bulgarian catalog pages
+ * separate metadata fields with `<br>`, and jsoup's `.text()` collapses them into a single
+ * space, which lets `[^\n]+` regexes greedily swallow every following field.
+ */
+private fun textWithLineBreaks(el: Element): String {
+    val clone = el.clone()
+    clone.select("br").forEach { it.replaceWith(TextNode("\n")) }
+    return clone.wholeText()
+}
 
 /**
  * Kotlin/jsoup port of `lib/scraper/chitanka.ts` from the reference
@@ -299,7 +311,7 @@ internal object GramofoncheScraper {
         val title = doc.selectFirst("#content-wrapper h1")?.text()?.trim().orEmpty()
             .ifEmpty { doc.selectFirst("h1")?.text()?.trim().orEmpty() }
 
-        val contentText = doc.selectFirst("#content-wrapper")?.text().orEmpty()
+        val contentText = doc.selectFirst("#content-wrapper")?.let(::textWithLineBreaks).orEmpty()
 
         val authors = mutableListOf<String>()
         Regex("автор:\\s*([^\\n]+)").find(contentText)?.let { m ->
@@ -308,7 +320,7 @@ internal object GramofoncheScraper {
 
         val narrators = mutableListOf<String>()
         doc.select("blockquote").forEach { el ->
-            val bqText = el.text()
+            val bqText = textWithLineBreaks(el)
             Regex("изпълнение:\\s*([^\\n]+)").find(bqText)?.let { m ->
                 m.groupValues[1].split(",").forEach { part ->
                     part.trim().takeIf { it.isNotEmpty() }?.let(narrators::add)

--- a/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraperTest.kt
+++ b/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraperTest.kt
@@ -142,5 +142,18 @@ class GramofoncheScraperTest {
         )
         assertEquals("Bulgarian", d.language)
         assertEquals("mp3", d.format)
+
+        // Regression: `<br>`-separated fields must not bleed into `автор:` / `изпълнение:`
+        // — `.text()` collapses `<br>` to a space, so the earlier `[^\n]+` regex was
+        // swallowing every subsequent metadata field into the author/narrator list.
+        assertEquals(listOf("Шехерезада"), d.authors)
+        assertTrue(
+            "narrators should not include stray field labels, got ${d.narrators}",
+            d.narrators.none { it.contains(":") || it.contains("издания") },
+        )
+        assertTrue(
+            "expected the first narrator to be a clean name, got ${d.narrators}",
+            d.narrators.isNotEmpty() && d.narrators.first() == "Георги Кадурин",
+        )
     }
 }


### PR DESCRIPTION
## Summary

Gramofonche detail pages separate metadata fields (`автор:`, `вид:`, `качество:`, `изпълнение:`, `издания:`, …) with `<br>` tags. jsoup's `Element.text()` collapses `<br>` into a single space, so the `[^\n]+`-terminated regexes for `автор:` and `изпълнение:` never hit a newline and greedily captured every following field.

Result: on the item details screen every gramofonche book showed the entire metadata blob under "By …", e.g. *"By Димитър Инкьов вид: театър/драматизация качество: ~/+ съдържание: горе-долу, хубав запис участници: режисьор: Бойко Кънев музика: Бойко Кънев изпълнение: Христо Руков …"*

## Fix

Small `textWithLineBreaks(Element)` helper that clones the element, replaces `<br>` with a `\n` `TextNode`, and reads `wholeText()` — so field-terminating newlines survive into the regex input. Applied to both the top-level `#content-wrapper` read (author, year) and the participants blockquote (narrators).

Bounded-pattern regexes (`година:\s*(\d{4})`, `(\d+)мин`) were already safe, and the description path (meta description with blockquote fallback) is untouched.

## Test plan

- [x] Extended `GramofoncheScraperTest`.`detail page extracts mp3 downloads and cover` to assert `authors == ["Шехерезада"]` and that the first narrator is a clean name (`Георги Кадурин`) with no `:` or field-label bleed. Would flip red if the fix were reverted.
- [x] `./gradlew :core:catalog-chitanka:test` — green.