### PR TITLE
fix(source): keep switcher order static, matching Settings

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
@@ -42,8 +42,14 @@ class SourceRepositoryImpl @Inject constructor(
     private val filesCleaner: SourceFilesCleaner,
 ) : SourceRepository {
 
+    // Sort by SourceType so consumers (Settings sources list, drawer source switcher) render in
+    // the same canonical order: ABS servers → LocalFiles → Chitanka. Kotlin's sortedBy is stable,
+    // so the DAO's alphabetical (username, url) ordering is preserved as the tiebreaker within
+    // each bucket.
     override fun observeAll(): Flow<List<Source>> =
-        dao.observeAll().map { list -> list.map { it.toDomain() } }
+        dao.observeAll().map { list ->
+            list.map { it.toDomain() }.sortedBy { it.type.ordinal }
+        }
 
     override suspend fun getActive(): Source? = dao.getActive()?.toDomain()
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
@@ -22,6 +22,7 @@ import com.riffle.core.network.AbsServerInfoApi
 import com.riffle.core.network.NetworkLibrary
 import com.riffle.core.network.StorytellerApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -204,6 +205,32 @@ class ServerRepositoryTest {
             error("should not be called")
         override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<com.riffle.core.network.NetworkCollection>> =
             error("should not be called")
+    }
+
+    // Settings renders sources as ABS → LocalFiles → Chitanka; the drawer source-switcher must
+    // agree, and neither surface may reshuffle when the active source changes.
+    @Test
+    fun `observeAll orders sources by SourceType (ABS, LocalFiles, Chitanka) regardless of active`() = runTest {
+        val abs1 = SourceEntity("abs-1", "https://abs-1", isActive = false, insecureConnectionAllowed = false, username = "a", type = "ABS")
+        val abs2 = SourceEntity("abs-2", "https://abs-2", isActive = false, insecureConnectionAllowed = false, username = "b", type = "ABS")
+        val local = SourceEntity("local", "content://local", isActive = false, insecureConnectionAllowed = false, username = "", type = "LOCAL_FILES")
+        val chitanka = SourceEntity("chit", "https://chitanka.info", isActive = false, insecureConnectionAllowed = false, username = "", type = "CHITANKA")
+
+        // Feed the DAO in an order that deliberately mixes types so any missing sort would show.
+        val dao = fakeDao(chitanka, abs2, local, abs1)
+        val repo = SourceRepositoryImpl(
+            dao, fakeTokenStorage(), AbsApi { _, _, _, _ -> error("not called") }, storytellerApiNotCalled,
+            fakeServerInfoApi, libsApiNotCalled, fakeLibraryDao(), fakeLibraryItemDao(),
+            fakeVisibilityStore(), fakeFilesCleaner(),
+        )
+
+        val idsInactive = repo.observeAll().first().map { it.id }
+        assertEquals(listOf("abs-2", "abs-1", "local", "chit"), idsInactive)
+
+        // Flipping active must NOT reshuffle the switcher order.
+        dao.setActiveAtomic("chit")
+        val idsAfterActive = repo.observeAll().first().map { it.id }
+        assertEquals(idsInactive, idsAfterActive)
     }
 
     @Test

--- a/core/database/src/main/kotlin/com/riffle/core/database/SourceDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/SourceDao.kt
@@ -10,7 +10,9 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface SourceDao {
 
-    @Query("SELECT * FROM sources ORDER BY isActive DESC, serverType ASC, username ASC, url ASC")
+    // Order is stable across active-source changes so the switcher list doesn't reshuffle on
+    // every switch — the check-mark alone identifies the active row.
+    @Query("SELECT * FROM sources ORDER BY serverType ASC, username ASC, url ASC")
     fun observeAll(): Flow<List<SourceEntity>>
 
     @Query("SELECT * FROM sources WHERE isActive = 1 LIMIT 1")


### PR DESCRIPTION
## Summary

The source switcher dropdown reshuffled on every source switch, and its order disagreed with the Settings sources list. Two root causes:

- `SourceDao.observeAll()` sorted by `isActive DESC` first, so flipping the active source moved its row to the top of the switcher — the check-mark already identifies the active row.
- `SourceRepositoryImpl.observeAll()` didn't group by `SourceType`, so the switcher (username/url alphabetical) disagreed with Settings, which groups **ABS → LocalFiles → Chitanka**.

Fix: drop `isActive DESC` from the DAO and apply a stable `sortedBy { it.type.ordinal }` at the repository seam so both surfaces (Settings + switcher) render sources in the same canonical order. Kotlin's stable sort preserves the DAO's `(username, url)` tiebreaker inside each bucket.

## Test plan

- [x] Added `SourceRepositoryTest."observeAll orders sources by SourceType (ABS, LocalFiles, Chitanka) regardless of active"` — asserts (a) a mixed DAO stream emerges ordered `ABS → LocalFiles → Chitanka` and (b) the id sequence is unchanged after `setActiveAtomic()`. Reverting either the DAO or the repo sort flips a specific `assertEquals`.
- [x] `./gradlew :core:data:testDebugUnitTest` green locally.