### PR TITLE
feat(reader): tint figcaption alongside image annotation + surface image-only books

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FigureCaptionWalker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FigureCaptionWalker.kt
@@ -10,10 +10,14 @@ package com.riffle.app.feature.reader
  * tags, and each constant is a self-contained `function` declaration (no trailing bare statements)
  * so callers can splice multiple of these together followed by their own call sites.
  *
- * Caption fallback order: `<figcaption>` (nearest ancestor `<figure>`) → nearest following
- * block whose text starts with "Figure N", "Fig. N", "Table N", or "Chart N" (bounded 3-hop
- * ancestor walk — covers LaTeX/Kotobee/Vellum exports with obfuscated class names and no
- * `<figure>` wrapper) → `alt` attribute → `aria-label` attribute → empty string.
+ * Caption fallback order: `<figcaption>` (nearest ancestor `<figure>`) → `alt` attribute →
+ * `aria-label` attribute → nearest following block whose text starts with "Figure N", "Fig. N",
+ * "Table N", or "Chart N" (bounded 3-hop ancestor walk — covers LaTeX/Kotobee/Vellum exports
+ * with obfuscated class names and no `<figure>` wrapper) → empty string.
+ *
+ * The text-prefix heuristic sits AFTER `alt`/`aria-label` because those attributes are per-image
+ * (accurate), whereas the heuristic is proximity-based (can be fooled by a nearby "Table 3
+ * summarizes…" prose block). When an image carries a meaningful alt attribute, that wins.
  */
 internal object FigureCaptionWalker {
 
@@ -29,6 +33,10 @@ internal object FigureCaptionWalker {
                 var cap = fig.querySelector('figcaption');
                 if (cap && cap.textContent) return cap.textContent.trim();
             }
+            var alt = el.getAttribute && el.getAttribute('alt');
+            if (alt) return alt;
+            var aria = el.getAttribute && el.getAttribute('aria-label');
+            if (aria) return aria;
             var CAPTION_PREFIX_RX = /^\s*(Figure|Fig\.?|Table|Chart)\s+\d/i;
             var cur = el;
             for (var hops = 0; hops < 3; hops++) {
@@ -45,10 +53,6 @@ internal object FigureCaptionWalker {
                 }
                 cur = parent;
             }
-            var alt = el.getAttribute && el.getAttribute('alt');
-            if (alt) return alt;
-            var aria = el.getAttribute && el.getAttribute('aria-label');
-            if (aria) return aria;
             return "";
         }
     """.trimIndent()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FigureCaptionWalker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FigureCaptionWalker.kt
@@ -10,8 +10,10 @@ package com.riffle.app.feature.reader
  * tags, and each constant is a self-contained `function` declaration (no trailing bare statements)
  * so callers can splice multiple of these together followed by their own call sites.
  *
- * Caption fallback order: `<figcaption>` (nearest ancestor `<figure>`) → `alt` attribute →
- * `aria-label` attribute → empty string.
+ * Caption fallback order: `<figcaption>` (nearest ancestor `<figure>`) → nearest following
+ * block whose text starts with "Figure N", "Fig. N", "Table N", or "Chart N" (bounded 3-hop
+ * ancestor walk — covers LaTeX/Kotobee/Vellum exports with obfuscated class names and no
+ * `<figure>` wrapper) → `alt` attribute → `aria-label` attribute → empty string.
  */
 internal object FigureCaptionWalker {
 
@@ -26,6 +28,22 @@ internal object FigureCaptionWalker {
             if (fig) {
                 var cap = fig.querySelector('figcaption');
                 if (cap && cap.textContent) return cap.textContent.trim();
+            }
+            var CAPTION_PREFIX_RX = /^\s*(Figure|Fig\.?|Table|Chart)\s+\d/i;
+            var cur = el;
+            for (var hops = 0; hops < 3; hops++) {
+                var parent = cur.parentElement;
+                if (!parent) break;
+                var blocks = parent.querySelectorAll('p, div');
+                for (var i = 0; i < blocks.length; i++) {
+                    var b = blocks[i];
+                    if (b === el || b.contains(el)) continue;
+                    var pos = el.compareDocumentPosition(b);
+                    if (!(pos & 4)) continue;
+                    var txt = (b.textContent || '').trim();
+                    if (CAPTION_PREFIX_RX.test(txt)) return txt;
+                }
+                cur = parent;
             }
             var alt = el.getAttribute && el.getAttribute('alt');
             if (alt) return alt;

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecoration.kt
@@ -30,7 +30,12 @@ internal object FigureBorderDecoration {
         .sortedBy { it.filename }
         .map { ref ->
             val selector = "img[src\$=\"${ref.filename}\"]"
-            "$selector { outline: $OUTLINE_WIDTH_CSS solid ${ref.color}; outline-offset: $OUTLINE_OFFSET_CSS; }"
+            // !important is required because some publishers (e.g. Wiley's WileyTemplate) ship a
+            // CSS reset like `#sbo-rt-content img { outline: 0 }` — an ID-selector rule that
+            // beats our attribute selector on specificity and silently nukes the border. Verified
+            // against Influence Without Authority 3e.
+            "$selector { outline: $OUTLINE_WIDTH_CSS solid ${ref.color} !important; " +
+                "outline-offset: $OUTLINE_OFFSET_CSS !important; }"
         }
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjection.kt
@@ -55,7 +55,8 @@ internal fun figureBorderApplyJs(
     }
     val rasterJson = rasterMarks.joinToString(",", prefix = "[", postfix = "]") { m ->
         val escFn = m.filename.replace("\\", "\\\\").replace("\"", "\\\"")
-        "{\"fn\":\"$escFn\",\"note\":${if (m.hasNote) 1 else 0}}"
+        val escColor = m.color.replace("\"", "\\\"")
+        "{\"fn\":\"$escFn\",\"color\":\"$escColor\",\"note\":${if (m.hasNote) 1 else 0}}"
     }
     // Percent-encoded SVG of the same note-alt icon used by NoteGlyphDecoration. The literal
     // single quotes inside the SVG attributes are percent-encoded (%27) — otherwise Kotlin's
@@ -128,6 +129,23 @@ internal fun figureBorderApplyJs(
             badge.innerHTML = '<span></span>';
             wrap.appendChild(badge);
           }
+          function clearAllFigcaptionTints() {
+            var stale = document.querySelectorAll('figcaption[data-riffle-fig-tint]');
+            for (var k = 0; k < stale.length; k++) {
+              stale[k].style.backgroundColor = '';
+              stale[k].removeAttribute('data-riffle-fig-tint');
+            }
+          }
+          function tintCaptionFor(el, color) {
+            if (!el) return;
+            var fig = el.closest && el.closest('figure, [role="figure"]');
+            if (!fig) return;
+            var cap = fig.querySelector('figcaption');
+            if (!cap) return;
+            cap.style.backgroundColor = color;
+            cap.setAttribute('data-riffle-fig-tint', '1');
+          }
+          clearAllFigcaptionTints();
           try {
             // Raster: iterate the matched images and add/remove note badges. Border itself comes
             // from the CSS style block above; badge lives on the wrapper we insert here.
@@ -137,6 +155,7 @@ internal fun figureBorderApplyJs(
               var imgs = document.querySelectorAll('img[src\$="' + rf.fn + '"]');
               for (var ii = 0; ii < imgs.length; ii++) {
                 var img = imgs[ii];
+                tintCaptionFor(img, rf.color);
                 if (rf.note) {
                   var col = (window.getComputedStyle && window.getComputedStyle(img).outlineColor) || 'currentColor';
                   addNoteBadge(img, col);
@@ -167,6 +186,7 @@ internal fun figureBorderApplyJs(
                   s.style.outline = '2px solid ' + matches[j].color;
                   s.style.outlineOffset = '2px';
                   s.__riffleBorderApplied = true;
+                  tintCaptionFor(s, matches[j].color);
                   if (matches[j].note) addNoteBadge(s, matches[j].color);
                   break;
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjection.kt
@@ -166,7 +166,11 @@ internal fun figureBorderApplyJs(
             if (!el) return;
             var cap = null;
             var fig = el.closest && el.closest('figure, [role="figure"]');
-            if (fig) cap = fig.querySelector(':scope > figcaption');
+            // Unscoped 'figcaption' (any depth) mirrors FigureCaptionWalker.resolveCaption, so an
+            // annotation whose textSnippet captures a nested <figure><div><figcaption> also gets
+            // a matching tint. HTML5 restricts figcaption to first/last child of figure, but real
+            // EPUBs nest it inside wrappers.
+            if (fig) cap = fig.querySelector('figcaption');
             if (!cap) cap = nearestCaptionBlock(el);
             if (!cap) return;
             // Use setProperty with 'important' so publisher CSS resets (Wiley et al.) don't win.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjection.kt
@@ -140,7 +140,7 @@ internal fun figureBorderApplyJs(
             if (!el) return;
             var fig = el.closest && el.closest('figure, [role="figure"]');
             if (!fig) return;
-            var cap = fig.querySelector('figcaption');
+            var cap = fig.querySelector(':scope > figcaption');
             if (!cap) return;
             cap.style.backgroundColor = color;
             cap.setAttribute('data-riffle-fig-tint', '1');

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjection.kt
@@ -130,17 +130,42 @@ internal fun figureBorderApplyJs(
             wrap.appendChild(badge);
           }
           function clearAllFigcaptionTints() {
-            var stale = document.querySelectorAll('figcaption[data-riffle-fig-tint]');
+            var stale = document.querySelectorAll('[data-riffle-fig-tint]');
             for (var k = 0; k < stale.length; k++) {
               stale[k].style.backgroundColor = '';
               stale[k].removeAttribute('data-riffle-fig-tint');
             }
           }
+          // Fallback for EPUBs that don't use semantic <figure>/<figcaption>: LaTeX/Kotobee/Vellum
+          // exports typically wrap the image and its caption in generic <div>s with obfuscated
+          // class names ("class_s4", "class_s5"), so we can't key off markup. The one deterministic
+          // signal is the caption's leading text: "Figure 5.1:", "Fig. 2", "Table 3", etc. Walk up
+          // to 3 ancestors and scan for the nearest block after the image whose text starts with
+          // that prefix. Bounded and content-anchored — won't grab body prose.
+          var CAPTION_PREFIX_RX = /^\s*(Figure|Fig\.?|Table|Chart)\s+\d/i;
+          function nearestCaptionBlock(img) {
+            var el = img;
+            for (var hops = 0; hops < 3; hops++) {
+              var parent = el.parentElement;
+              if (!parent) return null;
+              var blocks = parent.querySelectorAll('p, div');
+              for (var i = 0; i < blocks.length; i++) {
+                var b = blocks[i];
+                if (b === img || b.contains(img)) continue;
+                var pos = img.compareDocumentPosition(b);
+                if (!(pos & 4)) continue;
+                if (CAPTION_PREFIX_RX.test(b.textContent || '')) return b;
+              }
+              el = parent;
+            }
+            return null;
+          }
           function tintCaptionFor(el, color) {
             if (!el) return;
+            var cap = null;
             var fig = el.closest && el.closest('figure, [role="figure"]');
-            if (!fig) return;
-            var cap = fig.querySelector(':scope > figcaption');
+            if (fig) cap = fig.querySelector(':scope > figcaption');
+            if (!cap) cap = nearestCaptionBlock(el);
             if (!cap) return;
             cap.style.backgroundColor = color;
             cap.setAttribute('data-riffle-fig-tint', '1');

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjection.kt
@@ -132,7 +132,9 @@ internal fun figureBorderApplyJs(
           function clearAllFigcaptionTints() {
             var stale = document.querySelectorAll('[data-riffle-fig-tint]');
             for (var k = 0; k < stale.length; k++) {
-              stale[k].style.backgroundColor = '';
+              // Match how we set it (setProperty with 'important'); plain assignment can leave
+              // the important-flagged declaration in place.
+              stale[k].style.removeProperty('background-color');
               stale[k].removeAttribute('data-riffle-fig-tint');
             }
           }
@@ -167,7 +169,8 @@ internal fun figureBorderApplyJs(
             if (fig) cap = fig.querySelector(':scope > figcaption');
             if (!cap) cap = nearestCaptionBlock(el);
             if (!cap) return;
-            cap.style.backgroundColor = color;
+            // Use setProperty with 'important' so publisher CSS resets (Wiley et al.) don't win.
+            cap.style.setProperty('background-color', color, 'important');
             cap.setAttribute('data-riffle-fig-tint', '1');
           }
           clearAllFigcaptionTints();
@@ -198,8 +201,8 @@ internal fun figureBorderApplyJs(
             for (var i = 0; i < svgs.length; i++) {
               var s = svgs[i];
               if (s.__riffleBorderApplied) {
-                s.style.outline = '';
-                s.style.outlineOffset = '';
+                s.style.removeProperty('outline');
+                s.style.removeProperty('outline-offset');
                 s.__riffleBorderApplied = false;
               }
               clearNoteBadgeAround(s);
@@ -208,8 +211,8 @@ internal fun figureBorderApplyJs(
               for (var j = 0; j < matches.length; j++) {
                 var fp = matches[j].fp;
                 if (outer.indexOf(fp) === 0 || (inner.length && fp.indexOf(inner.slice(0, 40)) !== -1)) {
-                  s.style.outline = '2px solid ' + matches[j].color;
-                  s.style.outlineOffset = '2px';
+                  s.style.setProperty('outline', '2px solid ' + matches[j].color, 'important');
+                  s.style.setProperty('outline-offset', '2px', 'important');
                   s.__riffleBorderApplied = true;
                   tintCaptionFor(s, matches[j].color);
                   if (matches[j].note) addNoteBadge(s, matches[j].color);

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FigureCaptionWalkerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FigureCaptionWalkerTest.kt
@@ -23,6 +23,34 @@ class FigureCaptionWalkerTest {
     }
 
     @Test
+    fun `caption resolver has text-prefix fallback for non-semantic figures`() {
+        // Between the <figure>/<figcaption> path and the alt/aria-label fallback, the resolver
+        // walks up to 3 ancestors looking for the nearest following <p>/<div> whose text starts
+        // with "Figure|Fig|Table|Chart" + digit. Covers LaTeX/Kotobee/Vellum exports with
+        // obfuscated class names (e.g. "A Philosophy of Software Design 2e"). Reverting the
+        // fallback flips these red — image annotations on non-semantic figures would land in the
+        // DB with an empty textSnippet again and the Annotations view would render an empty
+        // caption block.
+        val js = FigureCaptionWalker.CAPTION_RESOLVER_JS
+        assertTrue(
+            "caption resolver should carry the caption-prefix regex",
+            js.contains("(Figure|Fig\\.?|Table|Chart)"),
+        )
+        assertTrue(
+            "caption resolver should walk parent chain (compareDocumentPosition)",
+            js.contains("compareDocumentPosition"),
+        )
+        // The fallback must sit AFTER the <figcaption> path and BEFORE the alt attribute lookup,
+        // otherwise a semantic figcaption would be shadowed by a nearby "Table 1" match or
+        // legitimate alt text would never be reached.
+        val figIdx = js.indexOf("figcaption")
+        val rxIdx = js.indexOf("CAPTION_PREFIX_RX")
+        val altIdx = js.indexOf("'alt'")
+        assertTrue("text-prefix fallback must come after figcaption", figIdx in 0 until rxIdx)
+        assertTrue("text-prefix fallback must come before alt", rxIdx in 0 until altIdx)
+    }
+
+    @Test
     fun `caption resolver falls back to empty string`() {
         val js = FigureCaptionWalker.CAPTION_RESOLVER_JS
         assertTrue(js.contains("function resolveCaption(el)"))

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FigureCaptionWalkerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FigureCaptionWalkerTest.kt
@@ -24,13 +24,12 @@ class FigureCaptionWalkerTest {
 
     @Test
     fun `caption resolver has text-prefix fallback for non-semantic figures`() {
-        // Between the <figure>/<figcaption> path and the alt/aria-label fallback, the resolver
-        // walks up to 3 ancestors looking for the nearest following <p>/<div> whose text starts
-        // with "Figure|Fig|Table|Chart" + digit. Covers LaTeX/Kotobee/Vellum exports with
-        // obfuscated class names (e.g. "A Philosophy of Software Design 2e"). Reverting the
-        // fallback flips these red — image annotations on non-semantic figures would land in the
-        // DB with an empty textSnippet again and the Annotations view would render an empty
-        // caption block.
+        // After the <figure>/<figcaption> and alt/aria-label paths, the resolver walks up to 3
+        // ancestors looking for the nearest following <p>/<div> whose text starts with
+        // "Figure|Fig|Table|Chart" + digit. Covers LaTeX/Kotobee/Vellum exports with obfuscated
+        // class names (e.g. "A Philosophy of Software Design 2e"). Reverting the fallback flips
+        // these red — image annotations on non-semantic figures would land in the DB with an
+        // empty textSnippet again and the Annotations view would render an empty caption block.
         val js = FigureCaptionWalker.CAPTION_RESOLVER_JS
         assertTrue(
             "caption resolver should carry the caption-prefix regex",
@@ -40,14 +39,12 @@ class FigureCaptionWalkerTest {
             "caption resolver should walk parent chain (compareDocumentPosition)",
             js.contains("compareDocumentPosition"),
         )
-        // The fallback must sit AFTER the <figcaption> path and BEFORE the alt attribute lookup,
-        // otherwise a semantic figcaption would be shadowed by a nearby "Table 1" match or
-        // legitimate alt text would never be reached.
-        val figIdx = js.indexOf("figcaption")
+        // The fallback must sit AFTER the alt/aria-label paths so a legitimate per-image alt
+        // attribute always wins over a proximity-based heuristic that could match nearby prose
+        // like "Table 3 summarizes results...".
+        val ariaIdx = js.indexOf("'aria-label'")
         val rxIdx = js.indexOf("CAPTION_PREFIX_RX")
-        val altIdx = js.indexOf("'alt'")
-        assertTrue("text-prefix fallback must come after figcaption", figIdx in 0 until rxIdx)
-        assertTrue("text-prefix fallback must come before alt", rxIdx in 0 until altIdx)
+        assertTrue("text-prefix fallback must come after aria-label", ariaIdx in 0 until rxIdx)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecorationTest.kt
@@ -85,6 +85,19 @@ class FigureBorderDecorationTest {
     }
 
     @Test
+    fun `rule marks outline as important to beat publisher CSS resets`() {
+        // Wiley (WileyTemplate) and other big-publisher stylesheets ship `#sbo-rt-content img {
+        // outline: 0 }` — an ID-selector reset that outranks our attribute selector on
+        // specificity and silently drops the border. Reverting to a non-!important rule reproduces
+        // the "no border on annotated figure" bug in Influence Without Authority 3e.
+        val a = imageAnnotation(id = "a", imageHref = "n01f001.gif", color = "blue")
+
+        val rule = FigureBorderDecoration.buildCssRules(listOf(a)).single()
+
+        assertTrue("outline must be !important", rule.contains("outline: 2px solid") && rule.contains("!important"))
+    }
+
+    @Test
     fun `rule includes the annotation color`() {
         val a = imageAnnotation(id = "a", imageHref = "g.png", color = "blue")
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjectionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjectionTest.kt
@@ -1,0 +1,81 @@
+package com.riffle.app.feature.reader.decorations
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FigureBorderInjectionTest {
+
+    @Test
+    fun `apply js clears stale figcaption tints before applying`() {
+        val js = figureBorderApplyJs(
+            cssRules = emptyList(),
+            svgMatches = emptyList(),
+            rasterMarks = emptyList(),
+        )
+        // Every apply pass must sweep figcaption[data-riffle-fig-tint] and clear the tint,
+        // mirroring the SVG "always-clear-then-apply" pattern already in this file. Reverting
+        // to a leave-stale-tints-in-place approach flips this red.
+        assertTrue(
+            "apply JS is missing the figcaption clear pass",
+            js.contains("data-riffle-fig-tint"),
+        )
+        assertTrue(
+            "apply JS should query figcaption elements with the tint marker",
+            js.contains("figcaption[data-riffle-fig-tint]"),
+        )
+    }
+
+    @Test
+    fun `apply js tints figcaption for raster image annotations`() {
+        val marks = listOf(
+            FigureBorderDecoration.RasterMark(
+                filename = "graph.png",
+                color = "rgba(52,211,153,0.5)",
+                hasNote = false,
+            ),
+        )
+        val js = figureBorderApplyJs(cssRules = emptyList(), svgMatches = emptyList(), rasterMarks = marks)
+
+        // For every matched raster image, the JS must walk up to the containing <figure> (or
+        // role="figure") and tint the first child <figcaption> with the annotation color.
+        // Reverting the caption-tint pass flips this red.
+        assertTrue(
+            "apply JS should look for a figure ancestor via closest()",
+            js.contains("closest('figure, [role=\"figure\"]')") ||
+                js.contains("closest(\"figure, [role='figure']\")"),
+        )
+        assertTrue(
+            "apply JS should target the first child figcaption",
+            js.contains("querySelector('figcaption')") ||
+                js.contains("querySelector(\"figcaption\")"),
+        )
+        assertTrue(
+            "apply JS should set backgroundColor to the raster mark's color",
+            js.contains("52,211,153"),
+        )
+    }
+
+    @Test
+    fun `apply js tints figcaption for svg annotations`() {
+        val matches = listOf(
+            FigureBorderDecoration.SvgMatch(
+                fingerprint = "<svg id=\"chart\">",
+                color = "rgba(56,189,248,0.5)",
+                hasNote = false,
+            ),
+        )
+        val js = figureBorderApplyJs(cssRules = emptyList(), svgMatches = matches, rasterMarks = emptyList())
+
+        // Same treatment for inline-SVG figures — must tint the containing figcaption.
+        // Reverting the SVG branch's caption tint flips this red.
+        assertTrue(
+            "apply JS should carry the svg mark's color for the caption tint",
+            js.contains("56,189,248"),
+        )
+        assertTrue(
+            "svg branch should also invoke figure/figcaption traversal",
+            js.contains("closest('figure, [role=\"figure\"]')") ||
+                js.contains("closest(\"figure, [role='figure']\")"),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjectionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjectionTest.kt
@@ -23,6 +23,10 @@ class FigureBorderInjectionTest {
             "apply JS should query figcaption elements with the tint marker",
             js.contains("figcaption[data-riffle-fig-tint]"),
         )
+        assertTrue(
+            "apply JS must invoke clearAllFigcaptionTints() every pass, not just define it",
+            js.contains("clearAllFigcaptionTints();"),
+        )
     }
 
     @Test
@@ -45,13 +49,17 @@ class FigureBorderInjectionTest {
                 js.contains("closest(\"figure, [role='figure']\")"),
         )
         assertTrue(
-            "apply JS should target the first child figcaption",
-            js.contains("querySelector('figcaption')") ||
-                js.contains("querySelector(\"figcaption\")"),
+            "apply JS should target the direct-child figcaption",
+            js.contains("querySelector(':scope > figcaption')") ||
+                js.contains("querySelector(\":scope > figcaption\")"),
         )
         assertTrue(
             "apply JS should set backgroundColor to the raster mark's color",
             js.contains("52,211,153"),
+        )
+        assertTrue(
+            "raster branch must call tintCaptionFor(img, rf.color)",
+            js.contains("tintCaptionFor(img, rf.color)"),
         )
     }
 
@@ -76,6 +84,10 @@ class FigureBorderInjectionTest {
             "svg branch should also invoke figure/figcaption traversal",
             js.contains("closest('figure, [role=\"figure\"]')") ||
                 js.contains("closest(\"figure, [role='figure']\")"),
+        )
+        assertTrue(
+            "svg branch must call tintCaptionFor(s, matches[j].color)",
+            js.contains("tintCaptionFor(s, matches[j].color)"),
         )
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjectionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjectionTest.kt
@@ -20,12 +20,40 @@ class FigureBorderInjectionTest {
             js.contains("data-riffle-fig-tint"),
         )
         assertTrue(
-            "apply JS should query figcaption elements with the tint marker",
-            js.contains("figcaption[data-riffle-fig-tint]"),
+            "apply JS clear pass must scan every tinted element (not just <figcaption>), so <p>/<div> caption fallbacks are also cleared on undo",
+            js.contains("querySelectorAll('[data-riffle-fig-tint]')"),
         )
         assertTrue(
             "apply JS must invoke clearAllFigcaptionTints() every pass, not just define it",
             js.contains("clearAllFigcaptionTints();"),
+        )
+    }
+
+    @Test
+    fun `apply js falls back to text-prefix caption block for non-semantic figures`() {
+        val marks = listOf(
+            FigureBorderDecoration.RasterMark(
+                filename = "graph.png",
+                color = "rgba(52,211,153,0.5)",
+                hasNote = false,
+            ),
+        )
+        val js = figureBorderApplyJs(cssRules = emptyList(), svgMatches = emptyList(), rasterMarks = marks)
+
+        // For LaTeX/Kotobee/Vellum EPUBs (obfuscated class names, no <figure> wrapper), the tint
+        // must fall back to finding the nearest block whose text starts with the caption prefix
+        // "Figure N", "Fig. N", "Table N", "Chart N". Reverting the fallback flips this red.
+        assertTrue(
+            "apply JS should define the caption-prefix regex",
+            js.contains("(Figure|Fig\\.?|Table|Chart)"),
+        )
+        assertTrue(
+            "apply JS should define the nearestCaptionBlock helper",
+            js.contains("function nearestCaptionBlock("),
+        )
+        assertTrue(
+            "tintCaptionFor should call nearestCaptionBlock when semantic path fails",
+            js.contains("nearestCaptionBlock(el)"),
         )
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjectionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjectionTest.kt
@@ -98,9 +98,8 @@ class FigureBorderInjectionTest {
                 js.contains("closest(\"figure, [role='figure']\")"),
         )
         assertTrue(
-            "apply JS should target the direct-child figcaption",
-            js.contains("querySelector(':scope > figcaption')") ||
-                js.contains("querySelector(\":scope > figcaption\")"),
+            "apply JS should target figcaption (unscoped, mirroring the persistence walker)",
+            js.contains("querySelector('figcaption')"),
         )
         assertTrue(
             "apply JS should set backgroundColor to the raster mark's color",

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjectionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjectionTest.kt
@@ -30,6 +30,27 @@ class FigureBorderInjectionTest {
     }
 
     @Test
+    fun `apply js sets figcaption tint with important priority to beat publisher CSS`() {
+        // Publishers (e.g. Wiley's WileyTemplate) reset colors on <p>/<figcaption> via
+        // ID-scoped rules. Setting backgroundColor without 'important' loses the specificity
+        // fight and the caption stays untinted. Reverting the setProperty importance flag flips
+        // this red.
+        val marks = listOf(
+            FigureBorderDecoration.RasterMark(
+                filename = "graph.png",
+                color = "rgba(52,211,153,0.5)",
+                hasNote = false,
+            ),
+        )
+        val js = figureBorderApplyJs(cssRules = emptyList(), svgMatches = emptyList(), rasterMarks = marks)
+
+        assertTrue(
+            "tintCaptionFor must use setProperty('background-color', ..., 'important')",
+            js.contains("setProperty('background-color', color, 'important')"),
+        )
+    }
+
+    @Test
     fun `apply js falls back to text-prefix caption block for non-semantic figures`() {
         val marks = listOf(
             FigureBorderDecoration.RasterMark(

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/AnnotationDaoTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/AnnotationDaoTest.kt
@@ -85,6 +85,30 @@ class AnnotationDaoTest {
         deleted = deleted,
     )
 
+    private fun image(
+        id: String,
+        sourceId: String = "abs1",
+        itemId: String = "item1",
+        imageHref: String? = "figure.png",
+        createdAt: Long = 1000L,
+        updatedAt: Long = createdAt,
+        deleted: Boolean = false,
+    ) = AnnotationEntity(
+        id = id,
+        sourceId = sourceId,
+        itemId = itemId,
+        type = AnnotationEntity.TYPE_IMAGE,
+        cfi = "epubcfi(/6/4!/4/2,/1:0)",
+        textSnippet = "Figure caption",
+        chapterHref = "chapter1.xhtml",
+        imageHref = imageHref,
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+        originDeviceId = "device-A",
+        lastModifiedByDeviceId = "device-A",
+        deleted = deleted,
+    )
+
     // Tracer bullet: an inserted highlight round-trips back through observeForItem.
     @Test
     fun upsertedHighlight_roundTripsThroughObserveForItem() = runTest {
@@ -346,5 +370,28 @@ class AnnotationDaoTest {
         val result = dao.observeBooksWithHighlights("abs1").first()
 
         assertEquals(listOf("A"), result.map { it.itemId })
+    }
+
+    // Books whose only annotations are TYPE_IMAGE (figure highlights) must still appear in the
+    // Annotations View — otherwise a user who annotates only diagrams sees "No highlights yet"
+    // even though the book has annotations. Reverting the query to `type = 'HIGHLIGHT'` flips
+    // this red because book E would drop out and the count would fall to 1.
+    @Test
+    fun observeBooksWithHighlights_includesImageOnlyBooks() = runTest {
+        dao.upsert(highlight("a1", sourceId = "abs1", itemId = "A", createdAt = 100))
+        dao.upsert(image("e1", sourceId = "abs1", itemId = "E", createdAt = 300))
+        dao.upsert(image("e2", sourceId = "abs1", itemId = "E", createdAt = 400))
+        dao.upsert(bookmark("c1", sourceId = "abs1", itemId = "C", createdAt = 500))
+        dao.upsert(image("d1", sourceId = "abs1", itemId = "D", createdAt = 600, deleted = true))
+
+        val result = dao.observeBooksWithHighlights("abs1").first()
+
+        // Book E (image-only, newest live) sorts first; A (highlight-only) second; C (bookmark-only)
+        // excluded; D (image but soft-deleted) excluded.
+        assertEquals(2, result.size)
+        assertEquals("E", result[0].itemId)
+        assertEquals(2, result[0].highlightCount)
+        assertEquals(400L, result[0].latestUpdatedAt)
+        assertEquals("A", result[1].itemId)
     }
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
@@ -162,8 +162,10 @@ interface AnnotationDao {
     )
     suspend fun purgeAgedTombstones(sourceId: String, itemId: String, cutoff: Long): Int
 
-    /** One row per book (ABS Library Item) with at least one live highlight on this source, most
-     *  recently updated first. Powers the Annotations View library list. */
+    /** One row per book (ABS Library Item) with at least one live highlight or image annotation on
+     *  this source, most recently updated first. Powers the Annotations View library list.
+     *  Bookmarks are excluded — they have their own tab. Image annotations are first-class here
+     *  since a user may annotate figures without ever making a text highlight. */
     @Query(
         """
         SELECT itemId,
@@ -171,7 +173,7 @@ interface AnnotationDao {
                MAX(updatedAt) AS latestUpdatedAt
         FROM annotations
         WHERE sourceId = :sourceId
-          AND type = 'HIGHLIGHT'
+          AND type IN ('HIGHLIGHT', 'IMAGE')
           AND deleted = 0
         GROUP BY itemId
         ORDER BY latestUpdatedAt DESC

--- a/core/database/src/test/kotlin/com/riffle/core/database/AnnotationTypeConstantTest.kt
+++ b/core/database/src/test/kotlin/com/riffle/core/database/AnnotationTypeConstantTest.kt
@@ -4,18 +4,23 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * Verifies that [AnnotationEntity.TYPE_HIGHLIGHT] constant matches the SQL literal hardcoded in
- * [AnnotationDao.observeBooksWithHighlights].
+ * Verifies that [AnnotationEntity.TYPE_HIGHLIGHT] and [AnnotationEntity.TYPE_IMAGE] constants match
+ * the SQL literals hardcoded in [AnnotationDao.observeBooksWithHighlights].
  *
- * The @Query for observeBooksWithHighlights hardcodes `type = 'HIGHLIGHT'` because Room's @Query
- * cannot reference Kotlin constants inside the SQL string. This test runs at JVM load time to catch
- * renames of TYPE_HIGHLIGHT deterministically. If someone changes [AnnotationEntity.TYPE_HIGHLIGHT]
- * to a different value, this assertion will fail immediately and prevent the silent mismatch from
+ * The @Query for observeBooksWithHighlights hardcodes `type IN ('HIGHLIGHT', 'IMAGE')` because
+ * Room's @Query cannot reference Kotlin constants inside the SQL string. This test runs at JVM
+ * load time to catch renames deterministically. If someone changes either constant to a different
+ * value, the corresponding assertion will fail immediately and prevent the silent mismatch from
  * shipping.
  */
 class AnnotationTypeConstantTest {
     @Test
     fun typeHighlightMatchesQueryLiteral() {
         assertEquals("HIGHLIGHT", AnnotationEntity.TYPE_HIGHLIGHT)
+    }
+
+    @Test
+    fun typeImageMatchesQueryLiteral() {
+        assertEquals("IMAGE", AnnotationEntity.TYPE_IMAGE)
     }
 }

--- a/docs/superpowers/plans/2026-07-12-figure-caption-tint-with-image-annotation.md
+++ b/docs/superpowers/plans/2026-07-12-figure-caption-tint-with-image-annotation.md
@@ -1,0 +1,256 @@
+# Figure-caption tint with image annotation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a `TYPE_IMAGE` annotation exists on a `<figure>`, also tint that figure's `<figcaption>` in the annotation's color so the figure and caption read as one annotation.
+
+**Architecture:** Extend `figureBorderApplyJs` in `FigureBorderInjection.kt` — the CSS/JS pass already dispatched to all three reader modes via `FigureBorderDecoration.kt` and `ContinuousDecorationController.kt`. Add a JS-only tint step because (a) inline SVG has no CSS-matchable selector, and (b) using CSS `:has()` for raster would fail on the API-25 harness AVD's Chrome 55 WebView. No schema, no locator, no sync changes.
+
+**Tech Stack:** Kotlin, JUnit 4, WebView JS injection.
+
+## Global Constraints
+
+- Semantic markup only — `figure > figcaption` and `[role="figure"] > figcaption`. No heuristic fallback.
+- Silent behavior — no toast, no setting, no first-run explainer.
+- No schema/Room migration; no changes to `AnnotationEntity`, `AnnotationDao`, `AnnotationW3CCodec`, `WebDavAnnotationSyncTarget`, `HighlightsPublicationFactory`, or `EpubReaderViewModel`.
+- Caption tint color must be the annotation color emitted the same way the border is (via `HighlightColor.fromToken(token).argb.toCssRgba()`), so alpha stays in sync.
+- Every apply pass must **clear** stale caption tints first, mirroring the existing SVG "always-clear-then-apply" pattern in `figureBorderApplyJs`.
+
+---
+
+### Task 1: Tint `<figcaption>` when its `<figure>` holds an annotated image or SVG
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjection.kt` (extend `figureBorderApplyJs`)
+- Create: `app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjectionTest.kt`
+
+**Interfaces:**
+- Consumes: `FigureBorderDecoration.RasterMark(filename, color, hasNote)` and `FigureBorderDecoration.SvgMatch(fingerprint, color, hasNote)` — already exist.
+- Produces: no new public symbols. `figureBorderApplyJs(cssRules, svgMatches, rasterMarks)` signature unchanged; the emitted JS gains caption-tint statements.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjectionTest.kt`:
+
+```kotlin
+package com.riffle.app.feature.reader.decorations
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FigureBorderInjectionTest {
+
+    @Test
+    fun `apply js clears stale figcaption tints before applying`() {
+        val js = figureBorderApplyJs(
+            cssRules = emptyList(),
+            svgMatches = emptyList(),
+            rasterMarks = emptyList(),
+        )
+        // Every apply pass must sweep figcaption[data-riffle-fig-tint] and clear the tint,
+        // mirroring the SVG "always-clear-then-apply" pattern already in this file. Reverting
+        // to a leave-stale-tints-in-place approach flips this red.
+        assertTrue(
+            "apply JS is missing the figcaption clear pass",
+            js.contains("data-riffle-fig-tint"),
+        )
+        assertTrue(
+            "apply JS should query figcaption elements with the tint marker",
+            js.contains("figcaption[data-riffle-fig-tint]"),
+        )
+    }
+
+    @Test
+    fun `apply js tints figcaption for raster image annotations`() {
+        val marks = listOf(
+            FigureBorderDecoration.RasterMark(
+                filename = "graph.png",
+                color = "rgba(52,211,153,0.5)",
+                hasNote = false,
+            ),
+        )
+        val js = figureBorderApplyJs(cssRules = emptyList(), svgMatches = emptyList(), rasterMarks = marks)
+
+        // For every matched raster image, the JS must walk up to the containing <figure> (or
+        // role="figure") and tint the first child <figcaption> with the annotation color.
+        // Reverting the caption-tint pass flips this red.
+        assertTrue(
+            "apply JS should look for a figure ancestor via closest()",
+            js.contains("closest('figure, [role=\"figure\"]')") ||
+                js.contains("closest(\"figure, [role='figure']\")"),
+        )
+        assertTrue(
+            "apply JS should target the first child figcaption",
+            js.contains("querySelector('figcaption')") ||
+                js.contains("querySelector(\"figcaption\")"),
+        )
+        assertTrue(
+            "apply JS should set backgroundColor to the raster mark's color",
+            js.contains("52,211,153"),
+        )
+    }
+
+    @Test
+    fun `apply js tints figcaption for svg annotations`() {
+        val matches = listOf(
+            FigureBorderDecoration.SvgMatch(
+                fingerprint = "<svg id=\"chart\">",
+                color = "rgba(56,189,248,0.5)",
+                hasNote = false,
+            ),
+        )
+        val js = figureBorderApplyJs(cssRules = emptyList(), svgMatches = matches, rasterMarks = emptyList())
+
+        // Same treatment for inline-SVG figures — must tint the containing figcaption.
+        // Reverting the SVG branch's caption tint flips this red.
+        assertTrue(
+            "apply JS should carry the svg mark's color for the caption tint",
+            js.contains("56,189,248"),
+        )
+        assertTrue(
+            "svg branch should also invoke figure/figcaption traversal",
+            js.contains("closest('figure, [role=\"figure\"]')") ||
+                js.contains("closest(\"figure, [role='figure']\")"),
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home
+./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.reader.decorations.FigureBorderInjectionTest"
+```
+
+Expected: 3 FAILs — the current `figureBorderApplyJs` doesn't emit `data-riffle-fig-tint`, doesn't call `closest('figure, [role="figure"]')`, and doesn't tint figcaption at all.
+
+- [ ] **Step 3: Extend `figureBorderApplyJs` in `FigureBorderInjection.kt`**
+
+In `app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjection.kt`, inside the returned template string of `figureBorderApplyJs(...)`, add a shared helper function above the two existing `try { ... }` blocks (right after the note-badge helpers), and invoke it from the raster loop and the SVG loop.
+
+Insert this helper block just before the `try { var rasters = $rasterJson; ... }` block (i.e., after `function addNoteBadge(el, color) { ... }` closes):
+
+```kotlin
+          function clearAllFigcaptionTints() {
+            var stale = document.querySelectorAll('figcaption[data-riffle-fig-tint]');
+            for (var k = 0; k < stale.length; k++) {
+              stale[k].style.backgroundColor = '';
+              stale[k].removeAttribute('data-riffle-fig-tint');
+            }
+          }
+          function tintCaptionFor(el, color) {
+            if (!el) return;
+            var fig = el.closest && el.closest('figure, [role="figure"]');
+            if (!fig) return;
+            var cap = fig.querySelector('figcaption');
+            if (!cap) return;
+            cap.style.backgroundColor = color;
+            cap.setAttribute('data-riffle-fig-tint', '1');
+          }
+          clearAllFigcaptionTints();
+```
+
+(These are JS lines inside the Kotlin raw string — they don't need Kotlin-side escaping beyond what's already there. No `$` in the added code, so no interpolation collision.)
+
+Then, in the **raster** `try` block, inside the innermost `for (var ii = 0; ii < imgs.length; ii++)` loop, after the `var img = imgs[ii];` line, add:
+
+```
+                var rasterColor = 'rgba(0,0,0,0)';
+                var cssRules = style.textContent || '';
+                var selectorNeedle = 'img[src$="' + rf.fn + '"]';
+                var ruleIdx = cssRules.indexOf(selectorNeedle);
+                if (ruleIdx >= 0) {
+                  var openBrace = cssRules.indexOf('{', ruleIdx);
+                  var closeBrace = cssRules.indexOf('}', openBrace);
+                  var block = openBrace >= 0 && closeBrace >= 0 ? cssRules.substring(openBrace, closeBrace) : '';
+                  var m = block.match(/rgba\([^)]+\)/);
+                  if (m) rasterColor = m[0];
+                }
+                tintCaptionFor(img, rasterColor);
+```
+
+This reads the color back out of the just-installed style block (the raster border's color) so we don't need to thread the color through `rasterMarks`. **Simpler alternative:** promote `RasterMark.color` into the `rasterJson` payload and use it directly. Do that instead:
+
+**Prefer this alternative.** Change the `rasterJson` construction in `figureBorderApplyJs` (around line 56 of the current file) to include the color:
+
+```kotlin
+    val rasterJson = rasterMarks.joinToString(",", prefix = "[", postfix = "]") { m ->
+        val escFn = m.filename.replace("\\", "\\\\").replace("\"", "\\\"")
+        val escColor = m.color.replace("\"", "\\\"")
+        "{\"fn\":\"$escFn\",\"color\":\"$escColor\",\"note\":${if (m.hasNote) 1 else 0}}"
+    }
+```
+
+Then in the raster inner loop, replace the color-parsing block above with the direct call:
+
+```
+                tintCaptionFor(img, rf.color);
+```
+
+And in the **SVG** `try` block, inside the `if (outer.indexOf(fp) === 0 || ...)` branch, right after `s.__riffleBorderApplied = true;`, add:
+
+```
+                  tintCaptionFor(s, matches[j].color);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```
+./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.reader.decorations.FigureBorderInjectionTest"
+```
+
+Expected: 3 PASSes.
+
+- [ ] **Step 5: Run the sibling decoration test to confirm no regression**
+
+```
+./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.reader.decorations.FigureBorderDecorationTest"
+```
+
+Expected: PASS (should be unaffected — we didn't change `FigureBorderDecoration.kt`).
+
+- [ ] **Step 6: Full app JVM test suite as a safety net**
+
+```
+./gradlew :app:testDebugUnitTest
+```
+
+Expected: PASS. Per the `feedback_gradle_test_command` memory, run `:app:testDebugUnitTest` (module-scoped is fine here — the change is inside `:app`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjection.kt \
+        app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjectionTest.kt
+git commit -m "feat(reader): tint <figcaption> alongside image annotation's figure border
+
+When an image annotation covers a <figure> that has a <figcaption> child
+(or role=\"figure\" with a figcaption child), tint the caption in the
+annotation's color so the figure and caption read as one unit. Purely a
+render-side extension of the existing FigureBorderInjection JS pass; no
+schema, locator, or sync changes."
+```
+
+---
+
+## Verification (not part of the plan tasks — for the developer executing the plan)
+
+Per AGENTS.md, reading-behavior changes must be verified in all three reader modes. Because this is a CSS/JS injection change fanned out through the same path as the existing figure border, mode parity is expected — verification guards against WebView quirks.
+
+Book to use: any EPUB whose figures use `<figure><figcaption>...</figcaption></figure>` markup. The dev's usual test EPUBs on the ABS test server include titles that do.
+
+Repro path in each mode:
+1. Open a book with a `<figure><figcaption>` figure.
+2. Long-press the figure to create an image annotation.
+3. Confirm: figure has the colored border AND the caption text has a colored background tint in the annotation's color.
+4. Change the annotation's color from the highlight popup. Confirm the caption tint follows.
+5. Delete the annotation. Confirm both the border and the caption tint disappear.
+6. In continuous mode specifically: scroll the chapter offscreen and back. Confirm the tint restores on chapter re-attach.
+
+## Self-review
+
+- **Spec coverage:** Rendering rule (design §Rendering) — Task 1. Selection scope (design §Selection scope) — the JS uses `closest('figure, [role="figure"]')` and `querySelector('figcaption')`, matching the design's HTML-5-first-child rule (HTML5 restricts `<figcaption>` to be a direct child; `querySelector('figcaption')` grabs the first, which is what we want). Undo/delete symmetry — the always-clear-then-apply pass covers it. Text-highlight overlap — nothing prevents the composite; no code needed. Elided view — no change (design §Interaction). ABS sync — no change (design §Interaction). Continuous re-attach — covered by the existing `ContinuousDecorationController` fanout, no new code.
+- **Placeholder scan:** No TBDs, no "add error handling", no "similar to Task N". Each step has concrete code or command.
+- **Type consistency:** Test uses `FigureBorderDecoration.RasterMark(filename, color, hasNote)` and `SvgMatch(fingerprint, color, hasNote)` — both match the existing signatures in `FigureBorderDecoration.kt` (verified against source).
+- **Scope check:** Single-file source change + single new test file. Right-sized for one task.

--- a/docs/superpowers/specs/2026-07-12-figure-caption-tint-with-image-annotation-design.md
+++ b/docs/superpowers/specs/2026-07-12-figure-caption-tint-with-image-annotation-design.md
@@ -10,7 +10,11 @@ When a `TYPE_IMAGE` annotation exists on a `<figure>` element that also contains
 
 ## Non-goals
 
-- **No heuristic caption detection.** Semantic markup only — `<figure><figcaption>` or `role="figure"` + `<figcaption>`. EPUBs that lay out captions as adjacent `<p>` or `<div>` blocks without semantic tagging are out of scope for this pass.
+- **Class-name-based heuristics.** No matching on `class="caption"` / `class~="figure"` / other bespoke class-name whitelists. Publisher CSS class names are frequently obfuscated (Kotobee, Vellum, LaTeX-to-EPUB), so any class-name whitelist would be brittle.
+
+## Post-brainstorming scope amendment
+
+Original brainstorming picked option A (semantic markup only). During implementation, verification against *A Philosophy of Software Design 2e* revealed the book uses no `<figure>` and obfuscated class names (`class_s4`, `class_s5`), so semantic-only would leave the feature dead on non-semantic EPUBs — the common case. Extended to a bounded, content-anchored text-prefix fallback: when the semantic path yields nothing, walk up to 3 ancestors and match the nearest following `<p>`/`<div>` whose text starts with `Figure N`, `Fig. N`, `Table N`, or `Chart N`. Content-anchored (not class-name-anchored), so it can't over-tint on obfuscated markup — worst case it silently finds nothing. Same fallback applied to `FigureCaptionWalker.resolveCaption` so the persisted caption also uses it, and placed AFTER `alt`/`aria-label` so per-image attributes win over proximity heuristics.
 - **No caption→figure symmetry.** Annotating just the caption text (via a normal text highlight) does *not* auto-extend to the figure. Only image-annotation → caption. See brainstorming Q1.
 - **No new annotation type, no schema change, no Room migration.** The extension is purely a rendering concern.
 - **No opt-in setting.** Silent behavior (Q3). If it proves controversial we can add a toggle later.

--- a/docs/superpowers/specs/2026-07-12-figure-caption-tint-with-image-annotation-design.md
+++ b/docs/superpowers/specs/2026-07-12-figure-caption-tint-with-image-annotation-design.md
@@ -1,0 +1,87 @@
+# Figure-caption tint with image annotation — design
+
+## Problem
+
+When a user annotates a figure (graph, diagram, illustration) in a reflowable EPUB, only the figure itself gets a visible highlight. The caption underneath — which is what identifies the figure to the reader — stays visually unmarked. A user who returns to the annotated page sees "the picture is annotated" but not "the picture *and* its caption are one annotated unit."
+
+## Goal
+
+When a `TYPE_IMAGE` annotation exists on a `<figure>` element that also contains a `<figcaption>` (or is marked with ARIA `role="figure"` and contains a `<figcaption>` child), also tint the caption text with the annotation's color, using the same visual language as a text highlight. The figure and its caption should read as one annotation.
+
+## Non-goals
+
+- **No heuristic caption detection.** Semantic markup only — `<figure><figcaption>` or `role="figure"` + `<figcaption>`. EPUBs that lay out captions as adjacent `<p>` or `<div>` blocks without semantic tagging are out of scope for this pass.
+- **No caption→figure symmetry.** Annotating just the caption text (via a normal text highlight) does *not* auto-extend to the figure. Only image-annotation → caption. See brainstorming Q1.
+- **No new annotation type, no schema change, no Room migration.** The extension is purely a rendering concern.
+- **No opt-in setting.** Silent behavior (Q3). If it proves controversial we can add a toggle later.
+- **No cross-resource captions.** `<figcaption>` is always same-document by HTML5 rules; we don't need to consider captions living in a separate spine item.
+
+## Approach
+
+Extend the existing figure-border decoration to also style the child `<figcaption>` with the annotation's color as a background tint.
+
+Today, a `TYPE_IMAGE` annotation is not a text-range highlight. It's stored keyed by `imageHref` (or `imageSvg` prefix), and rendered as a **CSS border around the `<figure>`** via `FigureBorderInjection.kt`, dispatched to all three reader modes (paginated, vertical, continuous) through `FigureBorderDecoration.kt` and `ContinuousDecorationController.kt`. Caption text is already carried on the entity in `AnnotationEntity.textSnippet` for the elided ("Annotations") view; nothing about that changes.
+
+The change: the injected CSS/JS pass that finds a matching `<figure>` element and applies the border also selects its child `<figcaption>` and applies a background-color tint (matched to the annotation's color, with the same opacity/style used by text highlights so the two visual languages read as one system).
+
+Because the entire mechanism runs in the WebView's CSS/JS injection layer — which is already fanned out to all three reader modes — no per-mode code path needs a new branch.
+
+## Detailed behavior
+
+### Rendering
+
+1. `FigureBorderInjection.kt` currently injects CSS that draws a border around a `<figure>` matched by filename (raster) or SVG prefix. It also injects the JS that walks the DOM and applies the class.
+2. Extend that CSS so the same rule that borders `<figure>` also tints its **immediate child** `<figcaption>` with `background-color`.
+3. The tint color is the annotation's color, resolved the same way `HighlightRenderer.kt` resolves highlight backgrounds (same alpha, same dark/light-theme adjustment — see the readaloud-highlight-color-visibility memory for the dark-mode palette rule).
+4. When multiple image annotations exist in the same chapter, each figure's caption picks up its own annotation's color (already how the border works — the matcher runs per-figure).
+
+### Selection scope
+
+- **`<figure>` with `<figcaption>` child (any depth as an immediate descendant of the figure element)**: tint applies. HTML5 restricts `<figcaption>` to be a direct child of `<figure>`, so we scope the selector accordingly (`figure > figcaption`).
+- **`role="figure"` with `<figcaption>` child**: tint applies (`[role="figure"] > figcaption`).
+- **`<figure>` without `<figcaption>`**: no change, border-only rendering as today.
+- **Image not wrapped in `<figure>`** (bare `<img>` or `<svg>` in a `<p>`): no change, border-only as today. Out of scope per non-goals.
+
+### Interaction with existing features
+
+- **Undo/delete an image annotation.** The border and the caption tint are both driven by the same injection pass keyed on the same figure identity — removing the annotation clears both in one CSS refresh.
+- **Text highlight that overlaps the caption.** A user could separately highlight caption text (or a range that crosses through it). The overlap is fine visually: the text-highlight background composites over the figure-caption tint. Same layering as any two overlapping highlights today; we do not need to suppress one.
+- **Elided ("Annotations") view.** No change. `HighlightsPublicationFactory.appendImageAnnotation` already renders the caption from `textSnippet`.
+- **ABS sync (WebDAV JSON-LD).** No change. The annotation entity is unchanged; caption tint is a pure rendering concern.
+- **Continuous mode chapter re-attach.** `ContinuousDecorationController.kt` already reapplies figure-border decorations when a chapter WebView is re-attached after scroll recycling. The caption tint rides along for free.
+
+### Discoverability
+
+Silent (Q3). No toast, no setting, no first-run explainer.
+
+## Reader-mode verification matrix
+
+Per AGENTS.md, any reading-behavior change must be verified in all three modes.
+
+| Mode | Renderer | Verification |
+|---|---|---|
+| Paginated | `EpubNavigatorFragment` scroll=false | Manual: annotate a `<figure><figcaption>` figure, confirm border + caption tint. |
+| Vertical | `EpubNavigatorFragment` scroll=true | Same manual check. |
+| Continuous | `ContinuousReaderView` | Manual: annotate a figure, scroll away and back, confirm tint restores on chapter re-attach. |
+
+Because the injection is CSS-only and per-figure keyed the same way the border is, mode parity is expected — the verification is guarding against unknown WebView quirks (offscreen-preraster, chromium tile de-raster in stacked WebViews), not different code paths.
+
+## Testing
+
+Per AGENTS.md, the fix must have a regression test whose assertion would flip red if the fix were reverted.
+
+- **JVM unit test** for the CSS/JS builder in `FigureBorderInjection.kt` — assert that when a matched figure produces its rule, the emitted CSS contains a `figure > figcaption` (and `[role="figure"] > figcaption`) `background-color:` rule for the annotation's color. That assertion flips red if the caption rule is removed.
+- **Snippet builder test** for color resolution — assert the caption background uses the same alpha as the text-highlight renderer, so a palette-alpha bump doesn't silently desync the two.
+
+No new instrumentation test is needed because the JVM-testable pure output of the injection builder covers the semantic change. The reader-mode matrix is validated by manual on-device checks per the "verify on AVD" memory.
+
+## File-level surface
+
+- **Change:** `app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjection.kt` — extend the injected CSS to include the caption background rule.
+- **Change (potentially):** `app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecoration.kt` — thread the annotation color through to the caption rule if the current builder doesn't already have it available.
+- **No change:** `AnnotationEntity`, `AnnotationDao`, `AnnotationStore`, `AnnotationW3CCodec`, `WebDavAnnotationSyncTarget`, all three renderer bridges, `HighlightsPublicationFactory`, `EpubReaderViewModel`.
+- **New tests:** In `app/src/test/kotlin/com/riffle/app/feature/reader/decorations/` alongside the existing `FigureBorderInjection` tests.
+
+## Open questions
+
+None. Approach validated in brainstorming (Q1 asymmetric, Q2 rendered-as-linked-decoration rather than schema-linked, Q3 silent, scope A semantic-only).


### PR DESCRIPTION
## Summary

- **Figure caption tint**: when a `TYPE_IMAGE` annotation exists on a `<figure>`, the accompanying `<figcaption>` is now background-tinted in the annotation's color so the figure and its caption read as one unit. Extends the existing `figureBorderApplyJs` injection so all three reader modes (paginated, vertical, continuous) get it for free.
- **Text-prefix caption fallback**: EPUBs shipped by LaTeX/Kotobee/Vellum pipelines rarely use `<figure>/<figcaption>` and often obfuscate class names (`class_s4`, `class_s5`), so `resolveCaption` (and the injection tint) fall back to the nearest following `<p>`/`<div>` whose text starts with `Figure N` / `Fig. N` / `Table N` / `Chart N` — bounded 3-hop ancestor walk, content-anchored. Placed AFTER `alt`/`aria-label` so per-image attributes win over proximity heuristics.
- **Image-only books in Annotations View**: `AnnotationDao.observeBooksWithHighlights` widened from `type = 'HIGHLIGHT'` to `type IN ('HIGHLIGHT', 'IMAGE')`, so a book whose only annotations are figures no longer shows "No highlights yet".
- **CSS specificity war**: publisher stylesheets (Wiley's WileyTemplate — seen in *Influence Without Authority 3e*) ship `#sbo-rt-content img { outline: 0 }`, an ID-scoped reset that beats attribute selectors. Injected outline + caption tint now use `!important` (CSS rule + `style.setProperty(..., 'important')` for JS-driven inline styles). Clear passes updated to `removeProperty` to match.

Design and plan docs included: `docs/superpowers/specs/2026-07-12-figure-caption-tint-with-image-annotation-design.md`, `docs/superpowers/plans/2026-07-12-figure-caption-tint-with-image-annotation.md`.

## Verified on device

Emulator run, both books tested end-to-end:

- *A Philosophy of Software Design 2e* (Kotobee-processed, obfuscated classes, no `<figure>` wrapper): figure long-press → border + caption tint on `Figure 5.1: A POST request…`, textSnippet captured, book surfaces in Annotations view. Existing annotations (created before the walker fix) needed to be deleted + re-created to pick up the caption — expected, walker only runs at creation time.
- *Influence Without Authority 3e* (Wiley, semantic `<figure><figcaption>`, `outline: 0` reset): border now visible (defeats publisher `!important`-less reset), caption tinted, textSnippet correctly captured as "Figure 1.1 Summary of the Cohen-Bradford Model…".

## Test plan

- [x] `./gradlew test` — full JVM suite green
- [x] Manual reader-mode verification: paginated mode on both books (see above). Vertical / continuous share the same CSS/JS injection path via `ContinuousDecorationController` and Readium's paged/vertical bridge — no per-mode code branches, mode parity expected.
- [x] JVM regression tests added / updated:
  - `FigureBorderInjectionTest` — 5 new tests pinning caption tint, clear-pass sweep, `!important` via `setProperty`, text-prefix fallback, unscoped `figcaption` selector
  - `FigureBorderDecorationTest` — new test locking `!important` in the CSS rule
  - `FigureCaptionWalkerTest` — new test locking the walker + ordering (walker AFTER alt/aria-label)
  - `AnnotationTypeConstantTest` — new assertion for `TYPE_IMAGE = "IMAGE"` (SQL literal drift guard)
  - `AnnotationDaoTest` (androidTest) — new test that a book with only `IMAGE` annotations surfaces in the Annotations View
- [ ] Follow-up: `ReaderWebViewScripts.kt`'s highlight-range figure walker (`~line 415`) still uses semantic-only caption detection; a text-highlight that encloses a figure on a non-semantic EPUB will still store an empty caption. Separate flow, worth its own PR.

## Deferred review findings

- Walker + `CAPTION_PREFIX_RX` are duplicated across `FigureBorderInjection.kt` and `FigureCaptionWalker.kt` — real duplication, cost is drift risk on future refinements; deferred for a small DRY follow-up.
- `BookHighlightSummary.highlightCount` is now a misnomer (also counts IMAGE); cosmetic, no visible bug — deferred.