### PR TITLE
feat(gutenberg): rename lone library to "Books"

### DIFF
--- a/core/catalog-gutenberg/src/main/kotlin/com/riffle/core/catalog/gutenberg/GutenbergCatalog.kt
+++ b/core/catalog-gutenberg/src/main/kotlin/com/riffle/core/catalog/gutenberg/GutenbergCatalog.kt
@@ -56,7 +56,7 @@ class GutenbergCatalog(
     // ---- Roots --------------------------------------------------------------
 
     override suspend fun listRoots(): List<CatalogRoot> = listOf(
-        CatalogRoot(id = ROOT_BOOKS, name = "Project Gutenberg", mediaType = "book"),
+        CatalogRoot(id = ROOT_BOOKS, name = "Books", mediaType = "book"),
     )
 
     // ---- Facets -------------------------------------------------------------

--- a/core/catalog-gutenberg/src/test/kotlin/com/riffle/core/catalog/gutenberg/GutenbergCatalogTest.kt
+++ b/core/catalog-gutenberg/src/test/kotlin/com/riffle/core/catalog/gutenberg/GutenbergCatalogTest.kt
@@ -53,6 +53,7 @@ class GutenbergCatalogTest {
         val roots = catalog.listRoots()
         assertEquals(1, roots.size)
         assertEquals(GutenbergCatalog.ROOT_BOOKS, roots.single().id)
+        assertEquals("Books", roots.single().name)
     }
 
     @Test

--- a/core/data/src/main/kotlin/com/riffle/core/data/gutenberg/GutenbergSourceInstaller.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/gutenberg/GutenbergSourceInstaller.kt
@@ -68,7 +68,7 @@ class GutenbergSourceInstaller @Inject constructor(
     private fun defaultLibraries(sourceId: String): List<LibraryEntity> = listOf(
         LibraryEntity(
             id = GutenbergCatalog.ROOT_BOOKS,
-            name = "Project Gutenberg",
+            name = "Books",
             mediaType = "book",
             sourceId = sourceId,
         ),

--- a/core/data/src/test/kotlin/com/riffle/core/data/gutenberg/GutenbergSourceInstallerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/gutenberg/GutenbergSourceInstallerTest.kt
@@ -65,6 +65,7 @@ class GutenbergSourceInstallerTest {
         assertEquals(1, libs.size)
         val books = libs.single()
         assertEquals(GutenbergCatalog.ROOT_BOOKS, books.id)
+        assertEquals("Books", books.name)
         assertEquals("book", books.mediaType)
     }
 


### PR DESCRIPTION
## Summary

The Gutenberg source has a single library, which was named "Project Gutenberg" — the same as the source itself. In the drawer this reads as a redundant "Project Gutenberg → Project Gutenberg". Rename the library to "Books" so it matches the other Chitanka/ABS libraries and reads cleanly nested under the Project Gutenberg source header.

Changed:

- `GutenbergCatalog.listRoots()` returns `CatalogRoot(name = "Books", ...)`.
- `GutenbergSourceInstaller` seeds `LibraryEntity(name = "Books", ...)`.

Existing installs pick up the new name on next launch because `GutenbergSourceInstaller.install()` self-heals the library row via an idempotent upsert by id.

Tests updated to pin the new name (would flip red if reverted):

- `GutenbergCatalogTest.listRoots returns a single Books root` — asserts `roots.single().name == "Books"`.
- `GutenbergSourceInstallerTest.install seeds the single Books library with the expected id` — asserts `books.name == "Books"`.