### PR TITLE
feat(chitanka): gate Recently Added on reader-open, not browse-tap

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/chitanka/ChitankaLibraryItemUpserter.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/chitanka/ChitankaLibraryItemUpserter.kt
@@ -33,7 +33,13 @@ class ChitankaLibraryItemUpserter @Inject constructor(
     suspend fun upsert(sourceId: String, item: CatalogItem) {
         val entity = item.toEntity(sourceId)
         libraryItemDao.insertOrIgnore(listOf(entity))
-        libraryItemDao.updateMetadata(LibraryItemMetadata.from(entity))
+        // Preserve the row's existing `addedAt`: for a fresh insert it's still the sentinel 0,
+        // but for a re-tap after the reader has promoted the row we must NOT let updateMetadata
+        // copy `entity.addedAt = 0` back on top and silently evict the book from Recently Added.
+        val existingAddedAt = libraryItemDao.getById(sourceId, entity.id)?.addedAt ?: 0L
+        libraryItemDao.updateMetadata(
+            LibraryItemMetadata.from(entity.copy(addedAt = existingAddedAt)),
+        )
     }
 
     private fun CatalogItem.toEntity(sourceId: String): LibraryItemEntity = LibraryItemEntity(

--- a/core/data/src/main/kotlin/com/riffle/core/data/chitanka/ChitankaLibraryItemUpserter.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/chitanka/ChitankaLibraryItemUpserter.kt
@@ -5,18 +5,23 @@ import com.riffle.core.catalog.CatalogItem
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.LibraryItemEntity
 import com.riffle.core.database.LibraryItemMetadata
-import com.riffle.core.domain.Clock
 import com.riffle.core.domain.EbookFormat
 import javax.inject.Inject
 
 /**
- * Bridges a browsed [CatalogItem] into the local `library_items` cache when the user opens it.
+ * Bridges a browsed [CatalogItem] into the local `library_items` cache when the user taps it.
  *
  * Chitanka is an unbounded remote catalogue (ADR 0042) — [LibraryRepositoryImpl.refreshLibraryItems]
- * intentionally does NOT populate `library_items` for it. But the reader and the audiobook player
- * both resolve the item via `LibraryObserver.getItem(itemId)`, so opening a Chitanka item requires
- * a row to exist. This upserter is the on-demand hop: called from
+ * intentionally does NOT populate `library_items` for it. But the reader, the audiobook player, and
+ * the detail screen resolve the item via `LibraryObserver.getItem(itemId)`, so opening a Chitanka
+ * item requires a row to exist. This upserter is the on-demand hop: called from
  * [com.riffle.app.feature.source.chitanka.ChitankaBrowseViewModel] just before navigation.
+ *
+ * The row is stamped with `addedAt = 0` (sentinel) — a browse tap is *not* an "add to library"
+ * intent, and [com.riffle.core.database.LibraryItemDao.observeRecentlyAdded] filters sentinel rows
+ * out. Opening the reader promotes the row via
+ * [com.riffle.core.database.LibraryItemDao.updateLastOpenedAt], which is where the item genuinely
+ * enters the user's library.
  *
  * Uses the same insert-or-ignore + updateMetadata pattern as
  * [com.riffle.core.database.LibraryItemDao.replaceAllForLibrary] so a re-open preserves the local
@@ -24,7 +29,6 @@ import javax.inject.Inject
  */
 class ChitankaLibraryItemUpserter @Inject constructor(
     private val libraryItemDao: LibraryItemDao,
-    private val clock: Clock,
 ) {
     suspend fun upsert(sourceId: String, item: CatalogItem) {
         val entity = item.toEntity(sourceId)
@@ -51,9 +55,9 @@ class ChitankaLibraryItemUpserter @Inject constructor(
         genres = genres.joinToString(","),
         publisher = publisher,
         language = language,
-        // Chitanka's HTML listings carry no `addedAt`, so stamp the moment this row enters
-        // `library_items` — matches the ADR-0042 semantics of "when the user opened it".
-        addedAt = addedAt ?: clock.nowMs(),
+        // Sentinel: browse-tap is not intent to add. observeRecentlyAdded filters this out;
+        // updateLastOpenedAt promotes it to the real timestamp on the first reader open.
+        addedAt = 0L,
         isbn = isbn,
         asin = asin,
     )

--- a/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
@@ -32,7 +32,11 @@ internal class FakeLibraryItemDao : LibraryItemDao {
         MutableStateFlow(scoped(sourceId, libraryId).filter { it.readingProgress == 1f })
 
     override fun observeRecentlyAdded(sourceId: String, libraryId: String): Flow<List<LibraryItemEntity>> =
-        MutableStateFlow(scoped(sourceId, libraryId).sortedByDescending { it.addedAt })
+        MutableStateFlow(
+            scoped(sourceId, libraryId)
+                .filter { it.addedAt > 0L }
+                .sortedByDescending { it.addedAt },
+        )
 
     override fun observeAllBooks(sourceId: String, libraryId: String): Flow<List<LibraryItemEntity>> =
         MutableStateFlow(scoped(sourceId, libraryId))
@@ -124,7 +128,18 @@ internal class FakeLibraryItemDao : LibraryItemDao {
         }
     }
 
-    override suspend fun updateLastOpenedAt(sourceId: String, itemId: String, timestamp: Long) {}
+    override suspend fun updateLastOpenedAt(sourceId: String, itemId: String, timestamp: Long) {
+        roomData.forEach { (_, flow) ->
+            flow.value = flow.value.map { existing ->
+                if (existing.sourceId == sourceId && existing.id == itemId) {
+                    existing.copy(
+                        lastOpenedAt = timestamp,
+                        addedAt = if (existing.addedAt == 0L) timestamp else existing.addedAt,
+                    )
+                } else existing
+            }
+        }
+    }
 
     override suspend fun getLastOpenedAtMap(sourceId: String, libraryId: String): List<LastOpenedAtRow> =
         scoped(sourceId, libraryId)

--- a/core/data/src/test/kotlin/com/riffle/core/data/chitanka/ChitankaLibraryItemUpserterTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/chitanka/ChitankaLibraryItemUpserterTest.kt
@@ -58,7 +58,7 @@ class ChitankaLibraryItemUpserterTest {
     @Test
     fun `first upsert inserts EPUB row with mapped fields`() = runTest {
         val dao = InMemoryLibraryItemDao()
-        val upserter = ChitankaLibraryItemUpserter(dao, com.riffle.core.domain.TestClock(initialMs = 7_000L))
+        val upserter = ChitankaLibraryItemUpserter(dao)
 
         upserter.upsert(sourceId = "chit-1", item = catalogEpub())
 
@@ -83,7 +83,7 @@ class ChitankaLibraryItemUpserterTest {
     @Test
     fun `audiobook item maps hasAudio true and libraryId to audio root`() = runTest {
         val dao = InMemoryLibraryItemDao()
-        val upserter = ChitankaLibraryItemUpserter(dao, com.riffle.core.domain.TestClock(initialMs = 7_000L))
+        val upserter = ChitankaLibraryItemUpserter(dao)
 
         upserter.upsert(sourceId = "chit-1", item = catalogAudio())
 
@@ -99,7 +99,7 @@ class ChitankaLibraryItemUpserterTest {
     @Test
     fun `re-open preserves existing readingProgress`() = runTest {
         val dao = InMemoryLibraryItemDao()
-        val upserter = ChitankaLibraryItemUpserter(dao, com.riffle.core.domain.TestClock(initialMs = 7_000L))
+        val upserter = ChitankaLibraryItemUpserter(dao)
         val item = catalogEpub()
 
         upserter.upsert("chit-1", item)
@@ -113,26 +113,25 @@ class ChitankaLibraryItemUpserterTest {
     }
 
     @Test
-    fun `addedAt falls back to clock when the CatalogItem has none`() = runTest {
-        // Regression: Chitanka listings carry no addedAt, so without a fallback these rows land
-        // with NULL addedAt and get silently ordered to the tail of Recently Added (or off the
-        // top-50 entirely when the audiobooks library also holds ABS items). Pin the stamp so
-        // reverting the fix flips this test red.
+    fun `browse-tap stamps addedAt = 0 sentinel so the item stays out of Recently Added`() = runTest {
+        // A Chitanka browse tap upserts a row so the reader / audiobook player can resolve the
+        // item, but that is not "added to the library" — writing a real clock timestamp here
+        // would surface the item in the Recently Added rail immediately after browsing. The
+        // sentinel is promoted to a real timestamp by LibraryItemDao.updateLastOpenedAt on the
+        // first reader open (see LibraryItemDao test coverage). Flipping this back to
+        // clock.nowMs() flips this test red.
         val dao = InMemoryLibraryItemDao()
-        val upserter = ChitankaLibraryItemUpserter(
-            dao,
-            com.riffle.core.domain.TestClock(initialMs = 12_345L),
-        )
+        val upserter = ChitankaLibraryItemUpserter(dao)
 
         upserter.upsert(sourceId = "chit-1", item = catalogEpub().copy(addedAt = null))
 
-        assertEquals(12_345L, dao.getById("chit-1", "text/12345-x")!!.addedAt)
+        assertEquals(0L, dao.getById("chit-1", "text/12345-x")!!.addedAt)
     }
 
     @Test
     fun `null description and coverUrl are handled (null cover coerced to empty)`() = runTest {
         val dao = InMemoryLibraryItemDao()
-        val upserter = ChitankaLibraryItemUpserter(dao, com.riffle.core.domain.TestClock(initialMs = 7_000L))
+        val upserter = ChitankaLibraryItemUpserter(dao)
 
         upserter.upsert(
             sourceId = "chit-1",

--- a/core/data/src/test/kotlin/com/riffle/core/data/chitanka/ChitankaLibraryItemUpserterTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/chitanka/ChitankaLibraryItemUpserterTest.kt
@@ -129,6 +129,33 @@ class ChitankaLibraryItemUpserterTest {
     }
 
     @Test
+    fun `re-tap after reader-open preserves the promoted addedAt`() = runTest {
+        // Regression: updateMetadata is a Room @Update that copies every column of
+        // LibraryItemMetadata onto the existing row, INCLUDING addedAt. Without the "read the
+        // current addedAt and preserve it" step in the upserter, a second browse-tap on a book
+        // whose sentinel had been promoted (by updateLastOpenedAt on the first reader open)
+        // would overwrite the promoted timestamp with 0 and silently evict the book from
+        // Recently Added. Simulating updateLastOpenedAt via updateMetadata here keeps the fake
+        // dao minimal; the DAO-level test in LibraryItemDaoTest covers the actual promotion SQL.
+        val dao = InMemoryLibraryItemDao()
+        val upserter = ChitankaLibraryItemUpserter(dao)
+        val item = catalogEpub()
+
+        upserter.upsert("chit-1", item)
+        // Simulate updateLastOpenedAt promoting the sentinel to a real timestamp.
+        val opened = dao.getById("chit-1", item.id)!!.copy(addedAt = 9_000L, lastOpenedAt = 9_000L)
+        dao.upsertAll(listOf(opened))
+
+        upserter.upsert("chit-1", item)
+
+        assertEquals(
+            "re-tap must not demote the promoted addedAt back to sentinel",
+            9_000L,
+            dao.getById("chit-1", item.id)!!.addedAt,
+        )
+    }
+
+    @Test
     fun `null description and coverUrl are handled (null cover coerced to empty)`() = runTest {
         val dao = InMemoryLibraryItemDao()
         val upserter = ChitankaLibraryItemUpserter(dao)

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/LibraryItemDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/LibraryItemDaoTest.kt
@@ -213,4 +213,42 @@ class LibraryItemDaoTest {
         }
         assertEquals(setOf("c", "d", "e"), emittedStates.last().map { it.id }.toSet())
     }
+
+    // observeRecentlyAdded filters out sentinel rows (addedAt == 0), which are written by
+    // on-demand browse upserters like ChitankaLibraryItemUpserter. A browse tap is not intent to
+    // add the book — the row only exists so the reader / audiobook player can resolve it.
+    // Reverting the `AND addedAt > 0` clause on the query flips this test red.
+    @Test
+    fun observeRecentlyAdded_excludesSentinelRows() = runTest {
+        dao.upsertAll(listOf(
+            item("browsed", readingProgress = 0f).copy(addedAt = 0L),
+            item("added-old", readingProgress = 0f).copy(addedAt = 1_000L),
+            item("added-new", readingProgress = 0f).copy(addedAt = 2_000L),
+        ))
+
+        val ids = dao.observeRecentlyAdded("s1", "lib1").first().map { it.id }
+
+        assertEquals(listOf("added-new", "added-old"), ids)
+    }
+
+    // updateLastOpenedAt is the strong-intent promotion for browse-cached rows: opening the
+    // reader flips the sentinel addedAt = 0 to the real timestamp, so the item now surfaces in
+    // Recently Added. Rows already carrying a real addedAt must keep it (never overwrite a
+    // canonical import date with lastOpenedAt). Removing the CASE branch flips this test red.
+    @Test
+    fun updateLastOpenedAt_promotesSentinelAddedAtOnFirstOpen() = runTest {
+        dao.upsertAll(listOf(
+            item("browsed", readingProgress = 0f).copy(addedAt = 0L),
+            item("imported", readingProgress = 0f).copy(addedAt = 500L),
+        ))
+
+        dao.updateLastOpenedAt("s1", "browsed", timestamp = 9_000L)
+        dao.updateLastOpenedAt("s1", "imported", timestamp = 9_000L)
+
+        val rows = dao.observeAllBooks("s1", "lib1").first().associateBy { it.id }
+        assertEquals(9_000L, rows.getValue("browsed").addedAt)
+        assertEquals(9_000L, rows.getValue("browsed").lastOpenedAt)
+        assertEquals(500L, rows.getValue("imported").addedAt)
+        assertEquals(9_000L, rows.getValue("imported").lastOpenedAt)
+    }
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
@@ -108,13 +108,24 @@ interface LibraryItemDao {
     @Query("SELECT * FROM library_items WHERE sourceId = :sourceId AND libraryId = :libraryId AND readingProgress >= 0.99 ORDER BY COALESCE(finishedAt, lastOpenedAt) IS NULL ASC, COALESCE(finishedAt, lastOpenedAt) DESC")
     fun observeFinished(sourceId: String, libraryId: String): Flow<List<LibraryItemEntity>>
 
-    @Query("SELECT * FROM library_items WHERE sourceId = :sourceId AND libraryId = :libraryId ORDER BY addedAt DESC")
+    // `addedAt > 0` filters out sentinel rows written by on-demand browse upserters
+    // (e.g. ChitankaLibraryItemUpserter). A tap-through-the-browser is not intent to add the book
+    // to the library — the row exists only so the reader can resolve the item. updateLastOpenedAt
+    // promotes the sentinel to a real timestamp on the first reader open.
+    @Query("SELECT * FROM library_items WHERE sourceId = :sourceId AND libraryId = :libraryId AND addedAt > 0 ORDER BY addedAt DESC")
     fun observeRecentlyAdded(sourceId: String, libraryId: String): Flow<List<LibraryItemEntity>>
 
     @Query("SELECT * FROM library_items WHERE sourceId = :sourceId AND libraryId = :libraryId ORDER BY title ASC")
     fun observeAllBooks(sourceId: String, libraryId: String): Flow<List<LibraryItemEntity>>
 
-    @Query("UPDATE library_items SET lastOpenedAt = :timestamp WHERE sourceId = :sourceId AND id = :itemId")
+    // Opening the reader is the strong-intent signal that promotes a browse-cached row (addedAt = 0
+    // sentinel, written by on-demand upserters like ChitankaLibraryItemUpserter) into "genuinely
+    // added" so it surfaces in Recently Added. Rows with a real addedAt keep their original stamp.
+    @Query(
+        "UPDATE library_items SET lastOpenedAt = :timestamp, " +
+            "addedAt = CASE WHEN addedAt = 0 THEN :timestamp ELSE addedAt END " +
+            "WHERE sourceId = :sourceId AND id = :itemId"
+    )
     suspend fun updateLastOpenedAt(sourceId: String, itemId: String, timestamp: Long)
 
     @Query("UPDATE library_items SET readingProgress = :progress WHERE sourceId = :sourceId AND id = :itemId")


### PR DESCRIPTION
## Summary

Chitanka's on-demand upserter (called from `ChitankaBrowseViewModel` on card-tap) was stamping `addedAt = clock.nowMs()`, so every drive-by tap in the Chitanka browser surfaced the book in the Recently Added rail even though the user hadn't actually added anything to their library.

Gate Recently Added on stronger intent: **opening the reader / audiobook player** promotes a browse-cached row into "genuinely added".

- `ChitankaLibraryItemUpserter` stamps `addedAt = 0L` (sentinel) on browse-tap.
- `LibraryItemDao.observeRecentlyAdded` filters `AND addedAt > 0` so sentinel rows never surface.
- `LibraryItemDao.updateLastOpenedAt` atomically promotes the sentinel to the open timestamp on the first Read / Listen (`CASE WHEN addedAt = 0 THEN :timestamp ELSE addedAt END`). Rows with a real `addedAt` — ABS/Storyteller sync, local files — keep their original stamp.
- Fix (self-review): the upserter re-reads the row's current `addedAt` before calling `updateMetadata` so a second browse-tap on an already-promoted book is a metadata-only refresh and does not demote `addedAt` back to sentinel via Room's `@Update`.

## Test plan

- [x] `:core:data:test` — updated `ChitankaLibraryItemUpserterTest`: browse-tap writes sentinel; re-tap after promotion preserves the promoted timestamp.
- [x] `:core:database:test` (JVM compile) + `:app:testDebugUnitTest` — green.
- [ ] `:core:database:connectedDebugAndroidTest` (new instrumentation tests in `LibraryItemDaoTest`: `observeRecentlyAdded_excludesSentinelRows`, `updateLastOpenedAt_promotesSentinelAddedAtOnFirstOpen`) — will run in CI.
- [ ] Manual: tap several Chitanka books in the browser without opening any → Recently Added stays empty. Open one → it appears at the top. Re-browse and re-tap the same book → it remains in Recently Added at its original position.