### PR TITLE
feat(library): silent-hide empty tab-bar filters

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -178,10 +178,12 @@ fun LibraryItemsScreen(
     // Reset to Home when the previously-selected tab has no data for the active library (e.g.
     // user was on Series, then the last series was deleted, or switched to a source whose library
     // has no series). Skip while tabVisibility is null (still resolving) so a `rememberSaveable`-
-    // restored selectedTab isn't silently clobbered before the real emptiness set lands.
-    LaunchedEffect(tabVisibility) {
-        val visibility = tabVisibility ?: return@LaunchedEffect
-        if (!isTabVisible(selectedTab, visibility)) selectedTab = 0
+    // restored selectedTab isn't silently clobbered before the real emptiness set lands. Skip
+    // during search too — `LibraryFilterEngine` filters `projection.series/collections` by the
+    // active query, so an unmatched search would flip a visibility flag off, clamp the user's
+    // tab, and the clamp would survive clearing the query.
+    LaunchedEffect(tabVisibility, searchQuery) {
+        if (shouldClampSelectedTab(searchQuery, tabVisibility, selectedTab)) selectedTab = 0
     }
 
     // Drive the grids off a local live scale so a pinch reflows instantly; the
@@ -1252,6 +1254,24 @@ internal fun LibraryItemCard(
  * out of sync with each other.
  */
 internal fun tabIndexForAnnotations(): Int = 2
+
+/**
+ * True when the tab-clamp LaunchedEffect should reset [selectedTab] to Home. Returns false while
+ * the user is searching ([searchQuery] non-empty) — `LibraryFilterEngine` filters
+ * `projection.series/collections` by the active query, so an unmatched search would otherwise
+ * flip a visibility flag off, clamp the tab, and the clamp would survive clearing the query.
+ * Also false while [visibility] is null (still resolving) so a `rememberSaveable`-restored tab
+ * survives the initial load window.
+ */
+internal fun shouldClampSelectedTab(
+    searchQuery: String,
+    visibility: LibraryTabVisibility?,
+    selectedTab: Int,
+): Boolean {
+    if (searchQuery.isNotEmpty()) return false
+    if (visibility == null) return false
+    return !isTabVisible(selectedTab, visibility)
+}
 
 /**
  * True when the tab currently rendered at [selectedTab] still has data to show under the current

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -175,10 +175,10 @@ fun LibraryItemsScreen(
     // everyone to Home on first launch after upgrade.
     var selectedTab by rememberSaveable(key = "library_selected_tab_v2") { mutableIntStateOf(0) }
 
-    // Reset to Home when the previously-selected tab is no longer visible for the active Source
-    // (e.g. user was on Series, then switched to a LocalFiles Source that lacks SeriesCapability).
-    // Skip while tabVisibility is null (Catalog still resolving) so a `rememberSaveable`-restored
-    // selectedTab isn't silently clobbered before the real capability set lands.
+    // Reset to Home when the previously-selected tab has no data for the active library (e.g.
+    // user was on Series, then the last series was deleted, or switched to a source whose library
+    // has no series). Skip while tabVisibility is null (still resolving) so a `rememberSaveable`-
+    // restored selectedTab isn't silently clobbered before the real emptiness set lands.
     LaunchedEffect(tabVisibility) {
         val visibility = tabVisibility ?: return@LaunchedEffect
         if (!isTabVisible(selectedTab, visibility)) selectedTab = 0
@@ -248,11 +248,10 @@ fun LibraryItemsScreen(
         },
         bottomBar = {
             if (searchQuery.isEmpty()) {
-                // Fall back to the full ABS-shape while the active Catalog is resolving so the
-                // tab bar renders immediately — hiding tabs mid-load would flash the bar layout.
-                // The LaunchedEffect above waits for a real emission before clamping selectedTab,
-                // so this permissive fallback can never route the user into a truly unavailable
-                // tab.
+                // Fall back to the full tab set while the library is still loading so the tab
+                // bar renders immediately — hiding tabs mid-load would flash the bar layout. The
+                // LaunchedEffect above waits for a real emission before clamping selectedTab, so
+                // this permissive fallback can never route the user into a truly empty tab.
                 LibraryTabBar(
                     selectedTab = selectedTab,
                     onTabSelected = { selectedTab = it },
@@ -1255,10 +1254,9 @@ internal fun LibraryItemCard(
 internal fun tabIndexForAnnotations(): Int = 2
 
 /**
- * True when the tab currently rendered at [selectedTab] is still valid given the active Source's
- * [visibility]. Callers use this to fall back to Home (index 0) after a Source switch (or a
- * library switch that hides Annotations) invalidates the previously-selected tab. Home and All
- * Books are always visible.
+ * True when the tab currently rendered at [selectedTab] still has data to show under the current
+ * [visibility]. Callers use this to fall back to Home (index 0) when the previously-selected tab
+ * has been emptied out. Home and All Books are always visible.
  */
 internal fun isTabVisible(selectedTab: Int, visibility: LibraryTabVisibility): Boolean =
     when (selectedTab) {

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -226,19 +226,27 @@ class LibraryItemsViewModel @Inject constructor(
      * `AnnotationsListViewModel` renders — so tab visibility cannot disagree with what the tab
      * content would show.
      *
-     * Null only for a moment between VM construction and the projection's first emission; the UI
-     * treats null as "show every tab" so the initial paint doesn't hide tabs before we know.
+     * Null while the library hasn't loaded any items yet ([allItems] empty is treated as "not yet
+     * settled") — Room's initial `emptyList()` tick from every projection sub-flow would otherwise
+     * fire the tab-bar clamp before real data lands and wipe a `rememberSaveable`-restored tab.
+     * The UI treats null as "show every tab" so the initial paint is stable and the LaunchedEffect
+     * doesn't run.
      */
     val tabVisibility: StateFlow<LibraryTabVisibility?> = combine(
         projection,
         annotatedBooksInLibrary,
-    ) { p, annotated ->
-        LibraryTabVisibility(
-            toRead = p.toRead.isNotEmpty(),
-            series = p.series.isNotEmpty(),
-            collections = p.collections.isNotEmpty(),
-            annotations = annotated.isNotEmpty(),
-        )
+        allItems,
+    ) { p, annotated, items ->
+        if (items.isEmpty()) {
+            null
+        } else {
+            LibraryTabVisibility(
+                toRead = p.toRead.isNotEmpty(),
+                series = p.series.isNotEmpty(),
+                collections = p.collections.isNotEmpty(),
+                annotations = annotated.isNotEmpty(),
+            )
+        }
     }
         .distinctUntilChanged()
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -19,11 +19,8 @@ import com.riffle.core.domain.usecase.RefreshCollections
 import com.riffle.core.domain.usecase.RefreshLibraryItems
 import com.riffle.core.domain.usecase.RefreshSeries
 import com.riffle.core.domain.Series
+import com.riffle.core.data.AnnotationsLibraryRepository
 import com.riffle.core.data.ToReadRepository
-import com.riffle.core.catalog.CatalogRegistry
-import com.riffle.core.catalog.CollectionsCapability
-import com.riffle.core.catalog.PlaylistsCapability
-import com.riffle.core.catalog.SeriesCapability
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.TokenStorage
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -32,6 +29,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -67,7 +65,7 @@ class LibraryItemsViewModel @Inject constructor(
     private val coverGridDensityStore: com.riffle.core.domain.CoverGridDensityStore,
     private val annotationStore: AnnotationStore,
     private val audiobookBookmarkStore: AudiobookBookmarkStore,
-    private val catalogRegistry: CatalogRegistry,
+    private val annotationsLibraryRepository: AnnotationsLibraryRepository,
 ) : ViewModel() {
 
     val libraryId: String = savedStateHandle.get<String>("libraryId") ?: ""
@@ -208,54 +206,40 @@ class LibraryItemsViewModel @Inject constructor(
     val projection: StateFlow<LibraryProjection> = filterEngine.projection
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), LibraryProjection.Empty)
 
-    /**
-     * Which optional Library tabs are visible for the active Source. Home, Annotations, and All
-     * Books are always available; the rest are gated on the active Catalog's capabilities per
-     * issue #439 / ADR 0041.
-     *
-     * Null before the active Source's Catalog resolves — composables read this and skip the
-     * "clamp selected tab back to Home" effect while unresolved, so a `rememberSaveable`-restored
-     * selected-tab isn't wiped by the initial empty state on cold start.
-     *
-     * Reactive against `sourceRepository.observeAll()` so an in-place Source switch (drawer tap,
-     * background sync, etc.) re-derives the visibility set instead of latching on whichever
-     * Source happened to be active when this VM was constructed. Raw `is X` checks stand in for
-     * the inline `Catalog.has<T>()` extension: core:catalog compiles at JVM target 21 (implicit)
-     * while every consumer pins target 17, so the inline can't cross the boundary today.
-     */
-    val tabVisibility: StateFlow<LibraryTabVisibility?> = combine(
+    // Books with at least one live highlight in THIS library — the same query the Annotations tab
+    // content uses (AnnotationsListViewModel), so tab visibility can't disagree with what the tab
+    // would render.
+    private val annotatedBooksInLibrary: Flow<List<com.riffle.core.data.AnnotatedBook>> =
         sourceRepository.observeAll()
             .map { servers -> servers.firstOrNull { it.isActive }?.id }
-            .distinctUntilChanged(),
-        allItems,
-    ) { sourceId, items ->
-        val catalog = sourceId?.let { catalogRegistry.forSourceId(it) }
+            .distinctUntilChanged()
+            .flatMapLatest { sourceId ->
+                if (sourceId == null) flowOf(emptyList())
+                else annotationsLibraryRepository.observeAnnotatedBooks(sourceId, libraryId)
+            }
+
+    /**
+     * Which optional Library tabs are visible. Home and All Books are unconditional; every other
+     * tab is shown iff the exact list the tab would render is non-empty. Backed by the same
+     * [LibraryProjection] the UI already reads (mapping stale To-Read IDs through the library's
+     * items, applying the offline filter, etc.) plus the same annotated-books query
+     * `AnnotationsListViewModel` renders — so tab visibility cannot disagree with what the tab
+     * content would show.
+     *
+     * Null only for a moment between VM construction and the projection's first emission; the UI
+     * treats null as "show every tab" so the initial paint doesn't hide tabs before we know.
+     */
+    val tabVisibility: StateFlow<LibraryTabVisibility?> = combine(
+        projection,
+        annotatedBooksInLibrary,
+    ) { p, annotated ->
         LibraryTabVisibility(
-            // To Read is available on every Source: [ToReadRepositoryImpl] falls back to a
-            // local Preferences DataStore when the Catalog has no server-side
-            // [PlaylistsCapability], so the tab shows for ABS, Local Files, and any future
-            // backend-less Source alike.
-            toRead = true,
-            series = catalog is SeriesCapability,
-            collections = catalog is CollectionsCapability,
-            // Highlights/notes are text-anchored — EPUB and PDF only. A CBZ archive (comics/manga
-            // libraries served by Komga; the same holds for future CBR/scan-image sources) is a
-            // stack of raster pages with no selectable text, so an Annotations tab on an entirely
-            // CBZ library is dead UI. Rule: show the tab as long as at least one item CAN be
-            // annotated. A Books library with 328 EPUBs + 64 PDFs shows it. A Comics library with
-            // 2497 CBZs + 5 stray PDFs shows it too — five real annotations are worth reaching,
-            // and a mixed library of 99 EPUBs + 100 CBZs must not lose access to the 99 EPUBs'
-            // notes (the previous majority-vote gate did exactly that). Empty list is treated as
-            // "not yet settled" (allItems' initial value is emptyList(), and a library refresh's
-            // replaceAllForLibrary window transiently drops rows) — keeping the tab visible there
-            // prevents a cold-start LaunchedEffect clamp from wiping a rememberSaveable-restored
-            // TAB_ANNOTATIONS.
-            annotations = items.isEmpty() || items.any { it.canAnnotate },
+            toRead = p.toRead.isNotEmpty(),
+            series = p.series.isNotEmpty(),
+            collections = p.collections.isNotEmpty(),
+            annotations = annotated.isNotEmpty(),
         )
     }
-        // Room emits on every DB write (progress ticks, download-state changes) but the
-        // capability + item-shape signals rarely change; collapse identical values so the
-        // tab bar doesn't recompose on every progress tick.
         .distinctUntilChanged()
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryTabVisibility.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryTabVisibility.kt
@@ -2,24 +2,20 @@ package com.riffle.app.feature.library
 
 /**
  * Which optional Library-tab-bar entries are shown for the active Source. Home and All Books are
- * unconditional and not tracked here. Populated by [LibraryItemsViewModel] from the active
- * Catalog's capabilities (issue #439 / ADR 0041) and, for [annotations], from whether the current
- * library contains any readable items.
+ * unconditional and not tracked here. Every other tab is visible iff its underlying data is
+ * non-empty — no source-type or Catalog-capability gating.
  */
 data class LibraryTabVisibility(
     val toRead: Boolean,
     val series: Boolean,
     val collections: Boolean,
-    // Annotations are anchored to ebook text — an audiobook-only library can never have any. Hide
-    // the tab when the current library contains no readable items so the surface isn't dead UI.
-    // Reactive: adding a readable item later flips this back on live.
     val annotations: Boolean,
 ) {
     companion object {
-        /** Default before the active Catalog has been resolved: hide every optional tab. */
+        /** Default before the library has settled: hide every optional tab. */
         val Empty = LibraryTabVisibility(toRead = false, series = false, collections = false, annotations = false)
 
-        /** Every optional tab present — mirrors what a full ABS Catalog exposes. */
+        /** Every optional tab present — used as the "still loading" fallback in the UI. */
         val All = LibraryTabVisibility(toRead = true, series = true, collections = true, annotations = true)
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -1138,6 +1138,7 @@ class LibraryItemsViewModelTest {
         val vm = makeViewModel(sourceRepository = srcRepo, toReadRepository = toRead)
         backgroundScope.launch { vm.projection.collect {} }
         allBooksFlow.value = listOf(item("book", "author"))
+        allItemsFlow.value = listOf(item("book", "author"))
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Baseline: library has items but no series/collections/toRead/annotations → all optional
@@ -1198,6 +1199,7 @@ class LibraryItemsViewModelTest {
         val vm = makeViewModel(sourceRepository = srcRepo, annotationsLibraryRepository = repo)
         backgroundScope.launch { vm.projection.collect {} }
         allBooksFlow.value = listOf(item("book", "author"))
+        allItemsFlow.value = listOf(item("book", "author"))
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(false, vm.tabVisibility.value?.annotations)
@@ -1221,6 +1223,7 @@ class LibraryItemsViewModelTest {
         val vm = makeViewModel(sourceRepository = srcRepo, toReadRepository = toRead)
         backgroundScope.launch { vm.projection.collect {} }
         allBooksFlow.value = listOf(item("book", "author"))
+        allItemsFlow.value = listOf(item("book", "author"))
         testDispatcher.scheduler.advanceUntilIdle()
 
         // Stale ID doesn't map to any item in this library's allBooks → tab hidden.
@@ -1232,22 +1235,44 @@ class LibraryItemsViewModelTest {
         assertEquals(true, vm.tabVisibility.value?.toRead)
     }
 
+    // Regression pin for the cold-start clobber: while the library has no items loaded yet
+    // (`allItems` empty — either genuinely empty or still refreshing), tabVisibility must stay
+    // null so the UI falls back to `LibraryTabVisibility.All`. Without this gate, Room's initial
+    // `emptyList()` tick from every projection sub-flow immediately emits an all-false visibility
+    // and the LaunchedEffect clamps a `rememberSaveable`-restored selectedTab to Home before real
+    // data can land.
     @Test
-    fun `tabVisibility is Empty when no active Source and no library data has arrived`() = runTest {
+    fun `tabVisibility stays null while allItems is empty so cold-start restore isn't clobbered`() = runTest {
+        val srv = source("s-abs", active = true)
         val srcRepo = object : SourceRepository {
-            override fun observeAll(): Flow<List<Source>> = MutableStateFlow(emptyList())
-            override suspend fun getActive(): Source? = null
+            override fun observeAll(): Flow<List<Source>> = MutableStateFlow(listOf(srv))
+            override suspend fun getActive(): Source? = srv
             override suspend fun commit(pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>) = throw UnsupportedOperationException()
             override suspend fun setActive(sourceId: String) {}
             override suspend fun remove(sourceId: String) {}
             override suspend fun getSourceVersion(sourceId: String): String? = null
         }
+        // Seed the source-side flows with values that would flip visibility ON if the settled
+        // gate weren't in place — proving null persists specifically because `allItems` is empty,
+        // not because there's nothing to show.
+        seriesFlow.value = listOf(series("Dune"))
+        collectionsFlow.value = listOf(collection("Sci-Fi"))
+        annotatedBooksFlow.value = listOf(
+            com.riffle.core.data.AnnotatedBook("s-abs", "id-book", "Book", "Author", null, 1, 0L),
+        )
         val vm = makeViewModel(sourceRepository = srcRepo)
         backgroundScope.launch { vm.projection.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
 
-        // Nothing to show → every optional tab hidden by default (Home + All Books still render).
-        assertEquals(LibraryTabVisibility.Empty, vm.tabVisibility.value)
+        assertEquals(null, vm.tabVisibility.value)
+
+        // Once allItems settles with real rows, visibility flips to the real per-tab values.
+        allItemsFlow.value = listOf(item("book", "author"))
+        allBooksFlow.value = listOf(item("book", "author"))
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(true, vm.tabVisibility.value?.series)
+        assertEquals(true, vm.tabVisibility.value?.collections)
+        assertEquals(true, vm.tabVisibility.value?.annotations)
     }
 
     private fun source(id: String, active: Boolean) = Source(

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -68,6 +68,14 @@ class LibraryItemsViewModelTest {
     private val seriesItemsBySeriesId = mutableMapOf<String, MutableStateFlow<List<LibraryItem>>>()
     private val librariesFlow = MutableStateFlow<List<Library>>(emptyList())
     private val annotationsFlow = MutableStateFlow<List<com.riffle.core.domain.Annotation>>(emptyList())
+    private val annotatedBooksFlow = MutableStateFlow<List<com.riffle.core.data.AnnotatedBook>>(emptyList())
+
+    private fun fakeAnnotationsLibraryRepository(): com.riffle.core.data.AnnotationsLibraryRepository =
+        object : com.riffle.core.data.AnnotationsLibraryRepository {
+            override fun observeAnnotatedBooks(sourceId: String) = annotatedBooksFlow
+            override fun observeAnnotatedBooks(sourceId: String, libraryId: String) =
+                annotatedBooksFlow.map { it.filter { book -> book.sourceId == sourceId } }
+        }
 
     private fun fakeAnnotationStore(): com.riffle.core.domain.AnnotationStore =
         object : com.riffle.core.domain.AnnotationStore {
@@ -210,7 +218,7 @@ class LibraryItemsViewModelTest {
         },
         annotationStore: com.riffle.core.domain.AnnotationStore = fakeAnnotationStore(),
         audiobookBookmarkStore: com.riffle.core.domain.AudiobookBookmarkStore = fakeAudiobookBookmarkStore(),
-        catalogRegistry: com.riffle.core.catalog.CatalogRegistry = fakeCatalogRegistry(),
+        annotationsLibraryRepository: com.riffle.core.data.AnnotationsLibraryRepository = fakeAnnotationsLibraryRepository(),
     ) = LibraryItemsViewModel(
         savedStateHandle = savedStateHandle,
         libraryObserver = libraryRepository,
@@ -235,16 +243,8 @@ class LibraryItemsViewModelTest {
         coverGridDensityStore = coverGridDensityStore,
         annotationStore = annotationStore,
         audiobookBookmarkStore = audiobookBookmarkStore,
-        catalogRegistry = catalogRegistry,
+        annotationsLibraryRepository = annotationsLibraryRepository,
     )
-
-    private fun fakeCatalogRegistry(
-        catalog: com.riffle.core.catalog.Catalog? = null,
-    ): com.riffle.core.catalog.CatalogRegistry = object : com.riffle.core.catalog.CatalogRegistry {
-        override suspend fun forActive(): com.riffle.core.catalog.Catalog? = catalog
-        override suspend fun forSource(source: com.riffle.core.domain.Source): com.riffle.core.catalog.Catalog? = catalog
-        override suspend fun forSourceId(sourceId: String): com.riffle.core.catalog.Catalog? = catalog
-    }
 
     private fun series(name: String) = Series("id-$name", "lib-1", name, null, 1)
     private fun collection(name: String) = Collection("id-$name", "lib-1", name, 1)
@@ -1121,124 +1121,60 @@ class LibraryItemsViewModelTest {
         assertEquals(emptyList<AnnotationSearchResult>(), vm.projection.value.annotations)
     }
 
-    // Regression pins for #439: tabVisibility must map from the active Catalog's capabilities and
-    // must re-derive when the active Source changes in place.
+    // Regression pins for the emptiness-based tabVisibility. Every gate is per-library — no
+    // Catalog-capability gating, and no cross-library leakage of annotations or stale To-Read IDs.
     @Test
-    fun `tabVisibility maps active Catalog capabilities to per-tab flags`() = runTest {
+    fun `tabVisibility flips each optional flag based on its own data's emptiness`() = runTest {
         val srv = source("s-abs", active = true)
-        val serversFlow = MutableStateFlow(listOf(srv))
         val srcRepo = object : SourceRepository {
-            override fun observeAll(): Flow<List<Source>> = serversFlow
-            override suspend fun getActive(): Source? = serversFlow.value.firstOrNull { it.isActive }
+            override fun observeAll(): Flow<List<Source>> = MutableStateFlow(listOf(srv))
+            override suspend fun getActive(): Source? = srv
             override suspend fun commit(pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>) = throw UnsupportedOperationException()
             override suspend fun setActive(sourceId: String) {}
             override suspend fun remove(sourceId: String) {}
             override suspend fun getSourceVersion(sourceId: String): String? = null
         }
-        val vm = makeViewModel(
-            sourceRepository = srcRepo,
-            catalogRegistry = catalogRegistryReturning(SeriesAndPlaylistsOnlyCatalog),
+        val toRead = FakeToReadRepository()
+        val vm = makeViewModel(sourceRepository = srcRepo, toReadRepository = toRead)
+        backgroundScope.launch { vm.projection.collect {} }
+        allBooksFlow.value = listOf(item("book", "author"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Baseline: library has items but no series/collections/toRead/annotations → all optional
+        // tabs hidden.
+        assertEquals(
+            LibraryTabVisibility(toRead = false, series = false, collections = false, annotations = false),
+            vm.tabVisibility.value,
         )
+
+        seriesFlow.value = listOf(series("Dune"))
         testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(true, vm.tabVisibility.value?.series)
+        assertEquals(false, vm.tabVisibility.value?.collections)
 
-        val visibility = vm.tabVisibility.value
-        assertEquals(true, visibility?.series)
-        assertEquals(true, visibility?.toRead)
-        assertEquals(false, visibility?.collections)
-    }
-
-    /**
-     * `toRead` is now [true] for every source since [ToReadRepositoryImpl] falls back to
-     * [com.riffle.core.data.LocalToReadStore] when the active Catalog has no PlaylistsCapability.
-     * The pre-fallback assertion (`toRead = false` for a LocalFiles-shape source) intentionally
-     * flipped as part of that consistency change — this test now pins the new invariant that
-     * `series` still tracks capability while `toRead` is universal.
-     */
-    @Test
-    fun `tabVisibility re-emits when the active Source flips to one with a different capability set`() = runTest {
-        val abs = source("s-abs", active = true)
-        val local = source("s-local", active = false)
-        val serversFlow = MutableStateFlow(listOf(abs, local))
-        val srcRepo = object : SourceRepository {
-            override fun observeAll(): Flow<List<Source>> = serversFlow
-            override suspend fun getActive(): Source? = serversFlow.value.firstOrNull { it.isActive }
-            override suspend fun commit(pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>) = throw UnsupportedOperationException()
-            override suspend fun setActive(sourceId: String) {}
-            override suspend fun remove(sourceId: String) {}
-            override suspend fun getSourceVersion(sourceId: String): String? = null
-        }
-        // ABS → SeriesAndPlaylistsOnlyCatalog; LocalFiles → SeriesOnlyCatalog. The mapping keys on
-        // source id so we can prove the flow re-fires on switch, not just latches the first value.
-        val registry = object : com.riffle.core.catalog.CatalogRegistry {
-            override suspend fun forActive(): com.riffle.core.catalog.Catalog? = null
-            override suspend fun forSource(source: Source): com.riffle.core.catalog.Catalog? = forSourceId(source.id)
-            override suspend fun forSourceId(sourceId: String): com.riffle.core.catalog.Catalog? = when (sourceId) {
-                "s-abs" -> SeriesAndPlaylistsOnlyCatalog
-                "s-local" -> SeriesOnlyCatalog
-                else -> null
-            }
-        }
-        val vm = makeViewModel(sourceRepository = srcRepo, catalogRegistry = registry)
+        collectionsFlow.value = listOf(collection("Sci-Fi"))
         testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(true, vm.tabVisibility.value?.collections)
 
+        // A To-Read ID pointing at an item in this library flips toRead on.
+        toRead.ids.value = setOf("id-book")
+        testDispatcher.scheduler.advanceUntilIdle()
         assertEquals(true, vm.tabVisibility.value?.toRead)
 
-        // Flip active to the LocalFiles-shaped source.
-        serversFlow.value = listOf(abs.copy(isActive = false), local.copy(isActive = true))
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        val v = vm.tabVisibility.value
-        assertEquals(true, v?.series)
-        // Universal now — local fallback provides To Read for sources without PlaylistsCapability.
-        assertEquals(true, v?.toRead)
-    }
-
-    // Regression pin for the Annotations tab gate: a library confirmed to contain only
-    // audiobook items reports annotations=false. An empty item list is treated as "not yet
-    // settled" (initial state / refresh consistency window) — annotations stays true so a
-    // cold-start LaunchedEffect clamp can't wipe a rememberSaveable-restored TAB_ANNOTATIONS.
-    @Test
-    fun `tabVisibility annotations reflects whether library contains any readable items`() = runTest {
-        val srv = source("s-abs", active = true)
-        val serversFlow = MutableStateFlow(listOf(srv))
-        val srcRepo = object : SourceRepository {
-            override fun observeAll(): Flow<List<Source>> = serversFlow
-            override suspend fun getActive(): Source? = serversFlow.value.firstOrNull { it.isActive }
-            override suspend fun commit(pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>) = throw UnsupportedOperationException()
-            override suspend fun setActive(sourceId: String) {}
-            override suspend fun remove(sourceId: String) {}
-            override suspend fun getSourceVersion(sourceId: String): String? = null
-        }
-        val vm = makeViewModel(
-            sourceRepository = srcRepo,
-            catalogRegistry = catalogRegistryReturning(SeriesAndPlaylistsOnlyCatalog),
+        // An annotated book on this (source, library) flips annotations on.
+        annotatedBooksFlow.value = listOf(
+            com.riffle.core.data.AnnotatedBook("s-abs", "id-book", "Book", "Author", null, 1, 0L),
         )
-
-        // Initial empty state → visible ("not yet settled"; don't clamp cold-start restore).
-        testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(true, vm.tabVisibility.value?.annotations)
-
-        // Audiobook-only, non-empty: EbookFormat.Unsupported → isReadable = false → hide.
-        val audiobook = LibraryItem(
-            "id-audiobook", "lib-1", "An Audiobook", "Author", null, 0f, false, false,
-            EbookFormat.Unsupported, hasAudio = true,
-        )
-        allItemsFlow.value = listOf(audiobook)
-        testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(false, vm.tabVisibility.value?.annotations)
-
-        // Add an EPUB → isReadable = true → tab reappears live.
-        allItemsFlow.value = listOf(audiobook, item("An Ebook", "Author"))
         testDispatcher.scheduler.advanceUntilIdle()
         assertEquals(true, vm.tabVisibility.value?.annotations)
     }
 
-    // Regression pin for the CBZ carve-out: a Komga Comics library is entirely CBZ (raster
-    // pages, no selectable text). CBZ items are readable but NOT annotable — an all-CBZ
-    // library must hide the Annotations tab even though every item passes the isReadable gate.
-    // Reverting the ViewModel's gate to `isReadable` flips this red.
+    // Reproduces the shipped bug: an annotated book on the same source but in a sibling library
+    // (Books, say) must not make the Annotations tab appear in the Audiobooks library. The gate
+    // uses `observeAnnotatedBooks(sourceId, libraryId)` which JOINs on library_items and excludes
+    // annotations whose item is not in this library.
     @Test
-    fun `tabVisibility annotations is hidden on an all-CBZ library`() = runTest {
+    fun `tabVisibility does not leak annotations across sibling libraries in the same source`() = runTest {
         val srv = source("s-abs", active = true)
         val srcRepo = object : SourceRepository {
             override fun observeAll(): Flow<List<Source>> = MutableStateFlow(listOf(srv))
@@ -1248,26 +1184,30 @@ class LibraryItemsViewModelTest {
             override suspend fun remove(sourceId: String) {}
             override suspend fun getSourceVersion(sourceId: String): String? = null
         }
-        val vm = makeViewModel(
-            sourceRepository = srcRepo,
-            catalogRegistry = catalogRegistryReturning(SeriesAndPlaylistsOnlyCatalog),
-        )
-
-        val cbz = LibraryItem(
-            "id-cbz", "lib-1", "A Comic", "Author", null, 0f, false, false,
-            EbookFormat.Cbz,
-        )
-        allItemsFlow.value = List(50) { cbz.copy(id = "id-cbz-$it") }
+        // Custom AnnotationsLibraryRepository: an annotation exists on s-abs but its libraryId is
+        // "other-lib", not "lib-1" — the tab must stay hidden for this VM (which is scoped to lib-1
+        // via SavedStateHandle).
+        val repo = object : com.riffle.core.data.AnnotationsLibraryRepository {
+            override fun observeAnnotatedBooks(sourceId: String) = MutableStateFlow(
+                listOf(com.riffle.core.data.AnnotatedBook("s-abs", "id-other", "T", "A", null, 1, 0L)),
+            )
+            override fun observeAnnotatedBooks(sourceId: String, libraryId: String) =
+                if (libraryId == "lib-1") MutableStateFlow(emptyList<com.riffle.core.data.AnnotatedBook>())
+                else MutableStateFlow(listOf(com.riffle.core.data.AnnotatedBook("s-abs", "id-other", "T", "A", null, 1, 0L)))
+        }
+        val vm = makeViewModel(sourceRepository = srcRepo, annotationsLibraryRepository = repo)
+        backgroundScope.launch { vm.projection.collect {} }
+        allBooksFlow.value = listOf(item("book", "author"))
         testDispatcher.scheduler.advanceUntilIdle()
+
         assertEquals(false, vm.tabVisibility.value?.annotations)
     }
 
-    // Regression pin for the ANY-annotable rule: as long as at least one item in the library can
-    // carry a highlight, the Annotations tab stays visible. A library dominated by CBZ but with a
-    // handful of EPUBs still shows it — the previous majority-vote gate lost access to those
-    // EPUBs' notes when non-annotable items outnumbered annotable ones, which was the bug.
+    // Reproduces the shipped bug: To-Read IDs whose items don't belong to this library must not
+    // keep the tab visible. The tab renders empty content because the ID-to-item lookup falls
+    // through — the gate must mirror that lookup.
     @Test
-    fun `tabVisibility annotations is shown when any item is annotable even if outnumbered`() = runTest {
+    fun `tabVisibility toRead is hidden when To-Read IDs do not resolve to library items`() = runTest {
         val srv = source("s-abs", active = true)
         val srcRepo = object : SourceRepository {
             override fun observeAll(): Flow<List<Source>> = MutableStateFlow(listOf(srv))
@@ -1277,27 +1217,37 @@ class LibraryItemsViewModelTest {
             override suspend fun remove(sourceId: String) {}
             override suspend fun getSourceVersion(sourceId: String): String? = null
         }
-        val vm = makeViewModel(
-            sourceRepository = srcRepo,
-            catalogRegistry = catalogRegistryReturning(SeriesAndPlaylistsOnlyCatalog),
-        )
-
-        val epub = item("EPUB", "Author")
-        val cbz = LibraryItem(
-            "id-cbz", "lib-1", "Comic", "A", null, 0f, false, false, EbookFormat.Cbz,
-        )
-        // Outnumbered case (previously hidden by the majority gate): 5 EPUBs, 100 CBZs → tab
-        // still visible because the 5 EPUBs' highlights are worth reaching.
-        allItemsFlow.value =
-            List(5) { epub.copy(id = "id-epub-$it") } + List(100) { cbz.copy(id = "id-cbz-$it") }
+        val toRead = FakeToReadRepository(initial = setOf("id-stale"))
+        val vm = makeViewModel(sourceRepository = srcRepo, toReadRepository = toRead)
+        backgroundScope.launch { vm.projection.collect {} }
+        allBooksFlow.value = listOf(item("book", "author"))
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(true, vm.tabVisibility.value?.annotations)
 
-        // Tie case (previously visible; still visible under the any-annotable rule).
-        allItemsFlow.value =
-            List(50) { epub.copy(id = "id-epub-$it") } + List(50) { cbz.copy(id = "id-cbz-$it") }
+        // Stale ID doesn't map to any item in this library's allBooks → tab hidden.
+        assertEquals(false, vm.tabVisibility.value?.toRead)
+
+        // The user adds the actual library item to their To Read set → tab reappears live.
+        toRead.ids.value = setOf("id-book")
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(true, vm.tabVisibility.value?.annotations)
+        assertEquals(true, vm.tabVisibility.value?.toRead)
+    }
+
+    @Test
+    fun `tabVisibility is Empty when no active Source and no library data has arrived`() = runTest {
+        val srcRepo = object : SourceRepository {
+            override fun observeAll(): Flow<List<Source>> = MutableStateFlow(emptyList())
+            override suspend fun getActive(): Source? = null
+            override suspend fun commit(pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>) = throw UnsupportedOperationException()
+            override suspend fun setActive(sourceId: String) {}
+            override suspend fun remove(sourceId: String) {}
+            override suspend fun getSourceVersion(sourceId: String): String? = null
+        }
+        val vm = makeViewModel(sourceRepository = srcRepo)
+        backgroundScope.launch { vm.projection.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Nothing to show → every optional tab hidden by default (Home + All Books still render).
+        assertEquals(LibraryTabVisibility.Empty, vm.tabVisibility.value)
     }
 
     private fun source(id: String, active: Boolean) = Source(
@@ -1309,49 +1259,6 @@ class LibraryItemsViewModelTest {
         type = if (id == "s-local") com.riffle.core.domain.SourceType.LOCAL_FILES else com.riffle.core.domain.SourceType.ABS,
         serverType = com.riffle.core.domain.ServerType.AUDIOBOOKSHELF,
     )
-
-    private fun catalogRegistryReturning(catalog: com.riffle.core.catalog.Catalog?): com.riffle.core.catalog.CatalogRegistry =
-        object : com.riffle.core.catalog.CatalogRegistry {
-            override suspend fun forActive(): com.riffle.core.catalog.Catalog? = catalog
-            override suspend fun forSource(source: Source): com.riffle.core.catalog.Catalog? = catalog
-            override suspend fun forSourceId(sourceId: String): com.riffle.core.catalog.Catalog? = catalog
-        }
-
-    private object SeriesAndPlaylistsOnlyCatalog :
-        com.riffle.core.catalog.Catalog,
-        com.riffle.core.catalog.SeriesCapability,
-        com.riffle.core.catalog.PlaylistsCapability {
-        override val sourceType = com.riffle.core.domain.SourceType.ABS
-        override suspend fun listRoots() = emptyList<com.riffle.core.catalog.CatalogRoot>()
-        override suspend fun browse(rootId: String, sort: com.riffle.core.catalog.SortKey, page: Int, pageSize: Int, facet: com.riffle.core.catalog.FacetSelection?) = emptyList<com.riffle.core.catalog.CatalogItem>()
-        override suspend fun search(rootId: String, query: String, page: Int, pageSize: Int) = emptyList<com.riffle.core.catalog.CatalogItem>()
-        override suspend fun getItem(itemId: String) = null
-        override suspend fun fetchFile(itemId: String, format: com.riffle.core.catalog.BookFormat) = error("unused")
-        override suspend fun openFile(itemId: String, format: com.riffle.core.catalog.BookFormat, handleHint: String?) = error("unused")
-        override suspend fun connectivityCheck() = error("unused")
-        override suspend fun listSeries(rootId: String) = emptyList<com.riffle.core.catalog.CatalogSeries>()
-        override suspend fun listItemsInSeries(rootId: String, seriesId: String) = emptyList<com.riffle.core.catalog.CatalogItem>()
-        override suspend fun listPlaylists(rootId: String) = emptyList<com.riffle.core.catalog.CatalogPlaylist>()
-        override suspend fun findPlaylist(rootId: String, name: String): com.riffle.core.catalog.CatalogPlaylist? = null
-        override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?) = error("unused")
-        override suspend fun addItemToPlaylist(playlistId: String, itemId: String) {}
-        override suspend fun removeItemFromPlaylist(playlistId: String, itemId: String) {}
-    }
-
-    private object SeriesOnlyCatalog :
-        com.riffle.core.catalog.Catalog,
-        com.riffle.core.catalog.SeriesCapability {
-        override val sourceType = com.riffle.core.domain.SourceType.LOCAL_FILES
-        override suspend fun listRoots() = emptyList<com.riffle.core.catalog.CatalogRoot>()
-        override suspend fun browse(rootId: String, sort: com.riffle.core.catalog.SortKey, page: Int, pageSize: Int, facet: com.riffle.core.catalog.FacetSelection?) = emptyList<com.riffle.core.catalog.CatalogItem>()
-        override suspend fun search(rootId: String, query: String, page: Int, pageSize: Int) = emptyList<com.riffle.core.catalog.CatalogItem>()
-        override suspend fun getItem(itemId: String) = null
-        override suspend fun fetchFile(itemId: String, format: com.riffle.core.catalog.BookFormat) = error("unused")
-        override suspend fun openFile(itemId: String, format: com.riffle.core.catalog.BookFormat, handleHint: String?) = error("unused")
-        override suspend fun connectivityCheck() = error("unused")
-        override suspend fun listSeries(rootId: String) = emptyList<com.riffle.core.catalog.CatalogSeries>()
-        override suspend fun listItemsInSeries(rootId: String, seriesId: String) = emptyList<com.riffle.core.catalog.CatalogItem>()
-    }
 
     // Regression: on ON_RESUME we always refresh so `_refreshFailed` clears if the server is back.
     // Connectivity self-heals inside the ConnectivityObserver via ProcessLifecycleOwner + the

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryTabVisibilityTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryTabVisibilityTest.kt
@@ -5,58 +5,50 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Regression pins for issue #439's Library-tab visibility gate. The `isTabVisible` helper is what
- * `LibraryItemsScreen` uses to clamp `selectedTab` back to Home when the active Source stops
- * exposing the previously-selected tab (e.g. user was on Series, then switched to a LocalFiles
- * Source that lacks `SeriesCapability`). If any of these assertions flips red, either the tab
- * indices in `LibraryTabBar` have drifted, or a capability got silently ungated.
+ * Pins the `isTabVisible` clamp helper — Home (0) and All Books (5) stay visible no matter what,
+ * and each optional tab is gated purely on its own emptiness bit. If any of these flip red, either
+ * the tab indices in `LibraryTabBar` have drifted or the emptiness routing has been rewired.
  */
 class LibraryTabVisibilityTest {
 
     @Test
-    fun `unconditional tabs stay visible regardless of capabilities`() {
+    fun `home and all books are always visible`() {
         val none = LibraryTabVisibility.Empty
-        // Home (0), All Books (5) are always shown. Annotations (2) is now conditional on the
-        // library containing readable items — covered separately below.
         assertTrue(isTabVisible(0, none))
         assertTrue(isTabVisible(5, none))
     }
 
     @Test
-    fun `annotations tab is hidden when the library has no readable items`() {
-        val audiobookOnly = LibraryTabVisibility(
-            toRead = true, series = false, collections = false, annotations = false,
-        )
-        assertFalse(isTabVisible(tabIndexForAnnotations(), audiobookOnly))
-
-        val mixed = audiobookOnly.copy(annotations = true)
-        assertTrue(isTabVisible(tabIndexForAnnotations(), mixed))
-    }
-
-    @Test
-    fun `to read tab is hidden without PlaylistsCapability`() {
+    fun `to read tab is hidden when the to-read set is empty`() {
         assertFalse(isTabVisible(1, LibraryTabVisibility.Empty))
         assertTrue(isTabVisible(1, LibraryTabVisibility.All))
     }
 
     @Test
-    fun `series tab is hidden without SeriesCapability`() {
+    fun `annotations tab is hidden when the library has no annotations`() {
+        assertFalse(isTabVisible(tabIndexForAnnotations(), LibraryTabVisibility.Empty))
+        assertTrue(isTabVisible(tabIndexForAnnotations(), LibraryTabVisibility.All))
+    }
+
+    @Test
+    fun `series tab is hidden when there are no series`() {
         assertFalse(isTabVisible(3, LibraryTabVisibility.Empty))
         assertTrue(isTabVisible(3, LibraryTabVisibility.All))
     }
 
     @Test
-    fun `collections tab is hidden without CollectionsCapability`() {
+    fun `collections tab is hidden when there are no collections`() {
         assertFalse(isTabVisible(4, LibraryTabVisibility.Empty))
         assertTrue(isTabVisible(4, LibraryTabVisibility.All))
     }
 
     @Test
-    fun `a partial visibility set only affects its own tab`() {
+    fun `each optional tab is gated independently`() {
         val onlyToRead = LibraryTabVisibility(
             toRead = true, series = false, collections = false, annotations = false,
         )
         assertTrue(isTabVisible(1, onlyToRead))
+        assertFalse(isTabVisible(tabIndexForAnnotations(), onlyToRead))
         assertFalse(isTabVisible(3, onlyToRead))
         assertFalse(isTabVisible(4, onlyToRead))
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryTabVisibilityTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryTabVisibilityTest.kt
@@ -52,4 +52,34 @@ class LibraryTabVisibilityTest {
         assertFalse(isTabVisible(3, onlyToRead))
         assertFalse(isTabVisible(4, onlyToRead))
     }
+
+    // Regression pin for the search-clearing clobber: `LibraryFilterEngine` filters
+    // `projection.series/collections` by the active query, so a search that yields no series
+    // would flip visibility.series off. Without this guard the LaunchedEffect clamps the user's
+    // Series tab to Home, and the clamp survives clearing the search.
+    @Test
+    fun `shouldClampSelectedTab returns false while the user is searching`() {
+        val noSeries = LibraryTabVisibility(
+            toRead = true, series = false, collections = true, annotations = true,
+        )
+        // User was on Series (index 3), types a query with no matches → do NOT clamp.
+        assertFalse(shouldClampSelectedTab("dune", noSeries, selectedTab = 3))
+    }
+
+    @Test
+    fun `shouldClampSelectedTab returns false while visibility is still resolving`() {
+        // Cold start — visibility hasn't emitted a real value yet.
+        assertFalse(shouldClampSelectedTab("", visibility = null, selectedTab = 3))
+    }
+
+    @Test
+    fun `shouldClampSelectedTab returns true only when the tab is truly unavailable`() {
+        val noSeries = LibraryTabVisibility(
+            toRead = true, series = false, collections = true, annotations = true,
+        )
+        // User was on Series, no search, series was deleted → clamp.
+        assertTrue(shouldClampSelectedTab("", noSeries, selectedTab = 3))
+        // User was on Collections, which still has data → don't clamp.
+        assertFalse(shouldClampSelectedTab("", noSeries, selectedTab = 4))
+    }
 }


### PR DESCRIPTION
## Summary
- Drop Catalog-capability gating for the Library tab bar (Series/Collections/To Read/Annotations). Every optional tab now shows iff its underlying data — scoped to the current library — is non-empty. Home and All Books stay unconditional.
- Derive visibility from the same source of truth the tab content itself renders (`projection.series/collections/toRead` plus the annotated-books query `AnnotationsListViewModel` uses), so the tab bar can't disagree with what a tab would show.
- Gate the "clamp selectedTab" LaunchedEffect on `allItems` being non-empty (cold-start protection) and on `searchQuery` being empty (a query that filters out series would otherwise clobber the user's Series tab, and the clamp would survive clearing the query).

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` — all green.
- [x] `LibraryTabVisibilityTest` pins the emptiness routing per tab and the three `shouldClampSelectedTab` cases (searching, still-resolving, truly-empty).
- [x] `LibraryItemsViewModelTest` regressions for:
  - each optional flag flipping on its own data's emptiness,
  - annotations NOT leaking across sibling libraries on the same source,
  - stale To-Read IDs (that don't resolve to items in the current library) NOT keeping the tab visible,
  - cold-start: visibility stays null while `allItems` is empty even when every other flow has data.
- [ ] Manual: install on device, open Books library — Series/Collections/To Read/Annotations tabs only appear when they have data; searching for an unmatched term does not lose the current tab after clearing.