### PR TITLE
fix(downloads): ungate Cached and Readaloud sections from active source

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
@@ -115,7 +115,7 @@ fun DownloadsScreen(
                 // Cached section renders only when the store actually has cached bytes.
                 // Sources with a local store but no user-visible cache tier (Chitanka's tacit
                 // page cache never populates this) then don't ship dead "No cached books" UI.
-                if (uiState.showCachedSection && uiState.cachedItems.isNotEmpty()) {
+                if (uiState.cachedItems.isNotEmpty()) {
                     item {
                         SectionHeader(
                             title = "Cached",
@@ -134,28 +134,22 @@ fun DownloadsScreen(
                     }
                 }
 
-                if (uiState.showReadaloudSection) {
+                if (uiState.readaloudSidecars.isNotEmpty()) {
                     item {
                         SectionHeader(
                             title = "Readaloud (streaming)",
-                            totalLabel = if (uiState.readaloudSidecars.isNotEmpty()) formatBytes(uiState.readaloudSidecarsTotalBytes) else null,
-                            actionLabel = if (uiState.readaloudSidecars.isNotEmpty()) "Clear all" else null,
+                            totalLabel = formatBytes(uiState.readaloudSidecarsTotalBytes),
+                            actionLabel = "Clear all",
                             onAction = { viewModel.clearAllReadaloudSidecars() },
                         )
                     }
-                    if (uiState.readaloudSidecars.isEmpty()) {
-                        item {
-                            EmptySection("No prepared readalouds")
-                        }
-                    } else {
-                        items(uiState.readaloudSidecars, key = { "sidecar/" + it.sourceId + "/" + it.item.id }) { entry ->
-                            LocalItemRow(
-                                entry = entry,
-                                pillColor = PillColor.Readaloud,
-                                onClick = { onItemSelected(entry.item) },
-                                onRemove = { viewModel.removeReadaloudSidecar(entry.sourceId, entry.item.id) },
-                            )
-                        }
+                    items(uiState.readaloudSidecars, key = { "sidecar/" + it.sourceId + "/" + it.item.id }) { entry ->
+                        LocalItemRow(
+                            entry = entry,
+                            pillColor = PillColor.Readaloud,
+                            onClick = { onItemSelected(entry.item) },
+                            onRemove = { viewModel.removeReadaloudSidecar(entry.sourceId, entry.item.id) },
+                        )
                     }
                 }
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsViewModel.kt
@@ -2,9 +2,6 @@ package com.riffle.app.feature.downloads
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.riffle.core.catalog.CatalogRegistry
-import com.riffle.core.catalog.DownloadsCapability
-import com.riffle.core.catalog.ReadaloudCapability
 import com.riffle.core.domain.DownloadsRepository
 import com.riffle.core.domain.LibraryItem
 import com.riffle.core.domain.LibraryObserver
@@ -25,12 +22,6 @@ data class DownloadsUiState(
     val downloadedItems: List<LocalItemUi> = emptyList(),
     val cachedItems: List<LocalItemUi> = emptyList(),
     val readaloudSidecars: List<LocalItemUi> = emptyList(),
-    /** True when the active Source's Catalog declares [DownloadsCapability] — gates both the
-     *  Downloaded and Cached sections (Cached is a tier of the same local store). */
-    val showCachedSection: Boolean = true,
-    /** True when the active Source's Catalog declares [ReadaloudCapability] — gates the
-     *  "Readaloud (streaming)" section header. */
-    val showReadaloudSection: Boolean = true,
 ) {
     val downloadedTotalBytes: Long get() = downloadedItems.sumOf { it.sizeBytes }
     val cachedTotalBytes: Long get() = cachedItems.sumOf { it.sizeBytes }
@@ -42,7 +33,6 @@ class DownloadsViewModel @Inject constructor(
     private val downloadsRepository: DownloadsRepository,
     private val libraryObserver: LibraryObserver,
     private val sidecarStore: com.riffle.core.data.ReadaloudSidecarStore,
-    private val catalogRegistry: CatalogRegistry,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(DownloadsUiState())
@@ -75,20 +65,10 @@ class DownloadsViewModel @Inject constructor(
                 }
             }
 
-            val activeCatalog = catalogRegistry.forActive()
-            // Absent active catalog → default to showing sections; a transient no-source-yet UI
-            // shouldn't flicker sections in and out. `is` check (not the inline `has<T>()`)
-            // because core:catalog compiles at JVM target 21 and this module pins 17 — the
-            // reified inline can't cross that boundary. Same rationale as
-            // [LibraryItemsViewModel.tabVisibility].
-            val hasDownloads = activeCatalog?.let { it is DownloadsCapability } ?: true
-            val hasReadaloud = activeCatalog?.let { it is ReadaloudCapability } ?: true
             _uiState.value = DownloadsUiState(
                 downloadedItems = downloadedItems,
                 cachedItems = cachedItems,
                 readaloudSidecars = readaloudSidecars,
-                showCachedSection = hasDownloads,
-                showReadaloudSection = hasReadaloud,
             )
         }
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/downloads/DownloadsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/downloads/DownloadsViewModelTest.kt
@@ -1,0 +1,91 @@
+package com.riffle.app.feature.downloads
+
+import com.riffle.core.data.ReadaloudSidecarStore
+import com.riffle.core.domain.DownloadsRepository
+import com.riffle.core.domain.EbookFormat
+import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.StoredItemRef
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DownloadsViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before fun setUp() { Dispatchers.setMain(dispatcher) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    private fun item(sourceId: String, id: String, title: String) = LibraryItem(
+        id = id,
+        libraryId = "lib-$sourceId",
+        title = title,
+        author = "author",
+        coverUrl = null,
+        readingProgress = 0f,
+        isCached = false,
+        isDownloaded = false,
+        ebookFormat = EbookFormat.Epub,
+        sourceId = sourceId,
+    )
+
+    /** Regression: PR fix ungating Cached and Readaloud sections from the active source.
+     *
+     *  Prior behavior threaded the active Catalog's DownloadsCapability / ReadaloudCapability into
+     *  showCachedSection / showReadaloudSection flags. When the active library was LocalFiles (which
+     *  omits both capabilities), the ViewModel silently produced state that told the UI to hide
+     *  every ABS/Chitanka/Storyteller Cached row and every Storyteller readaloud sidecar — even
+     *  though the Downloaded list was rendered app-wide. The fix removes the capability lookup so
+     *  all three lists behave the same way (populated whenever local artifacts exist).
+     *
+     *  This test would fail if someone re-adds capability gating: injecting a CatalogRegistry (or any
+     *  active-source predicate) that drops rows from non-matching sources would make the cached and
+     *  sidecar lists empty here. */
+    @Test
+    fun `populates all sections regardless of active source`() = runTest(dispatcher) {
+        val downloadsRepo = mockk<DownloadsRepository>(relaxed = true)
+        every { downloadsRepo.getDownloadedItems() } returns listOf(
+            StoredItemRef("abs", "abs-book"),
+            StoredItemRef("chitanka", "ch-book"),
+        )
+        every { downloadsRepo.getCachedItems() } returns listOf(
+            StoredItemRef("abs", "abs-cached"),
+        )
+        every { downloadsRepo.sizeOf(any(), any()) } returns 1024L
+
+        val libraryObserver = mockk<LibraryObserver>()
+        coEvery { libraryObserver.getItem("abs", "abs-book") } returns item("abs", "abs-book", "ABS Downloaded")
+        coEvery { libraryObserver.getItem("chitanka", "ch-book") } returns item("chitanka", "ch-book", "Chitanka Downloaded")
+        coEvery { libraryObserver.getItem("abs", "abs-cached") } returns item("abs", "abs-cached", "ABS Cached")
+        coEvery { libraryObserver.getItem("storyteller", "st-book") } returns item("storyteller", "st-book", "Storyteller Readaloud")
+
+        val sidecarStore = mockk<ReadaloudSidecarStore>(relaxed = true)
+        every { sidecarStore.listCached() } returns listOf(
+            ReadaloudSidecarStore.CachedSidecar("storyteller", "st-book", 2048L),
+        )
+
+        val vm = DownloadsViewModel(downloadsRepo, libraryObserver, sidecarStore)
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertEquals(
+            listOf("ABS Downloaded", "Chitanka Downloaded"),
+            state.downloadedItems.map { it.item.title },
+        )
+        assertEquals(listOf("ABS Cached"), state.cachedItems.map { it.item.title })
+        assertEquals(listOf("Storyteller Readaloud"), state.readaloudSidecars.map { it.item.title })
+    }
+}


### PR DESCRIPTION
## Summary

The Downloads screen previously showed the Downloaded list app-wide but hid the **Cached** and **Readaloud (streaming)** sections whenever the active library's Source lacked `DownloadsCapability` / `ReadaloudCapability`. In a Local Files library that meant downloaded ABS/Chitanka books were visible while their Cached tiers and prepared Storyteller sidecars silently disappeared — inconsistent with #512's goal of not stranding downloads when the active source changes.

This PR drops the per-active-catalog gating: all three sections are now driven purely by whether local artifacts exist. Cached and Readaloud stay hidden when their lists are empty (no dead "No cached books" / "No prepared readalouds" headers for sources without that tier), matching the pattern Cached already used.

## Changes

- `DownloadsViewModel` — remove `CatalogRegistry` injection and the `showCachedSection` / `showReadaloudSection` flags from `DownloadsUiState`.
- `DownloadsScreen` — the two section guards now just check `items.isNotEmpty()`.
- New `DownloadsViewModelTest` pins that all three lists populate regardless of which source is active. Would fail if capability gating is reintroduced.

Drawer visibility (per `NavigationDrawerViewModel` — link shows if any registered source has `DownloadsCapability`) is unchanged; the screen is now consistent with it.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests DownloadsViewModelTest` passes locally
- [ ] Manual: open a Local Files library on a device that also has ABS/Storyteller sources — Downloads screen shows Downloaded + Cached + Readaloud (streaming) rows for the other sources' artifacts.