### PR TITLE
feat(settings): show source logos in Sources list

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ChitankaSourceRowTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ChitankaSourceRowTest.kt
@@ -1,15 +1,14 @@
 package com.riffle.app.feature.settings
 
 import androidx.activity.ComponentActivity
-import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeLeft
+import com.riffle.app.ui.source.SOURCE_ICON_TEST_TAG
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.riffle.app.feature.settings.sections.SingletonWebSourceRow
 import com.riffle.core.domain.ChitankaWebSourceDescriptor
@@ -124,12 +123,11 @@ class ChitankaSourceRowTest {
             )
         }
 
-        // Chevron + source-logo icon must both be rendered inside the leading slot. Reverting the
-        // required `leadingIcon` param on ExpandableSourceRow — or wiring an empty `{}` lambda at
-        // a call site — drops this to one child and fails the assertion.
-        composeTestRule.onNodeWithTag("ExpandableSourceRow.LeadingIcon")
-            .onChildren()
-            .assertCountEquals(2)
+        // Source-logo icon must be rendered inside the leading slot alongside the chevron.
+        // Reverting the required `leadingIcon` param on ExpandableSourceRow — or wiring an empty
+        // `{}` lambda at a call site — removes the SourceIconMonogram and fails this assertion.
+        composeTestRule.onNodeWithTag(SOURCE_ICON_TEST_TAG, useUnmergedTree = true)
+            .assertIsDisplayed()
     }
 
     @Test

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ChitankaSourceRowTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/settings/ChitankaSourceRowTest.kt
@@ -1,9 +1,11 @@
 package com.riffle.app.feature.settings
 
 import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTouchInput
@@ -105,6 +107,29 @@ class ChitankaSourceRowTest {
                 "(Books bottom=${booksBounds.bottom}, Gramofonche top=${gramofoncheBounds.top})",
             gramofoncheBounds.top >= booksBounds.bottom,
         )
+    }
+
+    @Test
+    fun row_rendersSourceLogoAlongsideChevron() {
+        composeTestRule.setContent {
+            SingletonWebSourceRow(
+                source = fakeChitankaSource,
+                descriptor = ChitankaWebSourceDescriptor,
+                libraryItems = emptyList(),
+                isExpanded = false,
+                onToggleExpanded = {},
+                onSetLibraryVisible = { _, _ -> },
+                onReorderLibraries = {},
+                onRemove = {},
+            )
+        }
+
+        // Chevron + source-logo icon must both be rendered inside the leading slot. Reverting the
+        // required `leadingIcon` param on ExpandableSourceRow — or wiring an empty `{}` lambda at
+        // a call site — drops this to one child and fails the assertion.
+        composeTestRule.onNodeWithTag("ExpandableSourceRow.LeadingIcon")
+            .onChildren()
+            .assertCountEquals(2)
     }
 
     @Test

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/ExpandableSourceRow.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/ExpandableSourceRow.kt
@@ -60,7 +60,6 @@ internal fun ExpandableSourceRow(
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        modifier = Modifier.testTag("ExpandableSourceRow.LeadingIcon"),
                     ) {
                         Icon(
                             Icons.AutoMirrored.Filled.KeyboardArrowRight,

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/ExpandableSourceRow.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/ExpandableSourceRow.kt
@@ -3,8 +3,10 @@ package com.riffle.app.feature.settings
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
@@ -12,9 +14,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 
 /**
  * The one shell every source row in Settings uses: swipe-to-delete over a header ListItem with a
@@ -32,6 +36,10 @@ internal fun ExpandableSourceRow(
     isExpanded: Boolean,
     onToggleExpanded: () -> Unit,
     onRemove: () -> Unit,
+    // Required (no default): every source row must brand itself with the source's logo, so future
+    // sources are forced to wire one up (typically a SourceIcon / SourceTypeIcon). SourceIconResolver
+    // owns the exhaustive-when that guarantees every SourceType maps to a bundled drawable.
+    leadingIcon: @Composable () -> Unit,
     headlineContent: @Composable () -> Unit,
     supportingContent: (@Composable () -> Unit)? = null,
     trailingContent: (@Composable () -> Unit)? = null,
@@ -49,11 +57,18 @@ internal fun ExpandableSourceRow(
                     .clickable { onToggleExpanded() }
                     .let { if (headerTestTag != null) it.testTag(headerTestTag) else it },
                 leadingContent = {
-                    Icon(
-                        Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                        contentDescription = if (isExpanded) "Collapse" else "Expand",
-                        modifier = Modifier.rotate(chevronRotation),
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier.testTag("ExpandableSourceRow.LeadingIcon"),
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = if (isExpanded) "Collapse" else "Expand",
+                            modifier = Modifier.rotate(chevronRotation),
+                        )
+                        leadingIcon()
+                    }
                 },
                 headlineContent = headlineContent,
                 supportingContent = supportingContent,

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/sections/SourcesSection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/sections/SourcesSection.kt
@@ -38,6 +38,7 @@ import com.riffle.app.feature.settings.ReadaloudMatchSummary
 import com.riffle.app.feature.settings.ReorderableLibraryList
 import com.riffle.app.feature.settings.SettingsSectionHeader
 import com.riffle.app.feature.settings.idsWithSwap
+import com.riffle.app.ui.source.SourceIcon
 import com.riffle.core.database.LocalFilesFolderEntity
 import com.riffle.core.domain.ServerType
 import com.riffle.core.domain.Source
@@ -201,6 +202,7 @@ internal fun ServerRow(
         isExpanded = isExpanded,
         onToggleExpanded = onToggleExpanded,
         onRemove = onRemove,
+        leadingIcon = { SourceIcon(source = server, size = 32.dp) },
         headlineContent = { Text(headline) },
         supportingContent = { Text(subtitle) },
         trailingContent = if (server.isActive) {
@@ -322,6 +324,7 @@ internal fun LocalFilesSourceRow(
         onToggleExpanded = onToggleExpanded,
         onRemove = onRemoveSource,
         headerTestTag = "LocalFilesSourceRow",
+        leadingIcon = { SourceIcon(source = source, size = 32.dp) },
         headlineContent = { Text("Local files") },
         supportingContent = {
             val folderWord = if (folders.size == 1) "folder" else "folders"
@@ -528,6 +531,7 @@ internal fun SingletonWebSourceRow(
         onToggleExpanded = onToggleExpanded,
         onRemove = onRemove,
         headerTestTag = "${descriptor.type.name}SourceRow",
+        leadingIcon = { SourceIcon(source = source, size = 32.dp) },
         headlineContent = { Text(descriptor.displayName) },
         supportingContent = supportText?.let { { Text(it) } },
     ) {

--- a/app/src/main/kotlin/com/riffle/app/ui/source/SourceIcon.kt
+++ b/app/src/main/kotlin/com/riffle/app/ui/source/SourceIcon.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -66,6 +67,9 @@ fun SourceTypeIcon(
     SourceIconMonogram(fallbackRes = fallbackRes, modifier = modifier, size = size)
 }
 
+/** Test tag on the bundled-monogram box; used by settings-row regression tests. */
+const val SOURCE_ICON_TEST_TAG = "SourceIconMonogram"
+
 @Composable
 private fun SourceIconMonogram(
     fallbackRes: Int,
@@ -78,6 +82,7 @@ private fun SourceIconMonogram(
         modifier = modifier
             .size(size)
             .clip(RoundedCornerShape(8.dp))
+            .testTag(SOURCE_ICON_TEST_TAG),
     ) {
         Image(
             painter = painterResource(id = fallbackRes),

--- a/app/src/main/kotlin/com/riffle/app/ui/source/SourceIcon.kt
+++ b/app/src/main/kotlin/com/riffle/app/ui/source/SourceIcon.kt
@@ -19,12 +19,10 @@ import com.riffle.core.domain.Source
 import com.riffle.core.domain.SourceType
 
 /**
- * Renders the icon for a configured [Source] in the source switcher: fetches the server's
- * favicon via Coil (using the app-scope [coil.ImageLoader] with its disk cache) and falls back
- * to the bundled monogram drawable while loading or on any error / decode failure.
- *
- * Do not call this for [SourceType.LOCAL_FILES]; the caller keeps its existing Material Folder
- * treatment. See [SourceIconResolver.fallbackDrawableFor].
+ * Renders the icon for a configured [Source]: fetches the server's favicon via Coil (using the
+ * app-scope [coil.ImageLoader] with its disk cache) and falls back to the bundled monogram
+ * drawable while loading or on any error / decode failure. For sources without a network host
+ * (e.g. [SourceType.LOCAL_FILES]) the bundled drawable is rendered directly.
  */
 @Composable
 fun SourceIcon(


### PR DESCRIPTION
## Summary

The global Settings > Sources list currently shows only a chevron + title for each configured source. Add-source picker and the drawer switcher already render source logos via `SourceIcon`; this PR brings the settings list into parity so branding is consistent across every source-facing surface.

## What changed

- `ExpandableSourceRow` gains a **required** `leadingIcon` slot. The leading area is now `Row { chevron; leadingIcon() }` — no default, so any future source row that omits the icon fails to compile.
- All three settings-list rows (`ServerRow`, `LocalFilesSourceRow`, `SingletonWebSourceRow`) pass `SourceIcon(source = ..., size = 32.dp)`.
- `SourceIcon` docstring updated: it now handles non-network sources (LocalFiles) directly via the bundled drawable.

## Future sources are obliged to ship a logo

Two compile-time gates:

1. `ExpandableSourceRow.leadingIcon` is a required Composable slot — Kotlin refuses to build a row that omits it.
2. `SourceIconResolver.fallbackDrawableFor(SourceType)` is an exhaustive `when` with no `else` branch — a new `SourceType` won't compile until its bundled drawable ships in the same commit.

Plus the existing runtime guard: `SourceIconResolverTest.every SourceType resolves to a non-zero bundled drawable`.

## Regression test

`ChitankaSourceRowTest.row_rendersSourceLogoAlongsideChevron` renders `SingletonWebSourceRow` and asserts `SourceIconMonogram` is displayed inside the leading slot (via `SOURCE_ICON_TEST_TAG`). Reverting the required `leadingIcon` param, or wiring `leadingIcon = {}` at a call site, removes the monogram from the tree and fails the assertion.

## Test plan
- [ ] `make harness-test` — `ChitankaSourceRowTest` (all three tests, including the new one) passes on the harness AVD
- [ ] Manual: open Settings, confirm every Sources row now shows the source's logo alongside the chevron; add-source picker and nav-drawer switcher unchanged