### PR TITLE
refactor(sources): plug-and-play credentialed multi-instance sources (ADR 0044 Phase 7)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
@@ -197,10 +197,11 @@ private fun DrawerHeader(
 
     // Same product type appearing more than once forces the host to appear in the supporting
     // line so users can tell the two instances apart. With a single instance the host is noise.
-    // LocalFiles has no meaningful host (placeholder URL), so the host is never useful there.
+    // Zero-config web sources (LocalFiles, Chitanka, Gutenberg) have `hasNetworkHost = false` in
+    // their [WebSourceDescriptor] — the descriptor is the source of truth so a new credentialed
+    // source (Komga) drops in without editing this predicate.
     val activeNeedsHost = activeServer != null &&
-        activeServer.type != SourceType.LOCAL_FILES && activeServer.type != SourceType.CHITANKA &&
-        activeServer.type != SourceType.GUTENBERG &&
+        WebSourceDescriptors.forType(activeServer.type)?.hasNetworkHost == true &&
         allServers.count { it.serverType == activeServer.serverType && it.type == activeServer.type } > 1
 
     Box(modifier = Modifier
@@ -214,7 +215,7 @@ private fun DrawerHeader(
             headlineContent = {
                 val name = activeServer?.let(::sourceDisplayName) ?: "No source"
                 val username = activeServer
-                    ?.takeIf { it.type != SourceType.LOCAL_FILES && it.type != SourceType.CHITANKA && it.type != SourceType.GUTENBERG }
+                    ?.takeIf { WebSourceDescriptors.forType(it.type)?.hasCredentials == true }
                     ?.username?.takeIf { it.isNotEmpty() }
                 if (username != null) {
                     Text(
@@ -254,15 +255,14 @@ private fun DrawerHeader(
             modifier = if (headerWidth != Dp.Unspecified) Modifier.width(headerWidth) else Modifier,
         ) {
             allServers.forEach { server ->
-                val needsHost = server.type != SourceType.LOCAL_FILES && server.type != SourceType.CHITANKA &&
-                    server.type != SourceType.GUTENBERG &&
+                val needsHost = WebSourceDescriptors.forType(server.type)?.hasNetworkHost == true &&
                     allServers.count { it.serverType == server.serverType && it.type == server.type } > 1
                 DropdownMenuItem(
                     text = {
                         Column {
                             val displayName = sourceDisplayName(server)
                             val username = server
-                                .takeIf { it.type != SourceType.LOCAL_FILES && it.type != SourceType.CHITANKA && it.type != SourceType.GUTENBERG }
+                                .takeIf { WebSourceDescriptors.forType(it.type)?.hasCredentials == true }
                                 ?.username?.takeIf { it.isNotEmpty() }
                             if (username != null) {
                                 Text(
@@ -351,9 +351,12 @@ private fun sourceDisplayName(source: Source): String =
     else WebSourceDescriptors.forTypeOrError(source.type).displayName
 
 /**
- * Subtitle for the source-switcher row. Non-ABS sources have a static tagline in the descriptor;
- * ABS reuses [buildSupportingLine] (host · version).
+ * Subtitle for the source-switcher row. Credentialed sources with a network host (ABS today,
+ * Komga tomorrow) render [buildSupportingLine] (host · version); everything else falls back to
+ * the descriptor's static subtitle. Gated on [WebSourceDescriptor.hasNetworkHost] so a new
+ * credentialed source drops in without an edit here.
  */
-private fun sourceSubtitle(source: Source, host: String?, version: String?): String? =
-    if (source.type == SourceType.ABS) buildSupportingLine(host, version)
-    else WebSourceDescriptors.forTypeOrError(source.type).subtitle
+private fun sourceSubtitle(source: Source, host: String?, version: String?): String? {
+    val descriptor = WebSourceDescriptors.forType(source.type) ?: return null
+    return if (descriptor.hasNetworkHost) buildSupportingLine(host, version) else descriptor.subtitle
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceScreen.kt
@@ -50,8 +50,10 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.riffle.app.ui.TabletContentWidthContainer
+import com.riffle.core.domain.AddSourceCopy
 import com.riffle.core.domain.InsecureConnectionType
 import com.riffle.core.domain.PendingSource
+import com.riffle.core.domain.WebSourceDescriptors
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -71,13 +73,23 @@ fun AddSourceScreen(
 
     val backend = viewModel.backend
     val isEditing = viewModel.isEditing
-    val title = screenTitle(backend, isEditing)
-    val urlLabel = if (backend == AddSourceBackend.WEBDAV) "WebDAV URL" else "Source URL"
-    val urlPlaceholder = when (backend) {
+    // Descriptor-driven copy for credentialed [SourceType]s (ADR 0044 Phase 7 / issue #526).
+    // Non-null for backends whose [WebSourceDescriptor] ships an [AddSourceCopy] (currently only
+    // AUDIOBOOKSHELF-shaped SourceType.ABS descriptors). Storyteller and WebDAV keep the local
+    // when-tables until #441 splits Storyteller into its own SourceType and WebDAV moves to its
+    // own screen — both are documented as non-goals of this refactor.
+    val descriptorCopy: AddSourceCopy? = descriptorCopyFor(backend)
+    val title = descriptorCopy?.let { if (isEditing) it.editTitle else it.addTitle }
+        ?: screenTitle(backend, isEditing)
+    val urlLabel = descriptorCopy?.urlLabel
+        ?: if (backend == AddSourceBackend.WEBDAV) "WebDAV URL" else "Source URL"
+    val urlPlaceholder = descriptorCopy?.urlPlaceholder ?: when (backend) {
         AddSourceBackend.WEBDAV -> "server.example.com/dav/annotations"
         else -> "abs.example.com"
     }
-    val submitLabel = if (isEditing) "Save" else "Connect"
+    val submitLabel = descriptorCopy
+        ?.let { if (isEditing) it.submitLabelEdit else it.submitLabelAdd }
+        ?: if (isEditing) "Save" else "Connect"
 
     viewModel.insecureWarning?.let { type ->
         InsecureConnectionDialog(
@@ -109,7 +121,7 @@ fun AddSourceScreen(
                     .padding(24.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                val helpText = backendHelpText(backend)
+                val helpText = descriptorCopy?.helpText ?: backendHelpText(backend)
                 if (helpText.isNotEmpty()) {
                     Text(
                         text = helpText,
@@ -191,13 +203,28 @@ fun AddSourceScreen(
                                 contentColor = MaterialTheme.colorScheme.error,
                             ),
                         ) {
-                            Text(removeButtonLabel(backend))
+                            Text(descriptorCopy?.removeLabel ?: removeButtonLabel(backend))
                         }
                     }
                 }
             }
         }
     }
+}
+
+/**
+ * Bridge from the legacy [AddSourceBackend] enum (which still discriminates the WebDAV path and
+ * the ABS-Audiobookshelf vs ABS-Storyteller split until #441 lands) to the descriptor-driven
+ * copy pipeline (issue #526). Returns non-null only for backends whose corresponding
+ * [com.riffle.core.domain.WebSourceDescriptor] ships an [AddSourceCopy]; today that's just
+ * AUDIOBOOKSHELF. Storyteller shares [com.riffle.core.domain.SourceType.ABS] with Audiobookshelf
+ * and can't route through the descriptor path until #441 splits it out. WebDAV is not a
+ * browsable source, so it never will.
+ */
+internal fun descriptorCopyFor(backend: AddSourceBackend): AddSourceCopy? = when (backend) {
+    AddSourceBackend.AUDIOBOOKSHELF ->
+        WebSourceDescriptors.forTypeOrError(com.riffle.core.domain.SourceType.ABS).addSourceCopy
+    AddSourceBackend.STORYTELLER, AddSourceBackend.WEBDAV -> null
 }
 
 internal fun screenTitle(backend: AddSourceBackend, isEditing: Boolean): String = when (backend) {

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -64,6 +64,7 @@ fun SettingsScreen(
     windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onNavigateToAddSource: (backend: AddSourceBackend, editId: String?) -> Unit,
+    onNavigateToAddSourcePicker: () -> Unit = { onNavigateToAddSource(AddSourceBackend.AUDIOBOOKSHELF, null) },
     onNavigateToAddLocalFolder: () -> Unit = {},
     onNavigateToReadaloudSettings: () -> Unit = {},
     onNavigateToAnnotationsSyncSettings: () -> Unit = {},
@@ -97,7 +98,7 @@ fun SettingsScreen(
     LaunchedEffect(Unit) {
         viewModel.navigationEvents.collect { event ->
             when (event) {
-                is SettingsNavEvent.NavigateToAddSource -> onNavigateToAddSource(AddSourceBackend.AUDIOBOOKSHELF, null)
+                is SettingsNavEvent.NavigateToAddSource -> onNavigateToAddSourcePicker()
             }
         }
     }
@@ -146,7 +147,7 @@ fun SettingsScreen(
                     libraryItemsBySource = libraryItemsBySource,
                     readaloudSummaries = readaloudSummaries,
                     expandedServers = expandedServers,
-                    onNavigateToAddSource = onNavigateToAddSource,
+                    onNavigateToAddSourcePicker = onNavigateToAddSourcePicker,
                     onNavigateToAddLocalFolder = onNavigateToAddLocalFolder,
                     onOpenReadaloudMatches = { /* Storyteller no longer appears in the Sources list; wire is a no-op. */ },
                     onRemoveServer = viewModel::removeServer,

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/sections/SourcesSection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/sections/SourcesSection.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import com.riffle.app.feature.server.AddSourceBackend
 import com.riffle.app.feature.settings.ExpandableSourceRow
 import com.riffle.app.feature.settings.LibraryUiItem
 import com.riffle.app.feature.settings.ReadaloudMatchSummary
@@ -65,7 +64,7 @@ internal fun SourcesSection(
     libraryItemsBySource: Map<String, List<LibraryUiItem>>,
     readaloudSummaries: Map<String, ReadaloudMatchSummary>,
     expandedServers: androidx.compose.runtime.snapshots.SnapshotStateMap<String, Boolean>,
-    onNavigateToAddSource: (AddSourceBackend, String?) -> Unit,
+    onNavigateToAddSourcePicker: () -> Unit,
     onNavigateToAddLocalFolder: () -> Unit,
     onOpenReadaloudMatches: (String) -> Unit,
     onRemoveServer: (String) -> Unit,
@@ -75,11 +74,22 @@ internal fun SourcesSection(
     onReorderLibraries: (String, List<String>) -> Unit,
 ) {
     SettingsSectionHeader("Sources")
-    servers.filter {
-        it.serverType == ServerType.AUDIOBOOKSHELF && it.type == SourceType.ABS
+    // Credentialed multi-instance sources: any Source whose [WebSourceDescriptor] declares
+    // hasCredentials=true && isSingleton=false renders here. Storyteller Services are excluded
+    // because they live under the Readaloud drill-in (ADR 0020) — the exclusion is by
+    // `serverType`, not by SourceType, because Storyteller currently shares SourceType.ABS with
+    // Audiobookshelf. Once #441 splits Storyteller into its own SourceType the serverType clause
+    // drops out. A new credentialed source (Komga, Calibre-Web, …) drops in without an edit
+    // here; it just needs a `WebSourceDescriptor` with `hasCredentials=true, isSingleton=false`.
+    servers.filter { source ->
+        val descriptor = WebSourceDescriptors.forType(source.type)
+        descriptor != null && descriptor.hasCredentials && !descriptor.isSingleton &&
+            source.serverType != ServerType.STORYTELLER_SERVICE
     }.forEach { server ->
+        val descriptor = WebSourceDescriptors.forType(server.type) ?: return@forEach
         ServerRow(
             server = server,
+            descriptor = descriptor,
             isExpanded = expandedServers[server.id] == true,
             onToggleExpanded = {
                 expandedServers[server.id] = expandedServers[server.id] != true
@@ -138,7 +148,7 @@ internal fun SourcesSection(
         )
     }
     Button(
-        onClick = { onNavigateToAddSource(AddSourceBackend.AUDIOBOOKSHELF, null) },
+        onClick = onNavigateToAddSourcePicker,
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 8.dp),
@@ -155,6 +165,7 @@ internal fun SourcesSection(
 @Composable
 internal fun ServerRow(
     server: Source,
+    descriptor: WebSourceDescriptor,
     isExpanded: Boolean,
     onToggleExpanded: () -> Unit,
     onRemove: () -> Unit,
@@ -167,21 +178,30 @@ internal fun ServerRow(
 ) {
     val username = server.username.takeIf { it.isNotEmpty() }
     val subtitle = buildString {
-        if (username != null) {
+        if (descriptor.hasCredentials && username != null) {
             append(username)
             append(" · ")
         }
-        append(server.url.value)
-        if (serverVersion != null) {
-            append(" · v")
-            append(serverVersion)
+        if (descriptor.hasNetworkHost) {
+            append(server.url.value)
+            if (serverVersion != null) {
+                append(" · v")
+                append(serverVersion)
+            }
         }
     }
+    // Headline: for the ABS descriptor we keep the ABS/Storyteller product label because it's the
+    // one credentialed SourceType whose displayName ("Audiobookshelf") isn't the whole story —
+    // Storyteller Services would collapse into "Audiobookshelf" in the row title otherwise. Every
+    // other credentialed source (Komga, Calibre-Web, …) uses its descriptor's displayName directly.
+    // Once #441 splits Storyteller into its own SourceType this branch collapses.
+    val headline = if (server.type == SourceType.ABS) server.serverType.label
+    else descriptor.displayName
     ExpandableSourceRow(
         isExpanded = isExpanded,
         onToggleExpanded = onToggleExpanded,
         onRemove = onRemove,
-        headlineContent = { Text(server.serverType.label) },
+        headlineContent = { Text(headline) },
         supportingContent = { Text(subtitle) },
         trailingContent = if (server.isActive) {
             { Text("Active", style = MaterialTheme.typography.labelSmall) }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -411,22 +411,21 @@ fun MainScreen(
                 SettingsScreen(
                     windowSizeClass = windowSizeClass,
                     onNavigateBack = { navController.popBackStack() },
+                    // Storyteller/WebDAV are Services (not Sources) and deep-link straight to the
+                    // form from their respective Settings drill-ins; editing an existing ABS
+                    // Source also skips the picker (the Source Type is already known). All three
+                    // paths still flow through `onNavigateToAddSource(backend, editId)`.
                     onNavigateToAddSource = { backend, editId ->
-                        // The Source Type picker only fronts the "add a fresh ABS Source" flow.
-                        // Storyteller/WebDAV are Services (not Sources) and deep-link straight
-                        // to the form; editing an existing ABS Source also skips the picker
-                        // (Source Type is already known).
-                        val isNewAbs = backend == com.riffle.app.feature.server.AddSourceBackend.AUDIOBOOKSHELF && editId.isNullOrEmpty()
-                        if (isNewAbs) {
-                            navController.navigate(ADD_SOURCE_TYPE_PICKER)
-                        } else {
-                            val params = buildList {
-                                add("type=${backend.name.lowercase()}")
-                                if (!editId.isNullOrEmpty()) add("editId=${URLEncoder.encode(editId, "UTF-8")}")
-                            }.joinToString("&")
-                            navController.navigate("$ADD_SOURCE?$params")
-                        }
+                        val params = buildList {
+                            add("type=${backend.name.lowercase()}")
+                            if (!editId.isNullOrEmpty()) add("editId=${URLEncoder.encode(editId, "UTF-8")}")
+                        }.joinToString("&")
+                        navController.navigate("$ADD_SOURCE?$params")
                     },
+                    // The "Add source" button in the Sources section always launches the picker;
+                    // once a SourceType is picked the picker itself routes to the type's addRoute
+                    // (see [addSourceRouteFor]).
+                    onNavigateToAddSourcePicker = { navController.navigate(ADD_SOURCE_TYPE_PICKER) },
                     onNavigateToAddLocalFolder = { navController.navigate(ADD_LOCAL_FILES) },
                     onNavigateToReadaloudSettings = { navController.navigate(READALOUD_SETTINGS) },
                     onNavigateToAnnotationsSyncSettings = { navController.navigate(ANNOTATIONS_SYNC_SETTINGS) },

--- a/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
@@ -1,16 +1,14 @@
 package com.riffle.core.data
 
+import com.riffle.core.data.credentialed.CredentialedAuthenticator
+import com.riffle.core.data.credentialed.CredentialedSourceInstaller
+import com.riffle.core.data.credentialed.toDomain
 import com.riffle.core.database.LibraryDao
-import com.riffle.core.database.LibraryEntity
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.SourceDao
-import com.riffle.core.database.SourceEntity
 import com.riffle.core.domain.AuthenticateResult
 import com.riffle.core.domain.CommitSourceResult
-import com.riffle.core.domain.Library
-import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.PendingSource
-import com.riffle.core.domain.READALOUD_MEDIA_TYPE
 import com.riffle.core.domain.Source
 import com.riffle.core.domain.SourceFilesCleaner
 import com.riffle.core.domain.SourceRepository
@@ -18,28 +16,20 @@ import com.riffle.core.domain.ServerType
 import com.riffle.core.domain.SourceType
 import com.riffle.core.domain.SourceUrl
 import com.riffle.core.domain.TokenStorage
-import com.riffle.core.network.AbsApi
-import com.riffle.core.network.AbsLibraryApi
 import com.riffle.core.network.AbsServerInfoApi
-import com.riffle.core.network.NetworkResult
-import com.riffle.core.network.StorytellerApi
-import com.riffle.core.network.errorAsThrowable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import java.util.UUID
 import javax.inject.Inject
 
 class SourceRepositoryImpl @Inject constructor(
     private val dao: SourceDao,
     private val tokenStorage: TokenStorage,
-    private val absApiClient: AbsApi,
-    private val storytellerApi: StorytellerApi,
     private val serverInfoApi: AbsServerInfoApi,
-    private val libraryApi: AbsLibraryApi,
     private val libraryDao: LibraryDao,
     private val libraryItemDao: LibraryItemDao,
-    private val visibilityStore: LibraryVisibilityPreferencesStore,
     private val filesCleaner: SourceFilesCleaner,
+    private val authenticators: Map<SourceType, @JvmSuppressWildcards CredentialedAuthenticator>,
+    private val installer: CredentialedSourceInstaller,
 ) : SourceRepository {
 
     // Sort by SourceType so consumers (Settings sources list, drawer source switcher) render in
@@ -61,127 +51,19 @@ class SourceRepositoryImpl @Inject constructor(
         password: String,
         insecureAllowed: Boolean,
         serverType: ServerType,
-    ): AuthenticateResult = when (serverType) {
-        ServerType.AUDIOBOOKSHELF -> authenticateAbs(url, username, password, insecureAllowed)
-        ServerType.STORYTELLER_SERVICE -> authenticateStoryteller(url, username, password, insecureAllowed)
-    }
-
-    private suspend fun authenticateAbs(
-        url: SourceUrl,
-        username: String,
-        password: String,
-        insecureAllowed: Boolean,
     ): AuthenticateResult {
-        val loginResult = absApiClient.login(url.value, username, password, insecureAllowed)
-        return when (loginResult) {
-            NetworkResult.Auth -> AuthenticateResult.WrongCredentials(WRONG_CREDENTIALS_MESSAGE)
-            is NetworkResult.InsecureConnection -> AuthenticateResult.InsecureConnection(loginResult.type)
-            is NetworkResult.Success -> {
-                val libs = libraryApi.getLibraries(url.value, loginResult.value.token, insecureAllowed)
-                if (libs !is NetworkResult.Success) {
-                    AuthenticateResult.LibraryFetchFailed(libs.errorAsThrowable())
-                } else AuthenticateResult.Success(
-                    PendingSource(
-                        url = url,
-                        username = loginResult.value.username,
-                        userId = loginResult.value.userId,
-                        token = loginResult.value.token,
-                        password = password,
-                        insecureConnectionAllowed = insecureAllowed,
-                        libraries = libs.value
-                            .filter { it.mediaType == "book" }
-                            .map {
-                                Library(
-                                    id = it.id,
-                                    name = it.name,
-                                    mediaType = it.mediaType,
-                                    isUnsupported = false,
-                                )
-                            },
-                    )
-                )
-            }
-            else -> AuthenticateResult.NetworkError(loginResult.errorAsThrowable())
-        }
-    }
-
-    private suspend fun authenticateStoryteller(
-        url: SourceUrl,
-        username: String,
-        password: String,
-        insecureAllowed: Boolean,
-    ): AuthenticateResult = when (val result = storytellerApi.login(url.value, username, password, insecureAllowed)) {
-        NetworkResult.Auth -> AuthenticateResult.WrongCredentials(WRONG_CREDENTIALS_MESSAGE)
-        is NetworkResult.InsecureConnection -> AuthenticateResult.InsecureConnection(result.type)
-        is NetworkResult.Success -> AuthenticateResult.Success(
-            PendingSource(
-                url = url,
-                username = username,
-                userId = "", // Storyteller's auth response doesn't expose a user id; identity is the username + token.
-                token = result.value,
-                password = password,
-                insecureConnectionAllowed = insecureAllowed,
-                // Storyteller contributes no browsable Library (ADR 0026) — it is a Settings-only
-                // readaloud backend. The local namespace row that hosts its books as matcher input
-                // is created in [commit], not surfaced to the user.
-                libraries = emptyList(),
-                serverType = ServerType.STORYTELLER_SERVICE,
-            )
-        )
-        else -> AuthenticateResult.NetworkError(result.errorAsThrowable())
+        // Every SourceRepository.authenticate call today comes from the ABS/Storyteller flow, so
+        // dispatch on SourceType.ABS. Komga and any future SourceType will pass their own type
+        // through here once the AddSourceScreen goes descriptor-driven (issue #526 Phase 3).
+        val authenticator = authenticators[SourceType.ABS]
+            ?: error("no CredentialedAuthenticator bound for SourceType.ABS — check CredentialedAuthenticatorModule")
+        return authenticator.authenticate(url, username, password, insecureAllowed, serverType)
     }
 
     override suspend fun commit(
         pending: PendingSource,
         hiddenLibraryIds: Set<String>,
-    ): CommitSourceResult = try {
-        val id = UUID.randomUUID().toString()
-        val entity = SourceEntity(
-            id = id,
-            url = pending.url.value,
-            isActive = false,                    // overridden inside transaction
-            insecureConnectionAllowed = pending.insecureConnectionAllowed,
-            username = pending.username,
-            serverType = pending.serverType.name,
-            // ABS exposes `user.id` on the login response — persist it now so annotation sync has
-            // a cross-device-stable namespace from first open. Storyteller's login response
-            // carries no equivalent identity (auth is username + token), so leave it null.
-            absUserId = pending.userId.takeIf { it.isNotBlank() && pending.serverType == ServerType.AUDIOBOOKSHELF },
-            type = "ABS",
-        )
-        // A Storyteller Source is a Settings-only readaloud backend (ADR 0026) — it must never
-        // become the active browsable Source, not even as the first source added. ABS sources keep
-        // the "first source becomes active" convenience.
-        val inserted = if (pending.serverType == ServerType.STORYTELLER_SERVICE) {
-            dao.upsert(entity)
-            entity
-        } else {
-            dao.upsertAsFirstIfNoActive(entity)
-        }
-        tokenStorage.saveToken(id, pending.token)
-        tokenStorage.savePassword(id, pending.password)
-        val libraryRows = pending.libraries.map {
-            LibraryEntity(id = it.id, name = it.name, mediaType = it.mediaType, sourceId = id)
-        }.toMutableList()
-        // A Storyteller Source contributes no browsable Library (ADR 0026), but its readaloud books
-        // are stored in `library_items` as matcher input. They need an owning `libraries` row so the
-        // matcher's library→source join resolves their serverType and the source-removal cascade
-        // cleans them up. This row is never surfaced in the drawer or any library picker — the
-        // Source is never the active browsable Source.
-        if (pending.serverType == ServerType.STORYTELLER_SERVICE) {
-            libraryRows += LibraryEntity(
-                id = readaloudLibraryId(id),
-                name = "Readalouds",
-                mediaType = READALOUD_MEDIA_TYPE,
-                sourceId = id,
-            )
-        }
-        libraryDao.replaceAllForSource(sourceId = id, libraries = libraryRows)
-        hiddenLibraryIds.forEach { hidden -> visibilityStore.hideLibrary(id, hidden) }
-        CommitSourceResult.Success(inserted.toDomain())
-    } catch (t: Throwable) {
-        CommitSourceResult.Failure(t)
-    }
+    ): CommitSourceResult = installer.install(pending, hiddenLibraryIds)
 
     override suspend fun setActive(sourceId: String) {
         // A Storyteller Source is a Settings-only readaloud backend (ADR 0026) — it can never be the
@@ -219,14 +101,10 @@ class SourceRepositoryImpl @Inject constructor(
     }
 
     companion object {
-        // The local-only library id that namespaces a Storyteller Source's readaloud rows in
-        // `library_items` (matcher input; never browsable — ADR 0026). Its mediaType is the shared
-        // [READALOUD_MEDIA_TYPE] so consumers can filter it out of browsable surfaces.
-        fun readaloudLibraryId(sourceId: String): String = "readaloud:$sourceId"
-
-        // Surfaced when the network layer maps 401 to [NetworkResult.Auth] — the unified result type
-        // drops the server-provided string, so the user-facing message is owned here.
-        private const val WRONG_CREDENTIALS_MESSAGE = "Invalid username or password"
+        // Re-exported for legacy call sites that reference the ABS-family synthetic library id via
+        // this class. New code should use [CredentialedSourceInstaller.readaloudLibraryId] directly.
+        fun readaloudLibraryId(sourceId: String): String =
+            CredentialedSourceInstaller.readaloudLibraryId(sourceId)
     }
 
     override suspend fun ensureAbsUserId(sourceId: String): String? {
@@ -242,20 +120,5 @@ class SourceRepositoryImpl @Inject constructor(
         ) ?: return null
         dao.setAbsUserId(sourceId, fetched)
         return fetched
-    }
-
-    private fun SourceEntity.toDomain(): Source {
-        val parsedUrl = SourceUrl.parse(url)
-            ?: SourceUrl.parse("https://invalid.example.com")!!
-        return Source(
-            id = id,
-            url = parsedUrl,
-            isActive = isActive,
-            insecureConnectionAllowed = insecureConnectionAllowed,
-            username = username,
-            type = runCatching { SourceType.valueOf(type) }.getOrDefault(SourceType.ABS),
-            serverType = ServerType.fromStorageString(serverType),
-            absUserId = absUserId,
-        )
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/credentialed/AbsCredentialedAuthenticator.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/credentialed/AbsCredentialedAuthenticator.kt
@@ -1,0 +1,120 @@
+package com.riffle.core.data.credentialed
+
+import com.riffle.core.domain.AuthenticateResult
+import com.riffle.core.domain.Library
+import com.riffle.core.domain.PendingSource
+import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.SourceType
+import com.riffle.core.domain.SourceUrl
+import com.riffle.core.network.AbsApi
+import com.riffle.core.network.AbsLibraryApi
+import com.riffle.core.network.NetworkResult
+import com.riffle.core.network.StorytellerApi
+import com.riffle.core.network.errorAsThrowable
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * [CredentialedAuthenticator] for [SourceType.ABS]. Handles both Audiobookshelf servers (full
+ * login + library fetch) and Storyteller Services (token-only login, no browsable libraries per
+ * ADR 0026), dispatched on the [ServerType] arg.
+ *
+ * The Audiobookshelf/Storyteller subtype split lives inside this one authenticator because both
+ * currently share `SourceType.ABS`; once #441 splits Storyteller into its own SourceType, the two
+ * branches can be extracted into peer authenticators keyed by their own SourceType. Until then
+ * this class isolates that mess from the generic `SourceRepositoryImpl`.
+ */
+@Singleton
+class AbsCredentialedAuthenticator @Inject constructor(
+    private val absApi: AbsApi,
+    private val libraryApi: AbsLibraryApi,
+    private val storytellerApi: StorytellerApi,
+) : CredentialedAuthenticator {
+    override val sourceType: SourceType = SourceType.ABS
+
+    override suspend fun authenticate(
+        url: SourceUrl,
+        username: String,
+        password: String,
+        insecureAllowed: Boolean,
+        serverType: ServerType,
+    ): AuthenticateResult = when (serverType) {
+        ServerType.AUDIOBOOKSHELF -> authenticateAudiobookshelf(url, username, password, insecureAllowed)
+        ServerType.STORYTELLER_SERVICE -> authenticateStoryteller(url, username, password, insecureAllowed)
+    }
+
+    private suspend fun authenticateAudiobookshelf(
+        url: SourceUrl,
+        username: String,
+        password: String,
+        insecureAllowed: Boolean,
+    ): AuthenticateResult {
+        val loginResult = absApi.login(url.value, username, password, insecureAllowed)
+        return when (loginResult) {
+            NetworkResult.Auth -> AuthenticateResult.WrongCredentials(WRONG_CREDENTIALS_MESSAGE)
+            is NetworkResult.InsecureConnection -> AuthenticateResult.InsecureConnection(loginResult.type)
+            is NetworkResult.Success -> {
+                val libs = libraryApi.getLibraries(url.value, loginResult.value.token, insecureAllowed)
+                if (libs !is NetworkResult.Success) {
+                    AuthenticateResult.LibraryFetchFailed(libs.errorAsThrowable())
+                } else AuthenticateResult.Success(
+                    PendingSource(
+                        url = url,
+                        username = loginResult.value.username,
+                        userId = loginResult.value.userId,
+                        token = loginResult.value.token,
+                        password = password,
+                        insecureConnectionAllowed = insecureAllowed,
+                        libraries = libs.value
+                            .filter { it.mediaType == "book" }
+                            .map {
+                                Library(
+                                    id = it.id,
+                                    name = it.name,
+                                    mediaType = it.mediaType,
+                                    isUnsupported = false,
+                                )
+                            },
+                        serverType = ServerType.AUDIOBOOKSHELF,
+                        sourceType = SourceType.ABS,
+                    )
+                )
+            }
+            else -> AuthenticateResult.NetworkError(loginResult.errorAsThrowable())
+        }
+    }
+
+    private suspend fun authenticateStoryteller(
+        url: SourceUrl,
+        username: String,
+        password: String,
+        insecureAllowed: Boolean,
+    ): AuthenticateResult = when (val result = storytellerApi.login(url.value, username, password, insecureAllowed)) {
+        NetworkResult.Auth -> AuthenticateResult.WrongCredentials(WRONG_CREDENTIALS_MESSAGE)
+        is NetworkResult.InsecureConnection -> AuthenticateResult.InsecureConnection(result.type)
+        is NetworkResult.Success -> AuthenticateResult.Success(
+            PendingSource(
+                url = url,
+                username = username,
+                // Storyteller's auth response doesn't expose a user id; identity is the username + token.
+                userId = "",
+                token = result.value,
+                password = password,
+                insecureConnectionAllowed = insecureAllowed,
+                // Storyteller contributes no browsable Library (ADR 0026) — it is a Settings-only
+                // readaloud backend. The local namespace row that hosts its books as matcher input
+                // is created in [CredentialedSourceInstaller.install], not surfaced to the user.
+                libraries = emptyList(),
+                serverType = ServerType.STORYTELLER_SERVICE,
+                sourceType = SourceType.ABS,
+            )
+        )
+        else -> AuthenticateResult.NetworkError(result.errorAsThrowable())
+    }
+
+    companion object {
+        // Surfaced when the network layer maps 401 to [NetworkResult.Auth] — the unified result type
+        // drops the server-provided string, so the user-facing message is owned here.
+        private const val WRONG_CREDENTIALS_MESSAGE = "Invalid username or password"
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/credentialed/CredentialedAuthenticator.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/credentialed/CredentialedAuthenticator.kt
@@ -1,0 +1,42 @@
+package com.riffle.core.data.credentialed
+
+import com.riffle.core.domain.AuthenticateResult
+import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.SourceType
+import com.riffle.core.domain.SourceUrl
+
+/**
+ * Per-[SourceType] plug-in that owns the "user has typed URL + username + password" step of
+ * adding a credentialed source. Contributed to a `Map<SourceType, CredentialedAuthenticator>` via
+ * Hilt `@IntoMap` + [com.riffle.core.data.di.modules.SourceTypeKey], mirroring the
+ * [com.riffle.core.catalog.CatalogFactory] map that already dispatches per-source catalog access.
+ *
+ * `SourceRepository.authenticate` looks up the entry for the caller's [SourceType] and delegates
+ * the network round-trip here — the repository stays generic and a new credentialed source
+ * (Komga, Calibre-Web, Jellyfin, …) drops in by contributing one binding.
+ *
+ * The returned [com.riffle.core.domain.PendingSource] carries [SourceType] via its
+ * `sourceType` field so [CredentialedSourceInstaller] can stamp the correct
+ * `SourceEntity.type` column at commit — no more `type = "ABS"` hard-code.
+ */
+interface CredentialedAuthenticator {
+    /**
+     * The [SourceType] this authenticator handles. Used as a self-check in the Hilt map binding —
+     * the map key must match this value; a mismatch is a wiring bug.
+     */
+    val sourceType: SourceType
+
+    /**
+     * Authenticate against the source at [url] with [username]/[password]. [serverType] lets a
+     * single-[SourceType] authenticator further discriminate its target product (currently only
+     * ABS uses it, for the Audiobookshelf-vs-Storyteller split; Komga and future single-product
+     * sources ignore it).
+     */
+    suspend fun authenticate(
+        url: SourceUrl,
+        username: String,
+        password: String,
+        insecureAllowed: Boolean,
+        serverType: ServerType,
+    ): AuthenticateResult
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/credentialed/CredentialedSourceInstaller.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/credentialed/CredentialedSourceInstaller.kt
@@ -1,0 +1,124 @@
+package com.riffle.core.data.credentialed
+
+import com.riffle.core.database.LibraryDao
+import com.riffle.core.database.LibraryEntity
+import com.riffle.core.database.SourceDao
+import com.riffle.core.database.SourceEntity
+import com.riffle.core.domain.CommitSourceResult
+import com.riffle.core.domain.LibraryVisibilityPreferencesStore
+import com.riffle.core.domain.PendingSource
+import com.riffle.core.domain.READALOUD_MEDIA_TYPE
+import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.Source
+import com.riffle.core.domain.SourceType
+import com.riffle.core.domain.SourceUrl
+import com.riffle.core.domain.TokenStorage
+import java.util.UUID
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Owns the "commit an authenticated credentialed source" side of the Add-Source flow — the
+ * counterpart to [com.riffle.core.data.websource.SingletonWebSourceInstaller] for user-configured
+ * sources (Audiobookshelf servers, Storyteller Services, and any future credentialed source like
+ * Komga). Persists the [SourceEntity], its libraries, credentials, and hidden-library prefs in
+ * one atomic-ish sweep so [SourceRepository.commit] can stay a thin delegator.
+ *
+ * Notably fixes the pre-refactor `type = "ABS"` hard-code by reading [PendingSource.sourceType] —
+ * a new credentialed source now round-trips its own type through the installer without an edit
+ * here.
+ */
+@Singleton
+class CredentialedSourceInstaller @Inject constructor(
+    private val sourceDao: SourceDao,
+    private val libraryDao: LibraryDao,
+    private val tokenStorage: TokenStorage,
+    private val visibilityStore: LibraryVisibilityPreferencesStore,
+) {
+
+    /**
+     * Persist [pending] and its libraries. Returns [CommitSourceResult.Success] wrapping the
+     * committed [Source], or [CommitSourceResult.Failure] wrapping any thrown cause.
+     *
+     * Storyteller-specific carve-outs (never becomes the active source, seeds a synthetic
+     * "Readalouds" library row per ADR 0026) are still branched here on
+     * [PendingSource.serverType]. Once #441 splits Storyteller into its own SourceType those
+     * branches move behind a descriptor capability, but until then they're isolated to this file
+     * so `SourceRepositoryImpl` doesn't have to know.
+     */
+    suspend fun install(
+        pending: PendingSource,
+        hiddenLibraryIds: Set<String>,
+    ): CommitSourceResult = try {
+        val id = UUID.randomUUID().toString()
+        val entity = SourceEntity(
+            id = id,
+            url = pending.url.value,
+            isActive = false,                    // overridden inside transaction
+            insecureConnectionAllowed = pending.insecureConnectionAllowed,
+            username = pending.username,
+            serverType = pending.serverType.name,
+            // ABS exposes `user.id` on the login response — persist it now so annotation sync has
+            // a cross-device-stable namespace from first open. Storyteller's login response
+            // carries no equivalent identity (auth is username + token), so leave it null.
+            absUserId = pending.userId.takeIf {
+                it.isNotBlank() && pending.serverType == ServerType.AUDIOBOOKSHELF
+            },
+            type = pending.sourceType.name,
+        )
+        // A Storyteller Source is a Settings-only readaloud backend (ADR 0026) — it must never
+        // become the active browsable Source, not even as the first source added. Other
+        // credentialed sources keep the "first source becomes active" convenience.
+        val inserted = if (pending.serverType == ServerType.STORYTELLER_SERVICE) {
+            sourceDao.upsert(entity)
+            entity
+        } else {
+            sourceDao.upsertAsFirstIfNoActive(entity)
+        }
+        tokenStorage.saveToken(id, pending.token)
+        tokenStorage.savePassword(id, pending.password)
+        val libraryRows = pending.libraries.map {
+            LibraryEntity(id = it.id, name = it.name, mediaType = it.mediaType, sourceId = id)
+        }.toMutableList()
+        // A Storyteller Source contributes no browsable Library (ADR 0026), but its readaloud books
+        // are stored in `library_items` as matcher input. They need an owning `libraries` row so the
+        // matcher's library→source join resolves their serverType and the source-removal cascade
+        // cleans them up. This row is never surfaced in the drawer or any library picker — the
+        // Source is never the active browsable Source.
+        if (pending.serverType == ServerType.STORYTELLER_SERVICE) {
+            libraryRows += LibraryEntity(
+                id = readaloudLibraryId(id),
+                name = "Readalouds",
+                mediaType = READALOUD_MEDIA_TYPE,
+                sourceId = id,
+            )
+        }
+        libraryDao.replaceAllForSource(sourceId = id, libraries = libraryRows)
+        hiddenLibraryIds.forEach { hidden -> visibilityStore.hideLibrary(id, hidden) }
+        CommitSourceResult.Success(inserted.toDomain())
+    } catch (t: Throwable) {
+        CommitSourceResult.Failure(t)
+    }
+
+    companion object {
+        // The local-only library id that namespaces a Storyteller Source's readaloud rows in
+        // `library_items` (matcher input; never browsable — ADR 0026). Its mediaType is the shared
+        // [READALOUD_MEDIA_TYPE] so consumers can filter it out of browsable surfaces.
+        fun readaloudLibraryId(sourceId: String): String = "readaloud:$sourceId"
+    }
+}
+
+// package-private so both the installer and SourceRepositoryImpl can share the entity→domain map.
+internal fun SourceEntity.toDomain(): Source {
+    val parsedUrl = SourceUrl.parse(url) ?: SourceUrl.parse("https://invalid.example.com")!!
+    return Source(
+        id = id,
+        url = parsedUrl,
+        isActive = isActive,
+        insecureConnectionAllowed = insecureConnectionAllowed,
+        username = username,
+        type = runCatching { SourceType.valueOf(type) }.getOrDefault(SourceType.ABS),
+        serverType = ServerType.fromStorageString(serverType),
+        absUserId = absUserId,
+    )
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/CredentialedAuthenticatorModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/CredentialedAuthenticatorModule.kt
@@ -1,0 +1,27 @@
+package com.riffle.core.data.di.modules
+
+import com.riffle.core.data.credentialed.AbsCredentialedAuthenticator
+import com.riffle.core.data.credentialed.CredentialedAuthenticator
+import com.riffle.core.domain.SourceType
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoMap
+
+/**
+ * Wires the `Map<SourceType, CredentialedAuthenticator>` consumed by `SourceRepositoryImpl`.
+ * A new credentialed source (Komga, Calibre-Web, …) adds itself by contributing one `@IntoMap`
+ * binding here, mirroring [CatalogModule]'s per-source factory map.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CredentialedAuthenticatorModule {
+
+    @Binds
+    @IntoMap
+    @SourceTypeKey(SourceType.ABS)
+    abstract fun bindAbsCredentialedAuthenticator(
+        impl: AbsCredentialedAuthenticator,
+    ): CredentialedAuthenticator
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
@@ -183,6 +183,46 @@ class ServerRepositoryTest {
         override fun observeBySource(sourceId: String) = flowOf(emptyList<com.riffle.core.database.LibraryItemEntity>())
     }
 
+    // Constructs the refactored SourceRepositoryImpl with the same "positional" arg list the pre-
+    // refactor tests used, so the test bodies don't have to know about CredentialedAuthenticator /
+    // CredentialedSourceInstaller. Synthesises the SourceType.ABS authenticator from the supplied
+    // AbsApi + StorytellerApi + AbsLibraryApi (what the Hilt map entry does at runtime) and hands
+    // the shared installer to the repo.
+    private fun buildRepo(
+        dao: SourceDao,
+        tokens: TokenStorage,
+        absApi: AbsApi,
+        storytellerApi: StorytellerApi,
+        serverInfoApi: AbsServerInfoApi,
+        libraryApi: AbsLibraryApi,
+        libraryDao: LibraryDao,
+        libraryItemDao: com.riffle.core.database.LibraryItemDao,
+        visibilityStore: LibraryVisibilityPreferencesStore,
+        filesCleaner: SourceFilesCleaner,
+    ): SourceRepositoryImpl {
+        val authenticator = com.riffle.core.data.credentialed.AbsCredentialedAuthenticator(
+            absApi = absApi,
+            libraryApi = libraryApi,
+            storytellerApi = storytellerApi,
+        )
+        val installer = com.riffle.core.data.credentialed.CredentialedSourceInstaller(
+            sourceDao = dao,
+            libraryDao = libraryDao,
+            tokenStorage = tokens,
+            visibilityStore = visibilityStore,
+        )
+        return SourceRepositoryImpl(
+            dao = dao,
+            tokenStorage = tokens,
+            serverInfoApi = serverInfoApi,
+            libraryDao = libraryDao,
+            libraryItemDao = libraryItemDao,
+            filesCleaner = filesCleaner,
+            authenticators = mapOf(com.riffle.core.domain.SourceType.ABS to authenticator),
+            installer = installer,
+        )
+    }
+
     private val storytellerApiNotCalled = StorytellerApi { _, _, _, _ -> error("should not be called") }
     private fun storytellerApiReturning(result: NetworkResult<String>) = StorytellerApi { _, _, _, _ -> result }
 
@@ -218,7 +258,7 @@ class ServerRepositoryTest {
 
         // Feed the DAO in an order that deliberately mixes types so any missing sort would show.
         val dao = fakeDao(chitanka, abs2, local, abs1)
-        val repo = SourceRepositoryImpl(
+        val repo = buildRepo(
             dao, fakeTokenStorage(), AbsApi { _, _, _, _ -> error("not called") }, storytellerApiNotCalled,
             fakeServerInfoApi, libsApiNotCalled, fakeLibraryDao(), fakeLibraryItemDao(),
             fakeVisibilityStore(), fakeFilesCleaner(),
@@ -249,7 +289,7 @@ class ServerRepositoryTest {
                 )
             )
         )
-        val repo = SourceRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApi, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
+        val repo = buildRepo(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApi, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
         val url = SourceUrl.parse("https://abs.example.com")!!
 
         val result = repo.authenticate(url, "admin", "pass", insecureAllowed = false)
@@ -268,7 +308,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> NetworkResult.Auth }
-        val repo = SourceRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
+        val repo = buildRepo(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val result = repo.authenticate(SourceUrl.parse("https://x")!!, "u", "p", false)
 
@@ -285,7 +325,7 @@ class ServerRepositoryTest {
         val absApi = AbsApi { _, _, _, _ -> NetworkResult.Success(com.riffle.core.network.NetworkLoginUser("uid", "tok", "u")) }
         val cause = RuntimeException("boom")
         val libsApi = libsApiReturning(NetworkResult.Offline(cause))
-        val repo = SourceRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApi, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
+        val repo = buildRepo(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApi, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val result = repo.authenticate(SourceUrl.parse("https://x")!!, "u", "p", false)
 
@@ -299,7 +339,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> NetworkResult.InsecureConnection(InsecureConnectionType.SELF_SIGNED) }
-        val repo = SourceRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
+        val repo = buildRepo(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val result = repo.authenticate(SourceUrl.parse("https://abs.example.com")!!, "admin", "pass", insecureAllowed = false)
 
@@ -311,7 +351,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
-        val repo = SourceRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
+        val repo = buildRepo(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val url = SourceUrl.parse("https://abs.example.com")!!
         val pending = PendingSource(
@@ -341,7 +381,7 @@ class ServerRepositoryTest {
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("ABS auth must not be called for Storyteller") }
         val storyteller = storytellerApiReturning(NetworkResult.Success("tok-st"))
-        val repo = SourceRepositoryImpl(dao, tokens, absApi, storyteller, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
+        val repo = buildRepo(dao, tokens, absApi, storyteller, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val result = repo.authenticate(
             SourceUrl.parse("http://media-source:8001")!!, "plamen", "pw", insecureAllowed = false,
@@ -364,7 +404,7 @@ class ServerRepositoryTest {
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("ABS auth must not be called for Storyteller") }
         val storyteller = storytellerApiReturning(NetworkResult.Auth)
-        val repo = SourceRepositoryImpl(dao, tokens, absApi, storyteller, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
+        val repo = buildRepo(dao, tokens, absApi, storyteller, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val result = repo.authenticate(
             SourceUrl.parse("http://media-source:8001")!!, "plamen", "wrong", insecureAllowed = false,
@@ -380,7 +420,7 @@ class ServerRepositoryTest {
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
         val storyteller = storytellerApiReturning(NetworkResult.Success("tok-st"))
-        val repo = SourceRepositoryImpl(dao, tokens, absApi, storyteller, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
+        val repo = buildRepo(dao, tokens, absApi, storyteller, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val pendingA = PendingSource(
             url = SourceUrl.parse("http://media-source:8001")!!,
@@ -428,7 +468,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
-        val repo = SourceRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
+        val repo = buildRepo(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val pending = PendingSource(
             url = SourceUrl.parse("http://media-source:8001")!!,
@@ -453,7 +493,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
-        val repo = SourceRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
+        val repo = buildRepo(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val pending = PendingSource(
             url = SourceUrl.parse("http://media-source:8001")!!,
@@ -477,7 +517,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
-        val repo = SourceRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
+        val repo = buildRepo(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val pending = PendingSource(
             url = SourceUrl.parse("http://media-source:8001")!!,
@@ -494,6 +534,38 @@ class ServerRepositoryTest {
         assertEquals(com.riffle.core.domain.ServerType.STORYTELLER_SERVICE, source.serverType)
     }
 
+    // Pre-refactor SourceRepositoryImpl.commit hard-coded `SourceEntity.type = "ABS"` for every
+    // committed source. The credentialed-source refactor (issue #526) fixed that by reading
+    // pending.sourceType. A future Komga source will pass its own SourceType through PendingSource
+    // and expect the persisted row to carry it — asserting that here so a regression would flip red.
+    @Test
+    fun `commit stamps SourceEntity type from pending sourceType, not hard-coded ABS`() = runTest {
+        val dao = fakeDao(); val tokens = fakeTokenStorage()
+        val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
+        val absApi = AbsApi { _, _, _, _ -> error("not called") }
+        val repo = buildRepo(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
+
+        // Stand-in for a hypothetical Komga PendingSource — SourceType.CHITANKA is a convenient
+        // non-ABS enum value that already exists in the domain. The point is that the persisted
+        // row echoes back whatever SourceType the caller supplied, not the pre-refactor "ABS"
+        // literal.
+        val pending = PendingSource(
+            url = SourceUrl.parse("https://example.invalid")!!,
+            username = "u", userId = "uid", token = "t", password = "",
+            insecureConnectionAllowed = false,
+            libraries = emptyList(),
+            sourceType = com.riffle.core.domain.SourceType.CHITANKA,
+        )
+
+        val result = repo.commit(pending, hiddenLibraryIds = emptySet())
+
+        assertTrue(result is CommitSourceResult.Success)
+        val source = (result as CommitSourceResult.Success).source
+        assertEquals(com.riffle.core.domain.SourceType.CHITANKA, source.type)
+        // And it round-trips through the DAO so subsequent reads pick up the correct type.
+        assertEquals("CHITANKA", dao.getById(source.id)?.type)
+    }
+
     @Test
     fun `remove deletes source entity and token`() = runTest {
         val entity = SourceEntity("srv-1", "https://abs.example.com", true, false, username = "")
@@ -501,7 +573,7 @@ class ServerRepositoryTest {
         val tokens = fakeTokenStorage()
         tokens.tokens["srv-1"] = "tok"
         val absApi = AbsApi { _, _, _, _ -> NetworkResult.Auth }
-        val repo = SourceRepositoryImpl(
+        val repo = buildRepo(
             dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner()
         )
         repo.remove("srv-1")
@@ -514,7 +586,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
-        val repo = SourceRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
+        val repo = buildRepo(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val pending = PendingSource(
             url = SourceUrl.parse("https://abs.example.com")!!,
@@ -537,7 +609,7 @@ class ServerRepositoryTest {
         tokens.tokens["srv-1"] = "tok"
         tokens.passwords["srv-1"] = "hunter2"
         val absApi = AbsApi { _, _, _, _ -> NetworkResult.Auth }
-        val repo = SourceRepositoryImpl(
+        val repo = buildRepo(
             dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner()
         )
         repo.remove("srv-1")
@@ -552,7 +624,7 @@ class ServerRepositoryTest {
         tokens.tokens["srv-1"] = "tok"
         val cleaner = fakeFilesCleaner()
         val absApi = AbsApi { _, _, _, _ -> NetworkResult.Auth }
-        val repo = SourceRepositoryImpl(
+        val repo = buildRepo(
             dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), cleaner
         )
 
@@ -576,7 +648,7 @@ class ServerRepositoryTest {
             com.riffle.core.database.LibraryItemEntity("st-1", "99", libraryId, "Dune", "Frank Herbert", null, 0f, addedAt = 0L),
         ))
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
-        val repo = SourceRepositoryImpl(
+        val repo = buildRepo(
             dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, itemDao, fakeVisibilityStore(), fakeFilesCleaner()
         )
 
@@ -604,7 +676,7 @@ class ServerRepositoryTest {
         itemDao.seed("lib-1", listOf(com.riffle.core.database.LibraryItemEntity("s1", "i-1", "lib-1", "Dune", "Herbert", null, 0f, addedAt = 0L)))
         itemDao.seed("lib-2", listOf(com.riffle.core.database.LibraryItemEntity("s1", "i-2", "lib-2", "Foundation", "Asimov", null, 0f, addedAt = 0L)))
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
-        val repo = SourceRepositoryImpl(
+        val repo = buildRepo(
             dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, itemDao, fakeVisibilityStore(), fakeFilesCleaner()
         )
 
@@ -621,7 +693,7 @@ class ServerRepositoryTest {
         val e2 = SourceEntity("s2", "https://two.example.com", false, false, username = "")
         val dao = fakeDao(e1, e2)
         val absApi = AbsApi { _, _, _, _ -> NetworkResult.Auth }
-        val repo = SourceRepositoryImpl(
+        val repo = buildRepo(
             dao, fakeTokenStorage(), absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner()
         )
         repo.setActive("s2")
@@ -634,7 +706,7 @@ class ServerRepositoryTest {
         val st = SourceEntity("st", "http://media-source:8001", false, false, username = "", serverType = ServerType.STORYTELLER_SERVICE.name)
         val dao = fakeDao(abs, st)
         val absApi = AbsApi { _, _, _, _ -> NetworkResult.Auth }
-        val repo = SourceRepositoryImpl(
+        val repo = buildRepo(
             dao, fakeTokenStorage(), absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner()
         )
 
@@ -656,7 +728,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
-        val repo = SourceRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
+        val repo = buildRepo(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val result = repo.commit(
             PendingSource(
@@ -682,7 +754,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(); val tokens = fakeTokenStorage()
         val libDao = fakeLibraryDao(); val visibility = fakeVisibilityStore()
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
-        val repo = SourceRepositoryImpl(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
+        val repo = buildRepo(dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, fakeLibraryItemDao(), visibility, fakeFilesCleaner())
 
         val result = repo.commit(
             PendingSource(
@@ -703,7 +775,7 @@ class ServerRepositoryTest {
     fun `ensureAbsUserId returns the persisted value without hitting the network`() = runTest {
         val entity = SourceEntity("abs-1", "https://abs.example.com", true, false, username = "u", absUserId = "persisted-user-id")
         val infoApi = RecordingServerInfoApi(userId = "should-not-be-called")
-        val repo = SourceRepositoryImpl(
+        val repo = buildRepo(
             fakeDao(entity), fakeTokenStorage(), AbsApi { _, _, _, _ -> error("not called") },
             storytellerApiNotCalled, infoApi, libsApiNotCalled,
             fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner(),
@@ -723,7 +795,7 @@ class ServerRepositoryTest {
         val dao = fakeDao(entity)
         val tokens = fakeTokenStorage().also { it.tokens["abs-legacy"] = "tok-cached" }
         val infoApi = RecordingServerInfoApi(userId = "fetched-user-id")
-        val repo = SourceRepositoryImpl(
+        val repo = buildRepo(
             dao, tokens, AbsApi { _, _, _, _ -> error("not called") },
             storytellerApiNotCalled, infoApi, libsApiNotCalled,
             fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner(),
@@ -744,7 +816,7 @@ class ServerRepositoryTest {
         val entity = SourceEntity("abs-1", "https://abs.example.com", true, false, username = "u", absUserId = null)
         val tokens = fakeTokenStorage().also { it.tokens["abs-1"] = "tok" }
         val infoApi = RecordingServerInfoApi(userId = null) // simulates offline / 5xx / parse error
-        val repo = SourceRepositoryImpl(
+        val repo = buildRepo(
             fakeDao(entity), tokens, AbsApi { _, _, _, _ -> error("not called") },
             storytellerApiNotCalled, infoApi, libsApiNotCalled,
             fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner(),
@@ -759,7 +831,7 @@ class ServerRepositoryTest {
     fun `ensureAbsUserId returns null for a Storyteller source without fetching api me`() = runTest {
         val entity = SourceEntity("st-1", "http://media-source:8001", false, false, username = "u", serverType = ServerType.STORYTELLER_SERVICE.name)
         val infoApi = RecordingServerInfoApi(userId = "should-not-be-called")
-        val repo = SourceRepositoryImpl(
+        val repo = buildRepo(
             fakeDao(entity), fakeTokenStorage(), AbsApi { _, _, _, _ -> error("not called") },
             storytellerApiNotCalled, infoApi, libsApiNotCalled,
             fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner(),
@@ -773,7 +845,7 @@ class ServerRepositoryTest {
 
     @Test
     fun `ensureAbsUserId returns null for an unknown source id`() = runTest {
-        val repo = SourceRepositoryImpl(
+        val repo = buildRepo(
             fakeDao(), fakeTokenStorage(), AbsApi { _, _, _, _ -> error("not called") },
             storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled,
             fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner(),

--- a/core/data/src/test/kotlin/com/riffle/core/data/di/WebSourceRegistryCompletenessTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/di/WebSourceRegistryCompletenessTest.kt
@@ -46,6 +46,23 @@ class WebSourceRegistryCompletenessTest {
         assertEquals(expected, registered)
     }
 
+    // Every credentialed source (multi-instance, user-configured URL/creds) MUST ship an
+    // AddSourceCopy so the shared AddSourceScreen can render title/labels/help/buttons without a
+    // when(sourceType). A new credentialed descriptor without copy would fall through to `null`
+    // and crash the form at render time.
+    @Test
+    fun `every credentialed descriptor ships AddSourceCopy`() {
+        val missing = WebSourceDescriptors.all
+            .filter { it.hasCredentials }
+            .filter { it.addSourceCopy == null }
+            .map { it.type }
+        assertTrue(
+            "credentialed WebSourceDescriptor(s) without addSourceCopy: $missing — populate " +
+                "`addSourceCopy = AddSourceCopy(...)` in the descriptor object",
+            missing.isEmpty(),
+        )
+    }
+
     // Pins the invariant that `MainScreen.libraryEntryRoute` relies on: any SourceType flagged as
     // `isUnboundedCatalog = true` must ship a `browseRoutePrefix`, otherwise drawer library taps
     // silently fall back to the Room-mirrored `library_items` screen and render an empty grid.

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/PendingSource.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/PendingSource.kt
@@ -16,4 +16,11 @@ data class PendingSource(
     val insecureConnectionAllowed: Boolean,
     val libraries: List<Library>,
     val serverType: ServerType = ServerType.AUDIOBOOKSHELF,
+    /**
+     * The [SourceType] the credentialed installer should stamp on the persisted [Source] row.
+     * Defaults to [SourceType.ABS] for backwards compatibility with the pre-ADR-0044 Storyteller
+     * + Audiobookshelf path. Komga and any future credentialed source pass their own type so the
+     * installer no longer needs to hard-code the column value.
+     */
+    val sourceType: SourceType = SourceType.ABS,
 )

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/WebSourceDescriptor.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/WebSourceDescriptor.kt
@@ -86,7 +86,41 @@ interface WebSourceDescriptor {
      * unset — never surfaced with only a bare title.
      */
     val pickerBlurb: String get() = displayName
+
+    /**
+     * Copy strings for the shared credentialed "Add source" screen (`AddSourceScreen`). Non-null
+     * for every [hasCredentials] descriptor so the screen can render title / labels / help /
+     * button copy without a `when(sourceType)`. Null for zero-config singletons whose install path
+     * is a one-tap picker card — they never reach the URL+username+password form.
+     *
+     * A completeness test (`WebSourceRegistryCompletenessTest`) enforces the invariant.
+     */
+    val addSourceCopy: AddSourceCopy? get() = null
 }
+
+/**
+ * User-facing strings the shared credentialed Add-Source form needs to render itself for one
+ * [WebSourceDescriptor]. A new credentialed source drops in by supplying this object and its
+ * Hilt `CredentialedAuthenticator` — no edits to `AddSourceScreen` required.
+ */
+data class AddSourceCopy(
+    /** Top-bar title when adding a fresh source (e.g. "Add Audiobookshelf"). */
+    val addTitle: String,
+    /** Top-bar title when editing an existing source (e.g. "Edit Audiobookshelf"). */
+    val editTitle: String,
+    /** Label rendered on the URL text field (e.g. "Source URL"). */
+    val urlLabel: String,
+    /** Placeholder shown inside the URL text field when empty (e.g. "abs.example.com"). */
+    val urlPlaceholder: String,
+    /** Small-print paragraph above the form explaining what Riffle does with this backend. */
+    val helpText: String,
+    /** Label on the primary submit button when adding a new source. */
+    val submitLabelAdd: String = "Connect",
+    /** Label on the primary submit button when editing an existing source. */
+    val submitLabelEdit: String = "Save",
+    /** Label on the destructive "Remove source" button, only shown when editing. */
+    val removeLabel: String,
+)
 
 /** One library row to seed on singleton-source install. See [WebSourceDescriptor.defaultLibraries]. */
 data class DefaultLibrary(
@@ -139,6 +173,14 @@ object AbsWebSourceDescriptor : WebSourceDescriptor {
     override val addRoute = "add_source?type=audiobookshelf"
     override val pickerOrder = 0
     override val pickerBlurb = "Stream ebooks and audiobooks from your Audiobookshelf server."
+    override val addSourceCopy = AddSourceCopy(
+        addTitle = "Add Audiobookshelf",
+        editTitle = "Edit Audiobookshelf",
+        urlLabel = "Source URL",
+        urlPlaceholder = "abs.example.com",
+        helpText = "Stream ebooks and audiobooks from your Audiobookshelf server, with progress synced across devices.",
+        removeLabel = "Remove source",
+    )
 }
 
 object LocalFilesWebSourceDescriptor : WebSourceDescriptor {


### PR DESCRIPTION
## Summary

Generalises the ABS-shaped hard-codes so a new credentialed source (Komga, Calibre-Web, Jellyfin, …) drops in via a `WebSourceDescriptor` + Hilt plugin — with no edits to `MainScreen`, `SourcesSection`, `NavigationDrawerComposable`, or `AddSourceScreen`. Prep work for a future Komga spike, matching the descriptor-driven promise ADR 0044 already delivered for singleton web sources.

### Descriptor
- `WebSourceDescriptor` gains an `AddSourceCopy` (title / URL label / help text / submit / remove copy); populated on `AbsWebSourceDescriptor`.
- `WebSourceRegistryCompletenessTest` now enforces that every `hasCredentials` descriptor ships copy.

### Auth + install (`core/data/credentialed/`)
- New `CredentialedAuthenticator` interface + Hilt `Map<SourceType, ...>` binding via `CredentialedAuthenticatorModule` (mirrors `CatalogModule`'s per-source factory map).
- `AbsCredentialedAuthenticator` lifts today's `authenticateAbs` / `authenticateStoryteller` out of `SourceRepositoryImpl`.
- New `CredentialedSourceInstaller` owns the commit side: builds `SourceEntity`, writes libraries / token / password / hidden-lib prefs.
- `PendingSource` gains a `sourceType` field so the installer no longer hard-codes `type = "ABS"` — the fix-shaped bug the issue flagged.
- `SourceRepositoryImpl` becomes a thin delegator (`authenticate` = map lookup, `commit` = `installer.install`).

### UI surfaces
- `SourcesSection` filter is now descriptor-driven: `descriptor.hasCredentials && !descriptor.isSingleton`. `ServerRow` takes the descriptor and derives its subtitle from `hasNetworkHost` / `hasCredentials`.
- `NavigationDrawerComposable`'s three `type != LOCAL_FILES && != CHITANKA && != GUTENBERG` exclusion lists collapse into `descriptor.hasNetworkHost` / `hasCredentials` reads.
- Settings "Add source" button routes through the picker (not hard-wired `AddSourceBackend.AUDIOBOOKSHELF`).
- `AddSourceScreen` reads title/label/help/submit/remove from `descriptor.addSourceCopy` for descriptor-driven backends (ABS today, Komga tomorrow).

### Regression coverage
- New assertion in `SourceRepositoryTest`: `commit stamps SourceEntity type from pending sourceType, not hard-coded ABS`. Flips red if the pre-refactor `"ABS"` literal returns.
- All existing `SourceRepositoryTest` cases preserved via a `buildRepo(...)` helper that synthesises the ABS authenticator + installer for the old positional-arg constructor.

### Deferred to #441
- Storyteller shares `SourceType.ABS` with Audiobookshelf until #441 splits it into its own SourceType. The ABS-vs-Storyteller subtype branches are now isolated inside `AbsCredentialedAuthenticator` and `CredentialedSourceInstaller` so `SourceRepositoryImpl` and the UI surfaces stay clean.
- The ABS/Storyteller headline split in `NavigationDrawerComposable.sourceDisplayName` and `SourcesSection.ServerRow` remains, gated by an explicit `SourceType.ABS` branch documented as a #441 concern.

### Non-goals (per issue)
- WebDAV (annotation sync target) — keeps its own path. Non-goal.
- Komga implementation — architecture prepared, not built. Follow-up.

Closes #526

## Test plan
- [x] `./gradlew test` — all JVM tests green (14 files touched, 3 new files under `core/data/credentialed/`).
- [x] `:core:data:testDebugUnitTest` — `SourceRepositoryTest` (including the new type-stamping regression) green.
- [x] `WebSourceRegistryCompletenessTest.every credentialed descriptor ships AddSourceCopy` — green.
- [x] Smoke test on Android 13 AVD: fresh install → source picker shows 4 descriptor-driven cards → Audiobookshelf card → "Add Audiobookshelf" form renders descriptor-driven title / help / URL label / submit → Connect triggers HTTP-insecure dialog (proves full pipeline: form → `SourceRepositoryImpl.authenticate` → `AbsCredentialedAuthenticator`).
- [x] Drawer verified: source switcher renders correctly for a source with `hasCredentials + hasNetworkHost`; Downloads + Settings links present.

## Ready for Komga (next PR)
Dropping in a new credentialed source is now purely additive: new `SourceType` entry + `KomgaWebSourceDescriptor` (with `addSourceCopy`) + `@IntoMap` `KomgaCredentialedAuthenticator` binding + drawable + one line in `SourceIconResolver`. Nothing else touches the generic surfaces.