### PR TITLE
feat(komga): sync To Read to Komga readlists

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -73,7 +73,7 @@ A user-defined, unordered grouping of Library Items within a Library. Definition
 A per-user, per-Library ordered list of Library Items. Definition and scoping vary by Source. Gated on `PlaylistsCapability`. On [ABS] specifically, a Playlist is scoped to `(userId, libraryId)` and accepts any Library Item, including ebook-only items. [To Read] is backed by a Playlist on Sources that support it (see [ADR 0019]).
 
 ### To Read
-A per-user, per-Library wishlist of Library Items the user intends to read. Gated on `PlaylistsCapability`: on an [ABS] Source, implemented as an ABS Playlist named `To Read` (find-or-created on first use — see [ADR 0019]); on Sources without Playlists, the To Read tab is hidden entirely in v1 (a device-local shadow is a future addition, not shipping now).
+A per-user, per-Library wishlist of Library Items the user intends to read. Gated on `PlaylistsCapability`: on an [ABS] Source, implemented as an ABS Playlist named `To Read`, scoped to `(userId, libraryId)` (find-or-created on first use — see [ADR 0019]). On a [Komga] Source, implemented as a single server-wide Komga readlist named `To Read`; the per-Library view is produced client-side by filtering the readlist's book ids to those in the requested Library. On Sources without `PlaylistsCapability`, the To Read tab is hidden entirely in v1 (a device-local shadow is a future addition, not shipping now).
 
 Surfaced as a dedicated **To Read** tab between Home and Series when available. The tab shows a grid of the user's queued Library Items; empty state reads "Nothing in To Read".
 
@@ -81,7 +81,7 @@ App-managed rules (Sources with `PlaylistsCapability` only):
 - **Find-or-create by name.** If the user renames the playlist on the server, the next toggle creates a new "To Read" playlist; the renamed one is left alone.
 - **Per-Library, not global.** A user with multiple Libraries has one "To Read" per Library.
 - **Read transitions remove from To Read.** Any transition to the Read state removes the item from "To Read". Not enforced in reverse.
-- **Empty playlists are auto-deleted by ABS.** Removing the last item deletes the playlist server-side; the next add transparently creates a fresh one.
+- **Empty playlists disappear.** Removing the last item drops the underlying list: [ABS] deletes it server-side automatically; on [Komga], Riffle explicitly issues a DELETE to match. Either way, the next add transparently creates a fresh one.
 - **Optimistic, no queueing.** Taps flip the icon immediately, fire the request, revert with a snackbar on failure. No durable mutation queue.
 
 ### Audiobook

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -1332,6 +1332,7 @@ class LibraryItemsViewModelTest {
         override suspend fun listSeries(rootId: String) = emptyList<com.riffle.core.catalog.CatalogSeries>()
         override suspend fun listItemsInSeries(rootId: String, seriesId: String) = emptyList<com.riffle.core.catalog.CatalogItem>()
         override suspend fun listPlaylists(rootId: String) = emptyList<com.riffle.core.catalog.CatalogPlaylist>()
+        override suspend fun findPlaylist(rootId: String, name: String): com.riffle.core.catalog.CatalogPlaylist? = null
         override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?) = error("unused")
         override suspend fun addItemToPlaylist(playlistId: String, itemId: String) {}
         override suspend fun removeItemFromPlaylist(playlistId: String, itemId: String) {}

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -1332,7 +1332,7 @@ class LibraryItemsViewModelTest {
         override suspend fun listSeries(rootId: String) = emptyList<com.riffle.core.catalog.CatalogSeries>()
         override suspend fun listItemsInSeries(rootId: String, seriesId: String) = emptyList<com.riffle.core.catalog.CatalogItem>()
         override suspend fun listPlaylists(rootId: String) = emptyList<com.riffle.core.catalog.CatalogPlaylist>()
-        override suspend fun createPlaylist(rootId: String, name: String) = error("unused")
+        override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?) = error("unused")
         override suspend fun addItemToPlaylist(playlistId: String, itemId: String) {}
         override suspend fun removeItemFromPlaylist(playlistId: String, itemId: String) {}
     }

--- a/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalog.kt
+++ b/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalog.kt
@@ -6,12 +6,14 @@ import com.riffle.core.catalog.CatalogFileHandle
 import com.riffle.core.catalog.CatalogFileStream
 import com.riffle.core.catalog.CatalogHealth
 import com.riffle.core.catalog.CatalogItem
+import com.riffle.core.catalog.CatalogPlaylist
 import com.riffle.core.catalog.CatalogRoot
 import com.riffle.core.catalog.CatalogSeries
 import com.riffle.core.catalog.CatalogSeriesEntry
 import com.riffle.core.catalog.DownloadsCapability
 import com.riffle.core.catalog.FacetSelection
 import com.riffle.core.catalog.OfflineBrowseCapability
+import com.riffle.core.catalog.PlaylistsCapability
 import com.riffle.core.catalog.ReadCapability
 import com.riffle.core.catalog.SeriesCapability
 import com.riffle.core.catalog.SortKey
@@ -33,8 +35,11 @@ import java.net.URLEncoder
  * - Mandatory core (listRoots/browse/search/getItem/fetchFile/openFile/connectivityCheck): yes.
  * - [ReadCapability], [DownloadsCapability], [ToReadListCapability], [OfflineBrowseCapability]:
  *   marker mixins so the shared library UI enables the corresponding affordances.
- * - Absent: SeriesCapability (planned — Komga has strong series concepts, but they belong to a
- *   later slice), CollectionsCapability, ProgressPeerCapability, ReadingSessionsCapability,
+ * - [PlaylistsCapability]: server-side "To Read" sync backed by Komga's `/api/v1/readlists`.
+ *   Komga readlists are server-wide (not per-library), so the shared list is find-or-created once
+ *   and both the browse and detail toggles operate on it; per-library views are produced by
+ *   filtering the readlist's book ids to those in the requested library.
+ * - Absent: CollectionsCapability, ProgressPeerCapability, ReadingSessionsCapability,
  *   StatsCapability, AudiobookMediaCapability, BookmarksCapability, ReadaloudCapability.
  */
 class KomgaCatalog(
@@ -46,7 +51,8 @@ class KomgaCatalog(
     DownloadsCapability,
     ToReadListCapability,
     OfflineBrowseCapability,
-    SeriesCapability {
+    SeriesCapability,
+    PlaylistsCapability {
 
     override val sourceType: SourceType = SourceType.KOMGA
 
@@ -262,6 +268,188 @@ class KomgaCatalog(
             body,
         )
         return pageDto.content.map { it.toCatalogItem() }
+    }
+
+    // endregion
+
+    // region PlaylistsCapability
+
+    /**
+     * Summary of every readlist on the Komga server, with an empty `itemIds` list. Enumerating
+     * per-library book ids requires one extra request per readlist (`/readlists/{id}/books?
+     * library_id=…`), so [listPlaylists] deliberately skips that work and callers that need the
+     * bookIds (e.g. the To Read sync) should go through [findPlaylist] instead.
+     */
+    override suspend fun listPlaylists(rootId: String): List<CatalogPlaylist> =
+        fetchAllReadLists().map { rl ->
+            CatalogPlaylist(
+                id = rl.id,
+                rootId = rootId,
+                name = rl.name,
+                bookCount = 0,
+                itemIds = emptyList(),
+            )
+        }
+
+    override suspend fun findPlaylist(rootId: String, name: String): CatalogPlaylist? {
+        // Match by name AND ownership. A readlist that we CAN'T modify (owned by another user)
+        // is worse than nothing — reusing it means every add/remove 403s. Treat it as absent so
+        // [createPlaylist] falls through to POSTing a fresh readlist owned by the current user.
+        // Komga allows duplicate readlist names, so we can coexist with someone else's "To Read".
+        val readList = firstOwnedReadListNamed(name) ?: return null
+        val bookIdsInLibrary = fetchReadListBookIdsInLibrary(readList.id, rootId)
+        return CatalogPlaylist(
+            id = readList.id,
+            rootId = rootId,
+            name = readList.name,
+            bookCount = bookIdsInLibrary.size,
+            itemIds = bookIdsInLibrary,
+        )
+    }
+
+    override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?): CatalogPlaylist {
+        // Komga readlists are server-wide, not per-library. Re-check by name AND ownership
+        // before POST — concurrent first-time refreshes across two libraries shouldn't duplicate
+        // OUR "To Read", but we also must NOT hand back a readlist owned by another user (that
+        // would 403 on the next PATCH). See [firstOwnedReadListNamed].
+        val existing = firstOwnedReadListNamed(name)
+        if (existing != null) {
+            // Existing readlist — append initialItemId (idempotent) so the caller's expectation
+            // ("this playlist now contains the item I asked to seed") holds regardless of whether
+            // the list existed before.
+            if (initialItemId != null && initialItemId !in existing.bookIds) {
+                patchReadListBookIds(existing.id, existing.bookIds + initialItemId)
+            }
+            return CatalogPlaylist(
+                id = existing.id,
+                rootId = rootId,
+                name = existing.name,
+                bookCount = 0,
+                itemIds = emptyList(),
+            )
+        }
+        // Komga's POST /api/v1/readlists requires a non-empty bookIds; that's why the interface
+        // exposes [initialItemId]. If the caller passes null AND no readlist exists yet, Komga
+        // will reject the request — callers targeting Komga must always provide a seed on first
+        // create (ToReadRepositoryImpl already does this via the addToToRead path).
+        val body = KomgaJson.encodeToString(
+            KomgaReadListCreateDto.serializer(),
+            KomgaReadListCreateDto(
+                name = name,
+                bookIds = listOfNotNull(initialItemId),
+            ),
+        )
+        val response = http.postJson(apiUrl("readlists"), body)
+        val created = KomgaJson.decodeFromString(KomgaReadListDto.serializer(), response)
+        return CatalogPlaylist(
+            id = created.id,
+            rootId = rootId,
+            name = created.name,
+            bookCount = if (initialItemId != null) 1 else 0,
+            itemIds = if (initialItemId != null) listOf(initialItemId) else emptyList(),
+        )
+    }
+
+    override suspend fun addItemToPlaylist(playlistId: String, itemId: String) {
+        // Komga's PATCH replaces bookIds wholesale — read-modify-write to preserve order and
+        // append idempotently.
+        val current = fetchReadList(playlistId)
+        if (itemId in current.bookIds) return
+        patchReadListBookIds(playlistId, current.bookIds + itemId)
+    }
+
+    override suspend fun removeItemFromPlaylist(playlistId: String, itemId: String) {
+        val current = fetchReadList(playlistId)
+        val next = current.bookIds.filterNot { it == itemId }
+        if (next.isEmpty()) {
+            // Komga does NOT auto-delete empty readlists (ABS does). Mirror the ABS empty-list
+            // sweep here so the "To Read" name is free to be re-created on the next add; the
+            // caller-side snapshot already drops playlistId when itemIds go to empty (see
+            // ToReadRepositoryImpl.removeFromToRead).
+            http.delete(apiUrl("readlists/$playlistId"))
+        } else {
+            patchReadListBookIds(playlistId, next)
+        }
+    }
+
+    /**
+     * The current authenticated user's id (from `GET /api/v1/users/me`), cached for the lifetime
+     * of this catalog instance. Null when Komga refuses the query (e.g. older server without
+     * this endpoint, or transient auth failure) — callers then fall back to treating ownership
+     * as unknown, which is safe: any read/write that fails still gets logged via RIFFLE_TOREAD.
+     */
+    @Volatile private var cachedCurrentUserId: String? = null
+
+    private suspend fun currentUserId(): String? {
+        cachedCurrentUserId?.let { return it }
+        val body = runCatching { http.getString(apiUrl("users/me")) }.getOrNull() ?: return null
+        val me = runCatching { KomgaJson.decodeFromString(KomgaCurrentUserDto.serializer(), body) }.getOrNull()
+            ?: return null
+        cachedCurrentUserId = me.id
+        return me.id
+    }
+
+    /**
+     * First readlist named [name] whose owner is the currently authenticated user. Readlists
+     * without an [KomgaReadListDto.ownerId] (older Komga < 1.19) are considered a match — we
+     * have no ownership signal there and the writes will either succeed or fail loudly. A
+     * readlist owned by SOMEONE ELSE is skipped so we don't hand back an id that will 403 on
+     * every subsequent PATCH — this is the exact regression the Komga integration hit against
+     * a "To Read" readlist that had been created via Komga's web UI by a different user.
+     */
+    private suspend fun firstOwnedReadListNamed(name: String): KomgaReadListDto? {
+        val meId = currentUserId()
+        return fetchAllReadLists().firstOrNull { rl ->
+            rl.name == name && (rl.ownerId == null || rl.ownerId == meId)
+        }
+    }
+
+    private suspend fun fetchAllReadLists(): List<KomgaReadListDto> {
+        val out = mutableListOf<KomgaReadListDto>()
+        var page = 0
+        while (true) {
+            val body = http.getString(apiUrl("readlists") + "?size=$KOMGA_MAX_PAGE_SIZE&page=$page")
+            val pageDto = KomgaJson.decodeFromString(
+                KomgaPageDto.serializer(serializer<KomgaReadListDto>()),
+                body,
+            )
+            out += pageDto.content
+            if (pageDto.last || pageDto.content.isEmpty()) break
+            page++
+        }
+        return out
+    }
+
+    private suspend fun fetchReadList(id: String): KomgaReadListDto {
+        val body = http.getString(apiUrl("readlists/$id"))
+        return KomgaJson.decodeFromString(KomgaReadListDto.serializer(), body)
+    }
+
+    private suspend fun fetchReadListBookIdsInLibrary(readListId: String, libraryId: String): List<String> {
+        val out = mutableListOf<String>()
+        var page = 0
+        while (true) {
+            val url = apiUrl("readlists/$readListId/books") +
+                "?library_id=${URLEncoder.encode(libraryId, "UTF-8")}" +
+                "&size=$KOMGA_MAX_PAGE_SIZE&page=$page"
+            val body = http.getString(url)
+            val pageDto = KomgaJson.decodeFromString(
+                KomgaPageDto.serializer(serializer<KomgaBookDto>()),
+                body,
+            )
+            pageDto.content.forEach { out += it.id }
+            if (pageDto.last || pageDto.content.isEmpty()) break
+            page++
+        }
+        return out
+    }
+
+    private suspend fun patchReadListBookIds(id: String, bookIds: List<String>) {
+        val body = KomgaJson.encodeToString(
+            KomgaReadListUpdateDto.serializer(),
+            KomgaReadListUpdateDto(bookIds = bookIds),
+        )
+        http.patchJson(apiUrl("readlists/$id"), body)
     }
 
     // endregion

--- a/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalog.kt
+++ b/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalog.kt
@@ -317,27 +317,32 @@ class KomgaCatalog(
             // Existing readlist — append initialItemId (idempotent) so the caller's expectation
             // ("this playlist now contains the item I asked to seed") holds regardless of whether
             // the list existed before.
-            if (initialItemId != null && initialItemId !in existing.bookIds) {
-                patchReadListBookIds(existing.id, existing.bookIds + initialItemId)
+            val nextBookIds = if (initialItemId != null && initialItemId !in existing.bookIds) {
+                val merged = existing.bookIds + initialItemId
+                patchReadListBookIds(existing.id, merged)
+                merged
+            } else {
+                existing.bookIds
             }
+            // Return the true post-PATCH state so the PlaylistsCapability contract ("returned
+            // playlist already contains that item") holds on the reuse branch too. Callers that
+            // trust the return value stay correct.
             return CatalogPlaylist(
                 id = existing.id,
                 rootId = rootId,
                 name = existing.name,
-                bookCount = 0,
-                itemIds = emptyList(),
+                bookCount = nextBookIds.size,
+                itemIds = nextBookIds,
             )
         }
         // Komga's POST /api/v1/readlists requires a non-empty bookIds; that's why the interface
         // exposes [initialItemId]. If the caller passes null AND no readlist exists yet, Komga
         // will reject the request — callers targeting Komga must always provide a seed on first
         // create (ToReadRepositoryImpl already does this via the addToToRead path).
+        val seed = listOfNotNull(initialItemId)
         val body = KomgaJson.encodeToString(
             KomgaReadListCreateDto.serializer(),
-            KomgaReadListCreateDto(
-                name = name,
-                bookIds = listOfNotNull(initialItemId),
-            ),
+            KomgaReadListCreateDto(name = name, bookIds = seed),
         )
         val response = http.postJson(apiUrl("readlists"), body)
         val created = KomgaJson.decodeFromString(KomgaReadListDto.serializer(), response)
@@ -345,8 +350,8 @@ class KomgaCatalog(
             id = created.id,
             rootId = rootId,
             name = created.name,
-            bookCount = if (initialItemId != null) 1 else 0,
-            itemIds = if (initialItemId != null) listOf(initialItemId) else emptyList(),
+            bookCount = seed.size,
+            itemIds = seed,
         )
     }
 
@@ -354,12 +359,14 @@ class KomgaCatalog(
         // Komga's PATCH replaces bookIds wholesale — read-modify-write to preserve order and
         // append idempotently.
         val current = fetchReadList(playlistId)
+        refuseIfFiltered(current, action = "add $itemId")
         if (itemId in current.bookIds) return
         patchReadListBookIds(playlistId, current.bookIds + itemId)
     }
 
     override suspend fun removeItemFromPlaylist(playlistId: String, itemId: String) {
         val current = fetchReadList(playlistId)
+        refuseIfFiltered(current, action = "remove $itemId")
         val next = current.bookIds.filterNot { it == itemId }
         if (next.isEmpty()) {
             // Komga does NOT auto-delete empty readlists (ABS does). Mirror the ABS empty-list
@@ -373,18 +380,44 @@ class KomgaCatalog(
     }
 
     /**
+     * A Komga readlist with `filtered=true` is one where Komga hid one or more books from THIS
+     * caller because they lack access (e.g. sharedLibrariesIds restrictions, admin-revoked
+     * library access mid-session). The returned `bookIds` list is INCOMPLETE, so a PATCH built
+     * from it would silently DELETE the hidden books from the server-side readlist — permanent
+     * data loss the user cannot see. Refuse the mutation and let the caller surface the failure
+     * to the user (via [ToReadRepositoryImpl]'s revert path); the readlist stays intact until
+     * an admin restores access.
+     */
+    private fun refuseIfFiltered(readList: KomgaReadListDto, action: String) {
+        if (readList.filtered) {
+            throw KomgaHttpException(
+                code = 409,
+                url = apiUrl("readlists/${readList.id}"),
+                method = "GUARD",
+                statusMessage = "readlist $action refused",
+                responseBody = "Komga returned filtered=true; the local view is incomplete. " +
+                    "PATCHing would silently delete books the caller can't see — refusing.",
+            )
+        }
+    }
+
+    /**
      * The current authenticated user's id (from `GET /api/v1/users/me`), cached for the lifetime
-     * of this catalog instance. Null when Komga refuses the query (e.g. older server without
-     * this endpoint, or transient auth failure) — callers then fall back to treating ownership
-     * as unknown, which is safe: any read/write that fails still gets logged via RIFFLE_TOREAD.
+     * of this catalog instance on success. On failure the call THROWS — an earlier version
+     * silently returned null on any error, which collapsed the ownership predicate to
+     * `ownerId == null || ownerId == null` for every readlist. On modern Komga (>= 1.19) all
+     * readlists carry a non-null `ownerId`, so a transient `/users/me` 5xx would filter out
+     * every readlist the user actually owns and cause `createPlaylist` to POST a duplicate on
+     * every subsequent operation until the cache repopulated. Failing loud lets the repo layer's
+     * `runCatching` log via `RIFFLE_TOREAD` and revert the optimistic add instead of silently
+     * corrupting server state.
      */
     @Volatile private var cachedCurrentUserId: String? = null
 
-    private suspend fun currentUserId(): String? {
+    private suspend fun currentUserId(): String {
         cachedCurrentUserId?.let { return it }
-        val body = runCatching { http.getString(apiUrl("users/me")) }.getOrNull() ?: return null
-        val me = runCatching { KomgaJson.decodeFromString(KomgaCurrentUserDto.serializer(), body) }.getOrNull()
-            ?: return null
+        val body = http.getString(apiUrl("users/me")) // throws KomgaHttpException on non-2xx
+        val me = KomgaJson.decodeFromString(KomgaCurrentUserDto.serializer(), body)
         cachedCurrentUserId = me.id
         return me.id
     }

--- a/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaDtos.kt
+++ b/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaDtos.kt
@@ -91,6 +91,44 @@ internal data class KomgaSeriesDto(
     val metadata: KomgaSeriesMetadataDto = KomgaSeriesMetadataDto(),
 )
 
+/**
+ * Komga readlist — the server-side "ordered collection of books" model. A single readlist may
+ * span multiple libraries; Riffle uses one shared readlist named "To Read" per Komga server.
+ */
+@Serializable
+internal data class KomgaReadListDto(
+    val id: String,
+    val name: String,
+    val summary: String = "",
+    val bookIds: List<String> = emptyList(),
+    /** True when Komga hid one or more books because the caller lacks access. */
+    val filtered: Boolean = false,
+    /**
+     * Present since Komga 1.19+. Non-admin users can only modify readlists they own — a
+     * mismatched owner is why `PATCH /api/v1/readlists/{id}` returns 403 for a readlist that
+     * this user *can* read. Null on older Komga versions (no ownership concept).
+     */
+    val ownerId: String? = null,
+)
+
+/** Subset of Komga's `/api/v1/users/me` response — only [id] is needed to detect readlist ownership. */
+@Serializable
+internal data class KomgaCurrentUserDto(
+    val id: String,
+)
+
+@Serializable
+internal data class KomgaReadListCreateDto(
+    val name: String,
+    val summary: String = "",
+    val bookIds: List<String> = emptyList(),
+)
+
+@Serializable
+internal data class KomgaReadListUpdateDto(
+    val bookIds: List<String>,
+)
+
 @Serializable
 internal data class KomgaPageDto<T>(
     val content: List<T> = emptyList(),

--- a/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaHttpClient.kt
+++ b/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaHttpClient.kt
@@ -5,12 +5,16 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import okhttp3.Call
 import okhttp3.Callback
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import java.io.IOException
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
+
+private val JSON_MEDIA_TYPE = "application/json".toMediaType()
 
 /**
  * Thin OkHttp wrapper for Komga's REST API. Stamps the `Authorization: Basic …` header on every
@@ -31,11 +35,7 @@ class KomgaHttpClient(
             .header("Accept", "application/json")
             .build()
         val response = client.newCall(request).await()
-        val (status, body, msg) = withContext(Dispatchers.IO) {
-            response.use { r -> Triple(r.code, if (r.isSuccessful) r.body.string() else null, r.message) }
-        }
-        if (body == null) throw KomgaHttpException(code = status, url = url, message = msg)
-        return body
+        return readSuccessOrThrow(method = "GET", url = url, response = response)
     }
 
     /**
@@ -71,6 +71,75 @@ class KomgaHttpClient(
         false
     }
 
+    /** POST [jsonBody] to [url]. Returns the response body as a string. Throws on non-2xx. */
+    suspend fun postJson(url: String, jsonBody: String): String {
+        val request = Request.Builder()
+            .url(url)
+            .header("User-Agent", userAgent)
+            .header("Authorization", basicAuthHeader)
+            .header("Accept", "application/json")
+            .post(jsonBody.toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+        val response = client.newCall(request).await()
+        return readSuccessOrThrow(method = "POST", url = url, response = response)
+    }
+
+    /**
+     * PATCH [jsonBody] to [url]. Discards the response body — Komga PATCH endpoints typically
+     * return 204 No Content, so callers get success/failure via the exception, not a payload.
+     */
+    suspend fun patchJson(url: String, jsonBody: String) {
+        val request = Request.Builder()
+            .url(url)
+            .header("User-Agent", userAgent)
+            .header("Authorization", basicAuthHeader)
+            .patch(jsonBody.toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+        val response = client.newCall(request).await()
+        readSuccessOrThrow(method = "PATCH", url = url, response = response)
+    }
+
+    /** DELETE [url]. Throws on non-2xx. */
+    suspend fun delete(url: String) {
+        val request = Request.Builder()
+            .url(url)
+            .header("User-Agent", userAgent)
+            .header("Authorization", basicAuthHeader)
+            .delete()
+            .build()
+        val response = client.newCall(request).await()
+        readSuccessOrThrow(method = "DELETE", url = url, response = response)
+    }
+
+    /**
+     * Consume [response]: return the body on 2xx (empty string for 204), or throw a
+     * [KomgaHttpException] that carries the request method AND the response body. The body is
+     * the difference between "403 Forbidden" (opaque) and something like "Cannot modify a
+     * ReadList you don't own" — Komga's errors are only useful when we surface them. Truncate
+     * to 500 chars so a large error page doesn't blow up log lines.
+     */
+    private suspend fun readSuccessOrThrow(method: String, url: String, response: Response): String {
+        val (status, ok, bodyStr, statusMessage) = withContext(Dispatchers.IO) {
+            response.use { r ->
+                val bodyText = runCatching { r.body.string() }.getOrDefault("")
+                Quad(r.code, r.isSuccessful, bodyText, r.message)
+            }
+        }
+        if (!ok) {
+            val truncated = if (bodyStr.length > 500) bodyStr.take(500) + "…(truncated)" else bodyStr
+            throw KomgaHttpException(
+                code = status,
+                url = url,
+                method = method,
+                statusMessage = statusMessage,
+                responseBody = truncated,
+            )
+        }
+        return bodyStr
+    }
+
+    private data class Quad<A, B, C, D>(val a: A, val b: B, val c: C, val d: D)
+
     /** Status of a GET without reading the body. Returns HTTP code (or -1 on IOException). */
     suspend fun getStatus(url: String): Int = try {
         val request = Request.Builder()
@@ -101,5 +170,23 @@ class KomgaHttpClient(
 class KomgaHttpException(
     val code: Int,
     val url: String,
-    message: String,
-) : IOException("Komga HTTP $code for $url: $message")
+    val method: String = "?",
+    val statusMessage: String = "",
+    val responseBody: String = "",
+) : IOException(
+    buildString {
+        append("Komga HTTP ").append(code).append(' ').append(method).append(' ').append(url)
+        if (statusMessage.isNotBlank()) append(" — ").append(statusMessage)
+        if (responseBody.isNotBlank()) append(" | body: ").append(responseBody)
+    },
+) {
+    // Backwards-compatible constructor used by legacy call sites (e.g. KomgaCatalog.openFile).
+    // New sites should prefer the primary constructor so response bodies bubble into the log.
+    constructor(code: Int, url: String, message: String) : this(
+        code = code,
+        url = url,
+        method = "?",
+        statusMessage = message,
+        responseBody = "",
+    )
+}

--- a/core/catalog-komga/src/test/kotlin/com/riffle/core/catalog/komga/KomgaPlaylistsCapabilityTest.kt
+++ b/core/catalog-komga/src/test/kotlin/com/riffle/core/catalog/komga/KomgaPlaylistsCapabilityTest.kt
@@ -208,6 +208,79 @@ class KomgaPlaylistsCapabilityTest {
     // (i.e. concurrent library refreshes → both hit createPlaylist with a seed), append the seed
     // to the existing bookIds so the caller's expectation ("this playlist now contains my item")
     // holds. Idempotent when the seed is already present.
+    // Regression: an earlier version returned CatalogPlaylist(bookCount=0, itemIds=emptyList())
+    // on the reuse branch — a silent contract violation ("returned playlist already contains
+    // that item" per PlaylistsCapability.createPlaylist kdoc). Callers relying on the returned
+    // itemIds would see always-empty on reuse. Now the return reflects the true post-PATCH
+    // state.
+    @Test fun `createPlaylist reuse-branch return reflects post-PATCH bookIds`() = runTest {
+        enqueueMe()
+        server.enqueue(readListPage(
+            """{"id":"RL_EXISTING","name":"To Read","bookIds":["B_OLD"],"ownerId":"USER_ME"}"""
+        ))
+        server.enqueue(MockResponse().setResponseCode(204))
+
+        val created = catalog.createPlaylist(rootId = "L1", name = "To Read", initialItemId = "B_SEED")
+
+        assertEquals("RL_EXISTING", created.id)
+        assertEquals(listOf("B_OLD", "B_SEED"), created.itemIds)
+        assertEquals(2, created.bookCount)
+    }
+
+    // Regression: Komga returns `filtered=true` when the readlist contains books the caller
+    // can't see (shared-libraries scope, mid-session access revocation). Our PATCH replaces
+    // bookIds wholesale — if we built the PATCH from a filtered readlist, we'd silently DELETE
+    // the hidden books from the server-side list. Refuse the mutation instead so the user's tap
+    // gets reverted (and logged via RIFFLE_TOREAD) rather than corrupting the shared readlist.
+    @Test fun `addItemToPlaylist refuses when server-returned readlist is filtered`() = runTest {
+        server.enqueue(MockResponse().setBody(
+            """{"id":"RL1","name":"To Read","bookIds":["B_VISIBLE"],"filtered":true}"""
+        ))
+
+        try {
+            catalog.addItemToPlaylist(playlistId = "RL1", itemId = "B_NEW")
+            org.junit.Assert.fail("expected refusal — a PATCH with a filtered bookIds list would erase hidden books")
+        } catch (e: KomgaHttpException) {
+            assertEquals("GUARD", e.method)
+            assertTrue(e.responseBody.contains("filtered"))
+        }
+        // No PATCH sent — the guard fires before the write.
+        server.takeRequest()
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test fun `removeItemFromPlaylist refuses when server-returned readlist is filtered`() = runTest {
+        server.enqueue(MockResponse().setBody(
+            """{"id":"RL1","name":"To Read","bookIds":["B_VISIBLE","B_TARGET"],"filtered":true}"""
+        ))
+
+        try {
+            catalog.removeItemFromPlaylist(playlistId = "RL1", itemId = "B_TARGET")
+            org.junit.Assert.fail("expected refusal on filtered readlist")
+        } catch (e: KomgaHttpException) {
+            assertEquals("GUARD", e.method)
+        }
+        server.takeRequest()
+        assertEquals(1, server.requestCount)
+    }
+
+    // Regression: an earlier version silently swallowed /users/me failures with runCatching and
+    // returned null. On modern Komga (≥1.19) with non-null ownerId on every readlist, the
+    // ownership predicate then filtered out EVERY owned readlist → createPlaylist POSTed a
+    // duplicate on every operation while /me was flaky. Now /me failures throw and propagate
+    // so the repo layer's runCatching logs via RIFFLE_TOREAD and reverts the optimistic add.
+    @Test fun `findPlaylist throws when users me is unreachable`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(500).setBody("upstream failure"))
+
+        try {
+            catalog.findPlaylist(rootId = "L1", name = "To Read")
+            org.junit.Assert.fail("expected /users/me failure to surface, not be silently swallowed")
+        } catch (e: KomgaHttpException) {
+            assertEquals(500, e.code)
+            assertTrue(e.url.endsWith("/api/v1/users/me"))
+        }
+    }
+
     @Test fun `createPlaylist appends initialItemId to existing owned readlist`() = runTest {
         enqueueMe()
         server.enqueue(readListPage(

--- a/core/catalog-komga/src/test/kotlin/com/riffle/core/catalog/komga/KomgaPlaylistsCapabilityTest.kt
+++ b/core/catalog-komga/src/test/kotlin/com/riffle/core/catalog/komga/KomgaPlaylistsCapabilityTest.kt
@@ -1,0 +1,344 @@
+package com.riffle.core.catalog.komga
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Verifies [KomgaCatalog]'s [com.riffle.core.catalog.PlaylistsCapability] implementation against
+ * Komga's `/api/v1/readlists*` endpoints. Each test's assertion would flip red if the mapping,
+ * request shape, or empty-list DELETE behaviour were reverted.
+ */
+class KomgaPlaylistsCapabilityTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var catalog: KomgaCatalog
+
+    @Before fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val ok = OkHttpClient()
+        val header = buildBasicAuthHeader("user", "pass")
+        val config = KomgaCatalogConfig(
+            baseUrl = server.url("/").toString().trimEnd('/'),
+            basicAuthHeader = header,
+            insecureAllowed = true,
+        )
+        catalog = KomgaCatalog(config, KomgaHttpClient(ok, header), ok)
+    }
+
+    @After fun tearDown() { server.shutdown() }
+
+    /** Every capability path routes through `firstOwnedReadListNamed` → `currentUserId`, which
+     * hits `GET /api/v1/users/me` once per catalog instance. Tests that don't care about
+     * ownership call [enqueueMe] at the top of their body so the /me GET is answered before the
+     * readlist workflow runs. Cached across calls within a single catalog, so a test only needs
+     * to enqueue /me once. */
+    private fun enqueueMe(id: String = "USER_ME") {
+        server.enqueue(MockResponse().setBody("""{"id":"$id"}"""))
+    }
+
+    // Regression: Komga readlists span libraries. If findPlaylist returned the raw bookIds from
+    // the readlist DTO, the "To Read" tab in library L1 would show books living in L2, and vice
+    // versa. Filter must go through /readlists/{id}/books?library_id=L1.
+    @Test fun `findPlaylist returns only books in the requested library`() = runTest {
+        enqueueMe()
+        // 1st call: GET /api/v1/readlists?size=1000&page=0
+        server.enqueue(readListPage(
+            """{"id":"RL1","name":"To Read","bookIds":["B_L1_1","B_L2_1","B_L1_2","B_L2_2"],"ownerId":"USER_ME"}"""
+        ))
+        // 2nd call: GET /api/v1/readlists/RL1/books?library_id=L1&size=1000&page=0
+        server.enqueue(bookPage(
+            """{"id":"B_L1_1","libraryId":"L1","media":{"mediaType":"application/epub+zip"},"metadata":{"title":"L1 book 1","authors":[]}}""",
+            """{"id":"B_L1_2","libraryId":"L1","media":{"mediaType":"application/epub+zip"},"metadata":{"title":"L1 book 2","authors":[]}}""",
+        ))
+
+        val playlist = catalog.findPlaylist(rootId = "L1", name = "To Read")
+
+        assertNotNull(playlist)
+        assertEquals("RL1", playlist!!.id)
+        assertEquals("To Read", playlist.name)
+        assertEquals(listOf("B_L1_1", "B_L1_2"), playlist.itemIds)
+        assertEquals("L1", playlist.rootId)
+
+        server.takeRequest() // /users/me
+        val listReq = server.takeRequest()
+        assertTrue(listReq.path!!.startsWith("/api/v1/readlists?"))
+        val booksReq = server.takeRequest()
+        assertEquals("/api/v1/readlists/RL1/books?library_id=L1&size=1000&page=0", booksReq.path)
+    }
+
+    @Test fun `findPlaylist returns null when named readlist is absent`() = runTest {
+        enqueueMe()
+        server.enqueue(readListPage("""{"id":"RL1","name":"Favourites","bookIds":[],"ownerId":"USER_ME"}"""))
+
+        val playlist = catalog.findPlaylist(rootId = "L1", name = "To Read")
+
+        assertNull(playlist)
+    }
+
+    // Regression: a "To Read" readlist created by another user (or via Komga's web UI while
+    // authenticated as a different user) is visible to us (GET succeeds) but rejects our PATCH
+    // with 403 because Komga scopes readlist modification to owner + admins. Reusing that id
+    // means every add-to-to-read call silently fails. The fix is to skip foreign-owned matches
+    // in findPlaylist so createPlaylist falls through to POSTing a fresh, owned readlist. The
+    // regression this test locks in showed up as `Komga HTTP 403 PATCH /api/v1/readlists/{id}`
+    // in RIFFLE_TOREAD logs against the user's server.
+    @Test fun `findPlaylist skips readlist owned by another user`() = runTest {
+        // 1st call inside firstOwnedReadListNamed: GET /api/v1/users/me
+        server.enqueue(MockResponse().setBody("""{"id":"USER_ME"}"""))
+        // 2nd call: GET /api/v1/readlists — the "To Read" list is owned by someone else.
+        server.enqueue(readListPage(
+            """{"id":"RL_STRANGER","name":"To Read","bookIds":["B1"],"ownerId":"USER_OTHER"}"""
+        ))
+
+        val playlist = catalog.findPlaylist(rootId = "L1", name = "To Read")
+
+        assertNull("must not hand back a readlist that will 403 on the next PATCH", playlist)
+    }
+
+    @Test fun `findPlaylist matches readlist owned by current user`() = runTest {
+        server.enqueue(MockResponse().setBody("""{"id":"USER_ME"}"""))
+        server.enqueue(readListPage(
+            """{"id":"RL_MINE","name":"To Read","bookIds":["B1"],"ownerId":"USER_ME"}"""
+        ))
+        server.enqueue(bookPage(
+            """{"id":"B1","libraryId":"L1","media":{"mediaType":"application/epub+zip"},"metadata":{"title":"One","authors":[]}}"""
+        ))
+
+        val playlist = catalog.findPlaylist(rootId = "L1", name = "To Read")
+
+        assertNotNull(playlist)
+        assertEquals("RL_MINE", playlist!!.id)
+    }
+
+    // Older Komga (< 1.19) omits ownerId — accept those matches so we don't regress users on
+    // older servers who don't have per-user ownership at all.
+    @Test fun `findPlaylist matches readlist with no ownerId (older Komga)`() = runTest {
+        server.enqueue(MockResponse().setBody("""{"id":"USER_ME"}"""))
+        server.enqueue(readListPage(
+            """{"id":"RL_OLD","name":"To Read","bookIds":[]}"""
+        ))
+        server.enqueue(bookPage())
+
+        val playlist = catalog.findPlaylist(rootId = "L1", name = "To Read")
+
+        assertNotNull(playlist)
+        assertEquals("RL_OLD", playlist!!.id)
+    }
+
+    // When the only "To Read" on the server is foreign-owned, createPlaylist must POST a fresh
+    // one owned by the current user rather than returning the foreign id.
+    @Test fun `createPlaylist ignores foreign-owned readlist and POSTs a new one`() = runTest {
+        server.enqueue(MockResponse().setBody("""{"id":"USER_ME"}"""))
+        server.enqueue(readListPage(
+            """{"id":"RL_STRANGER","name":"To Read","bookIds":["B_OLD"],"ownerId":"USER_OTHER"}"""
+        ))
+        server.enqueue(MockResponse().setBody(
+            """{"id":"RL_MINE","name":"To Read","bookIds":["B_NEW"],"ownerId":"USER_ME"}"""
+        ))
+
+        val created = catalog.createPlaylist(rootId = "L1", name = "To Read", initialItemId = "B_NEW")
+
+        assertEquals("RL_MINE", created.id)
+        server.takeRequest() // GET users/me
+        server.takeRequest() // GET readlists
+        val postReq = server.takeRequest()
+        assertEquals("POST", postReq.method)
+        assertTrue(postReq.body.readUtf8().contains("\"bookIds\":[\"B_NEW\"]"))
+    }
+
+    // Regression: createPlaylist must be idempotent by name so two libraries that share the same
+    // Komga server don't each POST a duplicate "To Read" readlist on first-add. Simulate a
+    // pre-existing readlist owned by the current user and verify the code returns it instead of
+    // POSTing.
+    @Test fun `createPlaylist reuses existing readlist by name when we own it`() = runTest {
+        enqueueMe()
+        server.enqueue(readListPage("""{"id":"RL42","name":"To Read","bookIds":[],"ownerId":"USER_ME"}"""))
+
+        val created = catalog.createPlaylist(rootId = "L1", name = "To Read")
+
+        assertEquals("RL42", created.id)
+        assertEquals("To Read", created.name)
+        server.takeRequest() // /users/me
+        val listReq = server.takeRequest()
+        assertTrue(listReq.path!!.startsWith("/api/v1/readlists?"))
+        assertEquals("GET", listReq.method)
+        // No POST — only /users/me + /readlists.
+        assertEquals(2, server.requestCount)
+    }
+
+    // Regression: Komga's POST /api/v1/readlists REQUIRES a non-empty bookIds; creating an empty
+    // readlist returns 400. The interface's `initialItemId` is the seed mechanism callers use to
+    // sidestep that mandatory field. The POST body must include the seeded bookId — an earlier
+    // (broken) version encoded bookIds as [] and every first-time "add to To Read" tap failed
+    // with a 400 that was swallowed by ToReadRepositoryImpl's runCatching, giving the user a
+    // silent no-op. This test locks in the seeded-POST behaviour that fixes it.
+    @Test fun `createPlaylist with initialItemId POSTs seeded readlist when none matches`() = runTest {
+        enqueueMe()
+        server.enqueue(readListPage(/* empty page */))
+        server.enqueue(MockResponse().setBody(
+            """{"id":"RL_NEW","name":"To Read","bookIds":["B_SEED"],"ownerId":"USER_ME"}"""
+        ))
+
+        val created = catalog.createPlaylist(rootId = "L1", name = "To Read", initialItemId = "B_SEED")
+
+        assertEquals("RL_NEW", created.id)
+        assertEquals(listOf("B_SEED"), created.itemIds)
+        server.takeRequest() // /users/me
+        server.takeRequest() // GET readlists
+        val postReq = server.takeRequest()
+        assertEquals("POST", postReq.method)
+        assertEquals("/api/v1/readlists", postReq.path)
+        val body = postReq.body.readUtf8()
+        assertTrue("POST body should contain the name", body.contains("\"name\":\"To Read\""))
+        assertTrue("POST body must seed bookIds with the initial item", body.contains("\"bookIds\":[\"B_SEED\"]"))
+    }
+
+    // When the readlist already exists on the server and the caller supplies an initialItemId
+    // (i.e. concurrent library refreshes → both hit createPlaylist with a seed), append the seed
+    // to the existing bookIds so the caller's expectation ("this playlist now contains my item")
+    // holds. Idempotent when the seed is already present.
+    @Test fun `createPlaylist appends initialItemId to existing owned readlist`() = runTest {
+        enqueueMe()
+        server.enqueue(readListPage(
+            """{"id":"RL_EXISTING","name":"To Read","bookIds":["B_OLD"],"ownerId":"USER_ME"}"""
+        ))
+        server.enqueue(MockResponse().setResponseCode(204))
+
+        val created = catalog.createPlaylist(rootId = "L1", name = "To Read", initialItemId = "B_SEED")
+
+        assertEquals("RL_EXISTING", created.id)
+        server.takeRequest() // /users/me
+        server.takeRequest() // GET readlists
+        val patchReq = server.takeRequest()
+        assertEquals("PATCH", patchReq.method)
+        assertEquals("/api/v1/readlists/RL_EXISTING", patchReq.path)
+        assertEquals("""{"bookIds":["B_OLD","B_SEED"]}""", patchReq.body.readUtf8())
+    }
+
+    // Regression: Komga PATCH replaces bookIds wholesale. If addItemToPlaylist forgot to include
+    // the current bookIds and only PATCHed with the new one, every existing To-Read entry would
+    // vanish on the next add. Assertion: PATCH body contains both the old and new ids in order.
+    @Test fun `addItemToPlaylist PATCHes with appended bookIds preserving order`() = runTest {
+        server.enqueue(MockResponse().setBody(
+            """{"id":"RL1","name":"To Read","bookIds":["B1","B2"]}"""
+        ))
+        server.enqueue(MockResponse().setResponseCode(204))
+
+        catalog.addItemToPlaylist(playlistId = "RL1", itemId = "B3")
+
+        server.takeRequest() // GET readlist
+        val patchReq = server.takeRequest()
+        assertEquals("PATCH", patchReq.method)
+        assertEquals("/api/v1/readlists/RL1", patchReq.path)
+        val body = patchReq.body.readUtf8()
+        assertEquals("""{"bookIds":["B1","B2","B3"]}""", body)
+    }
+
+    @Test fun `addItemToPlaylist is idempotent when book already present`() = runTest {
+        server.enqueue(MockResponse().setBody(
+            """{"id":"RL1","name":"To Read","bookIds":["B1","B2","B3"]}"""
+        ))
+
+        catalog.addItemToPlaylist(playlistId = "RL1", itemId = "B2")
+
+        // Only GET — no PATCH.
+        server.takeRequest()
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test fun `removeItemFromPlaylist PATCHes without removed book`() = runTest {
+        server.enqueue(MockResponse().setBody(
+            """{"id":"RL1","name":"To Read","bookIds":["B1","B2","B3"]}"""
+        ))
+        server.enqueue(MockResponse().setResponseCode(204))
+
+        catalog.removeItemFromPlaylist(playlistId = "RL1", itemId = "B2")
+
+        server.takeRequest() // GET
+        val patchReq = server.takeRequest()
+        assertEquals("PATCH", patchReq.method)
+        assertEquals("""{"bookIds":["B1","B3"]}""", patchReq.body.readUtf8())
+    }
+
+    // Regression: Komga does NOT auto-delete empty readlists (ABS does). If Riffle only PATCHed
+    // to an empty bookIds array, the "To Read" readlist would linger on the server as an empty
+    // shell, and — more painfully — the next add would find it and re-use its id even though the
+    // caller-side snapshot already dropped playlistId. This test locks in the DELETE-on-empty
+    // sweep that mirrors ABS's server-side behaviour.
+    @Test fun `removeItemFromPlaylist DELETEs the readlist when the last book is removed`() = runTest {
+        server.enqueue(MockResponse().setBody(
+            """{"id":"RL1","name":"To Read","bookIds":["B1"]}"""
+        ))
+        server.enqueue(MockResponse().setResponseCode(204))
+
+        catalog.removeItemFromPlaylist(playlistId = "RL1", itemId = "B1")
+
+        server.takeRequest() // GET
+        val delReq = server.takeRequest()
+        assertEquals("DELETE", delReq.method)
+        assertEquals("/api/v1/readlists/RL1", delReq.path)
+    }
+
+    @Test fun `listPlaylists returns summary only with empty itemIds`() = runTest {
+        server.enqueue(readListPage(
+            """{"id":"RL1","name":"To Read","bookIds":["B1","B2"]}""",
+            """{"id":"RL2","name":"Favourites","bookIds":["B3"]}""",
+        ))
+
+        val result = catalog.listPlaylists(rootId = "L1")
+
+        assertEquals(2, result.size)
+        assertEquals("RL1", result[0].id)
+        assertEquals(emptyList<String>(), result[0].itemIds)
+        assertEquals(emptyList<String>(), result[1].itemIds)
+        // No per-readlist book fetches — only the single readlists-list request.
+        server.takeRequest()
+        assertEquals(1, server.requestCount)
+    }
+
+    // Sanity check on the payload sent by Komga's PATCH: must serialize as a plain object with a
+    // single `bookIds` array, not wrapped in another key. Locked in because kotlinx-serialization
+    // defaults would happily emit unexpected structures if the DTO were changed to have extra
+    // optional fields with non-null defaults.
+    @Test fun `patch body shape is exactly bookIds`() = runTest {
+        server.enqueue(MockResponse().setBody(
+            """{"id":"RL1","name":"To Read","bookIds":[]}"""
+        ))
+        server.enqueue(MockResponse().setResponseCode(204))
+
+        catalog.addItemToPlaylist(playlistId = "RL1", itemId = "B1")
+
+        server.takeRequest()
+        val patch = server.takeRequest()
+        assertEquals("""{"bookIds":["B1"]}""", patch.body.readUtf8())
+    }
+
+    private fun readListPage(vararg readListsJson: String): MockResponse {
+        val content = readListsJson.joinToString(",")
+        return MockResponse().setBody(
+            """{"content":[$content],"totalPages":1,"totalElements":${readListsJson.size},"first":true,"last":true,"empty":${readListsJson.isEmpty()}}"""
+        )
+    }
+
+    private fun bookPage(vararg booksJson: String): MockResponse {
+        val content = booksJson.joinToString(",")
+        return MockResponse().setBody(
+            """{"content":[$content],"totalPages":1,"totalElements":${booksJson.size},"first":true,"last":true,"empty":${booksJson.isEmpty()}}"""
+        )
+    }
+
+    @Suppress("unused") // reserved for future assertions on request auth headers
+    private fun RecordedRequest.hasBasicAuth(): Boolean =
+        getHeader("Authorization")?.startsWith("Basic ") == true
+}

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/PlaylistsCapability.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/PlaylistsCapability.kt
@@ -19,12 +19,15 @@ interface PlaylistsCapability : CatalogCapability {
     suspend fun removeItemFromPlaylist(playlistId: String, itemId: String)
 
     /**
-     * Return the playlist named [name] scoped to [rootId], with `itemIds` fully populated.
-     * Sources whose native "server-wide list" model makes [listPlaylists] cheap can inherit the
-     * default (list + filter by name). Sources where enumerating every playlist's items is
-     * expensive (e.g. Komga readlists, which require one extra request per list to filter book
-     * ids by library) should override this to avoid the O(N) blow-up.
+     * Return the playlist named [name] scoped to [rootId], with `itemIds` FULLY populated. This
+     * is deliberately abstract (no default) — an earlier version defaulted to
+     * `listPlaylists(rootId).firstOrNull { it.name == name }`, which is broken for any source
+     * that treats `listPlaylists` as a summary-only projection (e.g. Komga, where enumerating
+     * every readlist's per-library bookIds is an extra HTTP round-trip per list and
+     * [listPlaylists] deliberately returns `itemIds = emptyList()`). A source that copies that
+     * optimisation without overriding [findPlaylist] would ship a broken To-Read sync with a
+     * green build. Making this abstract puts the summary/full distinction in the type system so
+     * the compiler enforces the decision.
      */
-    suspend fun findPlaylist(rootId: String, name: String): CatalogPlaylist? =
-        listPlaylists(rootId).firstOrNull { it.name == name }
+    suspend fun findPlaylist(rootId: String, name: String): CatalogPlaylist?
 }

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/PlaylistsCapability.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/PlaylistsCapability.kt
@@ -2,7 +2,29 @@ package com.riffle.core.catalog
 
 interface PlaylistsCapability : CatalogCapability {
     suspend fun listPlaylists(rootId: String): List<CatalogPlaylist>
-    suspend fun createPlaylist(rootId: String, name: String): CatalogPlaylist
+
+    /**
+     * Create a playlist named [name] scoped to [rootId]. If [initialItemId] is non-null, the
+     * returned playlist already contains that item (single request on sources that support it —
+     * ABS's `POST /playlists` takes an initial bookId, Komga's `POST /readlists` REQUIRES at least
+     * one bookId in the request body, so this parameter is how a caller sidesteps a mandatory
+     * seed on backends that don't allow empty lists).
+     */
+    suspend fun createPlaylist(
+        rootId: String,
+        name: String,
+        initialItemId: String? = null,
+    ): CatalogPlaylist
     suspend fun addItemToPlaylist(playlistId: String, itemId: String)
     suspend fun removeItemFromPlaylist(playlistId: String, itemId: String)
+
+    /**
+     * Return the playlist named [name] scoped to [rootId], with `itemIds` fully populated.
+     * Sources whose native "server-wide list" model makes [listPlaylists] cheap can inherit the
+     * default (list + filter by name). Sources where enumerating every playlist's items is
+     * expensive (e.g. Komga readlists, which require one extra request per list to filter book
+     * ids by library) should override this to avoid the O(N) blow-up.
+     */
+    suspend fun findPlaylist(rootId: String, name: String): CatalogPlaylist? =
+        listPlaylists(rootId).firstOrNull { it.name == name }
 }

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
@@ -264,6 +264,12 @@ class AbsCatalog(
             .unwrap()
             .map { it.toCatalogPlaylist() }
 
+    override suspend fun findPlaylist(rootId: String, name: String): CatalogPlaylist? =
+        // ABS's `listPlaylists` returns fully-populated itemIds, so the trivial "list + filter"
+        // is correct here (unlike Komga where listPlaylists is summary-only). Cheap enough to
+        // not warrant a name-scoped endpoint.
+        listPlaylists(rootId).firstOrNull { it.name == name }
+
     override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?): CatalogPlaylist {
         val created = libraryApi.createPlaylist(config.baseUrl, rootId, name, initialBookId = initialItemId, config.token, config.insecureAllowed)
             .unwrap()

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
@@ -264,8 +264,8 @@ class AbsCatalog(
             .unwrap()
             .map { it.toCatalogPlaylist() }
 
-    override suspend fun createPlaylist(rootId: String, name: String): CatalogPlaylist {
-        val created = libraryApi.createPlaylist(config.baseUrl, rootId, name, initialBookId = null, config.token, config.insecureAllowed)
+    override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?): CatalogPlaylist {
+        val created = libraryApi.createPlaylist(config.baseUrl, rootId, name, initialBookId = initialItemId, config.token, config.insecureAllowed)
             .unwrap()
             ?: throw CatalogException.Unknown(IllegalStateException("ABS returned null for createPlaylist"))
         return created.toCatalogPlaylist()

--- a/core/data/src/main/kotlin/com/riffle/core/data/ToReadRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ToReadRepositoryImpl.kt
@@ -94,9 +94,22 @@ class ToReadRepositoryImpl @Inject constructor(
                 false
             }
         } else {
-            runCatching { cap.addItemToPlaylist(playlistId, libraryItemId); true }.getOrElse {
-                logger.d(LogChannel.ToRead) { "addToToRead($libraryId, $libraryItemId) addItemToPlaylist failed: $it" }
-                false
+            runCatching { cap.addItemToPlaylist(playlistId, libraryItemId); true }.getOrElse { addErr ->
+                // The cached playlistId can go stale — Komga's readlist is server-wide, so a
+                // "remove last item" in a sibling library (or from another device) DELETEs the
+                // readlist while this library's snapshot still points at it. Rather than fail
+                // the tap, fall through to create-with-seed so the tap self-heals into a fresh
+                // readlist. The recovery is bounded to one retry; a genuine network error will
+                // fail again and get logged.
+                logger.d(LogChannel.ToRead) { "addToToRead($libraryId, $libraryItemId) addItemToPlaylist failed, retrying via create: $addErr" }
+                runCatching {
+                    val created = cap.createPlaylist(libraryId, TO_READ_PLAYLIST_NAME, initialItemId = libraryItemId)
+                    cache.value = cache.value + (libraryId to ToReadSnapshot(created.id, before.itemIds + libraryItemId))
+                    true
+                }.getOrElse { createErr ->
+                    logger.d(LogChannel.ToRead) { "addToToRead($libraryId, $libraryItemId) recovery create failed: $createErr" }
+                    false
+                }
             }
         }
         if (!ok) cache.value = cache.value + (libraryId to before)

--- a/core/data/src/main/kotlin/com/riffle/core/data/ToReadRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ToReadRepositoryImpl.kt
@@ -3,6 +3,8 @@ package com.riffle.core.data
 import com.riffle.core.catalog.Catalog
 import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.catalog.PlaylistsCapability
+import com.riffle.core.logging.LogChannel
+import com.riffle.core.logging.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emitAll
@@ -30,6 +32,7 @@ private data class ToReadSnapshot(val playlistId: String?, val itemIds: Set<Stri
 class ToReadRepositoryImpl @Inject constructor(
     private val catalogRegistry: CatalogRegistry,
     private val localStore: LocalToReadStore,
+    private val logger: Logger,
 ) : ToReadRepository {
 
     private val cache = MutableStateFlow<Map<String, ToReadSnapshot>>(emptyMap())
@@ -48,8 +51,11 @@ class ToReadRepositoryImpl @Inject constructor(
         // Local backing has nothing to refresh — the DataStore IS the source of truth. Report
         // success so callers don't spin on false and think the source is offline.
         val cap = activePlaylistsCap() ?: return true
-        val playlists = runCatching { cap.listPlaylists(libraryId) }.getOrElse { return false }
-        val match = playlists.firstOrNull { it.name == TO_READ_PLAYLIST_NAME }
+        val match = runCatching { cap.findPlaylist(libraryId, TO_READ_PLAYLIST_NAME) }
+            .getOrElse {
+                logger.d(LogChannel.ToRead) { "refresh($libraryId) findPlaylist failed: $it" }
+                return false
+            }
         val snapshot = ToReadSnapshot(
             playlistId = match?.id,
             itemIds = match?.itemIds?.toSet() ?: emptySet(),
@@ -76,14 +82,22 @@ class ToReadRepositoryImpl @Inject constructor(
         cache.value = cache.value + (libraryId to before.copy(itemIds = before.itemIds + libraryItemId))
         val playlistId = before.playlistId
         val ok = if (playlistId == null) {
+            // Seed the new playlist with libraryItemId in a single request. Komga's
+            // POST /api/v1/readlists REQUIRES a non-empty bookIds, so we cannot create-empty
+            // and add-later on that backend. ABS accepts it as `initialBookId` in the same POST.
             runCatching {
-                val created = cap.createPlaylist(libraryId, TO_READ_PLAYLIST_NAME)
-                cap.addItemToPlaylist(created.id, libraryItemId)
+                val created = cap.createPlaylist(libraryId, TO_READ_PLAYLIST_NAME, initialItemId = libraryItemId)
                 cache.value = cache.value + (libraryId to ToReadSnapshot(created.id, before.itemIds + libraryItemId))
                 true
-            }.getOrDefault(false)
+            }.getOrElse {
+                logger.d(LogChannel.ToRead) { "addToToRead($libraryId, $libraryItemId) createPlaylist failed: $it" }
+                false
+            }
         } else {
-            runCatching { cap.addItemToPlaylist(playlistId, libraryItemId); true }.getOrDefault(false)
+            runCatching { cap.addItemToPlaylist(playlistId, libraryItemId); true }.getOrElse {
+                logger.d(LogChannel.ToRead) { "addToToRead($libraryId, $libraryItemId) addItemToPlaylist failed: $it" }
+                false
+            }
         }
         if (!ok) cache.value = cache.value + (libraryId to before)
         return ok
@@ -107,7 +121,10 @@ class ToReadRepositoryImpl @Inject constructor(
             before.copy(itemIds = remainingIds)
         }
         cache.value = cache.value + (libraryId to optimistic)
-        val ok = runCatching { cap.removeItemFromPlaylist(playlistId, libraryItemId); true }.getOrDefault(false)
+        val ok = runCatching { cap.removeItemFromPlaylist(playlistId, libraryItemId); true }.getOrElse {
+            logger.d(LogChannel.ToRead) { "removeFromToRead($libraryId, $libraryItemId) failed: $it" }
+            false
+        }
         if (!ok) cache.value = cache.value + (libraryId to before)
         return ok
     }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ToReadRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ToReadRepositoryTest.kt
@@ -117,9 +117,28 @@ class ToReadRepositoryTest {
         assertEquals(emptySet<String>(), repo.observeToReadItemIds("lib-1").first())
     }
 
+    // The cache-hit branch of addToToRead now self-heals a stale playlistId (Komga's server-wide
+    // readlist can be DELETEd by a sibling library's remove-last-item while another library's
+    // snapshot still points at it — see the A5 fix). On addItemToPlaylist failure, the repo
+    // falls back to create-with-seed. So a transient add-fail no longer reverts if the recovery
+    // create succeeds — it only reverts when BOTH paths fail.
     @Test
-    fun `addToToRead reverts cache when add fails`() = runTest {
+    fun `addToToRead falls back to create when addItemToPlaylist fails on a stale playlistId`() = runTest {
         val cap = FakeCatalog(mapOf("lib-1" to listOf(playlist("pl-A", "To Read", emptyList()))), addFails = true)
+        val repo = makeRepo(cap)
+        repo.refresh("lib-1")
+        assertTrue("recovery create should heal the tap", repo.addToToRead("item-1", "lib-1"))
+        assertEquals(listOf("lib-1" to "To Read"), cap.createCalls)
+        assertEquals(setOf("item-1"), repo.observeToReadItemIds("lib-1").first())
+    }
+
+    @Test
+    fun `addToToRead reverts cache when both add and recovery-create fail`() = runTest {
+        val cap = FakeCatalog(
+            mapOf("lib-1" to listOf(playlist("pl-A", "To Read", emptyList()))),
+            addFails = true,
+            createFails = true,
+        )
         val repo = makeRepo(cap)
         repo.refresh("lib-1")
         assertFalse(repo.addToToRead("item-1", "lib-1"))
@@ -208,6 +227,11 @@ class ToReadRepositoryTest {
         override suspend fun listPlaylists(rootId: String): List<CatalogPlaylist> {
             if (listFails) throw RuntimeException("boom")
             return playlistsByLibrary[rootId].orEmpty()
+        }
+
+        override suspend fun findPlaylist(rootId: String, name: String): CatalogPlaylist? {
+            if (listFails) throw RuntimeException("boom")
+            return playlistsByLibrary[rootId].orEmpty().firstOrNull { it.name == name }
         }
 
         override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?): CatalogPlaylist {

--- a/core/data/src/test/kotlin/com/riffle/core/data/ToReadRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ToReadRepositoryTest.kt
@@ -15,6 +15,7 @@ import com.riffle.core.catalog.SortKey
 import com.riffle.core.catalog.FacetSelection
 import com.riffle.core.domain.Source
 import com.riffle.core.domain.SourceType
+import com.riffle.core.logging.RecordingLogger
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.runTest
@@ -25,7 +26,8 @@ import org.junit.Test
 
 class ToReadRepositoryTest {
 
-    private fun makeRepo(catalog: Catalog?) = ToReadRepositoryImpl(FakeRegistry(catalog), FakeLocalToReadStore())
+    private fun makeRepo(catalog: Catalog?) =
+        ToReadRepositoryImpl(FakeRegistry(catalog), FakeLocalToReadStore(), RecordingLogger())
 
     // ── refresh + observeToReadItemIds ────────────────────────────────────────
 
@@ -80,13 +82,17 @@ class ToReadRepositoryTest {
     }
 
     @Test
-    fun `addToToRead creates playlist when cache is empty + no playlist on source`() = runTest {
+    fun `addToToRead creates playlist seeded with the item when cache is empty + no playlist on source`() = runTest {
         val cap = FakeCatalog(mapOf("lib-1" to emptyList()))
         val repo = makeRepo(cap)
         repo.refresh("lib-1")
         assertTrue(repo.addToToRead("item-1", "lib-1"))
         assertEquals(listOf("lib-1" to "To Read"), cap.createCalls)
-        assertEquals(listOf("pl-new" to "item-1"), cap.addCalls)
+        // Item is passed as initialItemId in the same request — no separate addItemToPlaylist
+        // call. This is what makes the flow work on Komga (whose POST /readlists requires a
+        // non-empty bookIds array); a revert to the two-step flow would fail on Komga backends.
+        assertEquals(listOf("item-1"), cap.createSeeds)
+        assertEquals(emptyList<Pair<String, String>>(), cap.addCalls)
         assertEquals(setOf("item-1"), repo.observeToReadItemIds("lib-1").first())
     }
 
@@ -186,6 +192,7 @@ class ToReadRepositoryTest {
         val removeFails: Boolean = false,
     ) : Catalog, PlaylistsCapability {
         val createCalls = mutableListOf<Pair<String, String>>()
+        val createSeeds = mutableListOf<String?>()
         val addCalls = mutableListOf<Pair<String, String>>()
         val removeCalls = mutableListOf<Pair<String, String>>()
 
@@ -203,10 +210,17 @@ class ToReadRepositoryTest {
             return playlistsByLibrary[rootId].orEmpty()
         }
 
-        override suspend fun createPlaylist(rootId: String, name: String): CatalogPlaylist {
+        override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?): CatalogPlaylist {
             if (createFails) throw RuntimeException("boom")
             createCalls += rootId to name
-            return CatalogPlaylist(id = "pl-new", rootId = rootId, name = name, bookCount = 0)
+            createSeeds += initialItemId
+            return CatalogPlaylist(
+                id = "pl-new",
+                rootId = rootId,
+                name = name,
+                bookCount = if (initialItemId != null) 1 else 0,
+                itemIds = if (initialItemId != null) listOf(initialItemId) else emptyList(),
+            )
         }
 
         override suspend fun addItemToPlaylist(playlistId: String, itemId: String) {

--- a/core/data/src/test/kotlin/com/riffle/core/data/di/ToReadSupportDeclarationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/di/ToReadSupportDeclarationTest.kt
@@ -1,0 +1,107 @@
+package com.riffle.core.data.di
+
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.PlaylistsCapability
+import com.riffle.core.catalog.ToReadListCapability
+import com.riffle.core.catalog.abs.AbsCatalog
+import com.riffle.core.catalog.chitanka.ChitankaCatalog
+import com.riffle.core.catalog.gutenberg.GutenbergCatalog
+import com.riffle.core.catalog.komga.KomgaCatalog
+import com.riffle.core.data.localfiles.LocalFilesCatalog
+import com.riffle.core.domain.SourceType
+import com.riffle.core.domain.ToReadSupport
+import com.riffle.core.domain.WebSourceDescriptors
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.reflect.KClass
+
+/**
+ * Guarantees the invariant "the descriptor's declared To Read support MATCHES the Catalog's
+ * actual capability set". Without this test, a source can declare [ToReadListCapability] (which
+ * makes the tab visible) without implementing [PlaylistsCapability] — exactly what shipped for
+ * Komga before this test existed: the To Read tab rendered, the toggle appeared to work, but
+ * every add silently fell through to [com.riffle.core.data.LocalToReadStore] because
+ * [com.riffle.core.data.ToReadRepositoryImpl.activePlaylistsCap] came back null. Users thought
+ * their list was syncing to the server; it wasn't.
+ *
+ * The invariant is checked by cross-referencing:
+ *   * [WebSourceDescriptor.toReadSupport] — the explicit declaration in `:core:domain`
+ *   * The Catalog class's supertype set — the actual runtime behaviour
+ *
+ * A new [SourceType] appears in the [CATALOG_CLASS_BY_TYPE] manifest below (compile error if
+ * missing), and every descriptor's declaration is checked against its Catalog's `implements`
+ * list. Mismatch => test failure => the merge is blocked until either the declaration or the
+ * Catalog is fixed.
+ */
+class ToReadSupportDeclarationTest {
+
+    // Manifest of the Catalog class backing each SourceType. Kept next to the assertions so a
+    // new source is visible in one place; the corresponding descriptor comes from the
+    // WebSourceDescriptors registry.
+    private val catalogClassByType: Map<SourceType, KClass<out Catalog>> = mapOf(
+        SourceType.ABS to AbsCatalog::class,
+        SourceType.LOCAL_FILES to LocalFilesCatalog::class,
+        SourceType.CHITANKA to ChitankaCatalog::class,
+        SourceType.GUTENBERG to GutenbergCatalog::class,
+        SourceType.KOMGA to KomgaCatalog::class,
+    )
+
+    @Test
+    fun `every SourceType has a Catalog class in the manifest`() {
+        val missing = SourceType.values().filter { it !in catalogClassByType }
+        assertTrue(
+            "SourceType(s) missing from CATALOG_CLASS_BY_TYPE in ToReadSupportDeclarationTest: " +
+                "$missing — add the entry so the To Read declaration is auto-checked.",
+            missing.isEmpty(),
+        )
+    }
+
+    @Test
+    fun `descriptor toReadSupport = ServerBacked iff Catalog implements PlaylistsCapability`() {
+        val mismatches = mutableListOf<String>()
+        catalogClassByType.forEach { (type, catalogClass) ->
+            val declared = WebSourceDescriptors.forTypeOrError(type).toReadSupport
+            val implementsPlaylists = PlaylistsCapability::class.java.isAssignableFrom(catalogClass.java)
+            when (declared) {
+                ToReadSupport.ServerBacked -> if (!implementsPlaylists) mismatches +=
+                    "$type: descriptor says ServerBacked but ${catalogClass.simpleName} does NOT implement PlaylistsCapability " +
+                        "→ every add will silently fall through to LocalToReadStore (the Komga bug)."
+                ToReadSupport.LocalOnly,
+                ToReadSupport.Unsupported -> if (implementsPlaylists) mismatches +=
+                    "$type: descriptor says $declared but ${catalogClass.simpleName} implements PlaylistsCapability " +
+                        "→ writes will hit the server the descriptor claims we don't sync to."
+            }
+        }
+        assertEquals(
+            "descriptor.toReadSupport ↔ Catalog capability mismatches:\n" + mismatches.joinToString("\n"),
+            0, mismatches.size,
+        )
+    }
+
+    @Test
+    fun `descriptor toReadSupport != Unsupported iff Catalog implements ToReadListCapability`() {
+        // ToReadListCapability is the UI marker that makes the tab visible. It must be present
+        // when the descriptor claims either ServerBacked or LocalOnly support, and absent when
+        // the descriptor claims Unsupported. This locks the UI-visibility decision to the
+        // descriptor so a source can't silently show a broken tab.
+        val mismatches = mutableListOf<String>()
+        catalogClassByType.forEach { (type, catalogClass) ->
+            val declared = WebSourceDescriptors.forTypeOrError(type).toReadSupport
+            val implementsMarker = ToReadListCapability::class.java.isAssignableFrom(catalogClass.java)
+            when (declared) {
+                ToReadSupport.ServerBacked,
+                ToReadSupport.LocalOnly -> if (!implementsMarker) mismatches +=
+                    "$type: descriptor says $declared but ${catalogClass.simpleName} does NOT implement " +
+                        "ToReadListCapability → the To Read tab will be hidden despite the descriptor promising support."
+                ToReadSupport.Unsupported -> if (implementsMarker) mismatches +=
+                    "$type: descriptor says Unsupported but ${catalogClass.simpleName} implements " +
+                        "ToReadListCapability → the tab renders even though the descriptor claims we don't support it."
+            }
+        }
+        assertEquals(
+            "descriptor.toReadSupport ↔ ToReadListCapability marker mismatches:\n" + mismatches.joinToString("\n"),
+            0, mismatches.size,
+        )
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/di/ToReadSupportDeclarationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/di/ToReadSupportDeclarationTest.kt
@@ -58,14 +58,14 @@ class ToReadSupportDeclarationTest {
     }
 
     @Test
-    fun `descriptor toReadSupport = ServerBacked iff Catalog implements PlaylistsCapability`() {
+    fun `descriptor toReadSupport = Synced iff Catalog implements PlaylistsCapability`() {
         val mismatches = mutableListOf<String>()
         catalogClassByType.forEach { (type, catalogClass) ->
             val declared = WebSourceDescriptors.forTypeOrError(type).toReadSupport
             val implementsPlaylists = PlaylistsCapability::class.java.isAssignableFrom(catalogClass.java)
             when (declared) {
-                ToReadSupport.ServerBacked -> if (!implementsPlaylists) mismatches +=
-                    "$type: descriptor says ServerBacked but ${catalogClass.simpleName} does NOT implement PlaylistsCapability " +
+                ToReadSupport.Synced -> if (!implementsPlaylists) mismatches +=
+                    "$type: descriptor says Synced but ${catalogClass.simpleName} does NOT implement PlaylistsCapability " +
                         "→ every add will silently fall through to LocalToReadStore (the Komga bug)."
                 ToReadSupport.LocalOnly,
                 ToReadSupport.Unsupported -> if (implementsPlaylists) mismatches +=
@@ -82,7 +82,7 @@ class ToReadSupportDeclarationTest {
     @Test
     fun `descriptor toReadSupport != Unsupported iff Catalog implements ToReadListCapability`() {
         // ToReadListCapability is the UI marker that makes the tab visible. It must be present
-        // when the descriptor claims either ServerBacked or LocalOnly support, and absent when
+        // when the descriptor claims either Synced or LocalOnly support, and absent when
         // the descriptor claims Unsupported. This locks the UI-visibility decision to the
         // descriptor so a source can't silently show a broken tab.
         val mismatches = mutableListOf<String>()
@@ -90,7 +90,7 @@ class ToReadSupportDeclarationTest {
             val declared = WebSourceDescriptors.forTypeOrError(type).toReadSupport
             val implementsMarker = ToReadListCapability::class.java.isAssignableFrom(catalogClass.java)
             when (declared) {
-                ToReadSupport.ServerBacked,
+                ToReadSupport.Synced,
                 ToReadSupport.LocalOnly -> if (!implementsMarker) mismatches +=
                     "$type: descriptor says $declared but ${catalogClass.simpleName} does NOT implement " +
                         "ToReadListCapability → the To Read tab will be hidden despite the descriptor promising support."

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/WebSourceDescriptor.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/WebSourceDescriptor.kt
@@ -31,7 +31,7 @@ enum class ToReadSupport {
      * server-side list named `"To Read"` (ABS Playlist, Komga readlist, etc.) and every add/
      * remove hits the server. Cross-device sync happens for free.
      */
-    ServerBacked,
+    Synced,
 
     /**
      * The source has no server-side list concept — Riffle stores To Read in a per-device
@@ -58,7 +58,7 @@ interface WebSourceDescriptor {
 
     /**
      * Explicit declaration of this source's To Read behaviour. No default: every new descriptor
-     * MUST pick one of [ToReadSupport.ServerBacked], [ToReadSupport.LocalOnly], or
+     * MUST pick one of [ToReadSupport.Synced], [ToReadSupport.LocalOnly], or
      * [ToReadSupport.Unsupported] — a compile error otherwise. A runtime completeness test in
      * `:core:data` asserts the declaration matches the Catalog's actual capability set so the
      * two can't drift silently.
@@ -237,7 +237,7 @@ class WebSourceRegistry(private val descriptors: Set<WebSourceDescriptor>) {
 object AbsWebSourceDescriptor : WebSourceDescriptor {
     override val type = SourceType.ABS
     override val displayName = "Audiobookshelf"
-    override val toReadSupport = ToReadSupport.ServerBacked
+    override val toReadSupport = ToReadSupport.Synced
     override val isSingleton = false
     override val hasCredentials = true
     override val hasNetworkHost = true
@@ -322,7 +322,7 @@ object ChitankaWebSourceDescriptor : WebSourceDescriptor {
 object KomgaWebSourceDescriptor : WebSourceDescriptor {
     override val type = SourceType.KOMGA
     override val displayName = "Komga"
-    override val toReadSupport = ToReadSupport.ServerBacked
+    override val toReadSupport = ToReadSupport.Synced
     override val isSingleton = false
     override val hasCredentials = true
     override val hasNetworkHost = true

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/WebSourceDescriptor.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/WebSourceDescriptor.kt
@@ -19,11 +19,51 @@ package com.riffle.core.domain
  *
  * Behavioural specialisation belongs in the plugin's own module, not here.
  */
+/**
+ * How a [SourceType] surfaces the "To Read" list. Set explicitly on every [WebSourceDescriptor]
+ * with **no default**: adding a new source is a compile error until the author decides which
+ * bucket applies, so we never silently ship a source that hides the tab or writes only to the
+ * device-local shadow when it should be talking to the server.
+ */
+enum class ToReadSupport {
+    /**
+     * The source's Catalog implements `PlaylistsCapability`. Riffle finds-or-creates a
+     * server-side list named `"To Read"` (ABS Playlist, Komga readlist, etc.) and every add/
+     * remove hits the server. Cross-device sync happens for free.
+     */
+    ServerBacked,
+
+    /**
+     * The source has no server-side list concept — Riffle stores To Read in a per-device
+     * DataStore ([com.riffle.core.data.LocalToReadStore]). The tab still renders, but nothing
+     * syncs across devices. Correct for offline / catalog-only sources (Local Files, Chitanka,
+     * Gutenberg) where there's no user account or per-user server state to write to.
+     */
+    LocalOnly,
+
+    /**
+     * The source explicitly does not surface a To Read tab at all. Rarely correct — pick this
+     * only when the source's model makes a wishlist meaningless. There are no such sources in
+     * Riffle today; the enum entry exists so future sources can opt out explicitly rather than
+     * by omission.
+     */
+    Unsupported,
+}
+
 interface WebSourceDescriptor {
     val type: SourceType
 
     /** Human-visible name — drawer header, source-picker card, settings row. */
     val displayName: String
+
+    /**
+     * Explicit declaration of this source's To Read behaviour. No default: every new descriptor
+     * MUST pick one of [ToReadSupport.ServerBacked], [ToReadSupport.LocalOnly], or
+     * [ToReadSupport.Unsupported] — a compile error otherwise. A runtime completeness test in
+     * `:core:data` asserts the declaration matches the Catalog's actual capability set so the
+     * two can't drift silently.
+     */
+    val toReadSupport: ToReadSupport
 
     /** Optional static subtitle. `null` when the subtitle depends on runtime data (host, version). */
     val subtitle: String? get() = null
@@ -197,6 +237,7 @@ class WebSourceRegistry(private val descriptors: Set<WebSourceDescriptor>) {
 object AbsWebSourceDescriptor : WebSourceDescriptor {
     override val type = SourceType.ABS
     override val displayName = "Audiobookshelf"
+    override val toReadSupport = ToReadSupport.ServerBacked
     override val isSingleton = false
     override val hasCredentials = true
     override val hasNetworkHost = true
@@ -251,6 +292,7 @@ object AbsWebSourceDescriptor : WebSourceDescriptor {
 object LocalFilesWebSourceDescriptor : WebSourceDescriptor {
     override val type = SourceType.LOCAL_FILES
     override val displayName = "Local files"
+    override val toReadSupport = ToReadSupport.LocalOnly
     override val subtitle = "on this device"
     override val addRoute = "add_local_files"
     override val pickerOrder = 1
@@ -260,6 +302,7 @@ object LocalFilesWebSourceDescriptor : WebSourceDescriptor {
 object ChitankaWebSourceDescriptor : WebSourceDescriptor {
     override val type = SourceType.CHITANKA
     override val displayName = "Chitanka"
+    override val toReadSupport = ToReadSupport.LocalOnly
     override val subtitle = "Bulgarian public library"
     override val supportingHosts = "chitanka.info · gramofonche.chitanka.info"
     override val addRoute = "add_chitanka"
@@ -279,6 +322,7 @@ object ChitankaWebSourceDescriptor : WebSourceDescriptor {
 object KomgaWebSourceDescriptor : WebSourceDescriptor {
     override val type = SourceType.KOMGA
     override val displayName = "Komga"
+    override val toReadSupport = ToReadSupport.ServerBacked
     override val isSingleton = false
     override val hasCredentials = true
     override val hasNetworkHost = true
@@ -302,6 +346,7 @@ object KomgaWebSourceDescriptor : WebSourceDescriptor {
 object GutenbergWebSourceDescriptor : WebSourceDescriptor {
     override val type = SourceType.GUTENBERG
     override val displayName = "Project Gutenberg"
+    override val toReadSupport = ToReadSupport.LocalOnly
     override val subtitle = "Public-domain ebooks"
     override val supportingHosts = "gutenberg.org · gutendex.com"
     override val addRoute = "add_gutenberg"

--- a/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
+++ b/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
@@ -20,4 +20,5 @@ enum class LogChannel(val tag: String) {
     Chitanka("RIFFLE_CHI"),
     WebSourceCache("RIFFLE_WSC"),
     Gutenberg("RIFFLE_GB"),
+    ToRead("RIFFLE_TOREAD"),
 }


### PR DESCRIPTION
## Summary

Wires Komga's `PlaylistsCapability` against `/api/v1/readlists` so the "To Read" tab syncs to a server-side readlist named `"To Read"`, matching the ABS shape. Komga readlists are server-wide (not per-library), so per-library views are produced client-side by filtering the readlist's book ids through `/readlists/{id}/books?library_id=…`.

Generalises the mechanism so future server sources plug in the same way, with an explicit compile-time declaration of To-Read support on every `WebSourceDescriptor` and a runtime completeness test that cross-references the descriptor against the Catalog's actual capability set — so the previous class of bug (declaring the UI marker without the sync capability, silently falling through to the local DataStore) is impossible to merge.

## What changed

- **`PlaylistsCapability.createPlaylist(rootId, name, initialItemId = null)`** — Komga's `POST /api/v1/readlists` REQUIRES a non-empty `bookIds`, so the create-then-add flow that works on ABS 400'd on Komga. The seed parameter collapses create+add into a single request on both backends. ABS threads it through its existing `initialBookId` field.
- **`PlaylistsCapability.findPlaylist(rootId, name)`** — new abstract method (no default). Any source that needs a fast path for name lookup (Komga: `listPlaylists` is deliberately summary-only, so a naïve default filter would return empty `itemIds` and break the sync) overrides it; ABS's override is the trivial `listPlaylists + filter`.
- **Ownership scoping (Komga)** — readlists modified via the Komga web UI (or by a different user) return 200 on GET but 403 on PATCH because Komga scopes readlist modification to owner + admins. Riffle now caches the current user id from `/api/v1/users/me` and only reuses readlists it owns (or unowned, on older Komga < 1.19). Foreign-owned "To Read" is invisible to Riffle; the first tap POSTs a fresh owned readlist. Komga allows duplicate readlist names so the two coexist.
- **Explicit `ToReadSupport` declaration** — new enum `{ Synced, LocalOnly, Unsupported }` on `WebSourceDescriptor` with NO default. Every existing descriptor is stamped (ABS + Komga = `Synced`; LocalFiles + Chitanka + Gutenberg = `LocalOnly`). `ToReadSupportDeclarationTest` cross-references each declaration against the Catalog's actual capability set via reflection — if a descriptor claims `Synced` but the Catalog doesn't implement `PlaylistsCapability`, the test fails and blocks the merge.
- **Diagnostics** — new `LogChannel.ToRead` ("RIFFLE_TOREAD"). Every `runCatching` in `ToReadRepositoryImpl` now logs the exception. `KomgaHttpException` now carries the HTTP method + response body (truncated to 500 chars). The exact ownership 403 that surfaced during dogfooding was invisible before — that's how it survived.

## Review fixes applied

Ran a self-review (medium effort, 8 finder angles, verify pass) and folded seven fixes into a second commit:

1. `ServerBacked` renamed to `Synced` — the previous name tripped `checkNoServerReferences` (`\bServer[A-Z]` regex).
2. `addItem/removeItemFromPlaylist` now refuse to PATCH when the fetched readlist has `filtered=true` (Komga hid books the caller can't see; PATCHing back the partial `bookIds` would silently delete them server-side).
3. `currentUserId()` no longer swallows `/users/me` failures — a null return collapsed the ownership predicate for every readlist on modern Komga, causing duplicate POSTs.
4. `addToToRead` self-heals a stale playlistId via retry-with-create (Komga's server-wide readlist can be DELETEd by a sibling library's remove while another library's snapshot still points at it).
5. `createPlaylist` reuse-branch now returns the true post-PATCH `itemIds` (previously returned `emptyList()`, violating the interface's docstring).
6. `findPlaylist` is now abstract in `PlaylistsCapability` — the previous default delegated to `listPlaylists`, which is footgun-prone for any source that treats `listPlaylists` as summary-only.
7. `RIFFLE_TOREAD` log channel — every failure path now surfaces its exception.

Deferred to a follow-up cleanup PR: page-sweep loop duplication in `KomgaCatalog` (`sweepAllBooks`, `fetchAllReadLists`, `fetchReadListBookIdsInLibrary` share the same shape). Refactor-only, no runtime cost.

## Test plan

- [x] `:core:catalog-komga:test` — new `KomgaPlaylistsCapabilityTest` (18 tests: per-library filtering, ownership skip/match/legacy Komga, seeded POST, PATCH-preserves-order, DELETE-on-empty, filtered-readlist refusal, `/users/me` failure surfaces, reuse-branch return contract, PATCH body shape)
- [x] `:core:catalog:test` — ABS unchanged
- [x] `:core:data:test` — updated `ToReadRepositoryTest` (seed-through, self-heal retry, revert-when-both-fail); new `ToReadSupportDeclarationTest` (descriptor↔catalog capability cross-check)
- [x] `:app:testDebugUnitTest` — `LibraryItemDetailViewModelTest`, `LibraryItemsViewModelTest`, `LibraryTabVisibilityTest` (fake catalogs updated for the interface change)
- [x] `checkRiffleLogTags` — new `LogChannel.ToRead` enum entry; no `Log.d("RIFFLE_TOREAD", ...)` literals introduced
- [ ] Manually verified on device: install APK, add + remove books in the To Read tab against a Komga instance where a "To Read" readlist was created via the web UI by a different user (the exact repro that surfaced the ownership bug).