### PR TITLE
fix(local-files): disable folder trash when only one folder remains

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/settings/sections/LocalFilesSourceRowTrashTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/settings/sections/LocalFilesSourceRowTrashTest.kt
@@ -1,0 +1,126 @@
+package com.riffle.app.feature.settings.sections
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.riffle.app.feature.settings.LibraryUiItem
+import com.riffle.core.database.LocalFilesFolderEntity
+import com.riffle.core.domain.Library
+import com.riffle.core.domain.Source
+import com.riffle.core.domain.SourceType
+import com.riffle.core.domain.SourceUrl
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Pins the "at least one folder must remain" invariant on the per-folder trash icon in the
+ * Local Files source row. If the trash on the last remaining folder becomes tappable, a user can
+ * strand the source with zero libraries; the source-wide "Remove Local Files source" action is
+ * the correct escape hatch instead.
+ */
+@RunWith(AndroidJUnit4::class)
+class LocalFilesSourceRowTrashTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val source = Source(
+        id = "local-files",
+        url = SourceUrl.parse("http://local-files.invalid")!!,
+        isActive = true,
+        insecureConnectionAllowed = false,
+        username = "",
+        type = SourceType.LOCAL_FILES,
+    )
+
+    private fun folder(index: Int) = LocalFilesFolderEntity(
+        sourceId = source.id,
+        treeUri = "content://tree/$index",
+        displayName = "Folder $index",
+        addedAtEpochMs = 0L,
+        libraryId = "lib-$index",
+    )
+
+    private fun libraryItem(index: Int, itemCount: Int) = LibraryUiItem(
+        library = Library(id = "lib-$index", name = "Folder $index", mediaType = "book", isUnsupported = false),
+        isVisible = true,
+        switchEnabled = itemCount > 1,
+    )
+
+    @Test
+    fun trashIcon_disabled_whenOnlyOneFolder() {
+        composeTestRule.setContent {
+            LocalFilesSourceRow(
+                source = source,
+                folders = listOf(folder(1)),
+                folderHealth = emptyMap(),
+                libraryItems = listOf(libraryItem(1, itemCount = 1)),
+                isExpanded = true,
+                onToggleExpanded = {},
+                onAddFolder = {},
+                onRemoveFolder = {},
+                onRemoveSource = {},
+                onSetLibraryVisible = { _, _ -> },
+                onReorderLibraries = {},
+            )
+        }
+
+        composeTestRule.onAllNodesWithContentDescription("Remove folder")[0].assertIsNotEnabled()
+    }
+
+    @Test
+    fun trashIcon_enabled_whenTwoOrMoreFolders() {
+        composeTestRule.setContent {
+            LocalFilesSourceRow(
+                source = source,
+                folders = listOf(folder(1), folder(2)),
+                folderHealth = emptyMap(),
+                libraryItems = listOf(libraryItem(1, itemCount = 2), libraryItem(2, itemCount = 2)),
+                isExpanded = true,
+                onToggleExpanded = {},
+                onAddFolder = {},
+                onRemoveFolder = {},
+                onRemoveSource = {},
+                onSetLibraryVisible = { _, _ -> },
+                onReorderLibraries = {},
+            )
+        }
+
+        val trashNodes = composeTestRule.onAllNodesWithContentDescription("Remove folder")
+        trashNodes[0].assertIsEnabled()
+        trashNodes[1].assertIsEnabled()
+    }
+
+    @Test
+    fun trashIcon_onLastFolder_doesNotOpenRemovalDialog() {
+        var removeCallCount = 0
+        composeTestRule.setContent {
+            LocalFilesSourceRow(
+                source = source,
+                folders = listOf(folder(1)),
+                folderHealth = emptyMap(),
+                libraryItems = listOf(libraryItem(1, itemCount = 1)),
+                isExpanded = true,
+                onToggleExpanded = {},
+                onAddFolder = {},
+                onRemoveFolder = { removeCallCount++ },
+                onRemoveSource = {},
+                onSetLibraryVisible = { _, _ -> },
+                onReorderLibraries = {},
+            )
+        }
+
+        composeTestRule.onAllNodesWithContentDescription("Remove folder")[0].performClick()
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText("Remove folder?").assertDoesNotExist()
+        assert(removeCallCount == 0) { "onRemoveFolder must not fire when the trash is disabled" }
+    }
+}

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/settings/sections/LocalFilesSourceRowTrashTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/settings/sections/LocalFilesSourceRowTrashTest.kt
@@ -1,7 +1,6 @@
 package com.riffle.app.feature.settings.sections
 
 import androidx.activity.ComponentActivity
-import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createAndroidComposeRule

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/sections/SourcesSection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/sections/SourcesSection.kt
@@ -441,7 +441,10 @@ internal fun LocalFilesSourceRow(
                                             enabled = item.switchEnabled,
                                         )
                                     }
-                                    IconButton(onClick = { pendingFolderRemoval = folder }) {
+                                    IconButton(
+                                        onClick = { pendingFolderRemoval = folder },
+                                        enabled = folders.size > 1,
+                                    ) {
                                         Icon(Icons.Default.Delete, contentDescription = "Remove folder")
                                     }
                                 }


### PR DESCRIPTION
## Summary

Mirror the "at least one library visible" rule that already governs the per-library visibility switch onto the per-folder trash icon in the Local Files source row. When only one folder is configured, its trash button is now disabled — otherwise a user could strand the source with zero libraries by removing the last folder. The "Remove Local Files source" button below remains the correct escape hatch for zeroing out the whole source.

## Changes

- `app/src/main/kotlin/com/riffle/app/feature/settings/sections/SourcesSection.kt` — trash `IconButton` now takes `enabled = folders.size > 1`.
- `app/src/androidTest/kotlin/com/riffle/app/feature/settings/sections/LocalFilesSourceRowTrashTest.kt` — new instrumentation test pinning: trash is disabled with 1 folder, enabled with 2+, and tapping the disabled trash neither opens the confirmation dialog nor calls `onRemoveFolder`.

## Test plan

- [ ] `make harness-test` passes the new `LocalFilesSourceRowTrashTest`.
- [ ] Manual: Settings → Local Files with a single folder → trash icon appears disabled; add a second folder → trash icons on both rows become enabled.