### PR TITLE
fix(chitanka): percent-encode raw spaces in gramofonche mp3 hrefs

### DIFF
--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraper.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraper.kt
@@ -15,15 +15,23 @@ internal object ChitankaScraper {
 
     const val BASE = "https://chitanka.info"
 
-    /** Resolves relative hrefs against [BASE]; percent-encodes non-ASCII as needed. */
+    /**
+     * Resolves relative hrefs against [BASE]; percent-encodes non-ASCII as needed. Gramofonche
+     * mp3 anchors carry raw spaces in the filename (e.g. `1-Vremeto na prabogovete.mp3`), which
+     * [URI] rejects with `IllegalArgumentException` — encode them to `%20` up front so the parse
+     * succeeds and the resulting URL is actually usable by OkHttp. Without this, HEAD-based
+     * per-track duration probing collapses to 0 for any book whose filenames contain spaces and
+     * the chapter drawer renders every entry as `0:00 / 0m`.
+     */
     internal fun toAbsolute(href: String?, pageUrl: String = "$BASE/"): String {
         if (href.isNullOrEmpty()) return ""
         if (href.startsWith("http")) return href
         if (href.startsWith("//")) return "https:$href"
+        val safeHref = href.replace(" ", "%20")
         return try {
-            URI(pageUrl).resolve(href).toASCIIString()
+            URI(pageUrl).resolve(safeHref).toASCIIString()
         } catch (_: Exception) {
-            "$BASE${if (href.startsWith("/")) href else "/$href"}"
+            "$BASE${if (safeHref.startsWith("/")) safeHref else "/$safeHref"}"
         }
     }
 

--- a/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraperTest.kt
+++ b/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraperTest.kt
@@ -97,6 +97,21 @@ class ChitankaScraperTest {
     }
 
     @Test
+    fun `toAbsolute percent-encodes raw spaces in relative hrefs`() {
+        // Gramofonche mp3 anchors carry raw spaces in the filename (e.g. grycki-legendi book).
+        // Without space→%20 pre-encoding, URI.resolve throws and the fallback produces a URL
+        // with literal spaces that OkHttp cannot parse — so per-track HEAD probes fail and every
+        // chapter renders as 0:00 / 0m in the drawer. Assertion would flip red on revert.
+        assertEquals(
+            "https://gramofonche.chitanka.info/prikazki/grycki-legendi/dir/1-Vremeto%20na%20prabogovete.mp3",
+            ChitankaScraper.toAbsolute(
+                "./dir/1-Vremeto na prabogovete.mp3",
+                pageUrl = "https://gramofonche.chitanka.info/prikazki/grycki-legendi/",
+            ),
+        )
+    }
+
+    @Test
     fun `empty href returns empty absolute`() {
         assertEquals("", ChitankaScraper.toAbsolute(null))
         assertEquals("", ChitankaScraper.toAbsolute(""))


### PR DESCRIPTION
## Summary

Every chapter in a gramofonche audiobook whose mp3 filenames contain spaces (e.g. `1-Vremeto na prabogovete.mp3` on `/prikazki/grycki-legendi/`) rendered as `0:00 / 0m` in the chapter drawer. The 14-story fixture used by #511's tests happened to have space-free filenames, so the regression only surfaced on real books.

**Root cause.** `ChitankaScraper.toAbsolute` calls `URI(pageUrl).resolve(href)` on the raw anchor href, and `URI` rejects raw spaces with `IllegalArgumentException: Illegal character in path`. The catch branch then concatenates `"$BASE/$href"` without any encoding, so downstream OkHttp receives a URL with literal spaces and refuses to parse it. `headContentLength` returns `null` for every track, `tracksFor` propagates `durationSec = 0.0`, and `synthesizeChaptersFromTracks` computes cumulative start/end = 0 for every chapter.

**Fix.** Replace `" "` with `"%20"` before handing the href to `URI.resolve`. `toASCIIString()` already percent-encodes any remaining non-ASCII, so no other characters need special handling.

## Test plan

- [x] `./gradlew :core:catalog-chitanka:test --tests ChitankaScraperTest` — new `toAbsolute percent-encodes raw spaces in relative hrefs` assertion passes and would flip red on revert.
- [ ] Manual: open a gramofonche audiobook with spaces in filenames (e.g. `/prikazki/grycki-legendi/`) and confirm the chapter drawer shows non-zero start/duration.