### PR TITLE
fix(source-browse): clear search query when closing the toolbar X

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
@@ -125,7 +125,11 @@ fun ChitankaBrowseScreen(
                 },
                 actions = {
                     if (selectedTab == TAB_LIBRARY) {
-                        IconButton(onClick = { searchOpen = !searchOpen }) {
+                        IconButton(onClick = {
+                            searchOpen = com.riffle.app.feature.source.common.toggleSearchOpen(searchOpen) {
+                                viewModel.onQueryChange("")
+                            }
+                        }) {
                             Icon(
                                 if (searchOpen) Icons.Default.Close else Icons.Default.Search,
                                 contentDescription = if (searchOpen) "Close search" else "Search",

--- a/app/src/main/kotlin/com/riffle/app/feature/source/common/SearchToggle.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/common/SearchToggle.kt
@@ -1,0 +1,10 @@
+package com.riffle.app.feature.source.common
+
+/**
+ * Toolbar Search/X toggle: collapsing must also clear the query so the result set
+ * returns to the full catalog instead of staying pinned to the last search.
+ */
+internal fun toggleSearchOpen(currentlyOpen: Boolean, clearQuery: () -> Unit): Boolean {
+    if (currentlyOpen) clearQuery()
+    return !currentlyOpen
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
@@ -102,7 +102,11 @@ fun GutenbergBrowseScreen(
                 },
                 actions = {
                     if (selectedTab == TAB_LIBRARY) {
-                        IconButton(onClick = { searchOpen = !searchOpen }) {
+                        IconButton(onClick = {
+                            searchOpen = com.riffle.app.feature.source.common.toggleSearchOpen(searchOpen) {
+                                viewModel.onQueryChange("")
+                            }
+                        }) {
                             Icon(
                                 if (searchOpen) Icons.Default.Close else Icons.Default.Search,
                                 contentDescription = if (searchOpen) "Close search" else "Search",

--- a/app/src/test/kotlin/com/riffle/app/feature/source/common/SearchToggleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/common/SearchToggleTest.kt
@@ -1,0 +1,31 @@
+package com.riffle.app.feature.source.common
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SearchToggleTest {
+    @Test
+    fun `collapsing an open search clears the query and returns closed`() {
+        var cleared = false
+        val next = toggleSearchOpen(currentlyOpen = true) { cleared = true }
+        assertFalse(next)
+        assertTrue("expected clearQuery() to be invoked on collapse", cleared)
+    }
+
+    @Test
+    fun `opening a closed search does not clear the query and returns open`() {
+        var cleared = false
+        val next = toggleSearchOpen(currentlyOpen = false) { cleared = true }
+        assertTrue(next)
+        assertFalse("clearQuery() must not fire when opening the field", cleared)
+    }
+
+    @Test
+    fun `collapse invokes clearQuery exactly once`() {
+        var calls = 0
+        toggleSearchOpen(currentlyOpen = true) { calls += 1 }
+        assertEquals(1, calls)
+    }
+}


### PR DESCRIPTION
## Summary

In the Chitanka and Gutenberg browse screens' Library tab, tapping the toolbar × to close the search field only hid the input — the ViewModel query was left intact, so the filtered grid stayed pinned to the last search results instead of returning to the full catalog.

The toggle now routes through a small shared helper `toggleSearchOpen(open, clearQuery)` (in `feature/source/common/`) that calls `onQueryChange("")` on collapse. That triggers the existing debounced `refresh()` and restores the unfiltered catalog. Opening the field (closed → open) is unchanged and preserves any in-progress query.

ABS Library uses an always-visible search bar with no × affordance, so it isn't affected — Back-to-clear already handles it there.

## Test plan

- [x] New `SearchToggleTest` — 3 assertions that flip red if either the collapse-clears or open-doesn't-clear behavior is reverted (`./gradlew :app:testDebugUnitTest --tests SearchToggleTest` passes locally).
- [ ] Manual: on Chitanka Library tab, tap search, type "abc", tap ×; grid returns to full catalog. Same on Gutenberg.