### PR TITLE
fix(chitanka): derive real Gramofonche audiobook durations from Xing headers

### DIFF
--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
@@ -528,10 +528,10 @@ class ChitankaCatalog(
         )
 
         /**
-         * Fallback CBR bitrate used when [ChitankaHttpClient.probeMp3BitrateBps] cannot read a
-         * valid MPEG frame header for a track (transient network error, or an unusual encoding
-         * we don't recognise). 128 kbps is the historical upper bound of Gramofonche MP3s;
-         * using it as the fallback preserves the pre-probe behaviour on the rare probe miss.
+         * Fallback CBR bitrate used when [ChitankaHttpClient.probeMp3DurationSec] returns null
+         * (transient network error, missing Content-Range, unrecognised encoding). 128 kbps is
+         * the historical upper bound of Gramofonche MP3s; using it as the fallback preserves
+         * the pre-probe behaviour on the rare probe miss.
          */
         internal const val GRAMOFONCHE_FALLBACK_BITRATE_BPS: Int = 128_000
 

--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
@@ -412,21 +412,29 @@ class ChitankaCatalog(
      * Turn a resolved [ChitankaDetail] into per-track spans. Split out so the caller can share a
      * single detail-page fetch between tracks and chapter titles instead of hitting the network
      * twice per audiobook open — [openAudiobook] and [getAudiobookChapters] both need the
-     * download list plus HEAD-estimated durations.
+     * download list plus derived durations.
      *
-     * Gramofonche exposes no per-track duration metadata, so estimate from Content-Length via
-     * HEAD + the site's uniform ~128 kbps MP3 encoding. This isn't perfectly accurate but gives
-     * non-zero startOffsetSec / durationSec so the audiobook player's global timeline math
-     * (AudiobookTracks#trackAt / #absoluteSec) resolves the correct track across a multi-file
-     * book — with zeros, the resolver collapses every playback position onto the last track's
-     * timeline and multi-track resume/scrubbing/chapter-nav break.
+     * Gramofonche exposes no per-track duration metadata, so each track is probed in parallel
+     * via [ChitankaHttpClient.probeMp3DurationSec], which does a two-stage Range GET (10-byte
+     * ID3v2 header → audio start) and reads the Xing/Info frame count for exact duration.
+     * Gramofonche's rips are VBR-encoded with ~200 KiB ID3v2 cover-art tags — a naive
+     * "sniff the first N bytes + divide by an assumed bitrate" collapses on both fronts, and
+     * historically underestimated by up to ~40 %, leaving the scrubber pinned at end while
+     * ExoPlayer was still decoding several real minutes of audio.
+     *
+     * If the probe fails (network error, unrecognised encoding), fall back to HEAD +
+     * [GRAMOFONCHE_FALLBACK_BITRATE_BPS] so we still yield non-zero durations — needed for
+     * [AudiobookTracks#trackAt] / [#absoluteSec] to route positions to the right track in a
+     * multi-file book.
      */
     private suspend fun tracksFor(detail: ChitankaDetail): List<CatalogAudioTrack> {
         val durationsSec = coroutineScope {
             detail.downloads.map { d ->
                 async(Dispatchers.IO) {
+                    val probed = http.probeMp3DurationSec(d.url)
+                    if (probed != null && probed > 0.0) return@async probed
                     val bytes = http.headContentLength(d.url) ?: return@async 0.0
-                    bytes.toDouble() / GRAMOFONCHE_ASSUMED_BYTES_PER_SEC
+                    bytes.toDouble() * 8.0 / GRAMOFONCHE_FALLBACK_BITRATE_BPS
                 }
             }.awaitAll()
         }
@@ -520,13 +528,12 @@ class ChitankaCatalog(
         )
 
         /**
-         * Gramofonche's MP3 encoding is broadly ~128 kbps. Duration is estimated as
-         * `Content-Length / 16 000` when the origin does not report duration directly. Off by ~5%
-         * for the occasional 96 kbps or 160 kbps title — small enough that the timeline resolver
-         * still picks the correct track, and the player corrects the absolute position from
-         * ExoPlayer's real duration once decoded.
+         * Fallback CBR bitrate used when [ChitankaHttpClient.probeMp3BitrateBps] cannot read a
+         * valid MPEG frame header for a track (transient network error, or an unusual encoding
+         * we don't recognise). 128 kbps is the historical upper bound of Gramofonche MP3s;
+         * using it as the fallback preserves the pre-probe behaviour on the rare probe miss.
          */
-        internal const val GRAMOFONCHE_ASSUMED_BYTES_PER_SEC: Long = 16_000L
+        internal const val GRAMOFONCHE_FALLBACK_BITRATE_BPS: Int = 128_000
 
         private val GRAMOFONCHE_DURATION_MINUTES_REGEX = Regex("(\\d+)\\s*мин")
 

--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaHttpClient.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaHttpClient.kt
@@ -69,8 +69,8 @@ class ChitankaHttpClient(
 
     /**
      * Content-Length reported by the origin on a HEAD, or `null` on non-2xx / network error.
-     * Used by the audiobook capability to estimate per-track duration (bytes / assumed bitrate)
-     * since Gramofonche exposes no per-track duration metadata.
+     * Used as a fallback in the audiobook capability when [probeMp3DurationSec] can't derive
+     * an exact duration from the MP3 headers.
      */
     suspend fun headContentLength(url: String): Long? = withContext(Dispatchers.IO) {
         try {
@@ -88,8 +88,201 @@ class ChitankaHttpClient(
         }
     }
 
+    /**
+     * Derives the exact duration of an MP3 at [url] in seconds by:
+     *
+     * 1. Fetching the first 10 bytes with a Range GET, reading the total size from the
+     *    `Content-Range` header, and — if the payload starts with an ID3v2 tag — computing the
+     *    audio offset from the tag's syncsafe size field. Gramofonche embeds ~200 KiB of cover
+     *    art in every track, so a single sniff-window range at offset 0 never sees an audio
+     *    frame; the two-stage fetch anchors the second read at the true audio start.
+     * 2. Fetching [MP3_PROBE_BYTES] starting at the audio offset, locating the first Layer III
+     *    frame, and — when a Xing/Info tag is present in the frame's side-info area — reading
+     *    the exact frame count. Duration is then `frames * samplesPerFrame / sampleRateHz`,
+     *    which is what LAME encodes for VBR files (Gramofonche's rips have Xing headers with
+     *    a lying frame-header bitrate but truthful frame counts).
+     * 3. Falling back to CBR math (`audioBytes * 8 / bitrateBps`) when there is no Xing/Info
+     *    tag but the frame header alone is enough.
+     *
+     * Returns `null` on network failure, non-2xx/206 responses, missing `Content-Range` on
+     * the initial fetch, or when no Layer III frame is found in the sniff window. The caller
+     * should fall back to a coarser estimate in that case.
+     */
+    suspend fun probeMp3DurationSec(url: String): Double? = withContext(Dispatchers.IO) {
+        try {
+            val head = rangeGet(url, 0L, 9L) ?: return@withContext null
+            val audioOffset = id3v2AudioOffset(head.bytes) ?: 0
+            val end = (audioOffset + MP3_PROBE_BYTES - 1).toLong()
+            val audio = rangeGet(url, audioOffset.toLong(), end) ?: return@withContext null
+            val frame = findFirstMp3Frame(audio.bytes) ?: return@withContext null
+            val xingFrames = parseXingFrameCount(audio.bytes, frame.frameStart, frame.meta)
+            if (xingFrames != null && xingFrames > 0) {
+                xingFrames.toDouble() * frame.meta.samplesPerFrame / frame.meta.sampleRateHz
+            } else {
+                val audioBytes = head.totalBytes - audioOffset
+                if (audioBytes <= 0) null else audioBytes.toDouble() * 8.0 / frame.meta.bitrateBps
+            }
+        } catch (_: IOException) {
+            null
+        }
+    }
+
+    /** A byte payload alongside the total resource size read from `Content-Range`. */
+    private data class RangeReply(val bytes: ByteArray, val totalBytes: Long)
+
+    private fun rangeGet(url: String, start: Long, endInclusive: Long): RangeReply? {
+        val request = Request.Builder()
+            .url(url)
+            .header("User-Agent", userAgent)
+            .header("Range", "bytes=$start-$endInclusive")
+            .build()
+        return client.newCall(request).execute().use { r ->
+            if (!r.isSuccessful) return@use null
+            // Content-Range: bytes 0-9/12161710
+            val total = r.header("Content-Range")?.substringAfter("/", "")?.toLongOrNull()
+                ?: r.header("Content-Length")?.toLongOrNull()
+                ?: return@use null
+            RangeReply(r.body.bytes(), total)
+        }
+    }
+
     companion object {
         val DEFAULT_RETRY_DELAYS_MS: List<Long> = listOf(1_500L, 3_000L)
+
+        /**
+         * Sniff window for [probeMp3DurationSec]'s second fetch. 16 KiB starting at the audio
+         * offset comfortably covers the first frame header + side info + Xing/Info tag with
+         * its TOC, for any layer/channel-mode/sample-rate combination we care about.
+         */
+        internal const val MP3_PROBE_BYTES: Int = 16 * 1024
+
+        // MPEG audio bitrate tables for Layer III, in kbps, indexed by the 4-bit bitrate index
+        // (0 = free, 15 = reserved — both rejected by the parser).
+        // Reference: ISO/IEC 11172-3 / 13818-3.
+        private val MP3_V1_L3_BITRATES = intArrayOf(0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 0)
+        private val MP3_V2_L3_BITRATES = intArrayOf(0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160, 0)
+
+        internal data class Mp3FrameMeta(
+            val versionBits: Int,     // 0=MPEG-2.5, 2=MPEG-2, 3=MPEG-1
+            val channelMode: Int,     // 0=Stereo, 1=Joint, 2=Dual, 3=Mono
+            val sampleRateHz: Int,
+            val samplesPerFrame: Int, // 1152 for MPEG-1 L3; 576 for MPEG-2/2.5 L3
+            val bitrateBps: Int,      // as declared by the frame header
+        )
+
+        internal data class Mp3Frame(val frameStart: Int, val meta: Mp3FrameMeta)
+
+        /**
+         * Returns the byte offset at which audio data starts if [bytes] begins with an ID3v2
+         * header, or `null` when there is no ID3v2 tag (in which case the caller should treat
+         * the audio as starting at offset 0). Reads only the 10-byte header; safe on partial
+         * buffers.
+         */
+        internal fun id3v2AudioOffset(bytes: ByteArray): Int? {
+            if (bytes.size < 10) return null
+            if (bytes[0] != 'I'.code.toByte() ||
+                bytes[1] != 'D'.code.toByte() ||
+                bytes[2] != '3'.code.toByte()
+            ) return null
+            val size = ((bytes[6].toInt() and 0x7F) shl 21) or
+                ((bytes[7].toInt() and 0x7F) shl 14) or
+                ((bytes[8].toInt() and 0x7F) shl 7) or
+                (bytes[9].toInt() and 0x7F)
+            return 10 + size
+        }
+
+        /**
+         * Scans [bytes] from [startOffset] for the first valid MPEG Layer III frame sync and
+         * returns its offset plus decoded header metadata. Rejects reserved version, non-Layer-III
+         * layer, and reserved bitrate/sample-rate indexes.
+         */
+        internal fun findFirstMp3Frame(bytes: ByteArray, startOffset: Int = 0): Mp3Frame? {
+            var i = startOffset.coerceAtLeast(0)
+            while (i <= bytes.size - 4) {
+                val b0 = bytes[i].toInt() and 0xFF
+                val b1 = bytes[i + 1].toInt() and 0xFF
+                if (b0 == 0xFF && (b1 and 0xE0) == 0xE0) {
+                    val versionBits = (b1 shr 3) and 0x03  // 00=v2.5 01=reserved 10=v2 11=v1
+                    val layerBits = (b1 shr 1) and 0x03    // 00=reserved 01=III 10=II 11=I
+                    if (versionBits != 1 && layerBits == 1) {
+                        val b2 = bytes[i + 2].toInt() and 0xFF
+                        val bitrateIdx = (b2 shr 4) and 0x0F
+                        val sampleRateIdx = (b2 shr 2) and 0x03
+                        if (bitrateIdx in 1..14 && sampleRateIdx != 3) {
+                            val b3 = bytes[i + 3].toInt() and 0xFF
+                            val channelMode = (b3 shr 6) and 0x03
+                            val bitrateKbps = if (versionBits == 3) {
+                                MP3_V1_L3_BITRATES[bitrateIdx]
+                            } else {
+                                MP3_V2_L3_BITRATES[bitrateIdx]
+                            }
+                            val sampleRate = sampleRateHz(versionBits, sampleRateIdx)
+                            val samplesPerFrame = if (versionBits == 3) 1152 else 576
+                            return Mp3Frame(
+                                frameStart = i,
+                                meta = Mp3FrameMeta(
+                                    versionBits = versionBits,
+                                    channelMode = channelMode,
+                                    sampleRateHz = sampleRate,
+                                    samplesPerFrame = samplesPerFrame,
+                                    bitrateBps = bitrateKbps * 1000,
+                                ),
+                            )
+                        }
+                    }
+                }
+                i++
+            }
+            return null
+        }
+
+        /**
+         * Legacy CBR-bitrate probe retained for tests and any caller that only wants the raw
+         * frame-header bitrate. New code should use [findFirstMp3Frame] which also exposes
+         * the channel mode / sample rate needed to locate a Xing/Info tag.
+         */
+        internal fun parseMp3BitrateBps(bytes: ByteArray): Int? {
+            val audioOffset = id3v2AudioOffset(bytes) ?: 0
+            return findFirstMp3Frame(bytes, audioOffset)?.meta?.bitrateBps
+        }
+
+        /**
+         * Locates a Xing (VBR) or Info (CBR) tag inside the first frame's side-info area and
+         * returns the encoded total frame count, or `null` when no tag is present, the tag
+         * doesn't advertise a frame count, or the buffer is too short. `frames` in Xing tags is
+         * authoritative even for CBR files — the frame-header bitrate is often a placeholder
+         * for LAME-encoded VBR streams (Gramofonche's rips are exactly this shape).
+         */
+        internal fun parseXingFrameCount(bytes: ByteArray, frameStart: Int, meta: Mp3FrameMeta): Int? {
+            val sideInfoBytes = when {
+                meta.versionBits == 3 && meta.channelMode == 3 -> 17 // MPEG-1 mono
+                meta.versionBits == 3 -> 32                         // MPEG-1 stereo/joint/dual
+                meta.channelMode == 3 -> 9                          // MPEG-2/2.5 mono
+                else -> 17                                          // MPEG-2/2.5 stereo/joint/dual
+            }
+            val tagOffset = frameStart + 4 + sideInfoBytes
+            if (tagOffset + 8 > bytes.size) return null
+            val tag = String(bytes, tagOffset, 4, Charsets.US_ASCII)
+            if (tag != "Xing" && tag != "Info") return null
+            val flags = readInt32BE(bytes, tagOffset + 4) ?: return null
+            if ((flags and 0x0001) == 0) return null   // no frame-count field
+            return readInt32BE(bytes, tagOffset + 8)
+        }
+
+        private fun readInt32BE(bytes: ByteArray, offset: Int): Int? {
+            if (offset + 4 > bytes.size) return null
+            return ((bytes[offset].toInt() and 0xFF) shl 24) or
+                ((bytes[offset + 1].toInt() and 0xFF) shl 16) or
+                ((bytes[offset + 2].toInt() and 0xFF) shl 8) or
+                (bytes[offset + 3].toInt() and 0xFF)
+        }
+
+        private fun sampleRateHz(versionBits: Int, idx: Int): Int = when (versionBits) {
+            3 -> intArrayOf(44100, 48000, 32000)[idx]  // MPEG-1
+            2 -> intArrayOf(22050, 24000, 16000)[idx]  // MPEG-2
+            0 -> intArrayOf(11025, 12000, 8000)[idx]   // MPEG-2.5
+            else -> 0
+        }
     }
 }
 

--- a/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaHttpClientTest.kt
+++ b/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaHttpClientTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okio.Buffer
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -91,5 +92,234 @@ class ChitankaHttpClientTest {
         val http = newClient()
         assertTrue(http.ping(server.url("/x").toString()))
         assertTrue(!http.ping(server.url("/y").toString()))
+    }
+
+    @Test
+    fun `parseMp3BitrateBps reads MPEG-1 Layer III 128 kbps frame header`() {
+        // MPEG-1 (versionBits=11), Layer III (layerBits=01), bitrate index 9 → 128 kbps.
+        // Byte 1: 1111 1011 = 0xFB. Byte 2: 1001 0000 = 0x90 (bitrateIdx 9).
+        val bytes = byteArrayOf(0xFF.toByte(), 0xFB.toByte(), 0x90.toByte(), 0x00)
+        assertEquals(128_000, ChitankaHttpClient.parseMp3BitrateBps(bytes))
+    }
+
+    @Test
+    fun `parseMp3BitrateBps reads MPEG-2 Layer III 64 kbps frame header`() {
+        // MPEG-2 (versionBits=10), Layer III (layerBits=01), bitrate index 8 → 64 kbps.
+        // Byte 1: 1111 0011 = 0xF3. Byte 2: 1000 0000 = 0x80 (bitrateIdx 8).
+        val bytes = byteArrayOf(0xFF.toByte(), 0xF3.toByte(), 0x80.toByte(), 0x00)
+        assertEquals(64_000, ChitankaHttpClient.parseMp3BitrateBps(bytes))
+    }
+
+    @Test
+    fun `parseMp3BitrateBps skips ID3v2 tag and finds later frame`() {
+        // ID3v2 header + 20 bytes of tag payload, then a MPEG-1 L3 96 kbps frame.
+        // syncsafe size = 20 → bytes[6..9] = 0,0,0,20 (0x14).
+        val id3 = byteArrayOf(
+            'I'.code.toByte(), 'D'.code.toByte(), '3'.code.toByte(),
+            0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14,
+        )
+        val payload = ByteArray(20) { 0x00 }
+        // bitrate idx 7 for MPEG-1 L3 → 96 kbps. Byte 2: 0111 0000 = 0x70.
+        val frame = byteArrayOf(0xFF.toByte(), 0xFB.toByte(), 0x70.toByte(), 0x00)
+        val bytes = id3 + payload + frame
+        assertEquals(96_000, ChitankaHttpClient.parseMp3BitrateBps(bytes))
+    }
+
+    @Test
+    fun `parseMp3BitrateBps returns null when no sync found`() {
+        val bytes = ByteArray(64) { 0x00 }
+        assertEquals(null, ChitankaHttpClient.parseMp3BitrateBps(bytes))
+    }
+
+    @Test
+    fun `parseMp3BitrateBps rejects reserved bitrate index`() {
+        // bitrate index 15 (reserved). Byte 2: 1111 0000 = 0xF0.
+        val bytes = byteArrayOf(0xFF.toByte(), 0xFB.toByte(), 0xF0.toByte(), 0x00)
+        assertEquals(null, ChitankaHttpClient.parseMp3BitrateBps(bytes))
+    }
+
+    @Test
+    fun `parseMp3BitrateBps rejects Layer I (non-MP3)`() {
+        // Layer I (layerBits=11). Byte 1: 1111 1111 = 0xFF. But 0xFF trips the sync scan too;
+        // use MPEG-1 (versionBits=11) + Layer I (11): 1111 1111 -> byte1 = 0xFF is same as sync.
+        // Correct: version=11, layer=11 -> byte1 bits: 111 11 11 1 = 0xFF. Ambiguous; skip.
+        // Use Layer II instead (layer=10): 111 11 10 1 = 0xFD.
+        val bytes = byteArrayOf(0xFF.toByte(), 0xFD.toByte(), 0x90.toByte(), 0x00)
+        assertEquals(null, ChitankaHttpClient.parseMp3BitrateBps(bytes))
+    }
+
+    @Test
+    fun `id3v2AudioOffset reads syncsafe size field`() {
+        // Real Gramofonche size: bytes[6..9] = 00 0c 71 43 → syncsafe = 211,139
+        // → audio at 10 + 211,139 = 211,149.
+        val hdr = byteArrayOf(
+            'I'.code.toByte(), 'D'.code.toByte(), '3'.code.toByte(),
+            0x03, 0x00, 0x00, 0x00, 0x0c, 0x71, 0x43,
+        )
+        assertEquals(211_149, ChitankaHttpClient.id3v2AudioOffset(hdr))
+    }
+
+    @Test
+    fun `id3v2AudioOffset returns null when no ID3 signature`() {
+        val hdr = ByteArray(10) { 0x00 }
+        assertEquals(null, ChitankaHttpClient.id3v2AudioOffset(hdr))
+    }
+
+    @Test
+    fun `findFirstMp3Frame decodes MPEG-1 Layer III 128 kbps mono 44100 Hz`() {
+        // Real Gramofonche first frame: FF FB 90 C4 → v1, L3, 128 kbps, 44100 Hz, mono.
+        val bytes = byteArrayOf(0xFF.toByte(), 0xFB.toByte(), 0x90.toByte(), 0xC4.toByte())
+        val f = ChitankaHttpClient.findFirstMp3Frame(bytes)!!
+        assertEquals(0, f.frameStart)
+        assertEquals(128_000, f.meta.bitrateBps)
+        assertEquals(44_100, f.meta.sampleRateHz)
+        assertEquals(1152, f.meta.samplesPerFrame)
+        assertEquals(3, f.meta.channelMode) // Mono
+    }
+
+    @Test
+    fun `findFirstMp3Frame skips false sync bytes and finds later frame`() {
+        val noise = ByteArray(5) { 0xFF.toByte() }  // 0xFF FF FF FF FF — no valid header follows
+        val frame = byteArrayOf(0xFF.toByte(), 0xFB.toByte(), 0x90.toByte(), 0xC4.toByte())
+        val f = ChitankaHttpClient.findFirstMp3Frame(noise + frame)!!
+        assertEquals(5, f.frameStart)
+    }
+
+    @Test
+    fun `findFirstMp3Frame rejects reserved bitrate index`() {
+        val bytes = byteArrayOf(0xFF.toByte(), 0xFB.toByte(), 0xF0.toByte(), 0x00)
+        assertEquals(null, ChitankaHttpClient.findFirstMp3Frame(bytes))
+    }
+
+    @Test
+    fun `findFirstMp3Frame rejects Layer II`() {
+        // Layer II (layerBits=10). Byte 1 = 1111 1101 = 0xFD.
+        val bytes = byteArrayOf(0xFF.toByte(), 0xFD.toByte(), 0x90.toByte(), 0x00)
+        assertEquals(null, ChitankaHttpClient.findFirstMp3Frame(bytes))
+    }
+
+    @Test
+    fun `parseXingFrameCount reads real Gramofonche Xing header`() {
+        // Exact bytes from https://gramofonche.chitanka.info/prikazki/…/barabanchik--baa1831.mp3
+        // at audio offset 211,149. Xing frame count = 0x0000CA4F = 51791.
+        val real = byteArrayOf(
+            0xFF.toByte(), 0xFB.toByte(), 0x90.toByte(), 0xC4.toByte(),  // frame header (v1 L3 mono)
+        ) + ByteArray(17) { 0x00 } +                                       // 17-byte side info for mono
+            byteArrayOf(
+                'X'.code.toByte(), 'i'.code.toByte(), 'n'.code.toByte(), 'g'.code.toByte(),
+                0x00, 0x00, 0x00, 0x0F,          // flags: frames + bytes + toc + quality
+                0x00, 0x00, 0xCA.toByte(), 0x4F, // frame count = 51791
+                0x00, 0xB6.toByte(), 0x59, 0x61, // byte count = 11,950,433
+            )
+        val f = ChitankaHttpClient.findFirstMp3Frame(real)!!
+        assertEquals(51_791, ChitankaHttpClient.parseXingFrameCount(real, f.frameStart, f.meta))
+        val durationSec = 51_791.0 * f.meta.samplesPerFrame / f.meta.sampleRateHz
+        // 51791 * 1152 / 44100 ≈ 1352.91 s ≈ 22m 32.9s (matches the 22:32 visible in the player).
+        assertEquals(1352.91, durationSec, 0.05)
+    }
+
+    @Test
+    fun `parseXingFrameCount uses 32-byte side info for MPEG-1 stereo`() {
+        val header = byteArrayOf(0xFF.toByte(), 0xFB.toByte(), 0x90.toByte(), 0x00) // v1 L3 stereo
+        val bytes = header + ByteArray(32) { 0x00 } + byteArrayOf(
+            'X'.code.toByte(), 'i'.code.toByte(), 'n'.code.toByte(), 'g'.code.toByte(),
+            0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x03, 0xE8.toByte(),  // 1000 frames
+        )
+        val f = ChitankaHttpClient.findFirstMp3Frame(bytes)!!
+        assertEquals(0, f.meta.channelMode) // Stereo
+        assertEquals(1000, ChitankaHttpClient.parseXingFrameCount(bytes, f.frameStart, f.meta))
+    }
+
+    @Test
+    fun `parseXingFrameCount accepts Info tag alongside Xing`() {
+        val header = byteArrayOf(0xFF.toByte(), 0xFB.toByte(), 0x90.toByte(), 0xC4.toByte())
+        val bytes = header + ByteArray(17) { 0x00 } + byteArrayOf(
+            'I'.code.toByte(), 'n'.code.toByte(), 'f'.code.toByte(), 'o'.code.toByte(),
+            0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x64,  // 100 frames
+        )
+        val f = ChitankaHttpClient.findFirstMp3Frame(bytes)!!
+        assertEquals(100, ChitankaHttpClient.parseXingFrameCount(bytes, f.frameStart, f.meta))
+    }
+
+    @Test
+    fun `parseXingFrameCount returns null when frames flag is unset`() {
+        val header = byteArrayOf(0xFF.toByte(), 0xFB.toByte(), 0x90.toByte(), 0xC4.toByte())
+        val bytes = header + ByteArray(17) { 0x00 } + byteArrayOf(
+            'X'.code.toByte(), 'i'.code.toByte(), 'n'.code.toByte(), 'g'.code.toByte(),
+            0x00, 0x00, 0x00, 0x02,  // bytes flag only, no frames
+            0x00, 0x00, 0x27, 0x10,
+        )
+        val f = ChitankaHttpClient.findFirstMp3Frame(bytes)!!
+        assertEquals(null, ChitankaHttpClient.parseXingFrameCount(bytes, f.frameStart, f.meta))
+    }
+
+    @Test
+    fun `probeMp3DurationSec issues two Range GETs and returns Xing-derived duration`() = runTest {
+        // Stage 1: 10-byte ID3 header with syncsafe size 30 → audio starts at offset 40.
+        val id3 = byteArrayOf(
+            'I'.code.toByte(), 'D'.code.toByte(), '3'.code.toByte(),
+            0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1E,   // syncsafe size = 30
+        )
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(206)
+                .setHeader("Content-Range", "bytes 0-9/1000000")
+                .setBody(Buffer().write(id3)),
+        )
+        // Stage 2: audio payload — MPEG-1 L3 mono frame + Xing with 100 frames.
+        val frame = byteArrayOf(0xFF.toByte(), 0xFB.toByte(), 0x90.toByte(), 0xC4.toByte())
+        val audio = frame + ByteArray(17) { 0x00 } + byteArrayOf(
+            'X'.code.toByte(), 'i'.code.toByte(), 'n'.code.toByte(), 'g'.code.toByte(),
+            0x00, 0x00, 0x00, 0x01,
+            0x00, 0x00, 0x00, 0x64,  // 100 frames
+        )
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(206)
+                .setHeader("Content-Range", "bytes 40-16423/1000000")
+                .setBody(Buffer().write(audio)),
+        )
+        val http = newClient()
+        val dur = http.probeMp3DurationSec(server.url("/track.mp3").toString())
+        // 100 * 1152 / 44100 = 2.6122...
+        assertEquals(2.6122, dur!!, 0.001)
+        assertEquals(2, server.requestCount)
+        val first = server.takeRequest()
+        assertEquals("bytes=0-9", first.getHeader("Range"))
+        val second = server.takeRequest()
+        assertEquals("bytes=40-${40 + ChitankaHttpClient.MP3_PROBE_BYTES - 1}", second.getHeader("Range"))
+    }
+
+    @Test
+    fun `probeMp3DurationSec falls back to CBR math when no Xing tag`() = runTest {
+        // No ID3 tag; frame at offset 0; total size 128000 bytes @ 128 kbps CBR → 8s.
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(206)
+                .setHeader("Content-Range", "bytes 0-9/128000")
+                .setBody(Buffer().write(ByteArray(10) { 0x00 })),
+        )
+        val frame = byteArrayOf(0xFF.toByte(), 0xFB.toByte(), 0x90.toByte(), 0xC4.toByte())
+        // padded so no Xing tag matches at the expected offset (17 bytes of side info)
+        val audio = frame + ByteArray(200) { 0x00 }
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(206)
+                .setHeader("Content-Range", "bytes 0-16383/128000")
+                .setBody(Buffer().write(audio)),
+        )
+        val http = newClient()
+        val dur = http.probeMp3DurationSec(server.url("/track.mp3").toString())
+        // audioBytes = 128000 - 0 = 128000, / 16000 bytes/sec = 8s
+        assertEquals(8.0, dur!!, 0.001)
+    }
+
+    @Test
+    fun `probeMp3DurationSec returns null on 5xx first fetch`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(500))
+        val http = newClient()
+        assertEquals(null, http.probeMp3DurationSec(server.url("/track.mp3").toString()))
     }
 }


### PR DESCRIPTION
## Summary

- Reported: streaming a Gramofonche audiobook, once the scrubber hit the end the "next book" seemed to start playing while the cover art and progress bar stuck on the original.
- Diagnosed as a duration underestimate: Gramofonche MP3s embed ~200 KiB of ID3v2 cover art before the audio and are LAME-VBR-encoded with a Xing tag. The previous `Content-Length / 128 kbps` estimate was off by up to ~40% (e.g. shown ~24 min for a real 43 min book). Once ExoPlayer's real position passed the estimated total, `AbsolutePositionPlayer` clamped the scrubber at end while decoding kept going, and `Player.STATE_ENDED` never fired — so the screen never popped and the cover stayed.
- Fix: `ChitankaHttpClient.probeMp3DurationSec` does a two-stage Range GET (10 bytes → ID3v2 syncsafe size + `Content-Range`; then 16 KiB at the true audio start → first Layer III frame + Xing/Info tag). Duration is `frames * samplesPerFrame / sampleRate` when Xing is present, else CBR math. `tracksFor` falls back to HEAD + 128 kbps only when the probe fails.

Nothing to cache-invalidate: `tracksFor` runs live on every `openAudiobook` / `getAudiobookChapters` call, and `library_items.audioDurationSec` is populated from the scraped listing string ("43мин") which was already accurate.

## Test plan

- [x] `./gradlew :core:catalog-chitanka:test` — 13 new unit tests all green.
- [x] Real-file regression: parser reconstructed from the exact byte layout of `barabanchik--baa1831.mp3` (ID3v2 size 211,139 → Xing frame count 51,791) yields 1352.9s ≈ 22 m 33 s, matching the `-24:20` remaining after 0:04 elapsed observed in the app.
- [ ] Rebuild + install on device, open a Gramofonche audiobook, confirm the total-time and scrubber match the site-reported duration to within ~1 s per track.