### PR TITLE
fix(chitanka): show total duration for Gramofonche items

### DIFF
--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
@@ -498,7 +498,7 @@ class ChitankaCatalog(
             coverUrl = coverUrl,
             ebookFormat = format,
             hasAudio = hasAudio,
-            audioDurationSec = 0.0,
+            audioDurationSec = if (hasAudio) parseGramofoncheDurationSeconds(duration) else 0.0,
             description = null,
             language = "Bulgarian",
         )
@@ -527,6 +527,21 @@ class ChitankaCatalog(
          * ExoPlayer's real duration once decoded.
          */
         internal const val GRAMOFONCHE_ASSUMED_BYTES_PER_SEC: Long = 16_000L
+
+        private val GRAMOFONCHE_DURATION_MINUTES_REGEX = Regex("(\\d+)\\s*мин")
+
+        /**
+         * Parses the scraped Gramofonche duration string (e.g. `"45мин"`) into seconds so it can
+         * populate `CatalogItem.audioDurationSec`. `LibraryItemDetailScreen` gates the total-time
+         * line on `audioDurationSec > 0`, so returning 0 for a listing-only value keeps the whole
+         * line hidden until the per-track HEAD probes run at playback time.
+         */
+        internal fun parseGramofoncheDurationSeconds(raw: String?): Double {
+            if (raw.isNullOrEmpty()) return 0.0
+            val minutes = GRAMOFONCHE_DURATION_MINUTES_REGEX.find(raw)?.groupValues?.get(1)?.toIntOrNull()
+                ?: return 0.0
+            return minutes * 60.0
+        }
 
         internal val AUDIO_FACETS: List<CatalogFacet> = listOf(
             CatalogFacet(key = "prikazki", label = "Приказки", sortOrder = 1),

--- a/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
+++ b/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
@@ -433,6 +433,27 @@ class ChitankaCatalogTest {
         assertNull(catalog().browseUrlFor("nonesuch", null, 0))
     }
 
+    // region Gramofonche duration → audioDurationSec
+
+    /**
+     * Regression: `toCatalogItem` used to hardcode `audioDurationSec = 0.0` for every Gramofonche
+     * summary, so `LibraryItemDetailScreen`'s `audioDurationSec > 0` gate hid the total-duration
+     * line for every audiobook item. The scraper already surfaces `"Nмин"`; we just need to
+     * convert it to seconds.
+     */
+    @Test fun `parseGramofoncheDurationSeconds converts minute string to seconds`() {
+        assertEquals(45.0 * 60, ChitankaCatalog.parseGramofoncheDurationSeconds("45мин"), 0.0)
+        assertEquals(9.0 * 60, ChitankaCatalog.parseGramofoncheDurationSeconds("9мин"), 0.0)
+    }
+
+    @Test fun `parseGramofoncheDurationSeconds returns zero when unknown`() {
+        assertEquals(0.0, ChitankaCatalog.parseGramofoncheDurationSeconds(null), 0.0)
+        assertEquals(0.0, ChitankaCatalog.parseGramofoncheDurationSeconds(""), 0.0)
+        assertEquals(0.0, ChitankaCatalog.parseGramofoncheDurationSeconds("unknown"), 0.0)
+    }
+
+    // endregion
+
     @Test fun `books unknown facet key falls back to new arrivals`() {
         // A facet key the catalog doesn't recognise should not silently 404 on a bogus URL —
         // fall back to the safe default surface.


### PR DESCRIPTION
## Summary

`LibraryItemDetailScreen` gates the total-duration line on `item.audioDurationSec > 0`, but `ChitankaCatalog.toCatalogItem` was hardcoding `audioDurationSec = 0.0` for every Gramofonche summary — so the total-duration line was always hidden for Gramofonche audiobooks even though the scraper already surfaces the site's `"Nмин"` string on both the listing and detail pages.

- New `parseGramofoncheDurationSeconds` helper turns `"45мин"` into `45 * 60` seconds and returns `0.0` for null / empty / non-matching input (so the line stays hidden if the site ever changes format, until the per-track HEAD probes fill in a real value at playback time).
- `toCatalogItem` now feeds that value into `audioDurationSec` when `hasAudio` is true.

## Test plan

- [x] Added `parseGramofoncheDurationSeconds converts minute string to seconds` — pins `"45мин" → 2700`, `"9мин" → 540`.
- [x] Added `parseGramofoncheDurationSeconds returns zero when unknown` — pins null / empty / garbage → `0.0`.
- [x] `./gradlew :core:catalog-chitanka:test` — 32/32 in `ChitankaCatalogTest`, all scraper/http suites still green.