### PR TITLE
fix(gutenberg): route web-source OkHttp cache to Gutenberg catalog

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/CatalogModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/CatalogModule.kt
@@ -97,7 +97,7 @@ object CatalogModule {
     @IntoMap
     @SourceTypeKey(SourceType.GUTENBERG)
     fun provideGutenbergCatalogFactory(
-        okHttpClient: OkHttpClient,
+        @WebSourceOkHttpClient okHttpClient: OkHttpClient,
     ): CatalogFactory = GutenbergCatalogFactory(
         okHttpClient = okHttpClient,
         userAgent = "Riffle/dev (Android) gutenberg-source",

--- a/core/data/src/test/kotlin/com/riffle/core/data/CatalogModuleQualifierTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/CatalogModuleQualifierTest.kt
@@ -1,0 +1,65 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.SourceType
+import org.junit.Test
+import java.io.File
+
+class CatalogModuleQualifierTest {
+
+    /**
+     * Every unbounded-catalog (web) source's `CatalogFactory` provider must inject the
+     * `@WebSourceOkHttpClient`-qualified `OkHttpClient`, not the app-wide default. The qualified
+     * client is the only one carrying the ADR 0043 disk cache + `ForceCacheHeadersInterceptor` +
+     * `OfflineStaleFallbackInterceptor`. Missing the qualifier turns filter switches into
+     * uncached, non-retriable Gutendex/… round-trips that fail fast on transient IO — the
+     * "couldn't reach Project Gutenberg" error the user hit after 1–2 filter taps (#516/#520).
+     *
+     * Regression test for #516: `provideGutenbergCatalogFactory` shipped without the qualifier
+     * and Gutenberg fetches bypassed the cache and stale-fallback interceptor entirely.
+     */
+    @Test
+    fun `every unbounded-catalog provider uses the WebSource OkHttp qualifier`() {
+        val source = catalogModuleSource()
+        val providerRegex = Regex(
+            """@SourceTypeKey\(SourceType\.(\w+)\)\s*fun\s+(\w+)\s*\(([^)]*)\)""",
+            RegexOption.DOT_MATCHES_ALL,
+        )
+        val matches = providerRegex.findAll(source).toList()
+        check(matches.isNotEmpty()) { "Could not find any @SourceTypeKey providers in CatalogModule" }
+
+        val offenders = mutableListOf<String>()
+        for (m in matches) {
+            val typeName = m.groupValues[1]
+            val fnName = m.groupValues[2]
+            val params = m.groupValues[3]
+            val type = runCatching { SourceType.valueOf(typeName) }.getOrNull() ?: continue
+            if (!type.isUnboundedCatalog) continue
+            val okHttpParam = params.split(",").firstOrNull { it.contains("OkHttpClient") }
+                ?: error("Provider $fnName for $type has no OkHttpClient parameter")
+            if (!okHttpParam.contains("@WebSourceOkHttpClient")) {
+                offenders += "$type → $fnName"
+            }
+        }
+        assert(offenders.isEmpty()) {
+            "Unbounded-catalog providers missing @WebSourceOkHttpClient: $offenders"
+        }
+    }
+
+    private fun catalogModuleSource(): String {
+        val candidates = listOf(
+            "core/data/src/main/kotlin/com/riffle/core/data/di/modules/CatalogModule.kt",
+            "src/main/kotlin/com/riffle/core/data/di/modules/CatalogModule.kt",
+            "../../src/main/kotlin/com/riffle/core/data/di/modules/CatalogModule.kt",
+        )
+        for (rel in candidates) {
+            val f = File(rel)
+            if (f.exists()) return f.readText()
+        }
+        val cwd = File(".").absolutePath
+        val fromRoot = generateSequence(File(cwd)) { it.parentFile }
+            .map { File(it, "core/data/src/main/kotlin/com/riffle/core/data/di/modules/CatalogModule.kt") }
+            .firstOrNull { it.exists() }
+        checkNotNull(fromRoot) { "CatalogModule.kt not found from cwd=$cwd" }
+        return fromRoot.readText()
+    }
+}


### PR DESCRIPTION
## Summary

`provideGutenbergCatalogFactory` in `core/data/.../CatalogModule.kt` was injecting the app-wide unqualified `OkHttpClient` instead of `@WebSourceOkHttpClient`, so every facet switch on Project Gutenberg bypassed the ADR 0043 disk cache and the `OfflineStaleFallbackInterceptor`. After 1–2 quick filter taps, the slow Gutendex `topic=poetry` endpoint (~30s) hit the socket timeout and surfaced as "Couldn't reach Project Gutenberg. Check your connection and try again." — the exact error the user was seeing. This is the follow-up promised in ADR 0043 that was skipped when #516 shipped.

Chitanka was already correctly wired (#520), which is why it doesn't exhibit the bug.

Fix: one-line qualifier addition — `GutenbergCatalogFactory.newBuilder()` already inherits the parent client's cache and interceptors, so no other changes are needed.

## Test plan

Added `CatalogModuleQualifierTest` (JVM) — source-scans `CatalogModule.kt` and asserts every `@SourceTypeKey` provider whose `SourceType.isUnboundedCatalog = true` has `@WebSourceOkHttpClient` on its `OkHttpClient` parameter. Verified red on the pre-fix wiring; green after. Future web sources are gated at check-time.

Device verification on AVD (`RIFFLE_GB` logs):

| Tap | Latency |
|---|---|
| Fiction (first) | 835 ms — network |
| History (first) | 50 ms — home preload cache |
| Fiction (second) | 7 ms — cache hit ✅ |
| History (second) | 7 ms — cache hit ✅ |

Repeat filter switches no longer surface transient IO as "Couldn't reach".

- [ ] CI green