### PR TITLE
feat(sync): annotation sync out of the box for every server source

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Riffle lets you browse your library, read EPUB, PDF, and CBZ files, listen to au
 - Attach notes to highlights for personal commentary
 - Bookmark pages for quick return
 - Search across all highlights, notes, and bookmarks in your library
-- Optional WebDAV keeps highlights, notes, and bookmarks in sync across devices — Audiobookshelf has no native annotation API, so Riffle uses a user-supplied WebDAV target instead.
+- Optional WebDAV keeps highlights, notes, and bookmarks in sync across devices — works out of the box for every server-backed source (Audiobookshelf, Komga, …); each account gets its own namespace on the same share.
 
 ### Listening
 - Full audiobook player for any Audiobookshelf audiobook, streamed directly from your server — including audiobook-only items with no paired ebook

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1023,7 +1023,8 @@ class EpubReaderViewModel @Inject constructor(
             // scheduleDebounce; a blank namespace with a resolvable WebDAV target would otherwise
             // build a malformed remote path instead of cleanly no-op'ing (only a null target is a
             // documented no-op — see AnnotationSyncController.syncOnOpen/scheduleDebounce).
-            val namespace = sourceRepository.ensureAbsUserId(sourceId)
+            val namespace = (sourceRepository.ensureSyncNamespace(sourceId)
+                as? com.riffle.core.domain.SyncNamespace.Configured)?.value
             annotationNamespace = namespace
             annotationSession.bind(
                 sourceId = sourceId,
@@ -1141,9 +1142,11 @@ class EpubReaderViewModel @Inject constructor(
                     .distinctUntilChanged()
                     .collect { bookmarks.onOrientationChanged(it) }
             }
-            // Resolve the ABS-side stable account id (`/api/me` → user.id) as the WebDAV path
-            // namespace. A null result means sync is skipped this session; DB stays canonical.
-            val namespace = sourceRepository.ensureAbsUserId(activeServer.id)
+            // Resolve the source's cross-device annotation-sync namespace (#529). Null when
+            // the source is LocalOnly (Storyteller peer, anonymous catalog, local files) or its
+            // remote id hasn't been fetched yet — sync is skipped this session; DB stays canonical.
+            val namespace = (sourceRepository.ensureSyncNamespace(activeServer.id)
+                as? com.riffle.core.domain.SyncNamespace.Configured)?.value
             annotationNamespace = namespace
             annotationSession.bind(
                 sourceId = activeServer.id,

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModel.kt
@@ -8,6 +8,7 @@ import com.riffle.core.domain.DeviceIdStore
 import com.riffle.core.domain.DeviceLabelResolver
 import com.riffle.core.domain.DeviceLabelStore
 import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.SyncNamespace
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -318,11 +319,19 @@ class AnnotationSyncMaintenanceViewModel @Inject constructor(
             .format(java.time.Instant.ofEpochMilli(atMs))
 
     private suspend fun resolveNamespace(): String? {
-        // Active server first (most relevant to the user), then any configured ABS server with a
-        // known absUserId — Maintenance shows files from whichever account currently owns them.
-        sourceRepository.getActive()?.absUserId?.takeIf { it.isNotBlank() }?.let { return it }
+        // Active server first (most relevant to the user), then any configured source that
+        // resolves to a Configured sync namespace — Maintenance shows files from whichever
+        // account currently owns them. Any descriptor returning LocalOnly (Storyteller peer,
+        // anonymous catalogs, local files) is skipped so its sources never crowd out a real
+        // sync-eligible source further down the list.
+        sourceRepository.getActive()?.let { active ->
+            (sourceRepository.ensureSyncNamespace(active.id) as? SyncNamespace.Configured)
+                ?.value?.let { return it }
+        }
         val all = sourceRepository.observeAll().first()
-        return all.firstNotNullOfOrNull { it.absUserId?.takeIf { id -> id.isNotBlank() } }
+        return all.firstNotNullOfOrNull { source ->
+            (sourceRepository.ensureSyncNamespace(source.id) as? SyncNamespace.Configured)?.value
+        }
     }
 
     private suspend fun currentDeviceLabel(): String =

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModel.kt
@@ -7,8 +7,10 @@ import com.riffle.core.data.AnnotationSyncStatusStore
 import com.riffle.core.domain.DeviceIdStore
 import com.riffle.core.domain.DeviceLabelResolver
 import com.riffle.core.domain.DeviceLabelStore
+import com.riffle.core.domain.Source
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.SyncNamespace
+import com.riffle.core.domain.WebSourceDescriptors
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -319,19 +321,22 @@ class AnnotationSyncMaintenanceViewModel @Inject constructor(
             .format(java.time.Instant.ofEpochMilli(atMs))
 
     private suspend fun resolveNamespace(): String? {
-        // Active server first (most relevant to the user), then any configured source that
-        // resolves to a Configured sync namespace — Maintenance shows files from whichever
-        // account currently owns them. Any descriptor returning LocalOnly (Storyteller peer,
-        // anonymous catalogs, local files) is skipped so its sources never crowd out a real
-        // sync-eligible source further down the list.
+        // Active server first, then any configured source whose descriptor already resolves to
+        // a Configured namespace from the persisted `absUserId`. Deliberately does NOT go
+        // through `ensureSyncNamespace` — that would trigger a per-source network probe for
+        // any legacy row whose id hasn't been backfilled, and Maintenance is opened often
+        // enough (and offline often enough) that N sequential connect-timeouts on screen open
+        // would be a real user-visible hitch. Backfill is the reader's and the sweep's job;
+        // Maintenance just shows what's already known.
+        fun namespaceFor(source: Source): String? {
+            val descriptor = WebSourceDescriptors.forType(source.type) ?: return null
+            return (descriptor.syncNamespaceFor(source) as? SyncNamespace.Configured)?.value
+        }
         sourceRepository.getActive()?.let { active ->
-            (sourceRepository.ensureSyncNamespace(active.id) as? SyncNamespace.Configured)
-                ?.value?.let { return it }
+            namespaceFor(active)?.let { return it }
         }
         val all = sourceRepository.observeAll().first()
-        return all.firstNotNullOfOrNull { source ->
-            (sourceRepository.ensureSyncNamespace(source.id) as? SyncNamespace.Configured)?.value
-        }
+        return all.firstNotNullOfOrNull { namespaceFor(it) }
     }
 
     private suspend fun currentDeviceLabel(): String =

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -100,7 +100,8 @@ class ReaderSessionLifecycleTest {
         override suspend fun setActive(sourceId: String) {}
         override suspend fun remove(sourceId: String) {}
         override suspend fun getSourceVersion(sourceId: String): String? = null
-        override suspend fun ensureAbsUserId(sourceId: String): String? = "abs-user"
+        override suspend fun ensureSyncNamespace(sourceId: String): com.riffle.core.domain.SyncNamespace =
+            com.riffle.core.domain.SyncNamespace.Configured("abs-user")
     }
 
     private class FakeReadaloudLinkRepository(

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModelTest.kt
@@ -312,7 +312,8 @@ class AnnotationSyncMaintenanceViewModelTest {
             absUserId = activeAbsUserId,
         )
         override suspend fun getById(sourceId: String): Source? = getActive()
-        override suspend fun ensureAbsUserId(sourceId: String): String = activeAbsUserId
+        override suspend fun ensureSyncNamespace(sourceId: String): com.riffle.core.domain.SyncNamespace =
+            com.riffle.core.domain.SyncNamespace.Configured(activeAbsUserId)
         override suspend fun commit(pending: PendingSource, hiddenLibraryIds: Set<String>): CommitSourceResult = error("not used")
         override suspend fun setActive(sourceId: String) {}
         override suspend fun remove(sourceId: String) {}

--- a/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaMeProbe.kt
+++ b/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaMeProbe.kt
@@ -1,0 +1,58 @@
+package com.riffle.core.catalog.komga
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Result of a `GET /api/v{2,1}/users/me` probe against a Komga server.
+ *
+ * @property status HTTP status of the last request Komga answered; ordinary auth logic treats
+ *   `200..399` as authenticated. Callers that need to distinguish `401 vs. transport error`
+ *   should catch [java.io.IOException] around [probeKomgaUserId] separately — this shape only
+ *   carries statuses the server actually returned.
+ * @property userId the parsed `id` field from a 2xx body, or `null` when the status is non-2xx
+ *   OR the body was 2xx but did not decode as `{id: String}` (mis-versioned or reverse-proxied
+ *   Komga). Callers that persisted a null id should retry on the next opportunity.
+ */
+data class KomgaMeProbeResult(val status: Int, val userId: String?)
+
+/**
+ * Shared `/users/me` probe used by both the add-source authenticator and the annotation-sync
+ * remote-user-id resolver (#529). Fixes the drift between the two prior implementations:
+ *  - Falls back to `/api/v1/users/me` ONLY on 404 (older Komga builds without the v2 endpoint).
+ *    A 401 stays a 401 — no doubling of failed requests on stale credentials.
+ *  - Propagates [kotlinx.coroutines.CancellationException] so cancelling the enclosing scope
+ *    actually cancels the coroutine (previously masked by a broad `catch (_: Throwable)`).
+ *  - Treats a 2xx-with-unparsable body as `userId = null` so auth still succeeds against
+ *    misconfigured proxies — the resolver will re-probe on the next reader open.
+ *
+ * IOException/SSLHandshakeException are surfaced to the caller so they can decide whether it
+ * means "network error, try again" or "wrong credentials, tell the user".
+ */
+suspend fun probeKomgaUserId(http: KomgaHttpClient, baseUrl: String): KomgaMeProbeResult {
+    val base = baseUrl.trimEnd('/')
+    val v2 = fetchMe(http, "$base/api/v2/users/me")
+    return if (v2.status == 404) fetchMe(http, "$base/api/v1/users/me") else v2
+}
+
+private suspend fun fetchMe(http: KomgaHttpClient, url: String): KomgaMeProbeResult {
+    // `getString` throws KomgaHttpException on non-2xx (carrying the status code) and IOException
+    // on transport failure. We catch the former to surface the status, but let the latter (and
+    // CancellationException) propagate up — the caller distinguishes auth failure from network
+    // failure and must be able to observe cancellation.
+    return try {
+        val body = http.getString(url)
+        val id = runCatching {
+            probeJson.decodeFromString(KomgaMeDto.serializer(), body).id.takeIf { it.isNotBlank() }
+        }.getOrNull()
+        KomgaMeProbeResult(status = 200, userId = id)
+    } catch (e: KomgaHttpException) {
+        KomgaMeProbeResult(status = e.code, userId = null)
+    }
+}
+
+private val probeJson = Json { ignoreUnknownKeys = true }
+
+@Serializable
+private data class KomgaMeDto(@SerialName("id") val id: String)

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSweep.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSweep.kt
@@ -6,6 +6,7 @@ import com.riffle.core.domain.DeviceIdStore
 import com.riffle.core.domain.DeviceLabelResolver
 import com.riffle.core.domain.AnnotationFileHeader
 import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.SyncNamespace
 import java.time.Instant
 
 /**
@@ -76,7 +77,8 @@ class AnnotationSweep(
         val outcome: CycleOutcome = try {
             val deviceId = deviceIdStore.getOrCreate()
             for ((sourceId, itemId) in dirtyLedger.dirtySourceItems()) {
-                val namespace = sourceRepository.ensureAbsUserId(sourceId) ?: continue
+                val namespace = (sourceRepository.ensureSyncNamespace(sourceId)
+                    as? SyncNamespace.Configured)?.value ?: continue
                 val bookTitle = bookTitleProvider(sourceId, itemId)
                 // Hold the per-book lock across the read-then-write so the live
                 // [AnnotationSyncController] cannot interleave on the same device file

--- a/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
@@ -111,6 +111,10 @@ class SourceRepositoryImpl @Inject constructor(
         val fetched = resolver.resolve(source, token)?.takeIf { it.isNotBlank() }
             ?: return SyncNamespace.PendingRemoteId
         dao.setAbsUserId(sourceId, fetched)
-        return descriptor.syncNamespaceFor(source.copy(absUserId = fetched))
+        // Project the freshly-fetched id through the descriptor's dedicated hook instead of
+        // synthesising a `source.copy(absUserId = fetched)` and re-invoking syncNamespaceFor —
+        // avoids the double-eval and keeps the "how do I turn an id into a namespace" logic in
+        // one method per descriptor.
+        return descriptor.namespaceFromRemoteId(source, fetched)
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
@@ -7,11 +7,15 @@ import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.SourceDao
 import com.riffle.core.domain.CommitSourceResult
 import com.riffle.core.domain.PendingSource
+import com.riffle.core.domain.RemoteUserIdResolver
 import com.riffle.core.domain.Source
 import com.riffle.core.domain.SourceFilesCleaner
 import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.SourceType
 import com.riffle.core.domain.ServerType
+import com.riffle.core.domain.SyncNamespace
 import com.riffle.core.domain.TokenStorage
+import com.riffle.core.domain.WebSourceDescriptors
 import com.riffle.core.network.AbsServerInfoApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -25,6 +29,7 @@ class SourceRepositoryImpl @Inject constructor(
     private val libraryItemDao: LibraryItemDao,
     private val filesCleaner: SourceFilesCleaner,
     private val installer: CredentialedSourceInstaller,
+    private val remoteUserIdResolvers: Map<SourceType, @JvmSuppressWildcards RemoteUserIdResolver>,
 ) : SourceRepository {
 
     // Sort by SourceType so consumers (Settings sources list, drawer source switcher) render in
@@ -87,18 +92,25 @@ class SourceRepositoryImpl @Inject constructor(
             CredentialedSourceInstaller.readaloudLibraryId(sourceId)
     }
 
-    override suspend fun ensureAbsUserId(sourceId: String): String? {
-        val row = dao.getById(sourceId) ?: return null
-        if (row.serverType == ServerType.STORYTELLER_SERVICE.name) return null
-        row.absUserId?.takeIf { it.isNotBlank() }?.let { return it }
-        // Legacy row (added before the column existed) — backfill from /api/me.
-        val token = tokenStorage.getToken(sourceId) ?: return null
-        val fetched = serverInfoApi.getCurrentUserId(
-            baseUrl = row.url,
-            token = token,
-            insecureAllowed = row.insecureConnectionAllowed,
-        ) ?: return null
+    override suspend fun ensureSyncNamespace(sourceId: String): SyncNamespace {
+        val source = dao.getById(sourceId)?.toDomain()
+            ?: return SyncNamespace.LocalOnly("Unknown source.")
+        val descriptor = WebSourceDescriptors.forType(source.type)
+            ?: return SyncNamespace.LocalOnly("No descriptor for source type ${source.type}.")
+        val initial = descriptor.syncNamespaceFor(source)
+        if (initial !is SyncNamespace.PendingRemoteId) return initial
+
+        // Descriptor advertises cross-device identity but the remote user id hasn't been fetched
+        // yet — dispatch to the per-SourceType resolver. Anonymous / local descriptors never
+        // reach this branch (they return LocalOnly above), so a missing resolver here means a
+        // sync-eligible source kind wasn't wired into RemoteUserIdResolverModule.
+        val resolver = remoteUserIdResolvers[source.type]
+            ?: return SyncNamespace.LocalOnly("No remote-id resolver registered for ${source.type}.")
+        val token = tokenStorage.getToken(sourceId)
+            ?: return SyncNamespace.PendingRemoteId
+        val fetched = resolver.resolve(source, token)?.takeIf { it.isNotBlank() }
+            ?: return SyncNamespace.PendingRemoteId
         dao.setAbsUserId(sourceId, fetched)
-        return fetched
+        return descriptor.syncNamespaceFor(source.copy(absUserId = fetched))
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/credentialed/CredentialedSourceInstaller.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/credentialed/CredentialedSourceInstaller.kt
@@ -60,9 +60,15 @@ class CredentialedSourceInstaller @Inject constructor(
             serverType = pending.serverType.name,
             // Persist the source's remote-user identity when the authenticator supplied one
             // (#529). ABS exposes `user.id` on /api/me, Komga exposes `id` on /api/v2/users/me;
-            // both flow through PendingSource.userId. Storyteller's login response carries no
-            // equivalent identity — its descriptor returns SyncNamespace.LocalOnly regardless.
-            absUserId = pending.userId.takeIf { it.isNotBlank() },
+            // both flow through PendingSource.userId. Storyteller is defence-in-depth-gated
+            // here: its descriptor returns SyncNamespace.LocalOnly regardless (annotations sync
+            // via the paired Audiobookshelf server), and its authenticator already sets
+            // userId="", but we belt-and-braces enforce the invariant at write time so a future
+            // authenticator refactor that stops zeroing out the id can't silently start
+            // persisting a Storyteller-side identity that then leaks into namespace logic.
+            absUserId = pending.userId.takeIf {
+                it.isNotBlank() && pending.serverType != ServerType.STORYTELLER_SERVICE
+            },
             type = pending.sourceType.name,
         )
         // Save credentials BEFORE inserting the row. `SourceDao.observeAll` is a Room Flow that

--- a/core/data/src/main/kotlin/com/riffle/core/data/credentialed/CredentialedSourceInstaller.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/credentialed/CredentialedSourceInstaller.kt
@@ -58,12 +58,11 @@ class CredentialedSourceInstaller @Inject constructor(
             insecureConnectionAllowed = pending.insecureConnectionAllowed,
             username = pending.username,
             serverType = pending.serverType.name,
-            // ABS exposes `user.id` on the login response — persist it now so annotation sync has
-            // a cross-device-stable namespace from first open. Storyteller's login response
-            // carries no equivalent identity (auth is username + token), so leave it null.
-            absUserId = pending.userId.takeIf {
-                it.isNotBlank() && pending.serverType == ServerType.AUDIOBOOKSHELF
-            },
+            // Persist the source's remote-user identity when the authenticator supplied one
+            // (#529). ABS exposes `user.id` on /api/me, Komga exposes `id` on /api/v2/users/me;
+            // both flow through PendingSource.userId. Storyteller's login response carries no
+            // equivalent identity — its descriptor returns SyncNamespace.LocalOnly regardless.
+            absUserId = pending.userId.takeIf { it.isNotBlank() },
             type = pending.sourceType.name,
         )
         // Save credentials BEFORE inserting the row. `SourceDao.observeAll` is a Room Flow that

--- a/core/data/src/main/kotlin/com/riffle/core/data/credentialed/KomgaCredentialedAuthenticator.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/credentialed/KomgaCredentialedAuthenticator.kt
@@ -3,6 +3,7 @@ package com.riffle.core.data.credentialed
 import com.riffle.core.catalog.komga.KomgaHttpException
 import com.riffle.core.catalog.komga.KomgaHttpClient
 import com.riffle.core.catalog.komga.buildBasicAuthHeader
+import com.riffle.core.catalog.komga.probeKomgaUserId
 import com.riffle.core.domain.AuthenticateResult
 import com.riffle.core.domain.InsecureConnectionType
 import com.riffle.core.domain.Library
@@ -51,7 +52,7 @@ class KomgaCredentialedAuthenticator @Inject constructor(
         // (#529) as this source's cross-device annotation-sync identity; falling back to v1 for
         // pre-Komga-1.9 builds that only serve the older endpoint shape.
         val meResult = try {
-            probeMe(http, base)
+            probeKomgaUserId(http, base)
         } catch (e: SSLHandshakeException) {
             return AuthenticateResult.InsecureConnection(InsecureConnectionType.SELF_SIGNED)
         } catch (e: IOException) {
@@ -99,34 +100,6 @@ class KomgaCredentialedAuthenticator @Inject constructor(
             )
         )
     }
-
-    private suspend fun probeMe(http: KomgaHttpClient, base: String): ProbeResult {
-        val v2 = fetchMe(http, "$base/api/v2/users/me")
-        if (v2.status == 404) return fetchMe(http, "$base/api/v1/users/me")
-        return v2
-    }
-
-    private suspend fun fetchMe(http: KomgaHttpClient, url: String): ProbeResult {
-        // Single GET so mock servers and real servers see exactly one request per probe. On
-        // non-2xx the client throws [KomgaHttpException] carrying the status; on 2xx we parse
-        // `id` for #529 (falling back to a userless success if the body doesn't match the
-        // shape — auth still passes).
-        return try {
-            val body = http.getString(url)
-            val id = runCatching {
-                Json { ignoreUnknownKeys = true }
-                    .decodeFromString(KomgaMeDto.serializer(), body).id.takeIf { it.isNotBlank() }
-            }.getOrNull()
-            ProbeResult(status = 200, userId = id)
-        } catch (e: KomgaHttpException) {
-            ProbeResult(status = e.code, userId = null)
-        }
-    }
-
-    private data class ProbeResult(val status: Int, val userId: String?)
-
-    @Serializable
-    private data class KomgaMeDto(@SerialName("id") val id: String)
 
     @Serializable
     private data class KomgaAuthLibraryDto(

--- a/core/data/src/main/kotlin/com/riffle/core/data/credentialed/KomgaCredentialedAuthenticator.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/credentialed/KomgaCredentialedAuthenticator.kt
@@ -46,8 +46,11 @@ class KomgaCredentialedAuthenticator @Inject constructor(
         }
         val base = url.value.trimEnd('/')
 
-        // Auth probe — /api/v2/users/me returns the current user or 401.
-        val meStatus = try {
+        // Auth probe — /api/v2/users/me returns the current user or 401. We read the body when
+        // the request succeeds so the response's `id` can be stashed into PendingSource.userId
+        // (#529) as this source's cross-device annotation-sync identity; falling back to v1 for
+        // pre-Komga-1.9 builds that only serve the older endpoint shape.
+        val meResult = try {
             probeMe(http, base)
         } catch (e: SSLHandshakeException) {
             return AuthenticateResult.InsecureConnection(InsecureConnectionType.SELF_SIGNED)
@@ -55,9 +58,9 @@ class KomgaCredentialedAuthenticator @Inject constructor(
             return AuthenticateResult.NetworkError(e)
         }
         when {
-            meStatus == 401 || meStatus == 403 -> return AuthenticateResult.WrongCredentials()
-            meStatus !in 200..399 -> return AuthenticateResult.NetworkError(
-                IOException("Komga returned HTTP $meStatus at /users/me")
+            meResult.status == 401 || meResult.status == 403 -> return AuthenticateResult.WrongCredentials()
+            meResult.status !in 200..399 -> return AuthenticateResult.NetworkError(
+                IOException("Komga returned HTTP ${meResult.status} at /users/me")
             )
         }
 
@@ -76,7 +79,7 @@ class KomgaCredentialedAuthenticator @Inject constructor(
             PendingSource(
                 url = url,
                 username = username,
-                userId = "",
+                userId = meResult.userId.orEmpty(),
                 // Stash the FULL `Authorization` header value ("Basic <base64>") in the token slot
                 // so cover-image fetch sites (which read `TokenStorage.getToken`) can pass it
                 // straight through `String.asAuthHeader` without inventing a Komga-specific code
@@ -97,11 +100,33 @@ class KomgaCredentialedAuthenticator @Inject constructor(
         )
     }
 
-    private suspend fun probeMe(http: KomgaHttpClient, base: String): Int {
-        val v2 = http.getStatus("$base/api/v2/users/me")
-        if (v2 == 404) return http.getStatus("$base/api/v1/users/me")
+    private suspend fun probeMe(http: KomgaHttpClient, base: String): ProbeResult {
+        val v2 = fetchMe(http, "$base/api/v2/users/me")
+        if (v2.status == 404) return fetchMe(http, "$base/api/v1/users/me")
         return v2
     }
+
+    private suspend fun fetchMe(http: KomgaHttpClient, url: String): ProbeResult {
+        // Single GET so mock servers and real servers see exactly one request per probe. On
+        // non-2xx the client throws [KomgaHttpException] carrying the status; on 2xx we parse
+        // `id` for #529 (falling back to a userless success if the body doesn't match the
+        // shape — auth still passes).
+        return try {
+            val body = http.getString(url)
+            val id = runCatching {
+                Json { ignoreUnknownKeys = true }
+                    .decodeFromString(KomgaMeDto.serializer(), body).id.takeIf { it.isNotBlank() }
+            }.getOrNull()
+            ProbeResult(status = 200, userId = id)
+        } catch (e: KomgaHttpException) {
+            ProbeResult(status = e.code, userId = null)
+        }
+    }
+
+    private data class ProbeResult(val status: Int, val userId: String?)
+
+    @Serializable
+    private data class KomgaMeDto(@SerialName("id") val id: String)
 
     @Serializable
     private data class KomgaAuthLibraryDto(

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/RemoteUserIdResolverModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/RemoteUserIdResolverModule.kt
@@ -1,0 +1,32 @@
+package com.riffle.core.data.di.modules
+
+import com.riffle.core.data.sync.AbsRemoteUserIdResolver
+import com.riffle.core.data.sync.KomgaRemoteUserIdResolver
+import com.riffle.core.domain.RemoteUserIdResolver
+import com.riffle.core.domain.SourceType
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoMap
+
+/**
+ * Wires the `Map<SourceType, RemoteUserIdResolver>` consumed by `SourceRepositoryImpl` (#529).
+ * A new server-backed source contributes one `@IntoMap` binding here to become sync-eligible;
+ * anonymous / local sources omit a binding (their descriptor returns
+ * [com.riffle.core.domain.SyncNamespace.LocalOnly] so the repository never asks).
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RemoteUserIdResolverModule {
+
+    @Binds
+    @IntoMap
+    @SourceTypeKey(SourceType.ABS)
+    abstract fun bindAbsResolver(impl: AbsRemoteUserIdResolver): RemoteUserIdResolver
+
+    @Binds
+    @IntoMap
+    @SourceTypeKey(SourceType.KOMGA)
+    abstract fun bindKomgaResolver(impl: KomgaRemoteUserIdResolver): RemoteUserIdResolver
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/sync/AbsRemoteUserIdResolver.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/sync/AbsRemoteUserIdResolver.kt
@@ -1,0 +1,25 @@
+package com.riffle.core.data.sync
+
+import com.riffle.core.domain.RemoteUserIdResolver
+import com.riffle.core.domain.Source
+import com.riffle.core.network.AbsServerInfoApi
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * [RemoteUserIdResolver] for [com.riffle.core.domain.SourceType.ABS]. Delegates to
+ * [AbsServerInfoApi.getCurrentUserId] (`GET /api/me` → `user.id`). Storyteller sources are
+ * gated at the descriptor level (returns [com.riffle.core.domain.SyncNamespace.LocalOnly]) so
+ * they never reach this resolver.
+ */
+@Singleton
+class AbsRemoteUserIdResolver @Inject constructor(
+    private val serverInfoApi: AbsServerInfoApi,
+) : RemoteUserIdResolver {
+    override suspend fun resolve(source: Source, token: String): String? =
+        serverInfoApi.getCurrentUserId(
+            baseUrl = source.url.value,
+            token = token,
+            insecureAllowed = source.insecureConnectionAllowed,
+        )
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/sync/KomgaRemoteUserIdResolver.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/sync/KomgaRemoteUserIdResolver.kt
@@ -1,0 +1,43 @@
+package com.riffle.core.data.sync
+
+import com.riffle.core.catalog.komga.KomgaHttpClient
+import com.riffle.core.domain.RemoteUserIdResolver
+import com.riffle.core.domain.Source
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * [RemoteUserIdResolver] for [com.riffle.core.domain.SourceType.KOMGA]. `token` is the pre-built
+ * `Authorization: Basic <base64>` header value stashed by [com.riffle.core.data.credentialed
+ * .KomgaCredentialedAuthenticator] — pass it straight through the shared [KomgaHttpClient].
+ *
+ * Legacy Komga rows (installed before #529 wired the id into the add-source handshake) get
+ * their id backfilled here on first sync.
+ */
+@Singleton
+class KomgaRemoteUserIdResolver @Inject constructor(
+    private val okHttpClient: OkHttpClient,
+) : RemoteUserIdResolver {
+    override suspend fun resolve(source: Source, token: String): String? {
+        val base = source.url.value.trimEnd('/')
+        val http = KomgaHttpClient(okHttpClient, token)
+        val json = Json { ignoreUnknownKeys = true }
+        // v2 is the current shape; v1 is the pre-Komga-1.9 fallback that still returns the same
+        // `{ "id": "..." }` envelope.
+        return try {
+            val body = runCatching { http.getString("$base/api/v2/users/me") }
+                .recoverCatching { http.getString("$base/api/v1/users/me") }
+                .getOrElse { return null }
+            json.decodeFromString(KomgaMeDto.serializer(), body).id.takeIf { it.isNotBlank() }
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    @Serializable
+    private data class KomgaMeDto(@SerialName("id") val id: String)
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/sync/KomgaRemoteUserIdResolver.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/sync/KomgaRemoteUserIdResolver.kt
@@ -1,12 +1,11 @@
 package com.riffle.core.data.sync
 
 import com.riffle.core.catalog.komga.KomgaHttpClient
+import com.riffle.core.catalog.komga.probeKomgaUserId
 import com.riffle.core.domain.RemoteUserIdResolver
 import com.riffle.core.domain.Source
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,28 +15,25 @@ import javax.inject.Singleton
  * .KomgaCredentialedAuthenticator] — pass it straight through the shared [KomgaHttpClient].
  *
  * Legacy Komga rows (installed before #529 wired the id into the add-source handshake) get
- * their id backfilled here on first sync.
+ * their id backfilled here on first sync. Delegates the actual `/users/me` handshake to
+ * [probeKomgaUserId] so the authenticator and the resolver stay in lockstep on fallback rules
+ * and cancellation semantics.
  */
 @Singleton
 class KomgaRemoteUserIdResolver @Inject constructor(
     private val okHttpClient: OkHttpClient,
 ) : RemoteUserIdResolver {
     override suspend fun resolve(source: Source, token: String): String? {
-        val base = source.url.value.trimEnd('/')
         val http = KomgaHttpClient(okHttpClient, token)
-        val json = Json { ignoreUnknownKeys = true }
-        // v2 is the current shape; v1 is the pre-Komga-1.9 fallback that still returns the same
-        // `{ "id": "..." }` envelope.
+        // Any HTTP status is preserved but only 2xx-with-parsable-body yields a usable id;
+        // callers treat a null return as "leave the source in PendingRemoteId and retry next
+        // time". IOException collapses to null too — offline resolve is a no-op, not a fatal
+        // error. CancellationException is not caught: it propagates so the enclosing scope
+        // (viewModelScope, reader lifecycle, sweep) can actually cancel the coroutine.
         return try {
-            val body = runCatching { http.getString("$base/api/v2/users/me") }
-                .recoverCatching { http.getString("$base/api/v1/users/me") }
-                .getOrElse { return null }
-            json.decodeFromString(KomgaMeDto.serializer(), body).id.takeIf { it.isNotBlank() }
-        } catch (_: Throwable) {
+            probeKomgaUserId(http, source.url.value).userId
+        } catch (_: IOException) {
             null
         }
     }
-
-    @Serializable
-    private data class KomgaMeDto(@SerialName("id") val id: String)
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSweepTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSweepTest.kt
@@ -288,7 +288,9 @@ class AnnotationSweepTest {
         private val absUserIds: Map<String, String>,
         private val usernames: Map<String, String> = emptyMap(),
     ) : SourceRepository {
-        override suspend fun ensureAbsUserId(sourceId: String): String? = absUserIds[sourceId]
+        override suspend fun ensureSyncNamespace(sourceId: String): com.riffle.core.domain.SyncNamespace =
+            absUserIds[sourceId]?.let { com.riffle.core.domain.SyncNamespace.Configured(it) }
+                ?: com.riffle.core.domain.SyncNamespace.LocalOnly("test fake")
         override suspend fun getById(sourceId: String): Source? = usernames[sourceId]?.let {
             Source(
                 id = sourceId,

--- a/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
@@ -40,7 +40,7 @@ class ServerRepositoryTest {
     }
 
     /** ServerInfo API stub that returns a fixed user id (or null) so backfill tests can drive both
-     *  the success and failure paths of [SourceRepositoryImpl.ensureAbsUserId]. */
+     *  the success and failure paths of [SourceRepositoryImpl.ensureSyncNamespace] for ABS. */
     private class RecordingServerInfoApi(private val userId: String?) : AbsServerInfoApi {
         var getCurrentUserIdCalls = 0
         override suspend fun getServerInfo(baseUrl: String, token: String, insecureAllowed: Boolean): String? = null
@@ -211,6 +211,13 @@ class ServerRepositoryTest {
             tokenStorage = tokens,
             visibilityStore = visibilityStore,
         )
+        // The repository dispatches remote-user-id probes through per-SourceType resolvers.
+        // Wire a live ABS resolver so ensureSyncNamespace's backfill path is exercised, and use
+        // the resolver map as the extension point for adding future source-kind probes.
+        val absResolver = com.riffle.core.data.sync.AbsRemoteUserIdResolver(serverInfoApi)
+        val resolvers = mapOf<com.riffle.core.domain.SourceType, com.riffle.core.domain.RemoteUserIdResolver>(
+            com.riffle.core.domain.SourceType.ABS to absResolver,
+        )
         return SourceRepositoryImpl(
             dao = dao,
             tokenStorage = tokens,
@@ -219,6 +226,7 @@ class ServerRepositoryTest {
             libraryItemDao = libraryItemDao,
             filesCleaner = filesCleaner,
             installer = installer,
+            remoteUserIdResolvers = resolvers,
         )
     }
 
@@ -781,7 +789,7 @@ class ServerRepositoryTest {
     }
 
     @Test
-    fun `ensureAbsUserId returns the persisted value without hitting the network`() = runTest {
+    fun `ensureSyncNamespace returns the persisted value without hitting the network`() = runTest {
         val entity = SourceEntity("abs-1", "https://abs.example.com", true, false, username = "u", absUserId = "persisted-user-id")
         val infoApi = RecordingServerInfoApi(userId = "should-not-be-called")
         val repo = buildRepo(
@@ -790,16 +798,16 @@ class ServerRepositoryTest {
             fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner(),
         )
 
-        val result = repo.ensureAbsUserId("abs-1")
+        val result = repo.ensureSyncNamespace("abs-1")
 
-        assertEquals("persisted-user-id", result)
+        assertEquals(com.riffle.core.domain.SyncNamespace.Configured("persisted-user-id"), result)
         assertEquals("must not /api/me when value is already cached", 0, infoApi.getCurrentUserIdCalls)
     }
 
     @Test
-    fun `ensureAbsUserId backfills a null column from api me and persists it`() = runTest {
+    fun `ensureSyncNamespace backfills a null column from api me and persists it`() = runTest {
         // Legacy row added before the absUserId column existed. The first sync attempt fetches
-        // /api/me, persists the result, and subsequent calls are cache hits.
+        // /api/me via the ABS resolver, persists the result, and subsequent calls are cache hits.
         val entity = SourceEntity("abs-legacy", "https://abs.example.com", true, false, username = "u", absUserId = null)
         val dao = fakeDao(entity)
         val tokens = fakeTokenStorage().also { it.tokens["abs-legacy"] = "tok-cached" }
@@ -810,18 +818,18 @@ class ServerRepositoryTest {
             fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner(),
         )
 
-        val first = repo.ensureAbsUserId("abs-legacy")
-        val second = repo.ensureAbsUserId("abs-legacy")
+        val first = repo.ensureSyncNamespace("abs-legacy")
+        val second = repo.ensureSyncNamespace("abs-legacy")
 
-        assertEquals("fetched-user-id", first)
-        assertEquals("fetched-user-id", second)
+        assertEquals(com.riffle.core.domain.SyncNamespace.Configured("fetched-user-id"), first)
+        assertEquals(com.riffle.core.domain.SyncNamespace.Configured("fetched-user-id"), second)
         // Persisted, so the second call is a DAO read — not a second network round-trip.
         assertEquals(1, infoApi.getCurrentUserIdCalls)
         assertEquals("fetched-user-id", dao.getById("abs-legacy")?.absUserId)
     }
 
     @Test
-    fun `ensureAbsUserId returns null when api me fails so callers skip sync instead of breaking`() = runTest {
+    fun `ensureSyncNamespace returns PendingRemoteId when api me fails so callers skip sync instead of breaking`() = runTest {
         val entity = SourceEntity("abs-1", "https://abs.example.com", true, false, username = "u", absUserId = null)
         val tokens = fakeTokenStorage().also { it.tokens["abs-1"] = "tok" }
         val infoApi = RecordingServerInfoApi(userId = null) // simulates offline / 5xx / parse error
@@ -831,13 +839,17 @@ class ServerRepositoryTest {
             fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner(),
         )
 
-        val result = repo.ensureAbsUserId("abs-1")
+        val result = repo.ensureSyncNamespace("abs-1")
 
-        assertNull("sync must skip silently — local DB stays the source of truth", result)
+        assertEquals(
+            "sync must skip silently — local DB stays the source of truth",
+            com.riffle.core.domain.SyncNamespace.PendingRemoteId,
+            result,
+        )
     }
 
     @Test
-    fun `ensureAbsUserId returns null for a Storyteller source without fetching api me`() = runTest {
+    fun `ensureSyncNamespace returns LocalOnly for a Storyteller source without fetching api me`() = runTest {
         val entity = SourceEntity("st-1", "http://media-source:8001", false, false, username = "u", serverType = ServerType.STORYTELLER_SERVICE.name)
         val infoApi = RecordingServerInfoApi(userId = "should-not-be-called")
         val repo = buildRepo(
@@ -846,20 +858,25 @@ class ServerRepositoryTest {
             fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner(),
         )
 
-        val result = repo.ensureAbsUserId("st-1")
+        val result = repo.ensureSyncNamespace("st-1")
 
-        assertNull(result)
-        assertEquals("ABS endpoint must not be called for a Storyteller source", 0, infoApi.getCurrentUserIdCalls)
+        assertTrue(
+            "Storyteller resolves to LocalOnly via the descriptor — no network probe runs",
+            result is com.riffle.core.domain.SyncNamespace.LocalOnly,
+        )
+        assertEquals(0, infoApi.getCurrentUserIdCalls)
     }
 
     @Test
-    fun `ensureAbsUserId returns null for an unknown source id`() = runTest {
+    fun `ensureSyncNamespace returns LocalOnly for an unknown source id`() = runTest {
         val repo = buildRepo(
             fakeDao(), fakeTokenStorage(), AbsApi { _, _, _, _ -> error("not called") },
             storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled,
             fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner(),
         )
 
-        assertNull(repo.ensureAbsUserId("does-not-exist"))
+        val result = repo.ensureSyncNamespace("does-not-exist")
+
+        assertTrue(result is com.riffle.core.domain.SyncNamespace.LocalOnly)
     }
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/RemoteUserIdResolver.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/RemoteUserIdResolver.kt
@@ -1,0 +1,23 @@
+package com.riffle.core.domain
+
+/**
+ * Per-[SourceType] hook that fetches this source kind's stable cross-device user identity from
+ * the remote server (#529). Consumed by [SourceRepository.ensureSyncNamespace] whenever a
+ * source's descriptor returns [SyncNamespace.PendingRemoteId] — the repository invokes the
+ * resolver keyed by [SourceType], persists the returned id into `Source.absUserId`, and
+ * re-evaluates the descriptor to produce a [SyncNamespace.Configured].
+ *
+ * Bind implementations via Hilt multibinding keyed by [SourceType]; the repository injects the
+ * `Map<SourceType, @JvmSuppressWildcards RemoteUserIdResolver>` and dispatches accordingly. A
+ * new server-backed source becomes sync-eligible by (a) overriding
+ * [WebSourceDescriptor.syncNamespaceFor], and (b) contributing a [RemoteUserIdResolver] to the
+ * multibinding — no changes to `AnnotationSyncController`, the sweep, or the reader required.
+ */
+interface RemoteUserIdResolver {
+    /**
+     * Resolve the currently-authenticated user's stable id on this source, or null on any
+     * network/parse failure (offline, server down, expired token). A null return leaves the
+     * source in [SyncNamespace.PendingRemoteId] — the caller retries on the next open.
+     */
+    suspend fun resolve(source: Source, token: String): String?
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/Source.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/Source.kt
@@ -9,9 +9,16 @@ data class Source(
     val type: SourceType = SourceType.ABS,
     val serverType: ServerType = ServerType.AUDIOBOOKSHELF,
     /**
-     * ABS-side stable user identity (the `/api/me` `user.id`). Used by annotation sync as the
-     * cross-device path namespace — see [com.riffle.core.domain.AnnotationSyncTarget]. Null on
-     * Storyteller services and on legacy rows that haven't been backfilled yet.
+     * Stable cross-device user identity on the remote server, generalized per #529 (name kept
+     * for storage/backwards-compat reasons). Populated per source kind:
+     *  - ABS: `/api/me` `user.id`
+     *  - Komga: `/api/v2/users/me` `id`
+     *  - Storyteller peer / local / anonymous catalogs: null (the descriptor returns
+     *    [SyncNamespace.LocalOnly] and no probe runs).
+     *
+     * Consumed by [WebSourceDescriptor.syncNamespaceFor] to produce the annotation-sync path
+     * namespace. Null on Storyteller sources, on public-catalog sources, on local files, and
+     * on legacy rows that haven't been backfilled yet.
      */
     val absUserId: String? = null,
 )

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/SourceRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/SourceRepository.kt
@@ -35,11 +35,15 @@ interface SourceRepository {
     suspend fun getSourceVersion(sourceId: String): String?
 
     /**
-     * Return the ABS-side stable user identity for this source, fetching it from `/api/me` if
-     * it hasn't been persisted yet (legacy rows created before the column existed). Returns
-     * null for Storyteller services, for unknown source ids, and when the fetch fails (offline,
-     * server down, invalid token). A successful fetch is persisted so subsequent calls are
-     * a single DB lookup.
+     * Resolve this source's annotation-sync namespace (#529). Delegates to
+     * [WebSourceDescriptor.syncNamespaceFor]; on [SyncNamespace.PendingRemoteId] the repository
+     * calls the source-kind-specific [RemoteUserIdResolver], persists the fetched id into
+     * `Source.absUserId`, and re-evaluates the descriptor. Returns [SyncNamespace.LocalOnly]
+     * for unknown source ids so callers can render a uniform local-only state.
+     *
+     * A successful cross-device resolution is persisted so subsequent calls are a single DB
+     * lookup — the resolver only runs on the first open of a legacy row.
      */
-    suspend fun ensureAbsUserId(sourceId: String): String? = null
+    suspend fun ensureSyncNamespace(sourceId: String): SyncNamespace =
+        SyncNamespace.LocalOnly("Unknown source.")
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/SyncNamespace.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/SyncNamespace.kt
@@ -1,0 +1,41 @@
+package com.riffle.core.domain
+
+/**
+ * Annotation-sync namespace resolution for a [Source] (#529).
+ *
+ * Every source that participates in annotation sync produces a cross-device-stable string —
+ * shared by every device signed into the *same* remote account — that keys the source's
+ * annotation files on the sync target (WebDAV today, per ADR 0035). Two devices resolve to the
+ * same [Configured.value] iff they should discover each other's annotation files.
+ *
+ * The namespace is a plain opaque [String] to the transport ([AnnotationSyncTarget]); the shape
+ * (`abs<userId>` vs. `komga_<userId>` vs. anything else future descriptors want) is entirely a
+ * [WebSourceDescriptor.syncNamespaceFor] concern. New source kinds don't require any change to
+ * the sync controller or the sweep — they only implement the descriptor hook.
+ *
+ * Sources that genuinely have no cross-device identity (pure local, anonymous public catalogs
+ * like Gutenberg/Chitanka) return [LocalOnly] so the UI can render a clear "local-only" state
+ * instead of silently no-opping.
+ */
+sealed interface SyncNamespace {
+    /**
+     * Cross-device sync is available for this source. [value] is the opaque namespace passed to
+     * [AnnotationSyncTarget] — treated as an atomic key by every downstream consumer.
+     */
+    data class Configured(val value: String) : SyncNamespace
+
+    /**
+     * This source has a cross-device identity in principle, but the remote user id hasn't been
+     * fetched yet (legacy row created before the column existed, or a fresh install where the
+     * add-source handshake didn't stash the id). Callers ask [SourceRepository.ensureSyncNamespace]
+     * to make the network call and persist the id, which then resolves to [Configured].
+     */
+    object PendingRemoteId : SyncNamespace
+
+    /**
+     * This source is not eligible for cross-device sync. [reason] is a short user-facing string
+     * (rendered in the annotation-sync status UI). Examples: "Local files stay on this device."
+     * or "Public-domain catalog — no account to sync against."
+     */
+    data class LocalOnly(val reason: String) : SyncNamespace
+}

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/WebSourceDescriptor.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/WebSourceDescriptor.kt
@@ -173,10 +173,23 @@ interface WebSourceDescriptor {
      * [SyncNamespace.Configured] (when the remote user id is already persisted) or
      * [SyncNamespace.PendingRemoteId] (when the identity contract exists but the id hasn't been
      * fetched from the server yet — the repository resolves it via a per-[SourceType]
-     * [RemoteUserIdResolver] and persists to `Source.absUserId`).
+     * [RemoteUserIdResolver], persists to `Source.absUserId`, and then calls
+     * [namespaceFromRemoteId] to project the freshly-resolved id into a namespace).
      */
     fun syncNamespaceFor(source: Source): SyncNamespace =
         SyncNamespace.LocalOnly("This source's books stay on this device.")
+
+    /**
+     * Project a freshly-fetched `remoteUserId` into this descriptor's namespace, without going
+     * through [syncNamespaceFor] on a synthesised `source.copy(absUserId = remoteUserId)`. The
+     * default (this base implementation) reads the persisted id off `source` via
+     * [syncNamespaceFor]; the repository never calls it on descriptors whose
+     * [syncNamespaceFor] returned [SyncNamespace.PendingRemoteId] without overriding this hook.
+     *
+     * Override on any descriptor whose [syncNamespaceFor] can return [SyncNamespace.PendingRemoteId].
+     */
+    fun namespaceFromRemoteId(source: Source, remoteUserId: String): SyncNamespace =
+        syncNamespaceFor(source)
 }
 
 /**
@@ -312,6 +325,13 @@ object AbsWebSourceDescriptor : WebSourceDescriptor {
             ?.let { SyncNamespace.Configured(it) }
             ?: SyncNamespace.PendingRemoteId
     }
+
+    override fun namespaceFromRemoteId(source: Source, remoteUserId: String): SyncNamespace =
+        when (source.serverType) {
+            ServerType.STORYTELLER_SERVICE ->
+                SyncNamespace.LocalOnly("Annotations on Storyteller readalouds sync via your paired Audiobookshelf server.")
+            ServerType.AUDIOBOOKSHELF -> SyncNamespace.Configured(remoteUserId)
+        }
 }
 
 object LocalFilesWebSourceDescriptor : WebSourceDescriptor {
@@ -373,13 +393,28 @@ object KomgaWebSourceDescriptor : WebSourceDescriptor {
     override fun iconRemoteUrl(sourceBaseUrl: String, serverType: ServerType): String =
         "${sourceBaseUrl.trimEnd('/')}/favicon.ico"
 
+    /**
+     * Namespace prefix stamped onto every Komga sync namespace. Extracted as a constant so the
+     * production site and every test/fixture reference the same value — a mis-typed literal
+     * (`"kmga_"`) at either end would otherwise round-trip green (AGENTS.md: "Always reference
+     * constants, never the literal").
+     *
+     * Guarantees non-collision with ABS: ABS namespaces are raw UUIDs (`19621aae-…`) which
+     * contain no underscore before the first hex block, so no ABS namespace can ever start
+     * with this prefix regardless of the id value.
+     */
+    const val KOMGA_NAMESPACE_PREFIX = "komga_"
+
     // Prefix with `komga_` so a Komga user id can't collide with an ABS user id (both are
     // stored in the same WebDAV share; the target's flat filename layout means the namespace
     // string alone has to distinguish source kinds).
     override fun syncNamespaceFor(source: Source): SyncNamespace =
         source.absUserId?.takeIf { it.isNotBlank() }
-            ?.let { SyncNamespace.Configured("komga_$it") }
+            ?.let { namespaceFromRemoteId(source, it) }
             ?: SyncNamespace.PendingRemoteId
+
+    override fun namespaceFromRemoteId(source: Source, remoteUserId: String): SyncNamespace =
+        SyncNamespace.Configured("$KOMGA_NAMESPACE_PREFIX$remoteUserId")
 }
 
 object GutenbergWebSourceDescriptor : WebSourceDescriptor {

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/WebSourceDescriptor.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/WebSourceDescriptor.kt
@@ -165,6 +165,18 @@ interface WebSourceDescriptor {
      * different logo paths); other descriptors ignore it.
      */
     fun iconRemoteUrl(sourceBaseUrl: String, serverType: ServerType): String? = null
+
+    /**
+     * Resolve this source's annotation-sync namespace (#529). Defaults to [SyncNamespace.LocalOnly]
+     * — the safe fallback for local / anonymous / public-catalog sources whose annotations can't
+     * meaningfully leave the device. Server-backed descriptors override this to return either
+     * [SyncNamespace.Configured] (when the remote user id is already persisted) or
+     * [SyncNamespace.PendingRemoteId] (when the identity contract exists but the id hasn't been
+     * fetched from the server yet — the repository resolves it via a per-[SourceType]
+     * [RemoteUserIdResolver] and persists to `Source.absUserId`).
+     */
+    fun syncNamespaceFor(source: Source): SyncNamespace =
+        SyncNamespace.LocalOnly("This source's books stay on this device.")
 }
 
 /**
@@ -287,6 +299,19 @@ object AbsWebSourceDescriptor : WebSourceDescriptor {
             ServerType.STORYTELLER_SERVICE -> "$base/apple-touch-icon.png"
         }
     }
+
+    // ABS is the historical sync source — its namespace is the raw ABS user id so existing
+    // installs' WebDAV files remain addressable without a rewrite. Storyteller peers exchange
+    // auth via ABS but have no independent cross-device identity (their annotations already
+    // ride on the paired Audiobookshelf server's namespace via reader-side matching); surface
+    // them as LocalOnly here so the sync status UI can explain the state.
+    override fun syncNamespaceFor(source: Source): SyncNamespace = when (source.serverType) {
+        ServerType.STORYTELLER_SERVICE ->
+            SyncNamespace.LocalOnly("Annotations on Storyteller readalouds sync via your paired Audiobookshelf server.")
+        ServerType.AUDIOBOOKSHELF -> source.absUserId?.takeIf { it.isNotBlank() }
+            ?.let { SyncNamespace.Configured(it) }
+            ?: SyncNamespace.PendingRemoteId
+    }
 }
 
 object LocalFilesWebSourceDescriptor : WebSourceDescriptor {
@@ -297,6 +322,9 @@ object LocalFilesWebSourceDescriptor : WebSourceDescriptor {
     override val addRoute = "add_local_files"
     override val pickerOrder = 1
     override val pickerBlurb = "Read EPUBs and PDFs from a folder on this device."
+
+    override fun syncNamespaceFor(source: Source): SyncNamespace =
+        SyncNamespace.LocalOnly("Local files have no server account to sync annotations against.")
 }
 
 object ChitankaWebSourceDescriptor : WebSourceDescriptor {
@@ -317,6 +345,9 @@ object ChitankaWebSourceDescriptor : WebSourceDescriptor {
         DefaultLibrary(id = "books", name = "Chitanka", mediaType = "book"),
         DefaultLibrary(id = "audiobooks", name = "Gramofonche", mediaType = "audiobook"),
     )
+
+    override fun syncNamespaceFor(source: Source): SyncNamespace =
+        SyncNamespace.LocalOnly("Chitanka is a public catalog with no per-user account to sync against.")
 }
 
 object KomgaWebSourceDescriptor : WebSourceDescriptor {
@@ -341,6 +372,14 @@ object KomgaWebSourceDescriptor : WebSourceDescriptor {
     // Komga serves its own PWA favicon at /favicon.ico from the web-UI root.
     override fun iconRemoteUrl(sourceBaseUrl: String, serverType: ServerType): String =
         "${sourceBaseUrl.trimEnd('/')}/favicon.ico"
+
+    // Prefix with `komga_` so a Komga user id can't collide with an ABS user id (both are
+    // stored in the same WebDAV share; the target's flat filename layout means the namespace
+    // string alone has to distinguish source kinds).
+    override fun syncNamespaceFor(source: Source): SyncNamespace =
+        source.absUserId?.takeIf { it.isNotBlank() }
+            ?.let { SyncNamespace.Configured("komga_$it") }
+            ?: SyncNamespace.PendingRemoteId
 }
 
 object GutenbergWebSourceDescriptor : WebSourceDescriptor {
@@ -362,4 +401,7 @@ object GutenbergWebSourceDescriptor : WebSourceDescriptor {
         // duplicated in the drawer).
         DefaultLibrary(id = "books", name = "Books", mediaType = "book"),
     )
+
+    override fun syncNamespaceFor(source: Source): SyncNamespace =
+        SyncNamespace.LocalOnly("Project Gutenberg is a public catalog with no per-user account to sync against.")
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/WebSourceDescriptorSyncNamespaceTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/WebSourceDescriptorSyncNamespaceTest.kt
@@ -71,10 +71,14 @@ class WebSourceDescriptorSyncNamespaceTest {
     @Test
     fun `Komga with persisted user id resolves to Configured with a komga prefix`() {
         val ns = KomgaWebSourceDescriptor.syncNamespaceFor(komgaSource(userId = "komga-uid-abc"))
-        // Prefix prevents a numeric Komga id from colliding with an ABS UUID on the same WebDAV
-        // share — the target's flat filename layout means the namespace string has to
-        // distinguish source kinds by itself.
-        assertEquals(SyncNamespace.Configured("komga_komga-uid-abc"), ns)
+        // Reference the descriptor's own const so a rename/typo trips a compile-time diff, not
+        // a silent round-trip via a mirrored string literal (AGENTS.md: never the literal).
+        val expected = SyncNamespace.Configured(
+            "${KomgaWebSourceDescriptor.KOMGA_NAMESPACE_PREFIX}komga-uid-abc",
+        )
+        assertEquals(expected, ns)
+        // Sanity: the prefix hasn't drifted to a subtly different value.
+        assertEquals("komga_", KomgaWebSourceDescriptor.KOMGA_NAMESPACE_PREFIX)
     }
 
     @Test

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/WebSourceDescriptorSyncNamespaceTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/WebSourceDescriptorSyncNamespaceTest.kt
@@ -1,0 +1,93 @@
+package com.riffle.core.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for #529. Every [WebSourceDescriptor] answers [WebSourceDescriptor
+ * .syncNamespaceFor] deterministically per source kind so a new server-backed source can be
+ * added by overriding the hook — no changes to the sync controller, the sweep, or the reader.
+ *
+ * Would-fail-if-reverted assertions:
+ *  - ABS Audiobookshelf with a persisted `absUserId` → `Configured(<id>)` (raw, no prefix)
+ *  - ABS Audiobookshelf without an `absUserId` → `PendingRemoteId` (repo triggers /api/me)
+ *  - ABS Storyteller peer → `LocalOnly` (never opens a WebDAV namespace of its own)
+ *  - Komga with a persisted id → `Configured("komga_<id>")` (prefixed so it can't collide with ABS)
+ *  - Komga without an id → `PendingRemoteId`
+ *  - Chitanka / Gutenberg / LocalFiles → `LocalOnly` (anonymous / local; UI surfaces the reason)
+ */
+class WebSourceDescriptorSyncNamespaceTest {
+
+    private fun absSource(userId: String? = null, serverType: ServerType = ServerType.AUDIOBOOKSHELF): Source =
+        Source(
+            id = "src-1",
+            url = SourceUrl.parse("https://abs.example.com")!!,
+            isActive = true,
+            insecureConnectionAllowed = false,
+            username = "u",
+            type = SourceType.ABS,
+            serverType = serverType,
+            absUserId = userId,
+        )
+
+    private fun komgaSource(userId: String? = null): Source =
+        Source(
+            id = "src-2",
+            url = SourceUrl.parse("https://komga.example.com")!!,
+            isActive = true,
+            insecureConnectionAllowed = false,
+            username = "u",
+            type = SourceType.KOMGA,
+            serverType = ServerType.AUDIOBOOKSHELF,
+            absUserId = userId,
+        )
+
+    @Test
+    fun `ABS Audiobookshelf with persisted user id resolves to Configured with the raw id`() {
+        val ns = AbsWebSourceDescriptor.syncNamespaceFor(absSource(userId = "abs-user-42"))
+        // Kept raw (no `abs_` prefix) so existing installs' WebDAV files stay addressable
+        // without a rewrite migration.
+        assertEquals(SyncNamespace.Configured("abs-user-42"), ns)
+    }
+
+    @Test
+    fun `ABS Audiobookshelf without a persisted user id resolves to PendingRemoteId`() {
+        val ns = AbsWebSourceDescriptor.syncNamespaceFor(absSource(userId = null))
+        assertEquals(SyncNamespace.PendingRemoteId, ns)
+    }
+
+    @Test
+    fun `ABS Storyteller peer resolves to LocalOnly regardless of user id`() {
+        // Storyteller peers piggyback on the paired Audiobookshelf server — they never open a
+        // WebDAV namespace of their own. Even a stray absUserId on the row shouldn't flip them
+        // to Configured; the ServerType is the discriminator.
+        val ns = AbsWebSourceDescriptor.syncNamespaceFor(
+            absSource(userId = "stray-id", serverType = ServerType.STORYTELLER_SERVICE),
+        )
+        assertTrue(ns is SyncNamespace.LocalOnly)
+    }
+
+    @Test
+    fun `Komga with persisted user id resolves to Configured with a komga prefix`() {
+        val ns = KomgaWebSourceDescriptor.syncNamespaceFor(komgaSource(userId = "komga-uid-abc"))
+        // Prefix prevents a numeric Komga id from colliding with an ABS UUID on the same WebDAV
+        // share — the target's flat filename layout means the namespace string has to
+        // distinguish source kinds by itself.
+        assertEquals(SyncNamespace.Configured("komga_komga-uid-abc"), ns)
+    }
+
+    @Test
+    fun `Komga without a persisted user id resolves to PendingRemoteId`() {
+        val ns = KomgaWebSourceDescriptor.syncNamespaceFor(komgaSource(userId = null))
+        assertEquals(SyncNamespace.PendingRemoteId, ns)
+    }
+
+    @Test
+    fun `Chitanka Gutenberg LocalFiles all resolve to LocalOnly`() {
+        val src = absSource().copy(type = SourceType.LOCAL_FILES)
+        assertTrue(LocalFilesWebSourceDescriptor.syncNamespaceFor(src) is SyncNamespace.LocalOnly)
+        assertTrue(ChitankaWebSourceDescriptor.syncNamespaceFor(src) is SyncNamespace.LocalOnly)
+        assertTrue(GutenbergWebSourceDescriptor.syncNamespaceFor(src) is SyncNamespace.LocalOnly)
+    }
+}

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/WebSourceDescriptorSyncNamespaceTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/WebSourceDescriptorSyncNamespaceTest.kt
@@ -94,4 +94,28 @@ class WebSourceDescriptorSyncNamespaceTest {
         assertTrue(ChitankaWebSourceDescriptor.syncNamespaceFor(src) is SyncNamespace.LocalOnly)
         assertTrue(GutenbergWebSourceDescriptor.syncNamespaceFor(src) is SyncNamespace.LocalOnly)
     }
+
+    @Test
+    fun `namespaceFromRemoteId projects a freshly-fetched id without needing the persisted absUserId`() {
+        // The repository calls this immediately after backfilling absUserId, using a source whose
+        // in-memory `absUserId` is still stale (null). The helper must return the same namespace
+        // syncNamespaceFor would produce on `source.copy(absUserId = fetched)` — same shape, no
+        // double-eval.
+        val absStale = absSource(userId = null)
+        assertEquals(
+            SyncNamespace.Configured("fresh-abs-id"),
+            AbsWebSourceDescriptor.namespaceFromRemoteId(absStale, "fresh-abs-id"),
+        )
+        val komgaStale = komgaSource(userId = null)
+        assertEquals(
+            SyncNamespace.Configured("${KomgaWebSourceDescriptor.KOMGA_NAMESPACE_PREFIX}fresh-komga-id"),
+            KomgaWebSourceDescriptor.namespaceFromRemoteId(komgaStale, "fresh-komga-id"),
+        )
+        // Storyteller stays LocalOnly even when a stray id is somehow forwarded — the invariant
+        // is enforced at the descriptor level, not at the installer/authenticator.
+        val storyStale = absSource(userId = null, serverType = ServerType.STORYTELLER_SERVICE)
+        assertTrue(
+            AbsWebSourceDescriptor.namespaceFromRemoteId(storyStale, "stray-id") is SyncNamespace.LocalOnly,
+        )
+    }
 }


### PR DESCRIPTION
Closes #529.

## Summary

Generalizes the annotation-sync namespace from ABS-only to every server-backed source, current and future. New sources become sync-eligible by (a) overriding `WebSourceDescriptor.syncNamespaceFor` and (b) contributing a `RemoteUserIdResolver` to the multibinding — no changes required in `AnnotationSyncController`, `AnnotationSweep`, the reader VM, or the Maintenance screen.

## What changed

- **`SyncNamespace`** (new, `:core:domain`) — sealed class: `Configured(value)` / `PendingRemoteId` / `LocalOnly(reason)`.
- **`WebSourceDescriptor.syncNamespaceFor(source)`** — default `LocalOnly`. Overrides:
  - `AbsWebSourceDescriptor` — Audiobookshelf → `Configured(<absUserId>)` (raw, backwards-compatible with existing installs' WebDAV files); Storyteller peer → `LocalOnly` (annotations piggyback on the paired ABS server).
  - `KomgaWebSourceDescriptor` — `Configured("komga_<id>")` (kind prefix so Komga can't collide with ABS on the same WebDAV share).
  - Chitanka / Gutenberg / LocalFiles → `LocalOnly` with per-source copy for the sync-status UI.
- **`RemoteUserIdResolver`** (new, `:core:domain`) — Hilt-multibound by `SourceType`. ABS impl calls `/api/me`; Komga impl calls `/api/v2/users/me` (with `/api/v1/users/me` fallback).
- **Komga add-source** now captures the user id from `/api/v2/users/me`'s body (previously discarded) and stashes it into `PendingSource.userId`; the installer persists it into the existing `absUserId` column (repurposed as a generic remote user id).
- **`SourceRepository.ensureSyncNamespace(sourceId): SyncNamespace`** replaces `ensureAbsUserId(sourceId): String?`. The reader, the sweep, and `AnnotationSyncMaintenanceViewModel` all consume the new API and skip cleanly on non-`Configured` namespaces.
- No DB migration — reused the existing `absUserId` column so existing ABS installs' WebDAV files remain addressable without a rewrite.

## Regression tests

- `WebSourceDescriptorSyncNamespaceTest` — matrix over ABS Audiobookshelf (Configured/Pending), ABS Storyteller (LocalOnly regardless of stray id), Komga (prefixed Configured / Pending), and every LocalOnly descriptor.
- `SourceRepositoryTest` — ABS cache hit avoids /api/me, backfill persists + is idempotent, resolver failure returns `PendingRemoteId`, Storyteller resolves to `LocalOnly` without a probe, unknown source id → `LocalOnly`.
- `KomgaCredentialedAuthenticatorTest` — single-round /users/me probe (avoids the double-fetch that would break MockWebServer sequences).
- `AnnotationSweepTest`, `ReaderSessionLifecycleTest`, `AnnotationSyncMaintenanceViewModelTest` — fakes ported to the new API to keep the existing coverage green.

Each of these asserts a value that flips red if the descriptor / repository behavior is reverted.

## Test plan

- [x] `./gradlew test` — full JVM suite green
- [ ] Device verification: add a Komga source on device A and device B (same Komga account); highlight a book on A; open the same book on B and confirm the highlight appears via WebDAV sync
- [ ] Regression on ABS: existing highlights on the WebDAV share remain visible after upgrading (namespace format for ABS is unchanged)
- [ ] Chitanka / Gutenberg / LocalFiles books remain functional; sync UI reflects `LocalOnly` state