### PR TITLE
feat(sync): prefix ABS annotation namespace with abs_ and migrate legacy files

### DIFF
--- a/app/src/test/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModelTest.kt
@@ -63,7 +63,7 @@ class AnnotationSyncMaintenanceViewModelTest {
         // the only honest source for the current device's "Last synced". The per-device sentinel
         // on disk lags the cycle store by a network write, and per-file headers don't capture
         // pull-only cycles at all.
-        val activeNs = "alice-userid"
+        val activeNs = "abs_alice-userid"
         val target = InMemoryTarget(
             files = mutableMapOf(
                 FileKey(activeNs, "i1", "annotations-this-device.jsonld") to "[]",
@@ -88,7 +88,7 @@ class AnnotationSyncMaintenanceViewModelTest {
         // Regression for the bug where Maintenance hid "Last synced" the moment we went offline:
         // it read lastCycleOutcome and pattern-matched Success, so a subsequent Failed.Network
         // erased the timestamp even though sync had succeeded an hour earlier.
-        val activeNs = "alice-userid"
+        val activeNs = "abs_alice-userid"
         val target = InMemoryTarget(
             files = mutableMapOf(
                 FileKey(activeNs, "i1", "annotations-this-device.jsonld") to "[]",
@@ -110,7 +110,7 @@ class AnnotationSyncMaintenanceViewModelTest {
 
     @Test
     fun `this-device row shows no Last synced when the status store is NeverRun`() = runTest {
-        val activeNs = "alice-userid"
+        val activeNs = "abs_alice-userid"
         val target = InMemoryTarget(
             files = mutableMapOf(
                 FileKey(activeNs, "i1", "annotations-this-device.jsonld") to "[]",
@@ -127,8 +127,8 @@ class AnnotationSyncMaintenanceViewModelTest {
 
     @Test
     fun `foreign namespace surfaces as Other Users group labelled by username from sentinel`() = runTest {
-        val activeNs = "alice-userid"
-        val foreignNs = "bob-userid"
+        val activeNs = "abs_alice-userid"
+        val foreignNs = "abs_bob-userid"
         val target = InMemoryTarget(
             files = mutableMapOf(
                 FileKey(activeNs, "i1", "annotations-this-device.jsonld") to "[]",
@@ -161,8 +161,8 @@ class AnnotationSyncMaintenanceViewModelTest {
 
     @Test
     fun `forget on a foreign-user device routes to the foreign namespace`() = runTest {
-        val activeNs = "alice-userid"
-        val foreignNs = "bob-userid"
+        val activeNs = "abs_alice-userid"
+        val foreignNs = "abs_bob-userid"
         val target = InMemoryTarget(
             files = mutableMapOf(
                 FileKey(activeNs, "i1", "annotations-this-device.jsonld") to "[]",
@@ -188,8 +188,8 @@ class AnnotationSyncMaintenanceViewModelTest {
 
     @Test
     fun `foreign namespace with no sentinel falls back to a null displayLabel`() = runTest {
-        val activeNs = "alice-userid"
-        val foreignNs = "old-userid"
+        val activeNs = "abs_alice-userid"
+        val foreignNs = "abs_old-userid"
         val target = InMemoryTarget(
             files = mutableMapOf(
                 FileKey(activeNs, "i1", "annotations-this-device.jsonld") to "[]",
@@ -213,13 +213,19 @@ class AnnotationSyncMaintenanceViewModelTest {
         statusStore: AnnotationSyncStatusStore = AnnotationSyncStatusStore(),
     ): AnnotationSyncMaintenanceViewModel {
         val maintenance = AnnotationSyncMaintenance(targetProvider = { target })
+        // Callers name test namespaces after their conceptual role ("alice-userid",
+        // "bob-userid"); the descriptor prepends `abs_` in production, so the fake source
+        // must carry the pre-prefix id so `syncNamespaceFor` reproduces the same [activeNs].
+        val activeRawUserId = activeNs.removePrefix(
+            com.riffle.core.domain.AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX,
+        )
         return AnnotationSyncMaintenanceViewModel(
             configStore = FakeConfigStore(configured = true),
             maintenance = maintenance,
             deviceIdStore = FakeDeviceIdStore("this-device"),
             deviceLabelStore = FakeDeviceLabelStore(),
             deviceLabelResolver = FakeDeviceLabelResolver("This Device"),
-            sourceRepository = FakeServerRepository(activeAbsUserId = activeNs),
+            sourceRepository = FakeServerRepository(activeAbsUserId = activeRawUserId),
             statusStore = statusStore,
         )
     }

--- a/core/data/src/androidTest/kotlin/com/riffle/core/data/LocalDirectoryTargetTest.kt
+++ b/core/data/src/androidTest/kotlin/com/riffle/core/data/LocalDirectoryTargetTest.kt
@@ -266,6 +266,51 @@ class LocalDirectoryTargetTest {
     }
 
     /**
+     * When the abs_-prefixed target dir already exists (fresh install synced down from
+     * WebDAV before the user side-loaded a legacy backup), migration must MERGE the
+     * legacy contents into the target instead of silently abandoning them. Existing files
+     * in the target win; legacy content only fills gaps.
+     */
+    @Test
+    fun migrationMergesLegacyContentIntoExistingAbsDir() = runTest {
+        val absUuid = "19621aae-1111-2222-3333-4a4a4a4a4a4a"
+        val itemId = "book1"
+        val root = File(filesDir, "annotation-sync")
+
+        // Seed both dirs: legacy has one file the target doesn't; target has one legacy conflicts with.
+        val legacyBookDir = File(root, "$absUuid/$itemId")
+        assertTrue(legacyBookDir.mkdirs())
+        File(legacyBookDir, "annotations-legacy-only.jsonld").writeText("""{"src":"legacy"}""")
+        File(legacyBookDir, "annotations-both.jsonld").writeText("""{"src":"legacy"}""")
+
+        val absBookDir = File(root, "abs_$absUuid/$itemId")
+        assertTrue(absBookDir.mkdirs())
+        File(absBookDir, "annotations-both.jsonld").writeText("""{"src":"fresh"}""")
+
+        val fresh = LocalDirectoryTarget(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        )
+        val listed = fresh.list("abs_$absUuid", itemId).toSet()
+
+        assertEquals(
+            setOf("annotations-legacy-only.jsonld", "annotations-both.jsonld"),
+            listed,
+        )
+        assertFalse("legacy dir must be gone after merge",
+            File(root, absUuid).exists())
+        // Fresh content wins on the conflict — legacy value must NOT overwrite fresh.
+        assertEquals(
+            """{"src":"fresh"}""",
+            fresh.read("abs_$absUuid", itemId, "annotations-both.jsonld"),
+        )
+        // Legacy-only content survived the merge.
+        assertEquals(
+            """{"src":"legacy"}""",
+            fresh.read("abs_$absUuid", itemId, "annotations-legacy-only.jsonld"),
+        )
+    }
+
+    /**
      * Legacy pre-`abs_` files (bare-UUID namespace dirs) must be renamed in place the first
      * time the target touches the annotation-sync root. After migration, a fresh
      * `list("abs_<uuid>", …)` call finds the legacy content under the new namespace path.

--- a/core/data/src/androidTest/kotlin/com/riffle/core/data/LocalDirectoryTargetTest.kt
+++ b/core/data/src/androidTest/kotlin/com/riffle/core/data/LocalDirectoryTargetTest.kt
@@ -264,4 +264,41 @@ class LocalDirectoryTargetTest {
         assertEquals(1, filesItem11b.size)
         assertEquals(file2, filesItem11b[0])
     }
+
+    /**
+     * Legacy pre-`abs_` files (bare-UUID namespace dirs) must be renamed in place the first
+     * time the target touches the annotation-sync root. After migration, a fresh
+     * `list("abs_<uuid>", …)` call finds the legacy content under the new namespace path.
+     *
+     * Would fail if reverted: the assertion below expects the abs_-prefixed directory to
+     * exist and the legacy directory to be gone.
+     */
+    @Test
+    fun listMigratesLegacyBareUuidNamespaceDirs() = runTest {
+        val absUuid = "19621aae-1111-2222-3333-4a4a4a4a4a4a"
+        val itemId = "book1"
+        val filename = "annotations-device-legacy.jsonld"
+
+        // Seed the disk in the pre-`abs_` layout — a bare-UUID namespace dir under the root.
+        val root = File(filesDir, "annotation-sync")
+        val legacyBookDir = File(root, "$absUuid/$itemId")
+        assertTrue(legacyBookDir.mkdirs())
+        File(legacyBookDir, filename).writeText("""{"legacy":"content"}""")
+
+        // Fresh target instance so `legacyAbsMigrated` starts false; then hit list().
+        val fresh = LocalDirectoryTarget(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+        )
+        val listed = fresh.list("abs_$absUuid", itemId)
+
+        assertEquals(listOf(filename), listed)
+        assertTrue("abs_-prefixed dir must exist after migration",
+            File(root, "abs_$absUuid").isDirectory)
+        assertFalse("bare-UUID dir must be gone after migration",
+            File(root, absUuid).exists())
+        assertEquals(
+            """{"legacy":"content"}""",
+            fresh.read("abs_$absUuid", itemId, filename),
+        )
+    }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/LegacyAbsNamespaceMigration.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LegacyAbsNamespaceMigration.kt
@@ -1,0 +1,56 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.AbsWebSourceDescriptor
+
+/**
+ * Classifier for the pre-`abs_` ABS annotation-file layout.
+ *
+ * Before [AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX] existed, ABS annotation files on the
+ * WebDAV share (and in [LocalDirectoryTarget]) named their namespace segment with the raw
+ * `/api/me` user id — a bare UUID with no source-tag prefix. After the switch, ABS behaves
+ * symmetrically with Komga: `abs_<uuid>` on the wire.
+ *
+ * Legacy files still exist on every user's share and must remain readable, so both targets run
+ * their listing through [migratedName] and MOVE-rename (WebDAV) or dir-rename (local) any hits.
+ * The classifier is pure Kotlin so it can be unit-tested at the JVM level without touching a
+ * real WebDAV server.
+ */
+internal object LegacyAbsNamespaceMigration {
+
+    /**
+     * True if [physicalName]'s namespace segment (`<ns>__…`) is a bare UUID — i.e. a legacy
+     * ABS file that predates [AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX]. Files already
+     * prefixed with any known source tag (`abs_`, `komga_`) or with a non-UUID first segment
+     * are left alone, so unrelated content on the share never gets accidentally rewritten.
+     */
+    fun isLegacyAbsFilename(physicalName: String): Boolean {
+        val sepIdx = physicalName.indexOf(NAMESPACE_SEPARATOR)
+        if (sepIdx <= 0) return false
+        val nsSegment = physicalName.substring(0, sepIdx)
+        return isLegacyAbsNamespaceSegment(nsSegment)
+    }
+
+    /**
+     * True if [nsSegment] is a bare UUID (matches [UUID_REGEX]) and doesn't already start with
+     * a known source-tag prefix. Kept public-to-the-package so [LocalDirectoryTarget] can use
+     * the same predicate on directory names.
+     */
+    fun isLegacyAbsNamespaceSegment(nsSegment: String): Boolean {
+        if (nsSegment.startsWith(AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX)) return false
+        if (nsSegment.startsWith(com.riffle.core.domain.KomgaWebSourceDescriptor.KOMGA_NAMESPACE_PREFIX)) return false
+        return UUID_REGEX.matches(nsSegment)
+    }
+
+    /**
+     * Return the post-migration filename for [physicalName], or [physicalName] unchanged when
+     * no rewrite applies. Idempotent: calling twice yields the same value.
+     */
+    fun migratedName(physicalName: String): String {
+        if (!isLegacyAbsFilename(physicalName)) return physicalName
+        return AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX + physicalName
+    }
+
+    private const val NAMESPACE_SEPARATOR = "__"
+    private val UUID_REGEX =
+        Regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/LocalDirectoryTarget.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LocalDirectoryTarget.kt
@@ -24,7 +24,34 @@ import java.io.File
  */
 class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget {
 
+    @Volatile private var legacyAbsMigrated: Boolean = false
+
+    /**
+     * Rename any bare-UUID namespace directories under [ROOT] to their `abs_<uuid>` form so
+     * pre-`abs_` local files stay addressable after the descriptor started stamping the new
+     * prefix. Runs at most once per instance — the first read/write/enumerate triggers it,
+     * every subsequent call short-circuits on [legacyAbsMigrated]. Idempotent when a fresh
+     * install has no legacy dirs (zero listFiles work).
+     */
+    private fun migrateLegacyAbsDirs() {
+        if (legacyAbsMigrated) return
+        legacyAbsMigrated = true
+        try {
+            val root = File(context.filesDir, ROOT)
+            if (!root.exists()) return
+            root.listFiles { f -> f.isDirectory }?.forEach { nsDir ->
+                if (!LegacyAbsNamespaceMigration.isLegacyAbsNamespaceSegment(nsDir.name)) return@forEach
+                val renamed = File(nsDir.parentFile, com.riffle.core.domain.AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX + nsDir.name)
+                if (renamed.exists()) return@forEach // another migration path already handled it
+                nsDir.renameTo(renamed)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Legacy ABS dir migration failed (best-effort)", e)
+        }
+    }
+
     override suspend fun list(namespace: String, itemId: String): List<String> {
+        migrateLegacyAbsDirs()
         return try {
             val directory = bookDir(namespace, itemId)
             if (!directory.exists()) return emptyList()
@@ -38,6 +65,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
     }
 
     override suspend fun read(namespace: String, itemId: String, filename: String): String? {
+        migrateLegacyAbsDirs()
         return try {
             val file = annotationFile(namespace, itemId, filename)
             if (!file.exists()) return null
@@ -49,6 +77,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
     }
 
     override suspend fun write(namespace: String, itemId: String, filename: String, content: String) {
+        migrateLegacyAbsDirs()
         try {
             val directory = bookDir(namespace, itemId)
             if (!directory.exists() && !directory.mkdirs()) {
@@ -71,6 +100,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
     }
 
     override suspend fun readDeviceMeta(namespace: String, deviceId: String): String? {
+        migrateLegacyAbsDirs()
         return try {
             val file = deviceMetaFile(namespace, deviceId)
             if (!file.exists()) null else file.readText()
@@ -81,6 +111,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
     }
 
     override suspend fun writeDeviceMeta(namespace: String, deviceId: String, content: String) {
+        migrateLegacyAbsDirs()
         try {
             val dir = namespaceDir(namespace)
             if (!dir.exists() && !dir.mkdirs()) {
@@ -103,6 +134,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
     }
 
     override suspend fun enumerateDevices(namespace: String): NamespaceDeviceListing {
+        migrateLegacyAbsDirs()
         return try {
             val nsDir = namespaceDir(namespace)
             if (!nsDir.exists()) return NamespaceDeviceListing(emptyList())
@@ -137,6 +169,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
     }
 
     override suspend fun enumerateNamespaces(): List<NamespaceSummary> {
+        migrateLegacyAbsDirs()
         return try {
             val root = File(context.filesDir, ROOT)
             if (!root.exists()) return emptyList()
@@ -159,6 +192,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
     }
 
     override suspend fun forgetNamespace(namespace: String): Int {
+        migrateLegacyAbsDirs()
         return try {
             val dir = namespaceDir(namespace)
             if (!dir.exists()) return 0

--- a/core/data/src/main/kotlin/com/riffle/core/data/LocalDirectoryTarget.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LocalDirectoryTarget.kt
@@ -29,25 +29,68 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
     /**
      * Rename any bare-UUID namespace directories under [ROOT] to their `abs_<uuid>` form so
      * pre-`abs_` local files stay addressable after the descriptor started stamping the new
-     * prefix. Runs at most once per instance — the first read/write/enumerate triggers it,
-     * every subsequent call short-circuits on [legacyAbsMigrated]. Idempotent when a fresh
-     * install has no legacy dirs (zero listFiles work).
+     * prefix. Runs at most once per instance AFTER a successful sweep — a mid-sweep throw
+     * or a per-dir renameTo failure leaves [legacyAbsMigrated] false so the next call
+     * retries. Idempotent when a fresh install has no legacy dirs (zero listFiles work).
+     *
+     * When the abs_-prefixed target already exists (fresh install synced down `abs_<uuid>/`
+     * from WebDAV before the user side-loaded a legacy backup), merge each legacy child
+     * into the target instead of abandoning it — otherwise the legacy annotations would be
+     * silently invisible under the new namespace.
      */
     private fun migrateLegacyAbsDirs() {
         if (legacyAbsMigrated) return
-        legacyAbsMigrated = true
+        val root = File(context.filesDir, ROOT)
+        if (!root.exists()) {
+            legacyAbsMigrated = true
+            return
+        }
+        var allSucceeded = true
         try {
-            val root = File(context.filesDir, ROOT)
-            if (!root.exists()) return
             root.listFiles { f -> f.isDirectory }?.forEach { nsDir ->
                 if (!LegacyAbsNamespaceMigration.isLegacyAbsNamespaceSegment(nsDir.name)) return@forEach
-                val renamed = File(nsDir.parentFile, com.riffle.core.domain.AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX + nsDir.name)
-                if (renamed.exists()) return@forEach // another migration path already handled it
-                nsDir.renameTo(renamed)
+                val target = File(
+                    nsDir.parentFile,
+                    com.riffle.core.domain.AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX + nsDir.name,
+                )
+                if (!target.exists()) {
+                    if (!nsDir.renameTo(target)) allSucceeded = false
+                } else if (!mergeInto(nsDir, target)) {
+                    allSucceeded = false
+                }
             }
         } catch (e: Exception) {
             Log.e(TAG, "Legacy ABS dir migration failed (best-effort)", e)
+            allSucceeded = false
         }
+        if (allSucceeded) legacyAbsMigrated = true
+    }
+
+    /**
+     * Move every regular file under [source] into [target] (preserving relative paths),
+     * then delete [source]. Returns true iff the source ends up empty and deletable.
+     * Existing files in [target] win — legacy content only fills gaps, never overwrites
+     * fresher post-migration data.
+     */
+    private fun mergeInto(source: File, target: File): Boolean {
+        var ok = true
+        source.walkTopDown().forEach { f ->
+            if (f == source) return@forEach
+            val rel = f.relativeTo(source)
+            val dest = File(target, rel.path)
+            if (f.isDirectory) {
+                if (!dest.exists() && !dest.mkdirs()) ok = false
+            } else if (!dest.exists()) {
+                dest.parentFile?.mkdirs()
+                if (!f.renameTo(dest)) ok = false
+            }
+        }
+        // Best-effort recursive delete of anything left in the source (may include files that
+        // couldn't merge because a fresher version already existed in target — those stay
+        // dropped by design).
+        source.walkBottomUp().forEach { if (it != source) it.delete() }
+        if (!source.delete()) ok = false
+        return ok
     }
 
     override suspend fun list(namespace: String, itemId: String): List<String> {

--- a/core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTarget.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTarget.kt
@@ -267,7 +267,7 @@ class WebDavAnnotationSyncTarget(
     }
 
     private suspend fun propfindBaseFilenames(): List<String> = withContext(dispatchers.io) {
-        classifyWebDavTransportErrors {
+        val raw = classifyWebDavTransportErrors {
             val request = baseRequest(basePath)
                 .header("Depth", "1")
                 .header("Content-Type", "application/xml; charset=utf-8")
@@ -284,6 +284,43 @@ class WebDavAnnotationSyncTarget(
                 }
             }
         }
+        migrateLegacyAbsNames(raw)
+    }
+
+    /**
+     * Rename any pre-`abs_` legacy ABS files in-place, so every downstream method
+     * (`list`, `enumerateDevices`, `enumerateNamespaces`, `forgetNamespace`) sees the
+     * post-migration filenames. MOVE is issued per legacy hit; the returned list swaps in
+     * the destination name on success. On any failure (network, 5xx, non-`412` collision),
+     * the legacy name is left in the returned list so callers still see the file — worst
+     * case a second sync retries the MOVE. Idempotent: a share with no legacy files does
+     * zero extra work.
+     */
+    private fun migrateLegacyAbsNames(names: List<String>): List<String> {
+        if (names.none { LegacyAbsNamespaceMigration.isLegacyAbsFilename(it) }) return names
+        return names.map { name ->
+            if (!LegacyAbsNamespaceMigration.isLegacyAbsFilename(name)) return@map name
+            val target = LegacyAbsNamespaceMigration.migratedName(name)
+            if (tryMoveOnServer(name, target)) target else name
+        }
+    }
+
+    private fun tryMoveOnServer(from: String, to: String): Boolean = try {
+        val src = basePath.newBuilder().addPathSegment(from).build()
+        val dst = basePath.newBuilder().addPathSegment(to).build()
+        val request = baseRequest(src)
+            .header("Destination", dst.toString())
+            // Fail-on-collide: another device may already have MOVE'd this file. Treat 412
+            // as "target exists — migration completed elsewhere" and return success so the
+            // caller uses the destination name.
+            .header("Overwrite", "F")
+            .method("MOVE", null)
+            .build()
+        client.newCall(request).execute().use { response ->
+            response.isSuccessful || response.code == 201 || response.code == 204 || response.code == 412
+        }
+    } catch (_: Exception) {
+        false
     }
 
     private fun put(url: HttpUrl, body: RequestBody): Response {

--- a/core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTarget.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTarget.kt
@@ -291,33 +291,55 @@ class WebDavAnnotationSyncTarget(
      * Rename any pre-`abs_` legacy ABS files in-place, so every downstream method
      * (`list`, `enumerateDevices`, `enumerateNamespaces`, `forgetNamespace`) sees the
      * post-migration filenames. MOVE is issued per legacy hit; the returned list swaps in
-     * the destination name on success. On any failure (network, 5xx, non-`412` collision),
-     * the legacy name is left in the returned list so callers still see the file — worst
-     * case a second sync retries the MOVE. Idempotent: a share with no legacy files does
-     * zero extra work.
+     * the destination name on success. On any hard failure (network, 5xx), the legacy
+     * name is left in the returned list so callers still see the file — worst case a
+     * second sync retries the MOVE. Concurrent-device edge cases:
+     *  - 404 on the source means a peer already MOVE'd it → treat as success.
+     *  - 412 (destination exists) means a peer already wrote the migrated file → DELETE
+     *    the orphan legacy source so a subsequent PROPFIND doesn't loop on it forever.
+     * Post-mapping the list is `distinct()`-ed to collapse the pair that arises when both
+     * `<uuid>__…` and `abs_<uuid>__…` were present in the same PROPFIND.
+     * Idempotent: a share with no legacy files does zero extra work.
      */
     private fun migrateLegacyAbsNames(names: List<String>): List<String> {
         if (names.none { LegacyAbsNamespaceMigration.isLegacyAbsFilename(it) }) return names
         return names.map { name ->
             if (!LegacyAbsNamespaceMigration.isLegacyAbsFilename(name)) return@map name
             val target = LegacyAbsNamespaceMigration.migratedName(name)
-            if (tryMoveOnServer(name, target)) target else name
-        }
+            if (migrateOne(name, target)) target else name
+        }.distinct()
     }
 
-    private fun tryMoveOnServer(from: String, to: String): Boolean = try {
+    /**
+     * Returns true iff [from] is at or has reached [to] on the server after this call.
+     * Handles the four outcomes: MOVE ok (2xx), source already gone (404 — peer got there
+     * first), destination already exists (412 — peer wrote it, so DELETE our orphan
+     * legacy source), or anything else (leave the file, caller will retry next sync).
+     */
+    private fun migrateOne(from: String, to: String): Boolean = try {
         val src = basePath.newBuilder().addPathSegment(from).build()
         val dst = basePath.newBuilder().addPathSegment(to).build()
         val request = baseRequest(src)
             .header("Destination", dst.toString())
-            // Fail-on-collide: another device may already have MOVE'd this file. Treat 412
-            // as "target exists — migration completed elsewhere" and return success so the
-            // caller uses the destination name.
             .header("Overwrite", "F")
             .method("MOVE", null)
             .build()
         client.newCall(request).execute().use { response ->
-            response.isSuccessful || response.code == 201 || response.code == 204 || response.code == 412
+            when {
+                response.isSuccessful || response.code == 201 || response.code == 204 -> true
+                // Peer already MOVEd it. Our source is gone; destination has the content.
+                response.code == 404 -> true
+                // Peer already wrote the destination independently. Delete our orphan source
+                // so a follow-up PROPFIND doesn't keep trying the same MOVE forever.
+                response.code == 412 -> {
+                    runCatching {
+                        val delReq = baseRequest(src).delete().build()
+                        client.newCall(delReq).execute().close()
+                    }
+                    true
+                }
+                else -> false
+            }
         }
     } catch (_: Exception) {
         false

--- a/core/data/src/test/kotlin/com/riffle/core/data/LegacyAbsNamespaceMigrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LegacyAbsNamespaceMigrationTest.kt
@@ -1,0 +1,100 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.AbsWebSourceDescriptor
+import com.riffle.core.domain.KomgaWebSourceDescriptor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for the pre-`abs_` legacy-file classifier that both [WebDavAnnotationSyncTarget]
+ * and [LocalDirectoryTarget] use to decide which annotation files to rename in place.
+ *
+ * Would-fail-if-reverted assertions:
+ *  - A bare-UUID first segment classifies as legacy (`19621aae-…__book__annotations-x.jsonld`).
+ *  - Already-prefixed segments (`abs_…`, `komga_…`) never re-migrate.
+ *  - Non-UUID first segments (arbitrary user content) are left alone.
+ *  - `migratedName` is idempotent — calling twice on the same input yields the same result.
+ *  - Device-meta files (`<ns>__device-meta-<dev>.json`) migrate too, because the classifier
+ *    only inspects the namespace segment, not the trailing filename shape.
+ */
+class LegacyAbsNamespaceMigrationTest {
+
+    private val absUuid = "19621aae-1111-2222-3333-4a4a4a4a4a4a"
+
+    @Test
+    fun `bare UUID namespace segment classifies as legacy`() {
+        assertTrue(LegacyAbsNamespaceMigration.isLegacyAbsNamespaceSegment(absUuid))
+        assertTrue(
+            LegacyAbsNamespaceMigration.isLegacyAbsFilename("${absUuid}__book1__annotations-devA.jsonld"),
+        )
+    }
+
+    @Test
+    fun `already-prefixed abs segments are not re-migrated`() {
+        val prefixed = "${AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX}$absUuid"
+        assertFalse(LegacyAbsNamespaceMigration.isLegacyAbsNamespaceSegment(prefixed))
+        assertFalse(
+            LegacyAbsNamespaceMigration.isLegacyAbsFilename("${prefixed}__book1__annotations-devA.jsonld"),
+        )
+    }
+
+    @Test
+    fun `komga-prefixed segments are not treated as legacy ABS`() {
+        val komga = "${KomgaWebSourceDescriptor.KOMGA_NAMESPACE_PREFIX}$absUuid"
+        assertFalse(LegacyAbsNamespaceMigration.isLegacyAbsNamespaceSegment(komga))
+        assertFalse(
+            LegacyAbsNamespaceMigration.isLegacyAbsFilename("${komga}__book1__annotations-devA.jsonld"),
+        )
+    }
+
+    @Test
+    fun `non-UUID first segments are ignored`() {
+        assertFalse(LegacyAbsNamespaceMigration.isLegacyAbsNamespaceSegment("some-random-string"))
+        assertFalse(
+            LegacyAbsNamespaceMigration.isLegacyAbsFilename("plain__book1__annotations-devA.jsonld"),
+        )
+    }
+
+    @Test
+    fun `no double underscore separator means not a candidate`() {
+        assertFalse(LegacyAbsNamespaceMigration.isLegacyAbsFilename("just-a-single-file.txt"))
+        assertFalse(LegacyAbsNamespaceMigration.isLegacyAbsFilename(absUuid))
+    }
+
+    @Test
+    fun `migratedName prepends abs prefix on legacy names`() {
+        val legacy = "${absUuid}__book1__annotations-devA.jsonld"
+        assertEquals(
+            "${AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX}$legacy",
+            LegacyAbsNamespaceMigration.migratedName(legacy),
+        )
+    }
+
+    @Test
+    fun `migratedName is idempotent — second call is a no-op`() {
+        val legacy = "${absUuid}__book1__annotations-devA.jsonld"
+        val once = LegacyAbsNamespaceMigration.migratedName(legacy)
+        val twice = LegacyAbsNamespaceMigration.migratedName(once)
+        assertEquals(once, twice)
+    }
+
+    @Test
+    fun `device-meta files also migrate — classifier looks at namespace only`() {
+        val legacyMeta = "${absUuid}__device-meta-devA.json"
+        assertTrue(LegacyAbsNamespaceMigration.isLegacyAbsFilename(legacyMeta))
+        assertEquals(
+            "${AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX}$legacyMeta",
+            LegacyAbsNamespaceMigration.migratedName(legacyMeta),
+        )
+    }
+
+    @Test
+    fun `unrelated content on the share is left alone`() {
+        // Users may already have Nextcloud/Synology apple-double shadows, README files, etc.
+        // The classifier must not touch anything that doesn't match the ABS legacy pattern.
+        assertFalse(LegacyAbsNamespaceMigration.isLegacyAbsFilename("._19621aae-1111-2222-3333-4a4a4a4a4a4a__book__annotations-dev.jsonld"))
+        assertFalse(LegacyAbsNamespaceMigration.isLegacyAbsFilename("README.md"))
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
@@ -802,7 +802,12 @@ class ServerRepositoryTest {
 
         val result = repo.ensureSyncNamespace("abs-1")
 
-        assertEquals(com.riffle.core.domain.SyncNamespace.Configured("persisted-user-id"), result)
+        assertEquals(
+            com.riffle.core.domain.SyncNamespace.Configured(
+                "${com.riffle.core.domain.AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX}persisted-user-id",
+            ),
+            result,
+        )
         assertEquals("must not /api/me when value is already cached", 0, infoApi.getCurrentUserIdCalls)
     }
 
@@ -823,8 +828,11 @@ class ServerRepositoryTest {
         val first = repo.ensureSyncNamespace("abs-legacy")
         val second = repo.ensureSyncNamespace("abs-legacy")
 
-        assertEquals(com.riffle.core.domain.SyncNamespace.Configured("fetched-user-id"), first)
-        assertEquals(com.riffle.core.domain.SyncNamespace.Configured("fetched-user-id"), second)
+        val expected = com.riffle.core.domain.SyncNamespace.Configured(
+            "${com.riffle.core.domain.AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX}fetched-user-id",
+        )
+        assertEquals(expected, first)
+        assertEquals(expected, second)
         // Persisted, so the second call is a DAO read — not a second network round-trip.
         assertEquals(1, infoApi.getCurrentUserIdCalls)
         assertEquals("fetched-user-id", dao.getById("abs-legacy")?.absUserId)

--- a/core/data/src/test/kotlin/com/riffle/core/data/WebDavAnnotationSyncTargetTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/WebDavAnnotationSyncTargetTest.kt
@@ -473,9 +473,131 @@ class WebDavAnnotationSyncTargetTest {
         assertEquals(listOf("annotations-dev.jsonld"), result)
     }
 
+    // ===== Legacy ABS namespace migration (bare-UUID → abs_<uuid>) =====
+
+    @Test
+    fun `list MOVEs legacy bare-UUID files to abs_ prefixed names and returns them under the new namespace`() = runTest {
+        // Fixture has one legacy ABS file (bare-UUID prefix) and one already-migrated abs_ file.
+        // A list() call under the post-migration namespace `abs_<uuid>` must MOVE the legacy file
+        // in place and then match both against the composite `abs_<uuid>__book1__` prefix.
+        source.enqueue(MockResponse().setResponseCode(207).setBody(PROPFIND_LEGACY_ABS_BODY))
+        source.enqueue(MockResponse().setResponseCode(201)) // MOVE of the legacy file
+
+        val target = newTarget()
+        val result = target.list("abs_$ABS_UUID", "book1")
+
+        // Both files (post-migration) are surfaced. Would fail (empty) if the legacy file
+        // wasn't renamed and re-classified into the new namespace's composite prefix.
+        assertEquals(
+            setOf("annotations-dev-legacy.jsonld", "annotations-dev-fresh.jsonld"),
+            result.toSet(),
+        )
+
+        // Verify a real MOVE went out with Destination header pointing to the abs_ path.
+        source.takeRequest() // PROPFIND
+        val move = source.takeRequest()
+        assertEquals("MOVE", move.method)
+        assertEquals("/annotations/${ABS_UUID}__book1__annotations-dev-legacy.jsonld", move.path)
+        val dest = move.getHeader("Destination") ?: ""
+        assertTrue(
+            "Destination must point at the abs_ path, was $dest",
+            dest.endsWith("/annotations/abs_${ABS_UUID}__book1__annotations-dev-legacy.jsonld"),
+        )
+        assertEquals("F", move.getHeader("Overwrite"))
+    }
+
+    @Test
+    fun `already-migrated share is a no-op — no MOVE issued`() = runTest {
+        source.enqueue(MockResponse().setResponseCode(207).setBody(PROPFIND_ALREADY_MIGRATED_BODY))
+
+        newTarget().list("abs_$ABS_UUID", "book1")
+
+        assertEquals("only PROPFIND should have fired", 1, source.requestCount)
+    }
+
+    @Test
+    fun `komga files on the share are left alone by the ABS migration`() = runTest {
+        // A share hosting BOTH an ABS legacy file AND a komga_ file: only the ABS one migrates.
+        source.enqueue(MockResponse().setResponseCode(207).setBody(PROPFIND_ABS_AND_KOMGA_BODY))
+        source.enqueue(MockResponse().setResponseCode(201)) // MOVE of the ABS legacy file only
+
+        newTarget().list("abs_$ABS_UUID", "book1")
+
+        source.takeRequest() // PROPFIND
+        val move = source.takeRequest()
+        assertEquals("MOVE", move.method)
+        assertTrue(
+            "must migrate the ABS file, not the komga file",
+            move.path?.startsWith("/annotations/${ABS_UUID}__") == true,
+        )
+        assertEquals("no second MOVE for the komga file", 2, source.requestCount)
+    }
+
     companion object {
         private const val USER = "alice"
         private const val PASS = "s3cret"
+        // Bare-UUID namespace representing a pre-`abs_` ABS user id on the WebDAV share.
+        private const val ABS_UUID = "19621aae-1111-2222-3333-4a4a4a4a4a4a"
+
+        // One legacy ABS file (bare-UUID namespace) + one already-migrated abs_ file, both
+        // under book1. Drives the migration path: MOVE the legacy, keep the fresh one.
+        private val PROPFIND_LEGACY_ABS_BODY = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <d:multistatus xmlns:d="DAV:">
+              <d:response>
+                <d:href>/annotations/</d:href>
+                <d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype></d:prop>
+                  <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+              </d:response>
+              <d:response>
+                <d:href>/annotations/${ABS_UUID}__book1__annotations-dev-legacy.jsonld</d:href>
+                <d:propstat><d:prop><d:resourcetype/></d:prop>
+                  <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+              </d:response>
+              <d:response>
+                <d:href>/annotations/abs_${ABS_UUID}__book1__annotations-dev-fresh.jsonld</d:href>
+                <d:propstat><d:prop><d:resourcetype/></d:prop>
+                  <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+              </d:response>
+            </d:multistatus>
+        """.trimIndent()
+
+        private val PROPFIND_ALREADY_MIGRATED_BODY = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <d:multistatus xmlns:d="DAV:">
+              <d:response>
+                <d:href>/annotations/</d:href>
+                <d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype></d:prop>
+                  <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+              </d:response>
+              <d:response>
+                <d:href>/annotations/abs_${ABS_UUID}__book1__annotations-dev.jsonld</d:href>
+                <d:propstat><d:prop><d:resourcetype/></d:prop>
+                  <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+              </d:response>
+            </d:multistatus>
+        """.trimIndent()
+
+        private val PROPFIND_ABS_AND_KOMGA_BODY = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <d:multistatus xmlns:d="DAV:">
+              <d:response>
+                <d:href>/annotations/</d:href>
+                <d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype></d:prop>
+                  <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+              </d:response>
+              <d:response>
+                <d:href>/annotations/${ABS_UUID}__book1__annotations-dev.jsonld</d:href>
+                <d:propstat><d:prop><d:resourcetype/></d:prop>
+                  <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+              </d:response>
+              <d:response>
+                <d:href>/annotations/komga_${ABS_UUID}__book1__annotations-dev.jsonld</d:href>
+                <d:propstat><d:prop><d:resourcetype/></d:prop>
+                  <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+              </d:response>
+            </d:multistatus>
+        """.trimIndent()
 
         // PROPFIND fixture for the flat layout: two srv1__book1__ files (matching), one srv1__book2__
         // file (must be filtered out by prefix), plus the parent collection entry.

--- a/core/data/src/test/kotlin/com/riffle/core/data/WebDavAnnotationSyncTargetTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/WebDavAnnotationSyncTargetTest.kt
@@ -516,6 +516,48 @@ class WebDavAnnotationSyncTargetTest {
     }
 
     @Test
+    fun `MOVE returning 404 (peer migrated first) still surfaces the file under the new namespace`() = runTest {
+        // Concurrent-device race: another device MOVE'd the source before us, so our MOVE
+        // returns 404 on the (now gone) source. The destination exists — we must treat 404
+        // as success and return the destination name, else list() filters it out.
+        source.enqueue(MockResponse().setResponseCode(207).setBody(PROPFIND_LEGACY_ABS_BODY))
+        source.enqueue(MockResponse().setResponseCode(404)) // MOVE — source already gone
+
+        val result = newTarget().list("abs_$ABS_UUID", "book1")
+
+        assertEquals(
+            setOf("annotations-dev-legacy.jsonld", "annotations-dev-fresh.jsonld"),
+            result.toSet(),
+        )
+    }
+
+    @Test
+    fun `MOVE returning 412 triggers DELETE of the legacy source and dedupes the list`() = runTest {
+        // Peer already wrote the abs_-prefixed file under the same book. Our PROPFIND sees
+        // BOTH the legacy source and the peer-written destination. MOVE returns 412 (dest
+        // exists, Overwrite: F); we DELETE the orphan legacy source and dedupe so the list
+        // doesn't contain the same logical filename twice.
+        source.enqueue(MockResponse().setResponseCode(207).setBody(PROPFIND_ORPHAN_LEGACY_BODY))
+        source.enqueue(MockResponse().setResponseCode(412)) // MOVE — destination exists
+        source.enqueue(MockResponse().setResponseCode(204)) // DELETE of orphan source
+
+        val result = newTarget().list("abs_$ABS_UUID", "book1")
+
+        // Deduped: only one entry per unique post-migration filename.
+        assertEquals(listOf("annotations-dev-shared.jsonld"), result)
+
+        // Confirm DELETE targeted the legacy path, not the destination.
+        source.takeRequest() // PROPFIND
+        source.takeRequest() // MOVE
+        val delete = source.takeRequest()
+        assertEquals("DELETE", delete.method)
+        assertEquals(
+            "/annotations/${ABS_UUID}__book1__annotations-dev-shared.jsonld",
+            delete.path,
+        )
+    }
+
+    @Test
     fun `komga files on the share are left alone by the ABS migration`() = runTest {
         // A share hosting BOTH an ABS legacy file AND a komga_ file: only the ABS one migrates.
         source.enqueue(MockResponse().setResponseCode(207).setBody(PROPFIND_ABS_AND_KOMGA_BODY))
@@ -572,6 +614,30 @@ class WebDavAnnotationSyncTargetTest {
               </d:response>
               <d:response>
                 <d:href>/annotations/abs_${ABS_UUID}__book1__annotations-dev.jsonld</d:href>
+                <d:propstat><d:prop><d:resourcetype/></d:prop>
+                  <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+              </d:response>
+            </d:multistatus>
+        """.trimIndent()
+
+        // Legacy source AND its already-existing abs_-prefixed destination — the shape that
+        // arises when a peer wrote the migrated file while our device was offline. Migration
+        // must DELETE the orphan legacy source and dedupe the composite.
+        private val PROPFIND_ORPHAN_LEGACY_BODY = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <d:multistatus xmlns:d="DAV:">
+              <d:response>
+                <d:href>/annotations/</d:href>
+                <d:propstat><d:prop><d:resourcetype><d:collection/></d:resourcetype></d:prop>
+                  <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+              </d:response>
+              <d:response>
+                <d:href>/annotations/${ABS_UUID}__book1__annotations-dev-shared.jsonld</d:href>
+                <d:propstat><d:prop><d:resourcetype/></d:prop>
+                  <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+              </d:response>
+              <d:response>
+                <d:href>/annotations/abs_${ABS_UUID}__book1__annotations-dev-shared.jsonld</d:href>
                 <d:propstat><d:prop><d:resourcetype/></d:prop>
                   <d:status>HTTP/1.1 200 OK</d:status></d:propstat>
               </d:response>

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/WebSourceDescriptor.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/WebSourceDescriptor.kt
@@ -313,16 +313,25 @@ object AbsWebSourceDescriptor : WebSourceDescriptor {
         }
     }
 
-    // ABS is the historical sync source — its namespace is the raw ABS user id so existing
-    // installs' WebDAV files remain addressable without a rewrite. Storyteller peers exchange
-    // auth via ABS but have no independent cross-device identity (their annotations already
-    // ride on the paired Audiobookshelf server's namespace via reader-side matching); surface
-    // them as LocalOnly here so the sync status UI can explain the state.
+    /**
+     * Namespace prefix stamped onto every ABS sync namespace. Symmetric with
+     * [KomgaWebSourceDescriptor.KOMGA_NAMESPACE_PREFIX] so every server-backed source's namespace
+     * carries a source-tag segment on the shared WebDAV target. Legacy files written before this
+     * prefix existed (bare-UUID first segment) are migrated in-place by
+     * [com.riffle.core.data.LegacyAbsNamespaceMigration] the next time the target enumerates the
+     * base directory.
+     */
+    const val ABS_NAMESPACE_PREFIX = "abs_"
+
+    // Storyteller peers exchange auth via ABS but have no independent cross-device identity
+    // (their annotations already ride on the paired Audiobookshelf server's namespace via
+    // reader-side matching); surface them as LocalOnly here so the sync status UI can explain
+    // the state.
     override fun syncNamespaceFor(source: Source): SyncNamespace = when (source.serverType) {
         ServerType.STORYTELLER_SERVICE ->
             SyncNamespace.LocalOnly("Annotations on Storyteller readalouds sync via your paired Audiobookshelf server.")
         ServerType.AUDIOBOOKSHELF -> source.absUserId?.takeIf { it.isNotBlank() }
-            ?.let { SyncNamespace.Configured(it) }
+            ?.let { namespaceFromRemoteId(source, it) }
             ?: SyncNamespace.PendingRemoteId
     }
 
@@ -330,7 +339,7 @@ object AbsWebSourceDescriptor : WebSourceDescriptor {
         when (source.serverType) {
             ServerType.STORYTELLER_SERVICE ->
                 SyncNamespace.LocalOnly("Annotations on Storyteller readalouds sync via your paired Audiobookshelf server.")
-            ServerType.AUDIOBOOKSHELF -> SyncNamespace.Configured(remoteUserId)
+            ServerType.AUDIOBOOKSHELF -> SyncNamespace.Configured("$ABS_NAMESPACE_PREFIX$remoteUserId")
         }
 }
 
@@ -399,9 +408,9 @@ object KomgaWebSourceDescriptor : WebSourceDescriptor {
      * (`"kmga_"`) at either end would otherwise round-trip green (AGENTS.md: "Always reference
      * constants, never the literal").
      *
-     * Guarantees non-collision with ABS: ABS namespaces are raw UUIDs (`19621aae-…`) which
-     * contain no underscore before the first hex block, so no ABS namespace can ever start
-     * with this prefix regardless of the id value.
+     * Symmetric with [AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX]; every server-backed source
+     * carries its own tag so a user id from one server cannot collide with a user id from
+     * another on the shared WebDAV target.
      */
     const val KOMGA_NAMESPACE_PREFIX = "komga_"
 

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/WebSourceDescriptorSyncNamespaceTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/WebSourceDescriptorSyncNamespaceTest.kt
@@ -10,7 +10,8 @@ import org.junit.Test
  * added by overriding the hook — no changes to the sync controller, the sweep, or the reader.
  *
  * Would-fail-if-reverted assertions:
- *  - ABS Audiobookshelf with a persisted `absUserId` → `Configured(<id>)` (raw, no prefix)
+ *  - ABS Audiobookshelf with a persisted `absUserId` → `Configured("abs_<id>")` (prefixed;
+ *    legacy bare-UUID files on the WebDAV share are migrated in-place on next enumerate)
  *  - ABS Audiobookshelf without an `absUserId` → `PendingRemoteId` (repo triggers /api/me)
  *  - ABS Storyteller peer → `LocalOnly` (never opens a WebDAV namespace of its own)
  *  - Komga with a persisted id → `Configured("komga_<id>")` (prefixed so it can't collide with ABS)
@@ -44,11 +45,14 @@ class WebSourceDescriptorSyncNamespaceTest {
         )
 
     @Test
-    fun `ABS Audiobookshelf with persisted user id resolves to Configured with the raw id`() {
+    fun `ABS Audiobookshelf with persisted user id resolves to Configured with an abs prefix`() {
         val ns = AbsWebSourceDescriptor.syncNamespaceFor(absSource(userId = "abs-user-42"))
-        // Kept raw (no `abs_` prefix) so existing installs' WebDAV files stay addressable
-        // without a rewrite migration.
-        assertEquals(SyncNamespace.Configured("abs-user-42"), ns)
+        val expected = SyncNamespace.Configured(
+            "${AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX}abs-user-42",
+        )
+        assertEquals(expected, ns)
+        // Sanity: the prefix hasn't drifted to a subtly different value.
+        assertEquals("abs_", AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX)
     }
 
     @Test
@@ -103,7 +107,7 @@ class WebSourceDescriptorSyncNamespaceTest {
         // double-eval.
         val absStale = absSource(userId = null)
         assertEquals(
-            SyncNamespace.Configured("fresh-abs-id"),
+            SyncNamespace.Configured("${AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX}fresh-abs-id"),
             AbsWebSourceDescriptor.namespaceFromRemoteId(absStale, "fresh-abs-id"),
         )
         val komgaStale = komgaSource(userId = null)


### PR DESCRIPTION
## Summary

Unifies the annotation-sync namespace shape across server sources — ABS now emits `abs_<userId>`, symmetric with Komga's `komga_<userId>`. Legacy files written before this prefix existed (bare-UUID first segment) are migrated in place on both WebDAV and `LocalDirectoryTarget` on the next enumeration.

Motivation: the two source-tag namespaces were asymmetric — Komga was prefixed for collision avoidance, ABS was raw for backwards compat. Every future server-backed source would inherit the same choice. Aligning them now keeps the layout self-documenting and gives new sources an obvious pattern to follow.

## Changes

- `AbsWebSourceDescriptor.syncNamespaceFor()` returns `Configured("abs_<userId>")`; new constant `ABS_NAMESPACE_PREFIX` mirrors `KOMGA_NAMESPACE_PREFIX`.
- New `LegacyAbsNamespaceMigration` classifier detects pre-`abs_` files by their bare-UUID first `__`-segment (ignores anything already tagged `abs_`/`komga_` or non-UUID).
- `WebDavAnnotationSyncTarget.propfindBaseFilenames()` MOVEs each legacy hit → `abs_<uuid>__…`. Handles concurrent-device races: MOVE 404 (peer already migrated) is success; MOVE 412 (destination already exists) triggers DELETE of the orphan source so a follow-up PROPFIND doesn't loop; the mapped list is `distinct()`-ed so a filename present as both legacy source and post-migration destination is only surfaced once.
- `LocalDirectoryTarget` lazily renames bare-UUID namespace dirs on first read/write/enumerate. When the `abs_`-prefixed target already exists, merges legacy children in (fresh content wins) instead of dropping the legacy dir. The one-shot flag is set only after a fully-successful sweep so a mid-sweep failure doesn't permanently disable retry.

## Test plan

- [x] `LegacyAbsNamespaceMigrationTest` (JVM): classifier truth table + idempotence + device-meta coverage.
- [x] `WebDavAnnotationSyncTargetTest` (JVM): mock-webserver drives PROPFIND → MOVE → post-migration list. Covers happy path, no-op on already-migrated, Komga files untouched, MOVE 404 (peer got there first), MOVE 412 with orphan-source DELETE + list dedup.
- [x] `LocalDirectoryTargetTest` (androidTest): seeds a bare-UUID dir on disk, hits `list("abs_<uuid>", …)`, asserts rename + read-through; separate test seeds both dirs and asserts the merge (fresh wins, legacy-only survives).
- [x] Existing `WebSourceDescriptorSyncNamespaceTest`, `SourceRepositoryTest`, `AnnotationSyncMaintenanceViewModelTest` updated to reflect the new prefix.
- [x] `./gradlew test` green (1814 tests).