### PR TITLE
fix(reader/cbz): restore swipe page-turns, enlarge thumbnails, inset nav bar

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/cbz/CbzThumbnailStripTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/cbz/CbzThumbnailStripTest.kt
@@ -38,11 +38,11 @@ class CbzThumbnailStripTest {
         composeTestRule.onNodeWithTag("cbz_thumbnail_strip").assertExists()
         composeTestRule.onNodeWithTag("cbz_thumb_0").assertExists()
 
-        // 40dp thumbs at a start-aligned LazyRow — index 5 sits well inside the initial
+        // 64dp thumbs at a start-aligned LazyRow — index 3 sits well inside the initial
         // viewport on the ~320dp+ harness screen.
-        composeTestRule.onNodeWithTag("cbz_thumb_5").performClick()
+        composeTestRule.onNodeWithTag("cbz_thumb_3").performClick()
 
-        assertEquals(5, lastSeek)
+        assertEquals(3, lastSeek)
     }
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -5,8 +5,11 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.calculatePan
+import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -15,6 +18,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
@@ -251,15 +255,33 @@ private fun CbzPage(
                 )
             }
             .pointerInput(pageIndex) {
-                detectTransformGestures { _, pan, zoom, _ ->
-                    scale = (scale * zoom).coerceIn(1f, 5f)
-                    if (scale > 1f) {
-                        offsetX += pan.x
-                        offsetY += pan.y
-                    } else {
-                        offsetX = 0f
-                        offsetY = 0f
-                    }
+                // Only consume pointer events for zoom (2+ fingers) or pan-while-zoomed.
+                // A single-finger drag at scale=1 must fall through to HorizontalPager
+                // so swipe-to-turn works.
+                awaitEachGesture {
+                    awaitFirstDown(requireUnconsumed = false)
+                    do {
+                        val event = awaitPointerEvent()
+                        val pointerCount = event.changes.count { it.pressed }
+                        if (pointerCount >= 2) {
+                            val zoom = event.calculateZoom()
+                            val pan = event.calculatePan()
+                            scale = (scale * zoom).coerceIn(1f, 5f)
+                            if (scale > 1f) {
+                                offsetX += pan.x
+                                offsetY += pan.y
+                            } else {
+                                offsetX = 0f
+                                offsetY = 0f
+                            }
+                            event.changes.forEach { it.consume() }
+                        } else if (scale > 1f && pointerCount == 1) {
+                            val pan = event.calculatePan()
+                            offsetX += pan.x
+                            offsetY += pan.y
+                            event.changes.forEach { it.consume() }
+                        }
+                    } while (event.changes.any { it.pressed })
                 }
             },
         contentAlignment = Alignment.Center,
@@ -294,7 +316,7 @@ internal fun CbzThumbnailStrip(
 
     LaunchedEffect(currentPage) {
         val viewport = listState.layoutInfo.viewportEndOffset - listState.layoutInfo.viewportStartOffset
-        // Centre the current thumb: item width ~= 40dp, and viewport is in px. If layout hasn't happened
+        // Centre the current thumb: item width ~= 64dp, and viewport is in px. If layout hasn't happened
         // yet (viewport == 0) fall back to scrollToItem with a small leading offset so the animation
         // becomes meaningful once measured.
         val leading = if (viewport > 0) -(viewport / 2) else 0
@@ -305,6 +327,7 @@ internal fun CbzThumbnailStrip(
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.9f))
+            .navigationBarsPadding()
             .padding(vertical = 8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
@@ -347,7 +370,7 @@ private fun CbzThumbnail(
     val borderColor = if (isCurrent) MaterialTheme.colorScheme.primary else Color.Transparent
     Box(
         modifier = Modifier
-            .size(width = 40.dp, height = 56.dp)
+            .size(width = 88.dp, height = 120.dp)
             .background(Color(0xFF1A1A1A), RoundedCornerShape(2.dp))
             .border(width = 2.dp, color = borderColor, shape = RoundedCornerShape(2.dp))
             .clickable { onClick() }
@@ -358,7 +381,7 @@ private fun CbzThumbnail(
             AsyncImage(
                 model = ImageRequest.Builder(context)
                     .data(currentBytes)
-                    .size(CoilSize(120, 168))
+                    .size(CoilSize(264, 360))
                     .crossfade(false)
                     .build(),
                 contentDescription = null,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -255,31 +255,34 @@ private fun CbzPage(
                 )
             }
             .pointerInput(pageIndex) {
-                // Only consume pointer events for zoom (2+ fingers) or pan-while-zoomed.
                 // A single-finger drag at scale=1 must fall through to HorizontalPager
-                // so swipe-to-turn works.
+                // so swipe-to-turn works. See [cbzPageGestureAction].
                 awaitEachGesture {
                     awaitFirstDown(requireUnconsumed = false)
                     do {
                         val event = awaitPointerEvent()
                         val pointerCount = event.changes.count { it.pressed }
-                        if (pointerCount >= 2) {
-                            val zoom = event.calculateZoom()
-                            val pan = event.calculatePan()
-                            scale = (scale * zoom).coerceIn(1f, 5f)
-                            if (scale > 1f) {
+                        when (cbzPageGestureAction(pointerCount, scale)) {
+                            CbzPageGestureAction.Zoom -> {
+                                val zoom = event.calculateZoom()
+                                val pan = event.calculatePan()
+                                scale = (scale * zoom).coerceIn(1f, 5f)
+                                if (scale > 1f) {
+                                    offsetX += pan.x
+                                    offsetY += pan.y
+                                } else {
+                                    offsetX = 0f
+                                    offsetY = 0f
+                                }
+                                event.changes.forEach { it.consume() }
+                            }
+                            CbzPageGestureAction.PanZoomed -> {
+                                val pan = event.calculatePan()
                                 offsetX += pan.x
                                 offsetY += pan.y
-                            } else {
-                                offsetX = 0f
-                                offsetY = 0f
+                                event.changes.forEach { it.consume() }
                             }
-                            event.changes.forEach { it.consume() }
-                        } else if (scale > 1f && pointerCount == 1) {
-                            val pan = event.calculatePan()
-                            offsetX += pan.x
-                            offsetY += pan.y
-                            event.changes.forEach { it.consume() }
+                            CbzPageGestureAction.Ignore -> Unit
                         }
                     } while (event.changes.any { it.pressed })
                 }
@@ -392,3 +395,17 @@ private fun CbzThumbnail(
 }
 
 private enum class TapZone { Left, Center, Right }
+
+internal enum class CbzPageGestureAction { Ignore, Zoom, PanZoomed }
+
+/**
+ * Decides how the per-page pointer handler should react to an event.
+ *
+ * The critical case is [Ignore]: a single-finger drag at scale=1 must NOT consume
+ * pointer events, so `HorizontalPager` receives the swipe and turns the page.
+ */
+internal fun cbzPageGestureAction(pointerCount: Int, scale: Float): CbzPageGestureAction = when {
+    pointerCount >= 2 -> CbzPageGestureAction.Zoom
+    pointerCount == 1 && scale > 1f -> CbzPageGestureAction.PanZoomed
+    else -> CbzPageGestureAction.Ignore
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/CbzPageGestureActionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/CbzPageGestureActionTest.kt
@@ -1,0 +1,37 @@
+package com.riffle.app.feature.reader.cbz
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the swipe-to-turn fix. Prior implementation used `detectTransformGestures`,
+ * which consumed single-finger drags at scale=1, starving HorizontalPager of the
+ * swipe. If someone reverts the gesture handler to unconditionally consume, the
+ * `Ignore` assertions below flip red.
+ */
+class CbzPageGestureActionTest {
+
+    @Test
+    fun single_finger_at_rest_scale_is_ignored_so_pager_gets_swipe() {
+        assertEquals(CbzPageGestureAction.Ignore, cbzPageGestureAction(pointerCount = 1, scale = 1f))
+    }
+
+    @Test
+    fun zero_pointers_is_ignored() {
+        assertEquals(CbzPageGestureAction.Ignore, cbzPageGestureAction(pointerCount = 0, scale = 1f))
+        assertEquals(CbzPageGestureAction.Ignore, cbzPageGestureAction(pointerCount = 0, scale = 2f))
+    }
+
+    @Test
+    fun single_finger_while_zoomed_pans_the_zoomed_page() {
+        assertEquals(CbzPageGestureAction.PanZoomed, cbzPageGestureAction(pointerCount = 1, scale = 1.5f))
+        assertEquals(CbzPageGestureAction.PanZoomed, cbzPageGestureAction(pointerCount = 1, scale = 5f))
+    }
+
+    @Test
+    fun two_or_more_fingers_zoom_regardless_of_current_scale() {
+        assertEquals(CbzPageGestureAction.Zoom, cbzPageGestureAction(pointerCount = 2, scale = 1f))
+        assertEquals(CbzPageGestureAction.Zoom, cbzPageGestureAction(pointerCount = 2, scale = 3f))
+        assertEquals(CbzPageGestureAction.Zoom, cbzPageGestureAction(pointerCount = 3, scale = 1f))
+    }
+}


### PR DESCRIPTION
## Summary

Three fixes to the CBZ reader:

- **Swipe-to-turn was broken.** The per-page `pointerInput` used `detectTransformGestures`, which consumes single-finger drags (with zoom≈1) and never let `HorizontalPager` see the swipe. Replaced with an `awaitEachGesture` loop that only consumes when 2+ fingers are down (pinch/zoom) or when a single finger drags while already zoomed in (pan a zoomed page). Single-finger drags at scale=1 fall through to the pager, so horizontal swipes turn pages again. Tap zones, double-tap-to-reset, and pinch-zoom all still work.
- **Bottom thumbnail strip was too small.** Bumped from 40×56dp to **88×120dp** (same 5:7 comic aspect), and updated the Coil decode size 120×168 → 264×360 to match the new pixel target.
- **Gesture nav bar drew over the thumbnails.** Added `navigationBarsPadding()` to the strip's `Column` so the strip sits above the system nav bar when the reader chrome is visible.

## Tests

- New JVM test `CbzPageGestureActionTest` pins the swipe fix by extracting the pointer-decision to a top-level `cbzPageGestureAction(pointerCount, scale)` helper. The specific bug — single-finger drag at scale=1 consumed → pager starved — flips the `Ignore` assertions red on revert.
- Existing `CbzThumbnailStripTest` updated: tap moved from thumb 5 to thumb 3 so the target still sits inside the initial `LazyRow` viewport with the larger tiles.

## Test plan

- [ ] Open a CBZ in the reader, swipe left/right — pages turn.
- [ ] Pinch-zoom a page, then single-finger pan — pans the zoomed page (no page turn).
- [ ] Toggle chrome on, check the thumbnail strip sits above the gesture nav pill.
- [ ] Tap a thumbnail — jumps to that page.