### PR TITLE
feat(reader): annotate figure caption as first-class text highlight

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/CaptionHighlightUpgrader.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/CaptionHighlightUpgrader.kt
@@ -1,0 +1,351 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.database.AnnotationEntity
+import com.riffle.core.domain.Annotation
+import com.riffle.core.domain.AnnotationStore
+import com.riffle.core.domain.EmbeddedFigure
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Node
+import org.jsoup.nodes.TextNode
+
+/**
+ * Opportunistically upgrades legacy `TYPE_IMAGE` annotations (figure long-presses whose caption
+ * used to be stuffed into `textSnippet` without a locator) into proper `TYPE_HIGHLIGHT`
+ * annotations covering the caption text with the figure carried as an `embeddedFigure`. Runs
+ * once per (VM lifecycle, book) from the reader's open path, per the 2026-07-14 design.
+ *
+ * The upgrade mirrors [FigureCaptionWalker.CAPTION_RESOLVER_JS] on the Kotlin side: for each
+ * legacy annotation, parse its chapter HTML with jsoup, locate the figure by `img[src$="…"]`
+ * filename match (or by inline-SVG prefix), walk up to the nearest `<figure>` for its
+ * `<figcaption>`, and if that fails hunt for the nearest following `<p>`/`<div>` whose text
+ * starts with `Figure N` / `Fig. N` / `Table N` / `Chart N` — the same content-anchored
+ * fallback used at create time for LaTeX/Kotobee/Vellum EPUBs without semantic figure markup.
+ *
+ * Fuzzy caption-text match: an annotation is upgraded only when the DOM-resolved caption's
+ * normalized text starts with the annotation's stored `textSnippet` (also normalized). This
+ * catches the common case where `textSnippet` was truncated / equal to the caption, and
+ * refuses to upgrade when the DOM has drifted (publisher republished the EPUB with a different
+ * caption). A refused upgrade leaves the annotation as legacy TYPE_IMAGE — the reader keeps
+ * showing the CSS caption tint until the next reopen tries again.
+ *
+ * The upgrade preserves the annotation's id so cross-device sync sees a normal field update
+ * (bumped `updatedAt` + provenance), not a delete/create dance.
+ */
+internal class CaptionHighlightUpgrader(
+    private val annotationStore: AnnotationStore,
+) {
+
+    /**
+     * Sweep result — counts for logging.
+     */
+    internal data class SweepResult(val merged: Int, val upgraded: Int) {
+        val total: Int get() = merged + upgraded
+    }
+
+    /**
+     * Two phases, in order:
+     *
+     *  1. **Duplicate-caption cleanup.** Group same-chapter `TYPE_HIGHLIGHT` rows by normalized
+     *     `textSnippet`. For each group with more than one row, pick a canonical (highest
+     *     `updatedAt`; tiebreaker: has at least one `embeddedFigure`), merge every other row's
+     *     figures into it via [AnnotationStore.mergeFiguresIntoHighlight], and tombstone the
+     *     others. Fixes the "two HIGHLIGHTs on the same caption" duplicates the initial
+     *     2026-07-14 change could leave behind on a re-long-press of the same figure.
+     *
+     *  2. **Legacy TYPE_IMAGE upgrade.** For each legacy `TYPE_IMAGE`, resolve the figure and
+     *     caption in the chapter DOM. If a same-chapter HIGHLIGHT already covers the caption
+     *     text (by normalized-snippet equality), merge the figure into that HIGHLIGHT and
+     *     tombstone the TYPE_IMAGE — mirrors [EpubReaderViewModel.onFigureLongPress]'s dedup
+     *     path so a legacy figure + a pre-existing text-selection highlight of the caption
+     *     converge to one annotation. Otherwise rewrite the TYPE_IMAGE in place via
+     *     [AnnotationStore.upgradeImageToCaptionHighlight].
+     */
+    suspend fun sweep(
+        annotations: List<Annotation>,
+        readChapterHtml: suspend (spineIndex: Int) -> String?,
+    ): SweepResult {
+        val merged = mergeDuplicateCaptionHighlights(annotations)
+        // Re-read the annotation set from the caller's snapshot; anything the merge phase
+        // tombstoned needs to be dropped so the upgrade phase doesn't touch a deleted row.
+        val liveIdsAfterMerge = annotations
+            .filter { it.type == AnnotationEntity.TYPE_HIGHLIGHT || it.type == AnnotationEntity.TYPE_IMAGE }
+            .filter { it.id !in tombstonedIds }
+            .map { it.id }
+            .toSet()
+        val liveAnnotations = annotations.filter { it.id in liveIdsAfterMerge }
+        val upgraded = upgradeLegacyImageAnnotations(liveAnnotations, readChapterHtml)
+        tombstonedIds.clear()
+        return SweepResult(merged = merged, upgraded = upgraded)
+    }
+
+    private val tombstonedIds = mutableSetOf<String>()
+
+    /**
+     * Runs only the duplicate-cleanup phase — no source HTML needed, so this fires from the
+     * Highlights-mode reader open too (where `lifecycle.publication` is never bound and the full
+     * [sweep] can't do the legacy-upgrade phase). Fixes the "captions still doubled" symptom that
+     * shows when the user opens a book via the Annotations tab without first opening it in
+     * FullBook mode: the legacy upgrade may have already happened in a prior FullBook open, but
+     * a later re-long-press-in-FullBook created a duplicate HIGHLIGHT, and until the user next
+     * opens the book in FullBook again the duplicates never got merged. Running cleanup here
+     * closes that gap.
+     */
+    suspend fun cleanupDuplicatesOnly(annotations: List<Annotation>): Int =
+        mergeDuplicateCaptionHighlights(annotations).also { tombstonedIds.clear() }
+
+    private suspend fun mergeDuplicateCaptionHighlights(annotations: List<Annotation>): Int {
+        val groups = annotations
+            .filter { it.type == AnnotationEntity.TYPE_HIGHLIGHT && it.textSnippet.isNotBlank() }
+            .groupBy { normalizeCaptionText(it.chapterHref) to normalizeCaptionText(it.textSnippet) }
+            .filterValues { it.size > 1 }
+        var mergedCount = 0
+        for ((_, rows) in groups) {
+            val canonical = rows.maxWithOrNull(
+                compareBy<Annotation>(
+                    { (it.embeddedFigures?.size ?: 0) > 0 },
+                    { it.updatedAt },
+                ),
+            ) ?: continue
+            val extras = rows.filter { it.id != canonical.id }
+            if (extras.isEmpty()) continue
+            val allFigures = extras.flatMap { it.embeddedFigures.orEmpty() }
+            if (allFigures.isNotEmpty()) {
+                runCatching { annotationStore.mergeFiguresIntoHighlight(canonical.id, allFigures) }
+            }
+            for (extra in extras) {
+                runCatching { annotationStore.delete(extra.id) }
+                tombstonedIds += extra.id
+                mergedCount++
+            }
+        }
+        return mergedCount
+    }
+
+    /**
+     * Attempt to upgrade every legacy `TYPE_IMAGE` annotation in [annotations] whose figure and
+     * caption can both be resolved against the current publication. [readChapterHtml] returns
+     * the raw XHTML for a given spine index (may cache), null when unavailable. Returns the
+     * count of upgraded annotations — used for logging and to fire a sync when non-zero.
+     *
+     * When a same-chapter `TYPE_HIGHLIGHT` already covers the caption text (normalized snippet
+     * equality), the legacy row's figure is merged into that HIGHLIGHT and the legacy row is
+     * tombstoned — a caption-highlight and a legacy image-annotation of the same figure
+     * converge to one annotation, matching [EpubReaderViewModel.onFigureLongPress]'s dedup.
+     */
+    suspend fun upgradeLegacyImageAnnotations(
+        annotations: List<Annotation>,
+        readChapterHtml: suspend (spineIndex: Int) -> String?,
+    ): Int {
+        val legacy = annotations.filter { it.type == AnnotationEntity.TYPE_IMAGE }
+        if (legacy.isEmpty()) return 0
+        val highlightsByChapterCaption = annotations
+            .filter { it.type == AnnotationEntity.TYPE_HIGHLIGHT && it.textSnippet.isNotBlank() }
+            .groupBy { normalizeCaptionText(it.chapterHref) to normalizeCaptionText(it.textSnippet) }
+            .mapValues { (_, rows) ->
+                rows.maxByOrNull { (it.embeddedFigures?.size ?: 0) * 1_000_000_000L + it.updatedAt }
+            }
+        var upgraded = 0
+        for (annotation in legacy) {
+            val html = readChapterHtml(annotation.spineIndex) ?: continue
+            val plan = planUpgrade(annotation, html) ?: continue
+            val chapterKey = normalizeCaptionText(annotation.chapterHref)
+            val captionKey = normalizeCaptionText(plan.captionText)
+            val existingHighlight = highlightsByChapterCaption[chapterKey to captionKey]
+            if (existingHighlight != null) {
+                val result = runCatching {
+                    annotationStore.mergeFiguresIntoHighlight(existingHighlight.id, listOf(plan.figure))
+                }.getOrNull()
+                if (result != null) {
+                    runCatching { annotationStore.delete(annotation.id) }
+                    upgraded++
+                }
+                continue
+            }
+            val result = runCatching {
+                annotationStore.upgradeImageToCaptionHighlight(
+                    id = annotation.id,
+                    cfi = plan.cfi,
+                    textSnippet = plan.captionText,
+                    textBefore = plan.textBefore,
+                    textAfter = plan.textAfter,
+                    figure = plan.figure,
+                )
+            }.getOrNull()
+            if (result != null) upgraded++
+        }
+        return upgraded
+    }
+
+    private fun planUpgrade(annotation: Annotation, html: String): UpgradePlan? {
+        val doc = runCatching { Jsoup.parse(html) }.getOrNull() ?: return null
+        val figureEl = findFigureElement(doc, annotation) ?: return null
+        val captionEl = resolveCaptionElement(figureEl) ?: return null
+        val captionText = normalizeWhitespace(captionEl.text())
+        if (captionText.isBlank()) return null
+        val storedSnippet = normalizeWhitespace(annotation.textSnippet)
+        // Fuzzy match: stored snippet equals or is a prefix of the DOM caption. Guards against
+        // upgrading when publisher HTML drifted (rewrapped, renumbered, or different caption).
+        if (storedSnippet.isNotBlank() && !captionText.startsWith(storedSnippet, ignoreCase = true)) {
+            return null
+        }
+        val textBefore = collectTextAround(doc.body(), captionEl, direction = -1, maxChars = 40)
+        val textAfter = collectTextAround(doc.body(), captionEl, direction = +1, maxChars = 40)
+        val startChar = locateSnippetInBody(html, captionText, textBefore) ?: return null
+        val spineStep = (annotation.spineIndex + 1) * 2
+        val cfiRange = buildHighlightCfiRange(
+            spineStep = spineStep,
+            html = html,
+            startChar = startChar,
+            endChar = (startChar + captionText.length - 1L).coerceAtLeast(startChar),
+        ) ?: return null
+        // caption="" — the upgraded HIGHLIGHT's textSnippet carries the caption; storing it on
+        // the figure too would cause the elided view to render the caption text twice
+        // (figure's own <figcaption> + outer <p> from the highlight's snippet chunk).
+        val figure = EmbeddedFigure(
+            href = annotation.imageHref,
+            svg = annotation.imageSvg,
+            caption = "",
+            order = 0,
+            imageBytes = annotation.imageBytes,
+            charOffset = 0L,
+        )
+        return UpgradePlan(cfiRange, captionText, textBefore, textAfter, figure)
+    }
+
+    private fun findFigureElement(doc: org.jsoup.nodes.Document, annotation: Annotation): Element? {
+        val href = annotation.imageHref
+        if (href != null) {
+            val filename = figureHrefFilename(href)
+            // Escape filename for use inside a jsoup [attr$="…"] selector; wrap the value in
+            // single quotes and escape any single quote in the filename itself. Jsoup accepts
+            // both quote styles for attribute selectors.
+            val safe = filename.replace("'", "\\'")
+            doc.select("img[src\$='$safe']").firstOrNull()?.let { return it }
+            doc.select("picture img[src\$='$safe']").firstOrNull()?.let { return it }
+        }
+        val svg = annotation.imageSvg
+        if (svg != null) {
+            val prefix = svg.take(200)
+            for (el in doc.select("svg")) {
+                if (el.outerHtml().startsWith(prefix)) return el
+            }
+        }
+        return null
+    }
+
+    /**
+     * Kotlin mirror of [FigureCaptionWalker]'s `resolveCaptionElement`. Prefers a `<figure>` /
+     * `[role="figure"]` ancestor's `<figcaption>` child; falls back to the nearest following
+     * `<p>`/`<div>` whose text starts with `Figure N` / `Fig. N` / `Table N` / `Chart N`
+     * within 3 ancestor hops.
+     */
+    internal fun resolveCaptionElement(figureEl: Element): Element? {
+        var scan: Element? = figureEl
+        while (scan != null) {
+            if (scan.tagName().equals("figure", ignoreCase = true) ||
+                scan.attr("role").equals("figure", ignoreCase = true)
+            ) {
+                scan.select("figcaption").firstOrNull { it.text().isNotBlank() }?.let { return it }
+                break
+            }
+            scan = scan.parent()
+        }
+        var cur: Element = figureEl
+        for (hops in 0 until 3) {
+            val parent = cur.parent() ?: break
+            for (block in parent.select("p, div")) {
+                if (block === figureEl || block.contains(figureEl)) continue
+                if (documentOrderCompare(figureEl, block) >= 0) continue
+                if (CAPTION_PREFIX_REGEX.containsMatchIn(block.text().trim())) return block
+            }
+            cur = parent
+        }
+        return null
+    }
+
+    /**
+     * Returns > 0 when [b] appears after [a] in document order, < 0 when before, 0 when equal.
+     * Uses jsoup's [Element.elementSiblingIndex] via a walk up the shared-ancestor chain.
+     */
+    private fun documentOrderCompare(a: Element, b: Element): Int {
+        if (a === b) return 0
+        val aAncestors = ancestorChain(a)
+        val bAncestors = ancestorChain(b)
+        // Walk from root downward until they diverge.
+        var i = 0
+        while (i < aAncestors.size && i < bAncestors.size && aAncestors[i] === bAncestors[i]) i++
+        // Compare the diverging siblings.
+        val aSibling = aAncestors.getOrNull(i) ?: return -1 // a is ancestor of b
+        val bSibling = bAncestors.getOrNull(i) ?: return 1
+        return aSibling.elementSiblingIndex() - bSibling.elementSiblingIndex()
+    }
+
+    private fun ancestorChain(el: Element): List<Element> {
+        val out = mutableListOf<Element>()
+        var cur: Element? = el
+        while (cur != null) {
+            out.add(0, cur)
+            cur = cur.parent()
+        }
+        return out
+    }
+
+    private fun collectTextAround(
+        root: Element?,
+        capEl: Element,
+        direction: Int,
+        maxChars: Int,
+    ): String {
+        if (root == null || !root.contains(capEl)) return ""
+        val out = StringBuilder()
+        var found = false
+        // Returns true to signal "stop walking" (either done collecting forward, or hit the
+        // caption while collecting backward — since we've now seen everything before it).
+        fun visit(node: Node): Boolean {
+            if (node === capEl) {
+                if (direction < 0) return true
+                found = true
+                return false
+            }
+            if (capEl.contains(node)) return false
+            if (node is TextNode) {
+                if (direction < 0 && !found) out.append(node.wholeText)
+                else if (direction > 0 && found) {
+                    out.append(node.wholeText)
+                    if (out.length >= maxChars) return true
+                }
+                return false
+            }
+            for (child in node.childNodes()) if (visit(child)) return true
+            return false
+        }
+        visit(root)
+        val joined = normalizeWhitespace(out.toString())
+        return if (direction < 0) joined.takeLast(maxChars) else joined.take(maxChars)
+    }
+
+    private fun normalizeWhitespace(s: String): String = s.replace(WHITESPACE_RUN, " ").trim()
+
+    private data class UpgradePlan(
+        val cfi: String,
+        val captionText: String,
+        val textBefore: String,
+        val textAfter: String,
+        val figure: EmbeddedFigure,
+    )
+
+    private companion object {
+        val WHITESPACE_RUN = Regex("\\s+")
+        val CAPTION_PREFIX_REGEX = Regex("^\\s*(Figure|Fig\\.?|Table|Chart)\\s+\\d", RegexOption.IGNORE_CASE)
+    }
+}
+
+/**
+ * Shared caption-identity normalizer used by both [CaptionHighlightUpgrader]'s dedup pass and
+ * [EpubReaderViewModel.onFigureLongPress]'s dedup check — squashes internal whitespace runs so
+ * different renderers of "the same" caption (`textSnippet` captured with newlines, jsoup
+ * `text()` collapsed) both compare equal.
+ */
+internal fun normalizeCaptionText(text: String): String =
+    text.replace(Regex("\\s+"), " ").trim()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/CaptionHighlightUpgrader.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/CaptionHighlightUpgrader.kt
@@ -139,12 +139,22 @@ internal class CaptionHighlightUpgrader(
     ): Int {
         val legacy = annotations.filter { it.type == AnnotationEntity.TYPE_IMAGE }
         if (legacy.isEmpty()) return 0
-        val highlightsByChapterCaption = annotations
-            .filter { it.type == AnnotationEntity.TYPE_HIGHLIGHT && it.textSnippet.isNotBlank() }
-            .groupBy { normalizeCaptionText(it.chapterHref) to normalizeCaptionText(it.textSnippet) }
-            .mapValues { (_, rows) ->
-                rows.maxByOrNull { (it.embeddedFigures?.size ?: 0) * 1_000_000_000L + it.updatedAt }
+        // Rebuildable running index: seeded from the input snapshot's HIGHLIGHTs, then updated
+        // as each legacy TYPE_IMAGE upgrades in place. Otherwise two legacy rows for the same
+        // figure/caption both upgrade fresh and produce a duplicate HIGHLIGHT that only the
+        // NEXT reopen's cleanup phase collapses.
+        val highlightsByChapterCaption = mutableMapOf<Pair<String, String>, Annotation>()
+        for (row in annotations) {
+            if (row.type != AnnotationEntity.TYPE_HIGHLIGHT || row.textSnippet.isBlank()) continue
+            val key = normalizeCaptionText(row.chapterHref) to normalizeCaptionText(row.textSnippet)
+            val current = highlightsByChapterCaption[key]
+            if (current == null ||
+                (row.embeddedFigures?.size ?: 0) * 1_000_000_000L + row.updatedAt >
+                (current.embeddedFigures?.size ?: 0) * 1_000_000_000L + current.updatedAt
+            ) {
+                highlightsByChapterCaption[key] = row
             }
+        }
         var upgraded = 0
         for (annotation in legacy) {
             val html = readChapterHtml(annotation.spineIndex) ?: continue
@@ -172,6 +182,11 @@ internal class CaptionHighlightUpgrader(
                     figure = plan.figure,
                 )
             }.getOrNull()
+            // On success, register the upgraded row so a SECOND legacy row for the same
+            // figure/caption folds into it via the merge branch above.
+            if (result != null) {
+                highlightsByChapterCaption[chapterKey to captionKey] = result
+            }
             if (result != null) upgraded++
         }
         return upgraded

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -226,6 +226,10 @@ class EpubReaderViewModel @Inject constructor(
     private val tocRepository: TocRepository,
     private val figuresInRangeResolver: FiguresInRangeResolver,
     private val catalogRegistry: com.riffle.core.catalog.CatalogRegistry,
+    @com.riffle.core.data.di.EpubDownloadsStore
+    private val epubDownloadsStore: com.riffle.core.domain.LocalStore,
+    @com.riffle.core.data.di.EpubCacheStore
+    private val epubCacheStore: com.riffle.core.domain.LocalStore,
 ) : AndroidViewModel(application) {
 
     // ReadingSessionCoordinator's per-call enabled gate reads this atomic; init below flips it once
@@ -233,6 +237,14 @@ class EpubReaderViewModel @Inject constructor(
     // that fires before init completes stays a no-op — the coordinator won't heartbeat/flush until
     // the capability is confirmed.
     private val readingSessionsEnabled = java.util.concurrent.atomic.AtomicBoolean(false)
+
+    // Once-per-(VM, book) flag + helper for the caption-annotation sweep — both cleanup (dedup
+    // duplicate caption HIGHLIGHTs) and legacy TYPE_IMAGE upgrade. Declared here (BEFORE the
+    // init block that launches openBook via viewModelScope) so they're initialized in time —
+    // property initializers run in declaration order, and a later declaration would leave these
+    // null when the launched coroutine's Highlights-mode branch reads them (crash 2026-07-14).
+    private val legacyImageUpgradeAttempted = java.util.concurrent.atomic.AtomicBoolean(false)
+    private val captionHighlightUpgrader by lazy { CaptionHighlightUpgrader(annotationStore) }
 
     // Formatting/typography/auto-scroll orchestrator — constructed with viewModelScope so
     // teardown is deterministic (the orchestrator's coroutines cancel when the VM is cleared).
@@ -951,6 +963,26 @@ class EpubReaderViewModel @Inject constructor(
                 _state.value = ReaderState.Error("No active source")
                 return
             }
+            // Duplicate-caption cleanup (2026-07-14, follow-up to the caption-annotation shape).
+            // FullBook's onOpenReady runs the full sweep, but Highlights mode is opened directly
+            // from the Annotations tab and never hits onOpenReady — without this pass, duplicate
+            // caption HIGHLIGHTs the FullBook path could produce stay stacked in the elided view
+            // ("the captions are still doubled" reproduced on AVD 5554). Fires once per (VM,
+            // book) via [legacyImageUpgradeAttempted]'s CAS, mirroring FullBook's own gate.
+            if (legacyImageUpgradeAttempted.compareAndSet(false, true)) {
+                val liveAnnotations = runCatching {
+                    annotationStore.observeAnnotations(sourceId, itemId).first()
+                }.getOrDefault(emptyList())
+                val merged = runCatching {
+                    captionHighlightUpgrader.cleanupDuplicatesOnly(liveAnnotations)
+                }.getOrDefault(0)
+                if (merged > 0) {
+                    logger.d(LogChannel.HighlightMerge) {
+                        "caption-highlight cleanup (highlights-mode) sourceId=$sourceId itemId=$itemId merged=$merged"
+                    }
+                    scheduleAnnotationSync()
+                }
+            }
             val rows = annotationDao.getForItem(sourceId, itemId)
             val toc = tocRepository.getCachedToc(sourceId, itemId)?.second.orEmpty()
             val chapters = buildChapterElisions(rows).mapIndexed { index, chapter ->
@@ -984,13 +1016,34 @@ class EpubReaderViewModel @Inject constructor(
             // way back to ReadiumCSS default (pre-issue-484 behaviour). See issue #484 and
             // [HighlightsPublicationFactory.buildHandle].
             elidedBodyFontFamily = pluralityOriginFont(chapters)
-            val handle = highlightsPublicationFactory.buildHandle(
-                sourceId = sourceId,
-                itemId = itemId,
-                bookTitle = realBookTitle?.let { "$it — Annotations" },
-                chapters = chapters,
-                bookBodyFontFamily = elidedBodyFontFamily,
+            // Serve figure bytes from the source EPUB (if it's been downloaded) so annotated
+            // figures render as their real image in the elided view instead of the "[figure
+            // image not captured]" placeholder. Highlights mode never runs the normal
+            // lifecycle.open() path, so the reader has no Readium `Publication` in hand —
+            // ZipEpubResourceFetcher bypasses Readium and reads entries directly from the local
+            // EPUB. Fetcher lives only across [buildHandle] since bytes are staged/encoded
+            // during that call; safe to close immediately after.
+            // Prefer the downloaded copy (persisted, guaranteed present); fall back to the cache
+            // (short-lived, populated on every reader open for streaming books). Either works to
+            // extract raster bytes for the elided view.
+            val localEpub = epubDownloadsStore.get(sourceId, itemId)
+                ?: epubCacheStore.get(sourceId, itemId)
+            val figureFetcher = localEpub?.let(
+                com.riffle.app.feature.reader.highlights.ZipEpubResourceFetcher::open,
             )
+            val handle = try {
+                highlightsPublicationFactory.buildHandle(
+                    sourceId = sourceId,
+                    itemId = itemId,
+                    bookTitle = realBookTitle?.let { "$it — Annotations" },
+                    chapters = chapters,
+                    bookBodyFontFamily = elidedBodyFontFamily,
+                    resourceFetcher = figureFetcher
+                        ?: com.riffle.app.feature.reader.highlights.ResourceFetcher { null },
+                )
+            } finally {
+                figureFetcher?.close()
+            }
             highlightsPublicationHandle = handle
             val pub = handle.publication
             // Per-device resume (Task 10, ADR 0041): jump back to the chapter containing the
@@ -1157,6 +1210,38 @@ class EpubReaderViewModel @Inject constructor(
                 highlightRenderResolver = { a -> annotationToRender(a) },
                 cfiLocatorResolver = { cfi -> cfiStringToLocator(cfi) },
             )
+            // Opportunistic caption-annotation upgrade (2026-07-14). For each legacy
+            // TYPE_IMAGE annotation on this book whose figure and caption can both be resolved
+            // against the current publication, rewrite it to a TYPE_HIGHLIGHT covering the
+            // caption text. Fires once per (VM, book); the store update propagates through
+            // the annotation Flow → session → decorations naturally.
+            if (legacyImageUpgradeAttempted.compareAndSet(false, true)) {
+                viewModelScope.launch {
+                    val serverId = activeServer.id
+                    val legacy = runCatching {
+                        annotationStore.observeAnnotations(serverId, itemId)
+                            .first()
+                            .filter { it.type == AnnotationEntity.TYPE_IMAGE }
+                    }.getOrDefault(emptyList())
+                    if (legacy.isEmpty()) return@launch
+                    val allAnnotations = runCatching {
+                        annotationStore.observeAnnotations(serverId, itemId).first()
+                    }.getOrDefault(emptyList())
+                    val result = runCatching {
+                        captionHighlightUpgrader.sweep(
+                            annotations = allAnnotations,
+                            readChapterHtml = { spineIndex -> readChapterHtml(spineIndex) },
+                        )
+                    }.getOrNull()
+                    if (result != null && result.total > 0) {
+                        logger.d(LogChannel.HighlightMerge) {
+                            "caption-highlight sweep sourceId=$serverId itemId=$itemId " +
+                                "merged=${result.merged} upgraded=${result.upgraded} legacy=${legacy.size}"
+                        }
+                        scheduleAnnotationSync()
+                    }
+                }
+            }
         }
 
         // Sync immediately while localUpdatedAt is still the genuine stored value — before the
@@ -1477,6 +1562,12 @@ class EpubReaderViewModel @Inject constructor(
     // triggers a DB backfill of every legacy null-font row for the same book, and is cached so
     // subsequent chapter loads (which re-fire the tracker install) don't re-write the DB.
     private val bookBodyFontFamilyReported = java.util.concurrent.atomic.AtomicReference<String>("")
+
+    // (Moved out of this block to above the init launch — see the fields near the constructor
+    // parameters. Kotlin property initializers run in declaration order, and this declaration
+    // used to sit below the init { viewModelScope.launch { openBook() } } block; when the
+    // launched coroutine ran on Main.immediate it hit openBook's Highlights branch before this
+    // field had been assigned, NPE-ing at `legacyImageUpgradeAttempted.compareAndSet(...)`.)
 
     /**
      * Called by [RiffleSelectionRectBridge.onBookBodyFont] on chapter install. Caches the value
@@ -2064,6 +2155,88 @@ class EpubReaderViewModel @Inject constructor(
         }.coerceAtLeast(0)
         val progression = locator.locations.progression ?: 0.0
         val cfi = locator.toPayload().ebookLocation
+
+        // Caption-highlight path: when the JS long-press payload resolved the figure's caption to
+        // a real DOM element (figcaption or a nearby "Figure N…" block), persist the figure as a
+        // TYPE_HIGHLIGHT that covers the caption text, with the figure carried as an
+        // embeddedFigure. This makes the caption a first-class annotated span — tap/select over
+        // the caption routes to this annotation, and a fresh highlight can't land on top of it.
+        // Falls back to the TYPE_IMAGE path below if the caption can't be located Kotlin-side
+        // (e.g. the JS payload had captionRange but jsoup couldn't disambiguate two identical
+        // captions in the same chapter).
+        val captionRange = payload.captionRange
+        if (captionRange != null) {
+            val spineStep = (spineIndex + 1) * 2
+            val html = readChapterHtml(spineIndex)
+            val startChar = html?.let { locateSnippetInBody(it, captionRange.text, captionRange.textBefore) }
+            val cfiRange = if (html != null && startChar != null) {
+                buildHighlightCfiRange(
+                    spineStep = spineStep,
+                    html = html,
+                    startChar = startChar,
+                    endChar = (startChar + captionRange.text.length - 1L).coerceAtLeast(startChar),
+                )
+            } else null
+            if (cfiRange != null) {
+                // caption="" — the highlight's textSnippet already carries the caption text, and
+                // the elided-view renderer would otherwise emit both the figure's own <figcaption>
+                // and an outer <p> for the same string (the "text doubled under each graph" bug
+                // observed on 2026-07-14). Leaving the field empty keeps the DB clean for new
+                // caption-highlights; existing rows are handled render-side.
+                val figure = com.riffle.core.domain.EmbeddedFigure(
+                    href = payload.href,
+                    svg = payload.svg,
+                    caption = "",
+                    order = 0,
+                    imageBytes = payload.imageBytes,
+                    charOffset = 0L,
+                )
+                // Dedup: a same-chapter HIGHLIGHT already covering the caption text (by CFI
+                // equality or normalized-textSnippet equality) absorbs the new figure into its
+                // `embeddedFigures` instead of stacking a duplicate row. Catches both (a) a
+                // re-long-press of the same figure whose first attempt landed as a bare-text
+                // caption HIGHLIGHT with empty embeddedFigures — the "1.5s duplicate" the user
+                // reproduced on 2026-07-14 — and (b) a pre-existing text-selection highlight of
+                // the caption that should upgrade in place instead of getting shadowed.
+                val normalizedCaption = normalizeCaptionText(captionRange.text)
+                val existingRows = runCatching {
+                    annotationDao.getForItem(sourceId, itemId)
+                }.getOrDefault(emptyList())
+                val existingHighlight = existingRows.firstOrNull { row ->
+                    row.type == com.riffle.core.database.AnnotationEntity.TYPE_HIGHLIGHT &&
+                        normalizeEpubHref(row.chapterHref) == normalizeEpubHref(href) &&
+                        (row.cfi == cfiRange ||
+                            normalizeCaptionText(row.textSnippet) == normalizedCaption)
+                }
+                if (existingHighlight != null) {
+                    annotationStore.mergeFiguresIntoHighlight(existingHighlight.id, listOf(figure))
+                    openHighlightActions(existingHighlight.id, anchorRect)
+                    scheduleAnnotationSync()
+                    return
+                }
+                val created = annotationStore.createHighlight(
+                    sourceId = sourceId,
+                    itemId = itemId,
+                    cfi = cfiRange,
+                    textSnippet = captionRange.text,
+                    chapterHref = href,
+                    textBefore = captionRange.textBefore,
+                    textAfter = captionRange.textAfter,
+                    color = annotationSession.lastUsedHighlightColor.value.token,
+                    spineIndex = spineIndex,
+                    progression = progression,
+                    embeddedFigures = listOf(figure),
+                    originFontFamily = FALLBACK_ORIGIN_FONT_FAMILY,
+                )
+                openHighlightActions(created.id, anchorRect)
+                scheduleAnnotationSync()
+                return
+            }
+        }
+
+        // No visible caption (alt/aria-label-only, or bare image with no nearby caption block):
+        // create a TYPE_IMAGE annotation as before. These carry no persisted text range, so their
+        // figcaption tint (if any) remains the render-side CSS pass in FigureBorderInjection.
         val created = annotationStore.createImageAnnotation(
             sourceId = sourceId,
             itemId = itemId,
@@ -2223,7 +2396,11 @@ class EpubReaderViewModel @Inject constructor(
                             title = titleByHref[chapterHref] ?: chapterHref,
                             highlights = livePeers,
                         )
-                        val freshHtml = highlightsPublicationFactory.renderChapterHtml(chapter, elidedBodyFontFamily)
+                        val freshHtml = highlightsPublicationFactory.renderChapterHtml(
+                            chapter = chapter,
+                            bookBodyFontFamily = elidedBodyFontFamily,
+                            dataUriByHref = highlightsPublicationHandle?.figureBytesByHref.orEmpty(),
+                        )
                         handle.setChapterBytes(chapterHref, freshHtml)
                     }
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -238,11 +238,15 @@ class EpubReaderViewModel @Inject constructor(
     // the capability is confirmed.
     private val readingSessionsEnabled = java.util.concurrent.atomic.AtomicBoolean(false)
 
-    // Once-per-(VM, book) flag + helper for the caption-annotation sweep — both cleanup (dedup
-    // duplicate caption HIGHLIGHTs) and legacy TYPE_IMAGE upgrade. Declared here (BEFORE the
-    // init block that launches openBook via viewModelScope) so they're initialized in time —
-    // property initializers run in declaration order, and a later declaration would leave these
-    // null when the launched coroutine's Highlights-mode branch reads them (crash 2026-07-14).
+    // Once-per-(VM, book) flags + helper for the caption-annotation sweep. Split into two
+    // separate flags — one for the Highlights-mode cleanup-only pass, one for the FullBook
+    // full sweep (cleanup + legacy TYPE_IMAGE upgrade) — so a Highlights-first open followed
+    // by a FullBook open in the same VM still runs the legacy upgrade. A single shared flag
+    // would let whichever branch fired first consume it and skip the other. Declared BEFORE
+    // the init block that launches openBook via viewModelScope so property initialization
+    // (which runs in declaration order) can't leave them null when the launched coroutine
+    // reads them (crash 2026-07-14).
+    private val captionHighlightCleanupAttempted = java.util.concurrent.atomic.AtomicBoolean(false)
     private val legacyImageUpgradeAttempted = java.util.concurrent.atomic.AtomicBoolean(false)
     private val captionHighlightUpgrader by lazy { CaptionHighlightUpgrader(annotationStore) }
 
@@ -968,8 +972,10 @@ class EpubReaderViewModel @Inject constructor(
             // from the Annotations tab and never hits onOpenReady — without this pass, duplicate
             // caption HIGHLIGHTs the FullBook path could produce stay stacked in the elided view
             // ("the captions are still doubled" reproduced on AVD 5554). Fires once per (VM,
-            // book) via [legacyImageUpgradeAttempted]'s CAS, mirroring FullBook's own gate.
-            if (legacyImageUpgradeAttempted.compareAndSet(false, true)) {
+            // book) via [captionHighlightCleanupAttempted]'s CAS. Uses a DIFFERENT flag from
+            // FullBook's [legacyImageUpgradeAttempted] so a Highlights-first-then-FullBook open
+            // in the same VM still runs the legacy upgrade.
+            if (captionHighlightCleanupAttempted.compareAndSet(false, true)) {
                 val liveAnnotations = runCatching {
                     annotationStore.observeAnnotations(sourceId, itemId).first()
                 }.getOrDefault(emptyList())
@@ -2198,15 +2204,24 @@ class EpubReaderViewModel @Inject constructor(
                 // caption HIGHLIGHT with empty embeddedFigures — the "1.5s duplicate" the user
                 // reproduced on 2026-07-14 — and (b) a pre-existing text-selection highlight of
                 // the caption that should upgrade in place instead of getting shadowed.
-                val normalizedCaption = normalizeCaptionText(captionRange.text)
+                // Dedup by CFI equality only. A textSnippet-equality fallback would collide
+                // when two figures in the same chapter share a short caption like "Fig. 1"
+                // (common in ranges "Fig. 1a"/"Fig. 1b" or footnote-numbered plates) — the
+                // second long-press would fold figure B into figure A's annotation, leaving
+                // the user with one annotation carrying both figures and no way to distinguish
+                // them. CFI equality is exact: two DIFFERENT captions at the same DOM range
+                // don't exist. A separate text-selection highlight of the caption text sits at
+                // a different CFI range (Readium's text selection uses different boundaries
+                // than jsoup's element-bounds range) and stays separate — the intended cleanup
+                // for that case is the sweep's per-chapter merge phase (safer, has full DAO
+                // context) rather than an eager guess here.
                 val existingRows = runCatching {
                     annotationDao.getForItem(sourceId, itemId)
                 }.getOrDefault(emptyList())
                 val existingHighlight = existingRows.firstOrNull { row ->
                     row.type == com.riffle.core.database.AnnotationEntity.TYPE_HIGHLIGHT &&
                         normalizeEpubHref(row.chapterHref) == normalizeEpubHref(href) &&
-                        (row.cfi == cfiRange ||
-                            normalizeCaptionText(row.textSnippet) == normalizedCaption)
+                        row.cfi == cfiRange
                 }
                 if (existingHighlight != null) {
                     annotationStore.mergeFiguresIntoHighlight(existingHighlight.id, listOf(figure))

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FigureCaptionWalker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FigureCaptionWalker.kt
@@ -26,17 +26,16 @@ internal object FigureCaptionWalker {
      * none of the fallbacks resolve.
      */
     val CAPTION_RESOLVER_JS: String = """
-        function resolveCaption(el) {
-            if (!el) return "";
-            var fig = el.closest ? el.closest('figure') : null;
-            if (fig) {
-                var cap = fig.querySelector('figcaption');
-                if (cap && cap.textContent) return cap.textContent.trim();
-            }
-            var alt = el.getAttribute && el.getAttribute('alt');
-            if (alt) return alt;
-            var aria = el.getAttribute && el.getAttribute('aria-label');
-            if (aria) return aria;
+        function resolveFigcaptionElement(el) {
+            if (!el) return null;
+            var fig = el.closest ? el.closest('figure, [role="figure"]') : null;
+            if (!fig) return null;
+            var cap = fig.querySelector('figcaption');
+            if (cap && (cap.textContent || '').trim()) return cap;
+            return null;
+        }
+        function resolveTextPrefixElement(el) {
+            if (!el) return null;
             var CAPTION_PREFIX_RX = /^\s*(Figure|Fig\.?|Table|Chart)\s+\d/i;
             var cur = el;
             for (var hops = 0; hops < 3; hops++) {
@@ -48,12 +47,61 @@ internal object FigureCaptionWalker {
                     if (b === el || b.contains(el)) continue;
                     var pos = el.compareDocumentPosition(b);
                     if (!(pos & 4)) continue;
-                    var txt = (b.textContent || '').trim();
-                    if (CAPTION_PREFIX_RX.test(txt)) return txt;
+                    if (CAPTION_PREFIX_RX.test((b.textContent || '').trim())) return b;
                 }
                 cur = parent;
             }
+            return null;
+        }
+        function resolveCaption(el) {
+            if (!el) return "";
+            // Order matters: figcaption (per-figure semantic) → alt (per-image attribute) →
+            // aria-label (accessibility) → text-prefix block (proximity heuristic — last so a
+            // real alt="Photo of author" beats a nearby "Table 3 summarizes…" prose block).
+            var cap = resolveFigcaptionElement(el);
+            if (cap) return (cap.textContent || '').trim();
+            var alt = el.getAttribute && el.getAttribute('alt');
+            if (alt) return alt;
+            var aria = el.getAttribute && el.getAttribute('aria-label');
+            if (aria) return aria;
+            var prefix = resolveTextPrefixElement(el);
+            if (prefix) return (prefix.textContent || '').trim();
             return "";
+        }
+        function riffleCollectTextAround(capEl, direction, maxChars) {
+            // Walk the document by text-node order, starting from capEl. direction === -1 = walk
+            // backwards; +1 = forwards. Collects up to maxChars of text OUTSIDE capEl. Uses a fresh
+            // TreeWalker over document.body so caption-boundary probes match how Kotlin locates the
+            // snippet in the flattened body text via jsoup.
+            if (!capEl || !document.body || !document.body.contains(capEl)) return "";
+            var walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, null);
+            var texts = []; var current = null;
+            while ((current = walker.nextNode())) {
+                if (capEl.contains(current)) continue;
+                var pos = capEl.compareDocumentPosition(current);
+                var isBefore = (pos & 2) !== 0; // capEl follows current → current is before
+                var isAfter = (pos & 4) !== 0;  // current follows capEl
+                if (direction < 0 && isBefore) texts.push(current.data || '');
+                else if (direction > 0 && isAfter) texts.push(current.data || '');
+            }
+            var joined = texts.join('').replace(/\s+/g, ' ');
+            if (direction < 0) return joined.slice(-maxChars);
+            return joined.slice(0, maxChars);
+        }
+        function resolveCaptionRange(el) {
+            // Non-null iff the caption resolves to a DOM element (figcaption or a text-prefix p/div).
+            // Returns null for alt/aria-label captions — those aren't visible ranges we can highlight.
+            // For range resolution the figcaption path wins over text-prefix (semantic > proximity);
+            // resolveCaption's alt/aria-label paths are skipped here because they carry no range.
+            var cap = resolveFigcaptionElement(el) || resolveTextPrefixElement(el);
+            if (!cap) return null;
+            var text = (cap.textContent || '').replace(/\s+/g, ' ').trim();
+            if (!text) return null;
+            return {
+                text: text,
+                textBefore: riffleCollectTextAround(cap, -1, 40),
+                textAfter: riffleCollectTextAround(cap, 1, 40),
+            };
         }
     """.trimIndent()
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FigureLongPressPayload.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FigureLongPressPayload.kt
@@ -35,6 +35,30 @@ internal data class FigureLongPressPayload(
      * Publication container to be reloaded. Null on cross-origin blocks or SVG capture failure.
      */
     val imageBytes: String? = null,
+    /**
+     * Non-null when the caption resolves to a real DOM element (`<figcaption>` or a nearby text-
+     * prefix `<p>`/`<div>`) — i.e. a range we can turn into a proper text-highlight anchor. Null
+     * when the caption came from `alt`/`aria-label` (invisible attribute, no range) or when no
+     * caption resolved at all. When present, [EpubReaderViewModel.onFigureLongPress] persists the
+     * figure as a `TYPE_HIGHLIGHT` covering the caption text with the figure as an
+     * `embeddedFigure`, so the caption becomes a real annotated span (tap/select routes to the
+     * same annotation; new highlights can't land on top of it). When null, the annotation falls
+     * back to `TYPE_IMAGE` (no visible caption to anchor to).
+     */
+    val captionRange: CaptionRange? = null,
+)
+
+/**
+ * A resolved caption's DOM text, plus a short text-context window on either side, captured on the
+ * JS side at long-press time. Kotlin re-locates the caption in the chapter HTML via the same
+ * `locateSnippetInBody`/`buildHighlightCfiRange` machinery a normal text selection uses; the
+ * before/after context disambiguates when the same caption text ("Fig. 1") appears more than
+ * once in the chapter.
+ */
+internal data class CaptionRange(
+    val text: String,
+    val textBefore: String,
+    val textAfter: String,
 )
 
 /**
@@ -47,6 +71,17 @@ internal data class FigureLongPressPayload(
 internal object FigureLongPressMessageParser {
     fun parse(json: String): FigureLongPressPayload {
         val obj = JSONObject(json)
+        val captionRange = if (obj.has("captionRange") && !obj.isNull("captionRange")) {
+            val cr = obj.getJSONObject("captionRange")
+            val text = cr.optString("text", "")
+            if (text.isNotBlank()) {
+                CaptionRange(
+                    text = text,
+                    textBefore = cr.optString("textBefore", ""),
+                    textAfter = cr.optString("textAfter", ""),
+                )
+            } else null
+        } else null
         return FigureLongPressPayload(
             kind = obj.getString("kind"),
             caption = obj.optString("caption", ""),
@@ -58,6 +93,7 @@ internal object FigureLongPressMessageParser {
             rectW = obj.optInt("rectW", 0),
             rectH = obj.optInt("rectH", 0),
             imageBytes = obj.optString("imageBytes").takeIf { !obj.isNull("imageBytes") && it.isNotEmpty() },
+            captionRange = captionRange,
         )
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapScript.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapScript.kt
@@ -198,9 +198,11 @@ internal object FigureTapScript {
                             }
                         }
                     } catch (e5) {}
+                    var captionRange = resolveCaptionRange(longPressTarget);
                     var payload = {
                         kind: tag,
                         caption: resolveCaption(longPressTarget),
+                        captionRange: captionRange,
                         href: tag === 'svg' ? null : (longPressTarget.currentSrc || longPressTarget.getAttribute('src') || null),
                         svg: tag === 'svg' ? serializeSvg(longPressTarget) : null,
                         elementId: longPressTarget.id || null,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecoration.kt
@@ -41,18 +41,34 @@ internal object FigureBorderDecoration {
     /**
      * Per-figure raster match — filename suffix (for CSS `[src$=…]` matching), the annotation's
      * CSS-ready color, and whether the annotation carries a note (drives the note-glyph badge).
+     * [tintCaption] is true only for `TYPE_IMAGE` annotations whose caption isn't a real
+     * annotated span — those get the render-side CSS caption tint. `TYPE_HIGHLIGHT` annotations
+     * whose range already covers the caption receive their tint from Readium's normal decoration
+     * pipeline, so this stays false to avoid double-painting.
      */
-    internal data class RasterMark(val filename: String, val color: String, val hasNote: Boolean)
+    internal data class RasterMark(
+        val filename: String,
+        val color: String,
+        val hasNote: Boolean,
+        val tintCaption: Boolean = true,
+    )
 
     fun buildRasterMarks(annotations: List<Annotation>): List<RasterMark> {
-        data class Ref(val href: String, val color: String, val hasNote: Boolean, val updatedAt: Long)
+        data class Ref(
+            val href: String,
+            val color: String,
+            val hasNote: Boolean,
+            val updatedAt: Long,
+            val tintCaption: Boolean,
+        )
         val refs = mutableListOf<Ref>()
         for (a in annotations) {
             val hasNote = !a.note.isNullOrBlank()
             when (a.type) {
-                AnnotationEntity.TYPE_IMAGE -> a.imageHref?.let { refs += Ref(it, a.color, hasNote, a.updatedAt) }
+                AnnotationEntity.TYPE_IMAGE ->
+                    a.imageHref?.let { refs += Ref(it, a.color, hasNote, a.updatedAt, tintCaption = true) }
                 AnnotationEntity.TYPE_HIGHLIGHT -> a.embeddedFigures?.forEach { fig ->
-                    fig.href?.let { refs += Ref(it, a.color, hasNote, a.updatedAt) }
+                    fig.href?.let { refs += Ref(it, a.color, hasNote, a.updatedAt, tintCaption = false) }
                 }
             }
         }
@@ -64,6 +80,7 @@ internal object FigureBorderDecoration {
                     filename = hrefFilename(it.href),
                     color = HighlightColor.fromToken(it.color).argb.toCssRgba(),
                     hasNote = it.hasNote,
+                    tintCaption = it.tintCaption,
                 )
             }
     }
@@ -92,21 +109,32 @@ internal object FigureBorderDecoration {
      * One entry per SVG annotation covering the current document. Newest-wins by `updatedAt` when
      * two annotations reference the same SVG (same fingerprint).
      */
-    internal data class SvgMatch(val fingerprint: String, val color: String, val hasNote: Boolean = false)
+    internal data class SvgMatch(
+        val fingerprint: String,
+        val color: String,
+        val hasNote: Boolean = false,
+        val tintCaption: Boolean = true,
+    )
 
     fun buildSvgMatches(annotations: List<Annotation>): List<SvgMatch> {
-        data class Ref(val fingerprint: String, val color: String, val hasNote: Boolean, val updatedAt: Long)
+        data class Ref(
+            val fingerprint: String,
+            val color: String,
+            val hasNote: Boolean,
+            val updatedAt: Long,
+            val tintCaption: Boolean,
+        )
 
         val refs = mutableListOf<Ref>()
         for (a in annotations) {
             val hasNote = !a.note.isNullOrBlank()
             when (a.type) {
                 AnnotationEntity.TYPE_IMAGE -> a.imageSvg?.take(SVG_FINGERPRINT_PREFIX_LEN)?.let {
-                    refs += Ref(it, a.color, hasNote, a.updatedAt)
+                    refs += Ref(it, a.color, hasNote, a.updatedAt, tintCaption = true)
                 }
                 AnnotationEntity.TYPE_HIGHLIGHT -> a.embeddedFigures?.forEach { figure ->
                     figure.svg?.take(SVG_FINGERPRINT_PREFIX_LEN)?.let {
-                        refs += Ref(it, a.color, hasNote, a.updatedAt)
+                        refs += Ref(it, a.color, hasNote, a.updatedAt, tintCaption = false)
                     }
                 }
             }
@@ -120,6 +148,7 @@ internal object FigureBorderDecoration {
                     fingerprint = it.fingerprint,
                     color = HighlightColor.fromToken(it.color).argb.toCssRgba(),
                     hasNote = it.hasNote,
+                    tintCaption = it.tintCaption,
                 )
             }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecoration.kt
@@ -68,7 +68,9 @@ internal object FigureBorderDecoration {
                 AnnotationEntity.TYPE_IMAGE ->
                     a.imageHref?.let { refs += Ref(it, a.color, hasNote, a.updatedAt, tintCaption = true) }
                 AnnotationEntity.TYPE_HIGHLIGHT -> a.embeddedFigures?.forEach { fig ->
-                    fig.href?.let { refs += Ref(it, a.color, hasNote, a.updatedAt, tintCaption = false) }
+                    fig.href?.let {
+                        refs += Ref(it, a.color, hasNote, a.updatedAt, tintCaption = !highlightCoversCaption(a, fig))
+                    }
                 }
             }
         }
@@ -106,6 +108,22 @@ internal object FigureBorderDecoration {
     private const val SVG_FINGERPRINT_PREFIX_LEN = 200
 
     /**
+     * True when the highlight's captured `textSnippet` covers the figure's caption text — the
+     * signal that Readium's highlight decoration is already painting the caption for us and the
+     * render-side CSS tint would double-paint. False when the highlight range excludes the
+     * caption (e.g. a pre-caption-highlight text-selection across body prose that happens to
+     * enclose a figure — the figcaption sits below the range and only the CSS tint can reach
+     * it). Normalizes whitespace on both sides so the check matches how the text-content walks
+     * on the two rendering paths collapse.
+     */
+    private fun highlightCoversCaption(annotation: Annotation, figure: com.riffle.core.domain.EmbeddedFigure): Boolean {
+        if (figure.caption.isBlank()) return false
+        val normalizedCaption = figure.caption.replace(Regex("\\s+"), " ").trim()
+        val normalizedSnippet = annotation.textSnippet.replace(Regex("\\s+"), " ").trim()
+        return normalizedSnippet.contains(normalizedCaption)
+    }
+
+    /**
      * One entry per SVG annotation covering the current document. Newest-wins by `updatedAt` when
      * two annotations reference the same SVG (same fingerprint).
      */
@@ -134,7 +152,7 @@ internal object FigureBorderDecoration {
                 }
                 AnnotationEntity.TYPE_HIGHLIGHT -> a.embeddedFigures?.forEach { figure ->
                     figure.svg?.take(SVG_FINGERPRINT_PREFIX_LEN)?.let {
-                        refs += Ref(it, a.color, hasNote, a.updatedAt, tintCaption = false)
+                        refs += Ref(it, a.color, hasNote, a.updatedAt, tintCaption = !highlightCoversCaption(a, figure))
                     }
                 }
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjection.kt
@@ -51,12 +51,14 @@ internal fun figureBorderApplyJs(
             .replace("\r", "")
             .replace("\t", " ")
         val escColor = m.color.replace("\"", "\\\"")
-        "{\"fp\":\"$escFp\",\"color\":\"$escColor\",\"note\":${if (m.hasNote) 1 else 0}}"
+        "{\"fp\":\"$escFp\",\"color\":\"$escColor\",\"note\":${if (m.hasNote) 1 else 0}," +
+            "\"tintCap\":${if (m.tintCaption) 1 else 0}}"
     }
     val rasterJson = rasterMarks.joinToString(",", prefix = "[", postfix = "]") { m ->
         val escFn = m.filename.replace("\\", "\\\\").replace("\"", "\\\"")
         val escColor = m.color.replace("\"", "\\\"")
-        "{\"fn\":\"$escFn\",\"color\":\"$escColor\",\"note\":${if (m.hasNote) 1 else 0}}"
+        "{\"fn\":\"$escFn\",\"color\":\"$escColor\",\"note\":${if (m.hasNote) 1 else 0}," +
+            "\"tintCap\":${if (m.tintCaption) 1 else 0}}"
     }
     // Percent-encoded SVG of the same note-alt icon used by NoteGlyphDecoration. The literal
     // single quotes inside the SVG attributes are percent-encoded (%27) — otherwise Kotlin's
@@ -187,7 +189,7 @@ internal fun figureBorderApplyJs(
               var imgs = document.querySelectorAll('img[src\$="' + rf.fn + '"]');
               for (var ii = 0; ii < imgs.length; ii++) {
                 var img = imgs[ii];
-                tintCaptionFor(img, rf.color);
+                if (rf.tintCap) tintCaptionFor(img, rf.color);
                 if (rf.note) {
                   var col = (window.getComputedStyle && window.getComputedStyle(img).outlineColor) || 'currentColor';
                   addNoteBadge(img, col);
@@ -218,7 +220,7 @@ internal fun figureBorderApplyJs(
                   s.style.setProperty('outline', '2px solid ' + matches[j].color, 'important');
                   s.style.setProperty('outline-offset', '2px', 'important');
                   s.__riffleBorderApplied = true;
-                  tintCaptionFor(s, matches[j].color);
+                  if (matches[j].tintCap) tintCaptionFor(s, matches[j].color);
                   if (matches[j].note) addNoteBadge(s, matches[j].color);
                   break;
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -44,6 +44,13 @@ class HighlightsPublicationHandle internal constructor(
     val publication: Publication,
     val chapterUrls: Map<String, Url>,
     private val byteStore: MutableMap<Url, ByteArray>,
+    /** Href → data-URI map for figure bytes fetched via the [ResourceFetcher] at
+     *  [HighlightsPublicationFactory.buildHandle] time. Exposed so the reader's live-patch path
+     *  can pass the same map into [HighlightsPublicationFactory.renderChapterHtml] when
+     *  regenerating a chapter for a per-annotation edit — otherwise the regen would overwrite
+     *  the initial figure-bearing HTML with a byte-less version and the elided view would
+     *  regress to "[figure image not captured]" after the first edit. */
+    val figureBytesByHref: Map<String, String>,
 ) {
     /** Overwrite the bytes for [chapterHref] with [freshHtml]'s UTF-8 encoding. No-op if the
      *  chapter isn't in the current spine (i.e. this handle predates a structural change). */
@@ -133,8 +140,17 @@ class HighlightsPublicationFactory @Inject constructor() {
                 }
             }
             .distinct()
+        val dataUriByHref = mutableMapOf<String, String>()
         for (href in hrefs) {
             val bytes = resourceFetcher.fetch(href) ?: continue
+            // Data-URI FIRST — this is what [appendFigureFigure] uses as the render-time
+            // fallback when the annotation itself has no captured `imageBytes`. Populating the
+            // map is independent of whether we can also stage the bytes at the synthetic
+            // container path (the synthetic path derivation can trip `urlFactory` on hrefs that
+            // contain `:` after path-flattening — Readium's `Url(String)` rejects those — and
+            // gating the map on that would silently drop the fallback for exactly those hrefs).
+            dataUriByHref[href] = "data:${mimeForHref(href)};base64," +
+                java.util.Base64.getEncoder().encodeToString(bytes)
             val url = urlFactory(syntheticPath(href)) ?: continue
             entries[url] = bytes
         }
@@ -142,7 +158,7 @@ class HighlightsPublicationFactory @Inject constructor() {
         nonEmptyChapters.forEachIndexed { index, chapter ->
             val href = "highlights/ch$index.xhtml"
             val url = requireNotNull(urlFactory(href)) { "Failed to build synthetic Url for $href" }
-            entries[url] = renderChapterHtml(chapter, bookBodyFontFamily).toByteArray(Charsets.UTF_8)
+            entries[url] = renderChapterHtml(chapter, bookBodyFontFamily, dataUriByHref).toByteArray(Charsets.UTF_8)
             chapterUrls[chapter.href] = url
             readingOrder += Link(
                 href = url,
@@ -169,7 +185,7 @@ class HighlightsPublicationFactory @Inject constructor() {
             manifest = manifest,
             container = InMemoryContainer(entries),
         )
-        return HighlightsPublicationHandle(publication, chapterUrls, entries)
+        return HighlightsPublicationHandle(publication, chapterUrls, entries, dataUriByHref)
     }
 
     /**
@@ -178,11 +194,15 @@ class HighlightsPublicationFactory @Inject constructor() {
      * chapter's bytes after a per-annotation edit and write them back through
      * [HighlightsPublicationHandle.setChapterBytes] without rebuilding the whole Publication.
      */
-    internal fun renderChapterHtml(chapter: ChapterElision, bookBodyFontFamily: String? = null): String {
+    internal fun renderChapterHtml(
+        chapter: ChapterElision,
+        bookBodyFontFamily: String? = null,
+        dataUriByHref: Map<String, String> = emptyMap(),
+    ): String {
         val body = buildString {
             for (annotation in chapter.highlights) {
                 when (annotation.type) {
-                    AnnotationEntity.TYPE_IMAGE -> appendImageAnnotation(this, annotation)
+                    AnnotationEntity.TYPE_IMAGE -> appendImageAnnotation(this, annotation, dataUriByHref)
                     else -> {
                         // Interleave text and figures at their captured [EmbeddedFigure.charOffset]
                         // (fix 2026-07-09) so a graph sitting between two paragraphs of the
@@ -192,7 +212,7 @@ class HighlightsPublicationFactory @Inject constructor() {
                         // whole highlight falls back to "text first, then figures" — the v1
                         // behaviour matches what shipped before offsets existed. See
                         // appendInterleavedHighlight's KDoc.
-                        appendInterleavedHighlight(this, annotation, bookBodyFontFamily)
+                        appendInterleavedHighlight(this, annotation, bookBodyFontFamily, dataUriByHref)
                     }
                 }
             }
@@ -266,24 +286,63 @@ private fun appendInterleavedHighlight(
     sb: StringBuilder,
     highlight: com.riffle.core.database.AnnotationEntity,
     bookBodyFontFamily: String?,
+    dataUriByHref: Map<String, String> = emptyMap(),
 ) {
     val figures = highlight.decodedEmbeddedFigures()?.sortedBy { it.order }.orEmpty()
+    val normalizedSnippetOuter = com.riffle.app.feature.reader.normalizeCaptionText(highlight.textSnippet)
     if (figures.isEmpty() || figures.any { it.charOffset == null }) {
+        // Caption-highlight shape (2026-07-14): the annotation is a HIGHLIGHT that covers only
+        // the figure's caption text, with the figure as its sole embeddedFigure. Natural
+        // reading order is FIGURE first, then caption text below — matches how the source book
+        // typesets a numbered figure. When the annotation's `charOffset` survives sync
+        // (interleaved branch below), that ordering happens automatically at charOffset=0; when
+        // it doesn't (older peer / sync round-trip dropped the field), we detect the caption-
+        // highlight shape here and reorder manually. Text-selection-across-figure highlights
+        // (>1 figure, or figure caption differs from the highlight's textSnippet) keep the v1
+        // "text first, figures after" fallback so a pre-caption-highlight annotation still
+        // renders the same.
+        val singleFigure = figures.singleOrNull()
+        val isCaptionHighlight = singleFigure != null && (
+            singleFigure.caption.isBlank() ||
+                com.riffle.app.feature.reader.normalizeCaptionText(singleFigure.caption) == normalizedSnippetOuter
+            )
+        if (isCaptionHighlight) {
+            appendFigureBlock(sb, singleFigure!!.copy(caption = ""), highlight.id, highlight.color, dataUriByHref)
+            appendTextHighlight(sb, highlight, bookBodyFontFamily)
+            return
+        }
         appendTextHighlight(sb, highlight, bookBodyFontFamily)
-        figures.forEach { appendFigureBlock(sb, it, highlight.id, highlight.color) }
+        figures.forEach { fig ->
+            val effective = if (
+                fig.caption.isNotBlank() &&
+                com.riffle.app.feature.reader.normalizeCaptionText(fig.caption) == normalizedSnippetOuter
+            ) fig.copy(caption = "") else fig
+            appendFigureBlock(sb, effective, highlight.id, highlight.color, dataUriByHref)
+        }
         return
     }
     val chunks = com.riffle.app.feature.reader.splitSnippetForFiguresAt(
         snippet = highlight.textSnippet,
         offsets = figures.map { it.charOffset },
     )
+    val normalizedSnippet = com.riffle.app.feature.reader.normalizeCaptionText(highlight.textSnippet)
     // Emit alternating: chunk[0], figure[0], chunk[1], figure[1], ..., chunk[last].
     chunks.forEachIndexed { index, chunk ->
         if (chunk.isNotEmpty()) {
             appendHighlightTextChunk(sb, highlight, chunk, bookBodyFontFamily)
         }
         figures.getOrNull(index)?.let { fig ->
-            appendFigureBlock(sb, fig, highlight.id, highlight.color)
+            // Caption-highlight dedup: when the figure's own caption is identical to the highlight's
+            // textSnippet (the caption-annotation shape from 2026-07-14), the outer text-chunk
+            // above already emits the caption text — so pass the figure through with a blanked
+            // caption to avoid rendering it twice. For a text-selection-encloses-figure highlight
+            // the figure's caption is a strict subset of textSnippet, not equal to it, so this
+            // guard is caption-highlight-specific.
+            val effectiveFigure = if (
+                fig.caption.isNotBlank() &&
+                com.riffle.app.feature.reader.normalizeCaptionText(fig.caption) == normalizedSnippet
+            ) fig.copy(caption = "") else fig
+            appendFigureBlock(sb, effectiveFigure, highlight.id, highlight.color, dataUriByHref)
         }
     }
     val note = highlight.note
@@ -435,13 +494,24 @@ internal fun sanitizeCssFontFamily(value: String?): String? {
  * [HighlightsPublicationFactory.build]. [AnnotationEntity.textSnippet] is used as the caption and
  * skipped entirely when blank — a TYPE_IMAGE annotation with no caption gets no `<figcaption>`.
  */
-private fun appendImageAnnotation(sb: StringBuilder, annotation: AnnotationEntity) {
+private fun appendImageAnnotation(
+    sb: StringBuilder,
+    annotation: AnnotationEntity,
+    dataUriByHref: Map<String, String> = emptyMap(),
+) {
+    // Fallback (2026-07-14): when the annotation itself has no captured `imageBytes` (JS canvas
+    // rasterization failed at long-press — often a cross-origin taint on `readium_package://`
+    // URLs), fall through to the bytes the factory fetched from the source publication and
+    // encoded as a data URI. Keeps the elided view showing the actual image rather than the
+    // "[figure image not captured]" placeholder.
+    val effectiveBytes = annotation.imageBytes
+        ?: annotation.imageHref?.let { dataUriByHref[it] }
     appendFigureFigure(
         sb = sb,
         annotationId = annotation.id,
         colorToken = annotation.color,
         svg = annotation.imageSvg,
-        bytes = annotation.imageBytes,
+        bytes = effectiveBytes,
         caption = annotation.textSnippet,
     )
 }
@@ -457,13 +527,17 @@ private fun appendFigureBlock(
     figure: EmbeddedFigure,
     ownerAnnotationId: String,
     ownerColorToken: String,
+    dataUriByHref: Map<String, String> = emptyMap(),
 ) {
+    // See [appendImageAnnotation]'s KDoc for the fallback rationale — same pattern applied to
+    // each embedded figure inside a TYPE_HIGHLIGHT.
+    val effectiveBytes = figure.imageBytes ?: figure.href?.let { dataUriByHref[it] }
     appendFigureFigure(
         sb = sb,
         annotationId = ownerAnnotationId,
         colorToken = ownerColorToken,
         svg = figure.svg,
-        bytes = figure.imageBytes,
+        bytes = effectiveBytes,
         caption = figure.caption,
     )
 }
@@ -533,6 +607,23 @@ private fun appendFigureFigure(
  * can never drift out of sync.
  */
 private fun syntheticPath(href: String): String = "synthetic/figures/" + href.replace('/', '_')
+
+/**
+ * Best-effort MIME type from a figure href, used when inlining fetched bytes as a `data:` URI
+ * inside the elided chapter HTML. Defaults to `image/jpeg` — the WebView renders that fallback
+ * fine even when the actual bytes are a PNG/GIF, so a wrong guess degrades visually rather than
+ * failing hard.
+ */
+private fun mimeForHref(href: String): String {
+    val trimmed = href.substringBefore('?').substringBefore('#').lowercase()
+    return when {
+        trimmed.endsWith(".png") -> "image/png"
+        trimmed.endsWith(".gif") -> "image/gif"
+        trimmed.endsWith(".webp") -> "image/webp"
+        trimmed.endsWith(".svg") -> "image/svg+xml"
+        else -> "image/jpeg"
+    }
+}
 
 /**
  * Strips external references (`<image href|xlink:href="…">` and `<use href|xlink:href="…">`) from

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -301,10 +301,19 @@ private fun appendInterleavedHighlight(
         // (>1 figure, or figure caption differs from the highlight's textSnippet) keep the v1
         // "text first, figures after" fallback so a pre-caption-highlight annotation still
         // renders the same.
+        // Require an explicit caption-shape signal so a legacy text-highlight enclosing a
+        // decorative uncaptioned figure (single embeddedFigure with caption="") doesn't get
+        // its image hoisted above the paragraph text. Two accepted signals:
+        //   (a) figure.caption normalizes to the highlight's textSnippet — the shape written
+        //       before caption="" became the default (kept for back-compat with existing rows).
+        //   (b) figure.caption is blank AND textSnippet starts with the canonical caption
+        //       prefix (Figure/Fig./Table/Chart + digit) — the shape written by the new
+        //       onFigureLongPress / CaptionHighlightUpgrader code paths.
         val singleFigure = figures.singleOrNull()
         val isCaptionHighlight = singleFigure != null && (
-            singleFigure.caption.isBlank() ||
-                com.riffle.app.feature.reader.normalizeCaptionText(singleFigure.caption) == normalizedSnippetOuter
+            (singleFigure.caption.isNotBlank() &&
+                com.riffle.app.feature.reader.normalizeCaptionText(singleFigure.caption) == normalizedSnippetOuter) ||
+                (singleFigure.caption.isBlank() && CAPTION_HIGHLIGHT_PREFIX_REGEX.containsMatchIn(normalizedSnippetOuter))
             )
         if (isCaptionHighlight) {
             appendFigureBlock(sb, singleFigure!!.copy(caption = ""), highlight.id, highlight.color, dataUriByHref)
@@ -607,6 +616,14 @@ private fun appendFigureFigure(
  * can never drift out of sync.
  */
 private fun syntheticPath(href: String): String = "synthetic/figures/" + href.replace('/', '_')
+
+/**
+ * Mirror of [com.riffle.app.feature.reader.FigureCaptionWalker]'s JS `CAPTION_PREFIX_RX` — kept
+ * as an isolated pattern here so [appendInterleavedHighlight]'s caption-highlight discriminator
+ * doesn't misfire on text-highlights that happen to enclose a decorative uncaptioned figure.
+ */
+private val CAPTION_HIGHLIGHT_PREFIX_REGEX =
+    Regex("^\\s*(Figure|Fig\\.?|Table|Chart)\\s+\\d", RegexOption.IGNORE_CASE)
 
 /**
  * Best-effort MIME type from a figure href, used when inlining fetched bytes as a `data:` URI

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/ZipEpubResourceFetcher.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/ZipEpubResourceFetcher.kt
@@ -22,13 +22,18 @@ internal class ZipEpubResourceFetcher private constructor(
 
     override fun fetch(href: String): ByteArray? {
         val trimmed = href.substringBefore('?').substringBefore('#')
-        val entryPath = when {
+        val stripped = when {
             trimmed.startsWith("https://readium_package/") -> trimmed.removePrefix("https://readium_package/")
             trimmed.startsWith("readium_package://") -> trimmed.removePrefix("readium_package://")
             trimmed.startsWith("/") -> trimmed.removePrefix("/")
             else -> trimmed
         }
-        val entry = zip.getEntry(entryPath) ?: return null
+        // Percent-decode: Chromium serves `img.src` as a URL-encoded string, but ZIP entry
+        // names are raw bytes. Without decoding, `OEBPS/Chapter%203/fig%201.png` misses the
+        // real entry `OEBPS/Chapter 3/fig 1.png`. Try the decoded form first, then fall back
+        // to the raw string in case the caller already pre-decoded.
+        val decoded = runCatching { java.net.URLDecoder.decode(stripped, "UTF-8") }.getOrNull()
+        val entry = decoded?.let { zip.getEntry(it) } ?: zip.getEntry(stripped) ?: return null
         return runCatching { zip.getInputStream(entry).use { it.readBytes() } }.getOrNull()
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/ZipEpubResourceFetcher.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/ZipEpubResourceFetcher.kt
@@ -1,0 +1,43 @@
+package com.riffle.app.feature.reader.highlights
+
+import java.io.File
+import java.util.zip.ZipFile
+
+/**
+ * [ResourceFetcher] backed by a raw [ZipFile] of the source EPUB. Bypasses Readium's asset
+ * pipeline so the elided-view factory can be given real figure bytes even in Highlights mode
+ * (where [com.riffle.app.feature.reader.session.ReaderSessionLifecycle.open] never runs and no
+ * Readium `Publication` is loaded). Callers construct with the local EPUB file, use in one
+ * [com.riffle.app.feature.reader.highlights.HighlightsPublicationFactory.buildHandle] call, then
+ * [close] to release the zip descriptor.
+ *
+ * The incoming [href] is typically an absolute readium_package URL (e.g.
+ * `https://readium_package/OEBPS/image_rsrc2HM.jpg`); ZIP entries inside the EPUB are relative
+ * paths (`OEBPS/image_rsrc2HM.jpg`). This class strips the scheme+authority prefix if present
+ * and any query/fragment before probing the zip.
+ */
+internal class ZipEpubResourceFetcher private constructor(
+    private val zip: ZipFile,
+) : ResourceFetcher, AutoCloseable {
+
+    override fun fetch(href: String): ByteArray? {
+        val trimmed = href.substringBefore('?').substringBefore('#')
+        val entryPath = when {
+            trimmed.startsWith("https://readium_package/") -> trimmed.removePrefix("https://readium_package/")
+            trimmed.startsWith("readium_package://") -> trimmed.removePrefix("readium_package://")
+            trimmed.startsWith("/") -> trimmed.removePrefix("/")
+            else -> trimmed
+        }
+        val entry = zip.getEntry(entryPath) ?: return null
+        return runCatching { zip.getInputStream(entry).use { it.readBytes() } }.getOrNull()
+    }
+
+    override fun close() {
+        runCatching { zip.close() }
+    }
+
+    companion object {
+        fun open(epubFile: File): ZipEpubResourceFetcher? =
+            runCatching { ZipFile(epubFile) }.getOrNull()?.let(::ZipEpubResourceFetcher)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModelTest.kt
@@ -75,6 +75,13 @@ class AnnotationSearchViewModelTest {
         override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.domain.EmbeddedFigure>?, originFontFamily: String) = error("unused")
         override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String, originFontFamily: String) = error("unused")
         override suspend fun createImageAnnotation(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, imageHref: String?, imageSvg: String?, imageBytes: String?, color: String) = error("unused")
+        override suspend fun upgradeImageToCaptionHighlight(
+            id: String, cfi: String, textSnippet: String, textBefore: String, textAfter: String,
+            figure: com.riffle.core.domain.EmbeddedFigure,
+        ): Annotation? = null
+        override suspend fun mergeFiguresIntoHighlight(
+            id: String, newFigures: List<com.riffle.core.domain.EmbeddedFigure>,
+        ): Annotation? = null
         override suspend fun delete(id: String) = error("unused")
         override suspend fun recolor(id: String, color: String) = error("unused")
         override suspend fun updateNote(id: String, note: String?) = error("unused")

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
@@ -83,6 +83,13 @@ class LibraryFilterEngineTest {
         override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.domain.EmbeddedFigure>?, originFontFamily: String) = error("unused")
         override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String, originFontFamily: String) = error("unused")
         override suspend fun createImageAnnotation(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, imageHref: String?, imageSvg: String?, imageBytes: String?, color: String) = error("unused")
+        override suspend fun upgradeImageToCaptionHighlight(
+            id: String, cfi: String, textSnippet: String, textBefore: String, textAfter: String,
+            figure: com.riffle.core.domain.EmbeddedFigure,
+        ): com.riffle.core.domain.Annotation? = null
+        override suspend fun mergeFiguresIntoHighlight(
+            id: String, newFigures: List<com.riffle.core.domain.EmbeddedFigure>,
+        ): com.riffle.core.domain.Annotation? = null
         override suspend fun delete(id: String) = error("unused")
         override suspend fun recolor(id: String, color: String) = error("unused")
         override suspend fun updateNote(id: String, note: String?) = error("unused")

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -87,6 +87,13 @@ class LibraryItemsViewModelTest {
             override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.domain.EmbeddedFigure>?, originFontFamily: String) = error("unused")
             override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String, originFontFamily: String) = error("unused")
             override suspend fun createImageAnnotation(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, imageHref: String?, imageSvg: String?, imageBytes: String?, color: String) = error("unused")
+            override suspend fun upgradeImageToCaptionHighlight(
+                id: String, cfi: String, textSnippet: String, textBefore: String, textAfter: String,
+                figure: com.riffle.core.domain.EmbeddedFigure,
+            ): com.riffle.core.domain.Annotation? = null
+            override suspend fun mergeFiguresIntoHighlight(
+                id: String, newFigures: List<com.riffle.core.domain.EmbeddedFigure>,
+            ): com.riffle.core.domain.Annotation? = null
             override suspend fun delete(id: String) = error("unused")
             override suspend fun recolor(id: String, color: String) = error("unused")
             override suspend fun updateNote(id: String, note: String?) = error("unused")

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/CaptionHighlightUpgraderTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/CaptionHighlightUpgraderTest.kt
@@ -1,0 +1,505 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.data.AnnotationStoreImpl
+import com.riffle.core.database.AnnotationDao
+import com.riffle.core.database.AnnotationEntity
+import com.riffle.core.database.BookHighlightSummary
+import com.riffle.core.domain.DeviceIdStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression coverage for [CaptionHighlightUpgrader]. Exercises the opportunistic legacy-annotation
+ * upgrade sweep the reader fires once per (VM lifecycle, book): each `TYPE_IMAGE` annotation is
+ * checked against the current chapter DOM; if the figure and its caption both resolve and the
+ * caption text matches the stored snippet, the annotation is rewritten in place as a `TYPE_HIGHLIGHT`
+ * covering the caption with the figure carried as an `embeddedFigure`.
+ */
+class CaptionHighlightUpgraderTest {
+
+    private val rows = MutableStateFlow<List<AnnotationEntity>>(emptyList())
+    private val dao = InMemoryDao(rows)
+
+    private val deviceIdStore = object : DeviceIdStore {
+        override suspend fun getOrCreate(): String = "device-X"
+    }
+
+    private fun store(): AnnotationStoreImpl {
+        var counter = 0
+        return AnnotationStoreImpl(
+            dao = dao,
+            deviceIdStore = deviceIdStore,
+            clock = { 5_000L },
+            idGenerator = { "generated-${counter++}" },
+        )
+    }
+
+    private fun legacyImageRow(
+        id: String = "ann-1",
+        textSnippet: String = "Figure 2. The observed distribution",
+        imageHref: String = "OEBPS/images/graph.png",
+        imageSvg: String? = null,
+        imageBytes: String? = "data:image/jpeg;base64,ZZZZ",
+        spineIndex: Int = 2,
+    ) = AnnotationEntity(
+        id = id,
+        sourceId = "srv",
+        itemId = "book-1",
+        type = AnnotationEntity.TYPE_IMAGE,
+        cfi = "epubcfi(/6/4!/4/2:0)",
+        color = AnnotationEntity.COLOR_YELLOW,
+        note = null,
+        textSnippet = textSnippet,
+        textBefore = "",
+        textAfter = "",
+        chapterHref = "OEBPS/ch2.xhtml",
+        spineIndex = spineIndex,
+        progression = 0.5,
+        bookmarkTitle = "",
+        createdAt = 1_000L,
+        updatedAt = 2_000L,
+        originDeviceId = "device-orig",
+        lastModifiedByDeviceId = "device-orig",
+        deleted = false,
+        embeddedFigures = null,
+        imageHref = imageHref,
+        imageSvg = imageSvg,
+        imageBytes = imageBytes,
+    )
+
+    @Test
+    fun `upgrades legacy TYPE_IMAGE when figcaption resolves and matches snippet`() = runTest {
+        val legacy = legacyImageRow(textSnippet = "Figure 2. The observed distribution")
+        dao.upsert(legacy)
+        val html = """
+            <html><body>
+              <p>Some preceding text before the graph.</p>
+              <figure>
+                <img src="images/graph.png"/>
+                <figcaption>Figure 2. The observed distribution</figcaption>
+              </figure>
+              <p>Following prose.</p>
+            </body></html>
+        """.trimIndent()
+        val upgrader = CaptionHighlightUpgrader(store())
+
+        val upgraded = upgrader.upgradeLegacyImageAnnotations(
+            annotations = dao.rows.value.map { it.toDomain() },
+            readChapterHtml = { _ -> html },
+        )
+
+        assertEquals(1, upgraded)
+        val row = dao.rows.value.single()
+        assertEquals(AnnotationEntity.TYPE_HIGHLIGHT, row.type)
+        assertEquals("Figure 2. The observed distribution", row.textSnippet)
+        assertNull("TYPE_HIGHLIGHT rows must not carry imageHref", row.imageHref)
+        assertNull("TYPE_HIGHLIGHT rows must not carry imageBytes", row.imageBytes)
+        assertTrue(
+            "embeddedFigures JSON must reference the figure href",
+            (row.embeddedFigures ?: "").contains("graph.png"),
+        )
+        // Id preserved so cross-device sync sees an update, not a delete/create.
+        assertEquals("ann-1", row.id)
+    }
+
+    @Test
+    fun `upgrades via text-prefix fallback when no figcaption present`() = runTest {
+        // LaTeX/Kotobee/Vellum EPUBs typically wrap the caption as a plain <p> whose text starts
+        // with "Figure N…". The upgrader mirrors the JS resolveCaption fallback.
+        val legacy = legacyImageRow(textSnippet = "Figure 2.1 The observed distribution across cohorts")
+        dao.upsert(legacy)
+        val html = """
+            <html><body>
+              <div>
+                <img src="images/graph.png"/>
+                <p>Figure 2.1 The observed distribution across cohorts</p>
+              </div>
+            </body></html>
+        """.trimIndent()
+        val upgrader = CaptionHighlightUpgrader(store())
+
+        val upgraded = upgrader.upgradeLegacyImageAnnotations(
+            annotations = dao.rows.value.map { it.toDomain() },
+            readChapterHtml = { _ -> html },
+        )
+
+        assertEquals(1, upgraded)
+        assertEquals(AnnotationEntity.TYPE_HIGHLIGHT, dao.rows.value.single().type)
+    }
+
+    @Test
+    fun `skips upgrade when DOM caption does not match stored snippet`() = runTest {
+        // Publisher republished with a different caption. Refuse to upgrade — annotation stays as
+        // legacy TYPE_IMAGE, its CSS caption tint keeps rendering unchanged.
+        val legacy = legacyImageRow(textSnippet = "Figure 2. Original caption")
+        dao.upsert(legacy)
+        val html = """
+            <html><body>
+              <figure>
+                <img src="images/graph.png"/>
+                <figcaption>Figure 2. Renamed caption entirely</figcaption>
+              </figure>
+            </body></html>
+        """.trimIndent()
+        val upgrader = CaptionHighlightUpgrader(store())
+
+        val upgraded = upgrader.upgradeLegacyImageAnnotations(
+            annotations = dao.rows.value.map { it.toDomain() },
+            readChapterHtml = { _ -> html },
+        )
+
+        assertEquals(0, upgraded)
+        assertEquals(AnnotationEntity.TYPE_IMAGE, dao.rows.value.single().type)
+    }
+
+    @Test
+    fun `skips upgrade when figure not in DOM`() = runTest {
+        // Chapter reorganised, figure href stale — nothing to hang the highlight on.
+        val legacy = legacyImageRow()
+        dao.upsert(legacy)
+        val html = """<html><body><p>No figures here.</p></body></html>"""
+        val upgrader = CaptionHighlightUpgrader(store())
+
+        val upgraded = upgrader.upgradeLegacyImageAnnotations(
+            annotations = dao.rows.value.map { it.toDomain() },
+            readChapterHtml = { _ -> html },
+        )
+
+        assertEquals(0, upgraded)
+    }
+
+    @Test
+    fun `skips upgrade when figure has no caption element`() = runTest {
+        // Bare <img> with alt-text only: no visible caption to anchor to. Annotation must stay
+        // TYPE_IMAGE (its textSnippet still holds the alt for the annotations panel).
+        val legacy = legacyImageRow(textSnippet = "Photo of author")
+        dao.upsert(legacy)
+        val html = """
+            <html><body>
+              <p>Introduction paragraph.</p>
+              <img src="images/graph.png" alt="Photo of author"/>
+              <p>Continuing prose.</p>
+            </body></html>
+        """.trimIndent()
+        val upgrader = CaptionHighlightUpgrader(store())
+
+        val upgraded = upgrader.upgradeLegacyImageAnnotations(
+            annotations = dao.rows.value.map { it.toDomain() },
+            readChapterHtml = { _ -> html },
+        )
+
+        assertEquals(0, upgraded)
+        assertEquals(AnnotationEntity.TYPE_IMAGE, dao.rows.value.single().type)
+    }
+
+    @Test
+    fun `preserves provenance and bumps updatedAt on upgrade`() = runTest {
+        val legacy = legacyImageRow()
+        dao.upsert(legacy)
+        val html = """
+            <html><body>
+              <figure>
+                <img src="images/graph.png"/>
+                <figcaption>${legacy.textSnippet}</figcaption>
+              </figure>
+            </body></html>
+        """.trimIndent()
+        val upgrader = CaptionHighlightUpgrader(store())
+
+        upgrader.upgradeLegacyImageAnnotations(
+            annotations = dao.rows.value.map { it.toDomain() },
+            readChapterHtml = { _ -> html },
+        )
+
+        val row = dao.rows.value.single()
+        // originDeviceId is stable — the annotation didn't change origin, just shape.
+        assertEquals("device-orig", row.originDeviceId)
+        assertEquals("device-X", row.lastModifiedByDeviceId)
+        // Clock stamps updatedAt = now() so sync sees the row as dirty and pushes the new shape.
+        assertEquals(5_000L, row.updatedAt)
+    }
+
+    @Test
+    fun `sweep merges duplicate caption HIGHLIGHTs into one`() = runTest {
+        // Regression: the initial 2026-07-14 caption-annotation change could stack a second
+        // HIGHLIGHT next to a first when a re-long-press of the same figure hit before the first
+        // annotation's embeddedFigures was populated (the "1.5s duplicate" the user reproduced on
+        // AVD 5554). The cleanup phase must merge duplicate HIGHLIGHTs at the same caption text
+        // into one canonical annotation carrying every figure and tombstone the extras.
+        val figureA = com.riffle.core.domain.EmbeddedFigure(
+            href = "images/g.png", svg = null, caption = "Figure 20.2: The original",
+            order = 0, imageBytes = "data:image/jpeg;base64,YYY", charOffset = 0L,
+        )
+        val chapter = "OEBPS/ch20.xhtml"
+        // Seed a HIGHLIGHT with the figure via the store's own createHighlight path — same
+        // production write path, so the JSON shape is real.
+        val storeInstance = store()
+        val withFig = storeInstance.createHighlight(
+            sourceId = "srv", itemId = "book-1",
+            cfi = "epubcfi(range-a)",
+            textSnippet = "Figure 20.2: The original",
+            chapterHref = chapter,
+            embeddedFigures = listOf(figureA),
+            originFontFamily = "serif",
+        )
+        val empty = storeInstance.createHighlight(
+            sourceId = "srv", itemId = "book-1",
+            cfi = "epubcfi(range-b)",
+            textSnippet = "Figure 20.2: The original",
+            chapterHref = chapter,
+            embeddedFigures = null,
+            originFontFamily = "serif",
+        )
+        // Set the with-fig row's updatedAt higher so it becomes canonical (also has figures →
+        // tiebreaker wins). The empty row is older.
+        dao.upsert(dao.rows.value.single { it.id == withFig.id }.copy(updatedAt = 200L))
+        dao.upsert(dao.rows.value.single { it.id == empty.id }.copy(updatedAt = 100L))
+
+        val result = CaptionHighlightUpgrader(storeInstance).sweep(
+            annotations = dao.rows.value.map { it.toDomain() },
+            readChapterHtml = { _ -> "" },
+        )
+
+        assertEquals(1, result.merged)
+        val live = dao.rows.value.filterNot { it.deleted }
+        assertEquals("one canonical row survives the merge", 1, live.size)
+        val canonical = live.single()
+        assertEquals(withFig.id, canonical.id)
+        val tomb = dao.rows.value.single { it.id == empty.id }
+        assertTrue("empty duplicate must be tombstoned", tomb.deleted)
+    }
+
+    @Test
+    fun `sweep merges legacy TYPE_IMAGE into pre-existing caption HIGHLIGHT`() = runTest {
+        // When a legacy TYPE_IMAGE of a figure coexists with a pre-existing text-selection
+        // HIGHLIGHT of the same caption (e.g. user text-highlighted the caption manually before
+        // long-pressing the figure), the upgrade must fold the figure into that HIGHLIGHT and
+        // tombstone the TYPE_IMAGE — not upgrade it into a duplicate HIGHLIGHT alongside.
+        val chapter = "OEBPS/ch20.xhtml"
+        val storeInstance = store()
+        val existingCaptionHighlight = storeInstance.createHighlight(
+            sourceId = "srv", itemId = "book-1",
+            cfi = "epubcfi(existing)",
+            textSnippet = "Figure 20.1: A Buffer object uses",
+            chapterHref = chapter,
+            embeddedFigures = null,
+            originFontFamily = "serif",
+        )
+        val legacyImage = legacyImageRow(
+            id = "legacy-img",
+            textSnippet = "Figure 20.1: A Buffer object uses",
+            imageHref = "images/graph.png",
+        ).copy(chapterHref = chapter)
+        dao.upsert(legacyImage)
+        val html = """
+            <html><body>
+              <figure>
+                <img src="images/graph.png"/>
+                <figcaption>Figure 20.1: A Buffer object uses</figcaption>
+              </figure>
+            </body></html>
+        """.trimIndent()
+
+        val result = CaptionHighlightUpgrader(storeInstance).sweep(
+            annotations = dao.rows.value.map { it.toDomain() },
+            readChapterHtml = { _ -> html },
+        )
+
+        assertEquals(1, result.upgraded)
+        val live = dao.rows.value.filterNot { it.deleted }
+        assertEquals("only the user's highlight survives", 1, live.size)
+        assertEquals(existingCaptionHighlight.id, live.single().id)
+        assertTrue(
+            "user-highlight now carries the figure",
+            (live.single().embeddedFigures ?: "").contains("graph.png"),
+        )
+        val tomb = dao.rows.value.single { it.id == "legacy-img" }
+        assertTrue("legacy TYPE_IMAGE must be tombstoned", tomb.deleted)
+    }
+
+    @Test
+    fun `mergeFiguresIntoHighlight unions figures deduped by filename`() = runTest {
+        // The store-level dedup: adding the same figure (same filename suffix) twice keeps a
+        // single entry. Preventing a re-long-press from bloating embeddedFigures with duplicates
+        // — the "5 copies of the same image" post-fix regression that would otherwise appear.
+        val figA = com.riffle.core.domain.EmbeddedFigure(
+            href = "images/g.png", svg = null, caption = "cap", order = 0,
+        )
+        val figAAgain = com.riffle.core.domain.EmbeddedFigure(
+            href = "https://cdn/images/g.png?v=2", svg = null, caption = "cap", order = 0,
+        )
+        val figB = com.riffle.core.domain.EmbeddedFigure(
+            href = "images/h.png", svg = null, caption = "cap", order = 0,
+        )
+        val storeInstance = store()
+        val seed = storeInstance.createHighlight(
+            sourceId = "srv", itemId = "book-1",
+            cfi = "epubcfi(x)",
+            textSnippet = "cap",
+            chapterHref = "ch",
+            embeddedFigures = listOf(figA),
+            originFontFamily = "serif",
+        )
+
+        storeInstance.mergeFiguresIntoHighlight(seed.id, listOf(figAAgain, figB))
+
+        val json = dao.rows.value.single().embeddedFigures ?: ""
+        assertEquals("only two figures: original + h.png", 2, json.split("\"href\"").size - 1)
+        assertTrue("h.png added", json.contains("h.png"))
+    }
+
+    @Test
+    fun `skips already-upgraded TYPE_HIGHLIGHT rows`() = runTest {
+        val already = legacyImageRow().copy(
+            type = AnnotationEntity.TYPE_HIGHLIGHT,
+            imageHref = null,
+        )
+        dao.upsert(already)
+        val html = "<html><body></body></html>"
+        val upgrader = CaptionHighlightUpgrader(store())
+
+        val upgraded = upgrader.upgradeLegacyImageAnnotations(
+            annotations = dao.rows.value.map { it.toDomain() },
+            readChapterHtml = { _ -> html },
+        )
+
+        assertEquals(0, upgraded)
+    }
+}
+
+/**
+ * Reusable in-memory [AnnotationDao] fake for the upgrader tests. Mirrors the fake in
+ * [EpubReaderViewModelImageAnnotationTest] but lives in its own class so the two suites don't
+ * fight over shared MutableState.
+ */
+private class InMemoryDao(val rows: MutableStateFlow<List<AnnotationEntity>>) : AnnotationDao {
+
+    override fun observeForItem(sourceId: String, itemId: String): Flow<List<AnnotationEntity>> =
+        rows.map { all -> all.filter { it.sourceId == sourceId && it.itemId == itemId && !it.deleted } }
+
+    override suspend fun getForItem(sourceId: String, itemId: String): List<AnnotationEntity> =
+        rows.value.filter { it.sourceId == sourceId && it.itemId == itemId && !it.deleted }
+
+    override suspend fun getAllForItemIncludingDeleted(sourceId: String, itemId: String) =
+        rows.value.filter { it.sourceId == sourceId && it.itemId == itemId }
+
+    override suspend fun getById(id: String) = rows.value.firstOrNull { it.id == id }
+
+    override suspend fun getByItemAndCfi(sourceId: String, itemId: String, cfi: String) =
+        rows.value.firstOrNull { it.sourceId == sourceId && it.itemId == itemId && it.cfi == cfi && !it.deleted }
+
+    override suspend fun findImageForFigure(
+        sourceId: String,
+        itemId: String,
+        chapterHref: String,
+        imageHref: String?,
+        imageSvg: String?,
+    ) = rows.value.firstOrNull {
+        it.sourceId == sourceId && it.itemId == itemId && it.chapterHref == chapterHref &&
+            it.type == AnnotationEntity.TYPE_IMAGE && !it.deleted &&
+            (imageHref == null || it.imageHref == imageHref) &&
+            (imageSvg == null || it.imageSvg == imageSvg)
+    }
+
+    override suspend fun upsert(entity: AnnotationEntity) {
+        rows.value = rows.value.filterNot { it.id == entity.id } + entity
+    }
+
+    override suspend fun upsertAll(annotations: List<AnnotationEntity>) {
+        val ids = annotations.map { it.id }.toSet()
+        rows.value = rows.value.filterNot { it.id in ids } + annotations
+    }
+
+    override suspend fun tombstone(id: String, updatedAt: Long, deviceId: String) {
+        rows.value = rows.value.map {
+            if (it.id == id) it.copy(deleted = true, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it
+        }
+    }
+
+    override suspend fun recolor(id: String, color: String, updatedAt: Long, deviceId: String) {
+        rows.value = rows.value.map {
+            if (it.id == id) it.copy(color = color, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it
+        }
+    }
+
+    override suspend fun updateNote(id: String, note: String?, updatedAt: Long, deviceId: String) {
+        rows.value = rows.value.map {
+            if (it.id == id) it.copy(note = note, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it
+        }
+    }
+
+    override fun observeAnnotationsByPosition(sourceId: String, itemId: String) =
+        rows.map { all ->
+            all.filter { it.sourceId == sourceId && it.itemId == itemId && !it.deleted }
+                .sortedWith(compareBy({ it.spineIndex }, { it.progression }))
+        }
+
+    override suspend fun renameBookmark(id: String, title: String, updatedAt: Long, deviceId: String) {
+        rows.value = rows.value.map {
+            if (it.id == id) it.copy(bookmarkTitle = title, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it
+        }
+    }
+
+    override fun observeForSource(sourceId: String) =
+        rows.map { all -> all.filter { it.sourceId == sourceId && !it.deleted } }
+
+    override fun observePendingCountForBook(sourceId: String, itemId: String) =
+        rows.map { all -> all.count { it.sourceId == sourceId && it.itemId == itemId && it.updatedAt > it.lastSyncedAt } }
+
+    override fun observePendingBookCountAcrossAll() =
+        rows.map { all -> all.filter { it.updatedAt > it.lastSyncedAt }.distinctBy { it.sourceId to it.itemId }.size }
+
+    override suspend fun dirtySourceItems() =
+        rows.value.filter { it.updatedAt > it.lastSyncedAt }
+            .map { AnnotationDao.DirtySourceItem(it.sourceId, it.itemId) }
+            .distinct()
+
+    override suspend fun markSynced(ids: List<String>, syncedAt: Long) {
+        rows.value = rows.value.map { if (it.id in ids) it.copy(lastSyncedAt = syncedAt) else it }
+    }
+
+    override suspend fun purgeAgedTombstones(sourceId: String, itemId: String, cutoff: Long) = 0
+
+    override suspend fun backfillNullOriginFontFamily(
+        sourceId: String,
+        itemId: String,
+        fontFamily: String,
+        updatedAt: Long,
+        deviceId: String,
+    ) = 0
+
+    override fun observeBooksWithHighlights(sourceId: String) = flowOf(emptyList<BookHighlightSummary>())
+}
+
+/** Reuses the internal mapper the store uses so this test's fixtures speak entity, not domain. */
+private fun AnnotationEntity.toDomain() = com.riffle.core.domain.Annotation(
+    id = id,
+    sourceId = sourceId,
+    itemId = itemId,
+    type = type,
+    cfi = cfi,
+    color = color,
+    note = note,
+    textSnippet = textSnippet,
+    textBefore = textBefore,
+    textAfter = textAfter,
+    chapterHref = chapterHref,
+    spineIndex = spineIndex,
+    progression = progression,
+    bookmarkTitle = bookmarkTitle,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+    embeddedFigures = null,
+    imageHref = imageHref,
+    imageSvg = imageSvg,
+    imageBytes = imageBytes,
+    originFontFamily = originFontFamily,
+)

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelImageAnnotationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelImageAnnotationTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -223,6 +224,99 @@ class EpubReaderViewModelImageAnnotationTest {
             imageBytes = payload.imageBytes,
         )
         return null
+    }
+
+    /**
+     * Mirrors [EpubReaderViewModel.onFigureLongPress]'s caption-highlight branch (2026-07-14):
+     * when the JS payload carried a `captionRange`, resolve the caption's char range Kotlin-side
+     * and persist as `TYPE_HIGHLIGHT` covering the caption with the figure carried as an
+     * `embeddedFigure`. Fully mirrors the production call site — a schema/type regression on
+     * either the store method or the VM branch flips this red.
+     */
+    private suspend fun onFigureLongPressWithCaptionRange(
+        store: AnnotationStoreImpl,
+        payload: FigureLongPressPayload,
+        html: String,
+        chapterHref: String,
+        spineIndex: Int,
+        progression: Double,
+    ): com.riffle.core.domain.Annotation? {
+        val captionRange = payload.captionRange ?: return null
+        val startChar = locateSnippetInBody(html, captionRange.text, captionRange.textBefore) ?: return null
+        val cfi = buildHighlightCfiRange(
+            spineStep = (spineIndex + 1) * 2,
+            html = html,
+            startChar = startChar,
+            endChar = (startChar + captionRange.text.length - 1L).coerceAtLeast(startChar),
+        ) ?: return null
+        val figure = com.riffle.core.domain.EmbeddedFigure(
+            href = payload.href,
+            svg = payload.svg,
+            caption = captionRange.text,
+            order = 0,
+            imageBytes = payload.imageBytes,
+            charOffset = 0L,
+        )
+        return store.createHighlight(
+            sourceId = "srv-abs",
+            itemId = "item-1",
+            cfi = cfi,
+            textSnippet = captionRange.text,
+            chapterHref = chapterHref,
+            textBefore = captionRange.textBefore,
+            textAfter = captionRange.textAfter,
+            spineIndex = spineIndex,
+            progression = progression,
+            embeddedFigures = listOf(figure),
+            originFontFamily = "serif",
+        )
+    }
+
+    @Test
+    fun `onFigureLongPress with captionRange persists TYPE_HIGHLIGHT with embedded figure`() = runTest {
+        val payload = FigureLongPressPayload(
+            kind = "img",
+            caption = "Figure 2. The observed distribution",
+            href = "images/g.png",
+            svg = null,
+            elementId = null,
+            imageBytes = "data:image/jpeg;base64,ZZZZ",
+            captionRange = CaptionRange(
+                text = "Figure 2. The observed distribution",
+                textBefore = "the graph",
+                textAfter = "Following prose",
+            ),
+        )
+        val html = """
+            <html><body>
+              <p>Prose before the graph</p>
+              <figure>
+                <img src="images/g.png"/>
+                <figcaption>Figure 2. The observed distribution</figcaption>
+              </figure>
+              <p>Following prose here</p>
+            </body></html>
+        """.trimIndent()
+
+        val saved = onFigureLongPressWithCaptionRange(
+            store = storeWithUniqueIds(),
+            payload = payload,
+            html = html,
+            chapterHref = "ch1.xhtml",
+            spineIndex = 0,
+            progression = 0.42,
+        )
+
+        assertNotNull(saved)
+        // Regression: this branch produces TYPE_HIGHLIGHT, not TYPE_IMAGE. A revert would show the
+        // caption's text un-highlighted and untappable — the exact bug the 2026-07-14 change fixed.
+        assertEquals(AnnotationEntity.TYPE_HIGHLIGHT, saved!!.type)
+        assertEquals("Figure 2. The observed distribution", saved.textSnippet)
+        assertNull("TYPE_HIGHLIGHT rows must not carry imageHref", saved.imageHref)
+        val figures = saved.embeddedFigures.orEmpty()
+        assertEquals(1, figures.size)
+        assertEquals("images/g.png", figures.single().href)
+        assertEquals("data:image/jpeg;base64,ZZZZ", figures.single().imageBytes)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FigureCaptionWalkerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FigureCaptionWalkerTest.kt
@@ -39,12 +39,52 @@ class FigureCaptionWalkerTest {
             "caption resolver should walk parent chain (compareDocumentPosition)",
             js.contains("compareDocumentPosition"),
         )
-        // The fallback must sit AFTER the alt/aria-label paths so a legitimate per-image alt
-        // attribute always wins over a proximity-based heuristic that could match nearby prose
-        // like "Table 3 summarizes results...".
-        val ariaIdx = js.indexOf("'aria-label'")
-        val rxIdx = js.indexOf("CAPTION_PREFIX_RX")
-        assertTrue("text-prefix fallback must come after aria-label", ariaIdx in 0 until rxIdx)
+        // The fallback must sit AFTER the alt/aria-label paths in resolveCaption so a legitimate
+        // per-image alt attribute always wins over a proximity-based heuristic that could match
+        // nearby prose like "Table 3 summarizes results...".
+        val ariaIdx = js.indexOf("if (aria) return aria;")
+        assertTrue("resolveCaption must handle aria before falling through", ariaIdx > 0)
+        val prefixCallIdx = js.indexOf("resolveTextPrefixElement(el)", ariaIdx)
+        assertTrue(
+            "text-prefix fallback must come after aria-label inside resolveCaption",
+            prefixCallIdx > ariaIdx,
+        )
+    }
+
+    @Test
+    fun `resolveCaptionRange emits figcaption then text-prefix but no alt or aria`() {
+        // For range resolution (2026-07-14 caption-highlight upgrade), alt/aria-label are
+        // invisible attributes with no persistable text range. resolveCaptionRange picks
+        // resolveFigcaptionElement first (semantic), then resolveTextPrefixElement (proximity
+        // heuristic), and skips alt/aria entirely. Reverting this — e.g. reusing resolveCaption's
+        // full fallback chain — would return alt-only "captions" that can't be anchored, and the
+        // upgrader/onFigureLongPress would silently drop them.
+        val js = FigureCaptionWalker.CAPTION_RESOLVER_JS
+        assertTrue(js.contains("function resolveCaptionRange(el)"))
+        val rangeStart = js.indexOf("function resolveCaptionRange(el)")
+        val rangeBody = js.substring(rangeStart)
+        assertTrue(
+            "resolveCaptionRange must call resolveFigcaptionElement",
+            rangeBody.contains("resolveFigcaptionElement(el)"),
+        )
+        assertTrue(
+            "resolveCaptionRange must call resolveTextPrefixElement",
+            rangeBody.contains("resolveTextPrefixElement(el)"),
+        )
+        // Slice at the next function boundary — resolveCaptionRange's body must not read alt or
+        // aria-label. `next` is the START of `function riffleCollectTextAround` above OR
+        // undefined if resolveCaptionRange is the last function; either way the slice below is
+        // safe (substring from rangeStart to end of file if no boundary).
+        val nextBoundary = rangeBody.indexOf("function ", startIndex = 40)
+        val bodyOnly = if (nextBoundary >= 0) rangeBody.substring(0, nextBoundary) else rangeBody
+        assertFalse(
+            "resolveCaptionRange body must not consult alt",
+            bodyOnly.contains("'alt'"),
+        )
+        assertFalse(
+            "resolveCaptionRange body must not consult aria-label",
+            bodyOnly.contains("'aria-label'"),
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FigureTapBridgeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FigureTapBridgeTest.kt
@@ -96,6 +96,62 @@ class FigureTapBridgeTest {
     }
 
     @Test
+    fun `bridge parses long-press payload with captionRange`() {
+        // Regression: the caption-range payload (2026-07-14) carries the DOM caption text plus a
+        // short text-context window on either side, so onFigureLongPress can persist the caption
+        // as a real annotated text range. Reverting captionRange parsing flips this red.
+        val received = AtomicReference<FigureLongPressPayload?>()
+        FigureTapBridge.setLongPressHandler { received.set(it) }
+
+        FigureTapBridge.bridge.onFigureLongPress(
+            """{"kind":"img","caption":"Fig 1. The graph","href":"a.png","svg":null,""" +
+                """"elementId":null,"captionRange":{"text":"Fig 1. The graph","textBefore":"prior text ","textAfter":" following text"}}""",
+        )
+
+        val p = received.get()
+        assertNotNull(p)
+        val cr = p!!.captionRange
+        assertNotNull(cr)
+        assertEquals("Fig 1. The graph", cr!!.text)
+        assertEquals("prior text ", cr.textBefore)
+        assertEquals(" following text", cr.textAfter)
+    }
+
+    @Test
+    fun `bridge treats missing captionRange as null`() {
+        // A long-press whose caption resolved only via alt/aria-label (invisible attribute, no
+        // range) produces no captionRange — the annotation falls back to TYPE_IMAGE. Reverting the
+        // JSONObject.has() guard on captionRange flips this red (would throw parsing null).
+        val received = AtomicReference<FigureLongPressPayload?>()
+        FigureTapBridge.setLongPressHandler { received.set(it) }
+
+        FigureTapBridge.bridge.onFigureLongPress(
+            """{"kind":"img","caption":"Photo of author","href":"a.png","svg":null,"elementId":null}""",
+        )
+
+        val p = received.get()
+        assertNotNull(p)
+        assertNull(p!!.captionRange)
+    }
+
+    @Test
+    fun `bridge treats blank captionRange text as null`() {
+        // Defensive: a captionRange with a blank text field is treated as no range at all — the
+        // caption text is what we anchor the highlight to, so blank is unlocatable.
+        val received = AtomicReference<FigureLongPressPayload?>()
+        FigureTapBridge.setLongPressHandler { received.set(it) }
+
+        FigureTapBridge.bridge.onFigureLongPress(
+            """{"kind":"img","caption":"","href":"a.png","svg":null,"elementId":null,""" +
+                """"captionRange":{"text":"","textBefore":"","textAfter":""}}""",
+        )
+
+        val p = received.get()
+        assertNotNull(p)
+        assertNull(p!!.captionRange)
+    }
+
+    @Test
     fun `bridge preserves JSON null as Kotlin null`() {
         // Regression: org.json.JSONObject#optString collapses a JSON null to "" — reverting the
         // `.takeIf { !obj.isNull(...) } ` guard in FigureLongPressMessageParser flips this red.

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
@@ -95,6 +95,20 @@ class BookmarksControllerTest {
             return a
         }
 
+        override suspend fun upgradeImageToCaptionHighlight(
+            id: String,
+            cfi: String,
+            textSnippet: String,
+            textBefore: String,
+            textAfter: String,
+            figure: com.riffle.core.domain.EmbeddedFigure,
+        ): Annotation? = null
+
+        override suspend fun mergeFiguresIntoHighlight(
+            id: String,
+            newFigures: List<com.riffle.core.domain.EmbeddedFigure>,
+        ): Annotation? = null
+
         override suspend fun delete(id: String) {
             deleted.add(id)
             bookmarks.value = bookmarks.value.filter { it.id != id }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecorationTest.kt
@@ -105,10 +105,13 @@ class FigureBorderDecorationTest {
         // TYPE_IMAGE annotations still need the render-side tint because their caption isn't a
         // real annotated span. Reverting the tintCaption plumbing flips this red.
         val legacyImage = imageAnnotation(id = "img", imageHref = "g.png", color = "yellow")
+        // Caption-highlight shape: textSnippet contains the figure's caption text → Readium's
+        // highlight decoration paints the caption span → skip the CSS tint (would double-paint).
         val captionHighlight = highlightAnnotation(
             id = "hl",
             color = "green",
             embedded = listOf(EmbeddedFigure(href = "g2.png", svg = null, caption = "cap", order = 0)),
+            textSnippet = "cap",
         )
 
         val rasters = FigureBorderDecoration.buildRasterMarks(listOf(legacyImage, captionHighlight))
@@ -120,10 +123,33 @@ class FigureBorderDecorationTest {
             id = "hl2",
             color = "green",
             embedded = listOf(EmbeddedFigure(href = null, svg = "<svg id=\"h\"></svg>", caption = "cap", order = 0)),
+            textSnippet = "cap",
         )
         val svgs = FigureBorderDecoration.buildSvgMatches(listOf(svgImage, svgHighlight))
         assertTrue(svgs.single { it.fingerprint.contains("id=\"i\"") }.tintCaption)
         assertFalse(svgs.single { it.fingerprint.contains("id=\"h\"") }.tintCaption)
+    }
+
+    @Test
+    fun `TYPE_HIGHLIGHT whose range excludes the figcaption keeps CSS caption tint`() {
+        // Regression pin for the 2026-07-14 review finding: a legacy text-highlight of body
+        // prose that happens to enclose a figure (PR #533 shape) does NOT cover the
+        // <figcaption> text — its textSnippet is the surrounding paragraphs, not the caption.
+        // Before this fix all TYPE_HIGHLIGHT-with-embeddedFigures got tintCaption=false and
+        // the CSS tint was suppressed, silently regressing every pre-caption-highlight user's
+        // figcaption tint. Now we set tintCaption=false ONLY when the highlight's textSnippet
+        // actually contains the caption text.
+        val bodyProseHighlight = highlightAnnotation(
+            id = "hl-body",
+            color = "yellow",
+            embedded = listOf(EmbeddedFigure(href = "g.png", svg = null, caption = "Figure 1", order = 0)),
+            textSnippet = "This paragraph precedes the figure and the next paragraph follows it.",
+        )
+        val marks = FigureBorderDecoration.buildRasterMarks(listOf(bodyProseHighlight))
+        assertTrue(
+            "text-highlight whose range excludes the caption must keep the CSS caption tint",
+            marks.single().tintCaption,
+        )
     }
 
     @Test
@@ -157,12 +183,14 @@ class FigureBorderDecorationTest {
         color: String = "yellow",
         embedded: List<EmbeddedFigure>? = null,
         updatedAt: Long = 0L,
+        textSnippet: String = "",
     ): Annotation = baseAnnotation(
         id = id,
         type = AnnotationEntity.TYPE_HIGHLIGHT,
         color = color,
         updatedAt = updatedAt,
         embeddedFigures = embedded,
+        textSnippet = textSnippet,
     )
 
     private fun baseAnnotation(
@@ -173,6 +201,7 @@ class FigureBorderDecorationTest {
         imageHref: String? = null,
         imageSvg: String? = null,
         embeddedFigures: List<EmbeddedFigure>? = null,
+        textSnippet: String = "",
     ): Annotation = Annotation(
         id = id,
         sourceId = "S1",
@@ -181,7 +210,7 @@ class FigureBorderDecorationTest {
         cfi = "epubcfi(/6/2!/dummy)",
         color = color,
         note = null,
-        textSnippet = "",
+        textSnippet = textSnippet,
         textBefore = "",
         textAfter = "",
         chapterHref = "chA.xhtml",

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecorationTest.kt
@@ -98,6 +98,35 @@ class FigureBorderDecorationTest {
     }
 
     @Test
+    fun `TYPE_IMAGE marks request caption tint but TYPE_HIGHLIGHT marks do not`() {
+        // Post-2026-07-14 rule (caption-highlight upgrade): TYPE_HIGHLIGHT annotations whose
+        // range already covers the caption receive their tint from Readium's normal decoration
+        // pipeline. Firing the render-side tintCaptionFor pass for them again would double-paint.
+        // TYPE_IMAGE annotations still need the render-side tint because their caption isn't a
+        // real annotated span. Reverting the tintCaption plumbing flips this red.
+        val legacyImage = imageAnnotation(id = "img", imageHref = "g.png", color = "yellow")
+        val captionHighlight = highlightAnnotation(
+            id = "hl",
+            color = "green",
+            embedded = listOf(EmbeddedFigure(href = "g2.png", svg = null, caption = "cap", order = 0)),
+        )
+
+        val rasters = FigureBorderDecoration.buildRasterMarks(listOf(legacyImage, captionHighlight))
+        assertTrue(rasters.single { it.filename == "g.png" }.tintCaption)
+        assertFalse(rasters.single { it.filename == "g2.png" }.tintCaption)
+
+        val svgImage = imageAnnotation(id = "img2", imageSvg = "<svg id=\"i\"></svg>", color = "yellow")
+        val svgHighlight = highlightAnnotation(
+            id = "hl2",
+            color = "green",
+            embedded = listOf(EmbeddedFigure(href = null, svg = "<svg id=\"h\"></svg>", caption = "cap", order = 0)),
+        )
+        val svgs = FigureBorderDecoration.buildSvgMatches(listOf(svgImage, svgHighlight))
+        assertTrue(svgs.single { it.fingerprint.contains("id=\"i\"") }.tintCaption)
+        assertFalse(svgs.single { it.fingerprint.contains("id=\"h\"") }.tintCaption)
+    }
+
+    @Test
     fun `rule includes the annotation color`() {
         val a = imageAnnotation(id = "a", imageHref = "g.png", color = "blue")
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjectionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderInjectionTest.kt
@@ -112,6 +112,53 @@ class FigureBorderInjectionTest {
     }
 
     @Test
+    fun `apply js gates raster caption tint on the tintCap flag`() {
+        // Post-2026-07-14: TYPE_HIGHLIGHT annotations that cover a caption already emit a real
+        // Readium highlight over the caption text; firing tintCaptionFor for them again would
+        // double-paint. buildRasterMarks flags TYPE_IMAGE marks with tintCaption=true and
+        // TYPE_HIGHLIGHT-derived marks with tintCaption=false; the JS must respect it. Reverting
+        // the `if (rf.tintCap)` guard reintroduces the double-paint bug.
+        val marks = listOf(
+            FigureBorderDecoration.RasterMark(
+                filename = "hl.png",
+                color = "rgba(52,211,153,0.5)",
+                hasNote = false,
+                tintCaption = false,
+            ),
+        )
+        val js = figureBorderApplyJs(cssRules = emptyList(), svgMatches = emptyList(), rasterMarks = marks)
+        assertTrue(
+            "tintCap flag must be encoded in the raster JSON payload",
+            js.contains("\"tintCap\":0"),
+        )
+        assertTrue(
+            "raster branch must gate tintCaptionFor on rf.tintCap",
+            js.contains("if (rf.tintCap) tintCaptionFor(img, rf.color)"),
+        )
+    }
+
+    @Test
+    fun `apply js gates svg caption tint on the tintCap flag`() {
+        val matches = listOf(
+            FigureBorderDecoration.SvgMatch(
+                fingerprint = "<svg id=\"chart\">",
+                color = "rgba(56,189,248,0.5)",
+                hasNote = false,
+                tintCaption = false,
+            ),
+        )
+        val js = figureBorderApplyJs(cssRules = emptyList(), svgMatches = matches, rasterMarks = emptyList())
+        assertTrue(
+            "tintCap flag must be encoded in the svg JSON payload",
+            js.contains("\"tintCap\":0"),
+        )
+        assertTrue(
+            "svg branch must gate tintCaptionFor on matches[j].tintCap",
+            js.contains("if (matches[j].tintCap) tintCaptionFor(s, matches[j].color)"),
+        )
+    }
+
+    @Test
     fun `apply js tints figcaption for svg annotations`() {
         val matches = listOf(
             FigureBorderDecoration.SvgMatch(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryImageTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryImageTest.kt
@@ -184,6 +184,65 @@ class HighlightsPublicationFactoryImageTest {
     }
 
     @Test
+    fun `caption-highlight does not render the caption twice`() {
+        // Regression: the 2026-07-14 caption-annotation shape (TYPE_HIGHLIGHT whose textSnippet is
+        // the caption text and whose single embeddedFigure carries the same caption on itself)
+        // was rendering the caption twice — once as the figure's <figcaption>, once as the outer
+        // <p> from the highlight's snippet chunk after the charOffset=0 split. Reverting the
+        // dedup in appendInterleavedHighlight flips this red.
+        val caption = "Figure 20.2: The original code for allocating new space at the end of a Buffer, using an internal chunk."
+        val ann = highlightAnnotation(
+            textSnippet = caption,
+            embedded = listOf(
+                EmbeddedFigure(
+                    href = "images/graph.png", svg = null, caption = caption, order = 0,
+                    imageBytes = "data:image/png;base64,AAA", charOffset = 0L,
+                ),
+            ),
+        )
+        val pub = factory.build(
+            "S1", "B1", "Book",
+            listOf(ChapterElision("ch1.xhtml", "One", listOf(ann))),
+            urlFactory = ::fakeUrl,
+        )
+        val html = readChapterHtml(pub)
+        // The caption text appears exactly once — either the figure's <figcaption> or the outer
+        // <p>, not both. (Renderer chooses the outer <p> since it carries the highlight's accent
+        // bar + tap dispatch; the figure's own figcaption is blanked.)
+        val count = html.split(caption).size - 1
+        assertTrue(
+            "caption must render exactly once, got $count occurrences",
+            count == 1,
+        )
+    }
+
+    @Test
+    fun `caption-highlight with blank figure caption renders caption once`() {
+        // Creation-side clean fix: new caption-highlights set embeddedFigure.caption="" so the
+        // outer <p> from the highlight's textSnippet is the sole source of the caption text.
+        // Reverting the caption="" default (or otherwise reintroducing figure.caption for the
+        // caption-highlight write path) would flip this red.
+        val caption = "Figure 20.2: The original code for allocating new space."
+        val ann = highlightAnnotation(
+            textSnippet = caption,
+            embedded = listOf(
+                EmbeddedFigure(
+                    href = "images/graph.png", svg = null, caption = "", order = 0,
+                    imageBytes = "data:image/png;base64,AAA", charOffset = 0L,
+                ),
+            ),
+        )
+        val pub = factory.build(
+            "S1", "B1", "Book",
+            listOf(ChapterElision("ch1.xhtml", "One", listOf(ann))),
+            urlFactory = ::fakeUrl,
+        )
+        val html = readChapterHtml(pub)
+        val count = html.split(caption).size - 1
+        assertTrue("caption must render exactly once, got $count", count == 1)
+    }
+
+    @Test
     fun `TYPE_HIGHLIGHT with embeddedFigures renders text then caption placeholders in order`() {
         val ann = highlightAnnotation(
             textSnippet = "highlighted text",

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/ZipEpubResourceFetcherTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/ZipEpubResourceFetcherTest.kt
@@ -1,0 +1,96 @@
+package com.riffle.app.feature.reader.highlights
+
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Sanity coverage for [ZipEpubResourceFetcher]'s href-normalization and entry lookup — the two
+ * failure modes that would silently regress the elided-view image rendering. Uses a temp
+ * EPUB-shaped zip so the fetcher is exercised the same way the ViewModel wires it in
+ * Highlights mode (downloaded copy → open by ZipFile → fetch by href).
+ */
+class ZipEpubResourceFetcherTest {
+
+    @get:Rule val temp = TemporaryFolder()
+
+    private fun tempEpub(entries: Map<String, ByteArray>): File {
+        val f = temp.newFile("book.epub")
+        ZipOutputStream(f.outputStream()).use { zos ->
+            for ((path, bytes) in entries) {
+                zos.putNextEntry(ZipEntry(path))
+                zos.write(bytes)
+                zos.closeEntry()
+            }
+        }
+        return f
+    }
+
+    @Test
+    fun `fetch strips readium_package scheme and finds the entry`() {
+        // The href stored on live annotations is the resolved absolute URL Chromium sees:
+        // `https://readium_package/OEBPS/…`. The fetcher must strip that prefix before probing
+        // the zip. Reverting the prefix-strip flips this red — every figure fetch would miss.
+        val bytes = byteArrayOf(1, 2, 3, 4, 5)
+        val fetcher = ZipEpubResourceFetcher.open(tempEpub(mapOf("OEBPS/image.jpg" to bytes)))!!
+        try {
+            assertArrayEquals(bytes, fetcher.fetch("https://readium_package/OEBPS/image.jpg"))
+        } finally {
+            fetcher.close()
+        }
+    }
+
+    @Test
+    fun `fetch handles readium_package colon-slash variant`() {
+        val bytes = byteArrayOf(9, 8, 7)
+        val fetcher = ZipEpubResourceFetcher.open(tempEpub(mapOf("OEBPS/a.png" to bytes)))!!
+        try {
+            assertArrayEquals(bytes, fetcher.fetch("readium_package://OEBPS/a.png"))
+        } finally {
+            fetcher.close()
+        }
+    }
+
+    @Test
+    fun `fetch strips leading slash on relative paths`() {
+        val bytes = byteArrayOf(4, 2)
+        val fetcher = ZipEpubResourceFetcher.open(tempEpub(mapOf("OEBPS/b.png" to bytes)))!!
+        try {
+            assertArrayEquals(bytes, fetcher.fetch("/OEBPS/b.png"))
+        } finally {
+            fetcher.close()
+        }
+    }
+
+    @Test
+    fun `fetch drops query and fragment before probing zip`() {
+        val bytes = byteArrayOf(0xAA.toByte())
+        val fetcher = ZipEpubResourceFetcher.open(tempEpub(mapOf("OEBPS/c.png" to bytes)))!!
+        try {
+            assertArrayEquals(bytes, fetcher.fetch("https://readium_package/OEBPS/c.png?v=42#foo"))
+        } finally {
+            fetcher.close()
+        }
+    }
+
+    @Test
+    fun `fetch returns null when entry missing`() {
+        val fetcher = ZipEpubResourceFetcher.open(tempEpub(mapOf("OEBPS/a.png" to byteArrayOf(1))))!!
+        try {
+            assertNull(fetcher.fetch("https://readium_package/OEBPS/does-not-exist.png"))
+        } finally {
+            fetcher.close()
+        }
+    }
+
+    @Test
+    fun `open returns null for a non-zip file`() {
+        val bogus = temp.newFile("not-a-zip.epub").also { it.writeText("just plain text") }
+        assertNull(ZipEpubResourceFetcher.open(bogus))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/ZipEpubResourceFetcherTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/ZipEpubResourceFetcherTest.kt
@@ -68,6 +68,25 @@ class ZipEpubResourceFetcherTest {
     }
 
     @Test
+    fun `fetch percent-decodes href before probing zip`() {
+        // Chromium serves img.src URL-encoded (spaces → %20, unicode → %xx). ZIP entry names
+        // are raw bytes. Reverting the URLDecoder step misses every figure whose EPUB path
+        // contains a space or non-ASCII character.
+        val bytes = byteArrayOf(1, 2, 3)
+        val fetcher = ZipEpubResourceFetcher.open(
+            tempEpub(mapOf("OEBPS/Chapter 3/fig 1.png" to bytes)),
+        )!!
+        try {
+            assertArrayEquals(
+                bytes,
+                fetcher.fetch("https://readium_package/OEBPS/Chapter%203/fig%201.png"),
+            )
+        } finally {
+            fetcher.close()
+        }
+    }
+
+    @Test
     fun `fetch drops query and fragment before probing zip`() {
         val bytes = byteArrayOf(0xAA.toByte())
         val fetcher = ZipEpubResourceFetcher.open(tempEpub(mapOf("OEBPS/c.png" to bytes)))!!

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -86,6 +86,13 @@ class AnnotationSessionTest {
             sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String,
             spineIndex: Int, progression: Double, imageHref: String?, imageSvg: String?, imageBytes: String?, color: String,
         ): Annotation = makeAnnotation(id = "img1", type = "image", cfi = cfi, color = color)
+        override suspend fun upgradeImageToCaptionHighlight(
+            id: String, cfi: String, textSnippet: String, textBefore: String, textAfter: String,
+            figure: com.riffle.core.domain.EmbeddedFigure,
+        ): Annotation? = null
+        override suspend fun mergeFiguresIntoHighlight(
+            id: String, newFigures: List<com.riffle.core.domain.EmbeddedFigure>,
+        ): Annotation? = null
         override suspend fun delete(id: String) { deletedIds.add(id) }
         override suspend fun recolor(id: String, color: String) { recoloredIds.add(id to color) }
         override suspend fun updateNote(id: String, note: String?) { updatedNotes.add(id to note) }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -166,6 +166,13 @@ class ReaderSessionLifecycleTest {
             sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String,
             spineIndex: Int, progression: Double, imageHref: String?, imageSvg: String?, imageBytes: String?, color: String,
         ): Annotation = error("not needed")
+        override suspend fun upgradeImageToCaptionHighlight(
+            id: String, cfi: String, textSnippet: String, textBefore: String, textAfter: String,
+            figure: com.riffle.core.domain.EmbeddedFigure,
+        ): Annotation? = null
+        override suspend fun mergeFiguresIntoHighlight(
+            id: String, newFigures: List<com.riffle.core.domain.EmbeddedFigure>,
+        ): Annotation? = null
         override suspend fun delete(id: String) {}
         override suspend fun recolor(id: String, color: String) {}
         override suspend fun updateNote(id: String, note: String?) {}

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationMergeOrchestrator.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationMergeOrchestrator.kt
@@ -5,6 +5,7 @@ import com.riffle.core.database.AnnotationEntity
 import com.riffle.core.domain.AnnotationMergeService
 import com.riffle.core.domain.AnnotationSyncTarget
 import com.riffle.core.domain.DeviceIdStore
+import com.riffle.core.domain.EmbeddedFigure
 import com.riffle.core.domain.W3CAnnotation
 
 /**
@@ -139,9 +140,21 @@ internal class AnnotationMergeOrchestrator(
                     lastModifiedByDeviceId = w3cAnnotation.lastModifiedByDeviceId,
                     deleted = w3cAnnotation.deleted,
                     lastSyncedAt = preservedLastSyncedAt,
-                    embeddedFigures = embeddedFiguresListToColumn(w3cAnnotation.embeddedFigures),
+                    // Preserve local imageBytes / per-figure imageBytes / per-figure charOffset
+                    // when the remote row was written by an older peer that didn't sync them.
+                    // Without this, a WebDAV round-trip resets a locally-rasterized figure to
+                    // "[figure image not captured]" and drops charOffset (which controls the
+                    // caption position in the elided view). Explicit override still wins when
+                    // the remote row does carry the extension fields.
+                    embeddedFigures = embeddedFiguresListToColumn(
+                        preserveLocalFigureExtensions(
+                            remote = w3cAnnotation.embeddedFigures,
+                            local = existing?.embeddedFigures?.let { embeddedFiguresColumnToList(it) },
+                        ),
+                    ),
                     imageHref = w3cAnnotation.imageHref,
                     imageSvg = w3cAnnotation.imageSvg,
+                    imageBytes = w3cAnnotation.imageBytes ?: existing?.imageBytes,
                 )
             }
 
@@ -155,4 +168,41 @@ internal class AnnotationMergeOrchestrator(
         }
     }
 
+    /**
+     * Merge each remote [EmbeddedFigure] with its matching local counterpart (by href filename
+     * or SVG-prefix key), promoting local's `imageBytes` and `charOffset` when the remote row's
+     * values are null. Older peers don't sync these extension fields ([AnnotationW3CCodec] added
+     * them 2026-07-14); without this promotion a round-trip resets a locally-rasterized figure
+     * and drops the figure's position-in-range, which flips the caption to render ABOVE the
+     * image in the elided view (bug reproduced on AVD 5554).
+     */
+    private fun preserveLocalFigureExtensions(
+        remote: List<EmbeddedFigure>?,
+        local: List<EmbeddedFigure>?,
+    ): List<EmbeddedFigure>? {
+        if (remote.isNullOrEmpty()) return remote
+        if (local.isNullOrEmpty()) return remote
+        val localByKey = local.associateBy { fig -> figureMatchKey(fig) }
+        return remote.map { r ->
+            val key = figureMatchKey(r)
+            val l = localByKey[key]
+            if (l == null) r
+            else r.copy(
+                imageBytes = r.imageBytes ?: l.imageBytes,
+                charOffset = r.charOffset ?: l.charOffset,
+            )
+        }
+    }
+
+    private fun figureMatchKey(fig: EmbeddedFigure): String {
+        val href = fig.href
+        if (href != null) {
+            val trimmed = href.substringBefore('?').substringBefore('#')
+            val slash = trimmed.lastIndexOf('/')
+            return "h:" + if (slash >= 0) trimmed.substring(slash + 1) else trimmed
+        }
+        val svg = fig.svg
+        if (svg != null) return "s:" + svg.take(200)
+        return "?:${fig.order}"
+    }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
@@ -188,6 +188,88 @@ class AnnotationStoreImpl(
         )
     }
 
+    override suspend fun upgradeImageToCaptionHighlight(
+        id: String,
+        cfi: String,
+        textSnippet: String,
+        textBefore: String,
+        textAfter: String,
+        figure: EmbeddedFigure,
+    ): Annotation? {
+        val existing = dao.getById(id) ?: return null
+        if (existing.deleted || existing.type != AnnotationEntity.TYPE_IMAGE) return null
+        val deviceId = deviceIdStore.getOrCreate()
+        val now = clock()
+        val upgraded = existing.copy(
+            type = AnnotationEntity.TYPE_HIGHLIGHT,
+            cfi = cfi,
+            textSnippet = textSnippet,
+            textBefore = textBefore,
+            textAfter = textAfter,
+            embeddedFigures = listOf(figure).toEntityJson(),
+            imageHref = null,
+            imageSvg = null,
+            imageBytes = null,
+            updatedAt = now,
+            lastModifiedByDeviceId = deviceId,
+        )
+        dao.upsert(upgraded)
+        return upgraded.toDomain()
+    }
+
+    override suspend fun mergeFiguresIntoHighlight(
+        id: String,
+        newFigures: List<EmbeddedFigure>,
+    ): Annotation? {
+        if (newFigures.isEmpty()) return null
+        val existing = dao.getById(id) ?: return null
+        if (existing.deleted || existing.type != AnnotationEntity.TYPE_HIGHLIGHT) return null
+        val current = existing.embeddedFigures.toEmbeddedFigures().orEmpty()
+        // Union each incoming figure into the current list. When keys (href-filename or
+        // svg-prefix) already match, PROMOTE non-null bytes/svg/caption from the incoming
+        // figure onto the matching current one — a canonical row that was picked over a
+        // duplicate whose figure had imageBytes must not silently drop those bytes just because
+        // the canonical's own figure came in bytes-less. When keys don't match, append the
+        // incoming figure with a fresh order index.
+        val merged = current.toMutableList()
+        var changed = false
+        for (incoming in newFigures) {
+            val incomingHrefKey = incoming.href?.let(::figureKeyFromHref)
+            val incomingSvgKey = incoming.svg?.take(200)
+            val matchIndex = merged.indexOfFirst { existingFig ->
+                (incomingHrefKey != null && existingFig.href?.let(::figureKeyFromHref) == incomingHrefKey) ||
+                    (incomingSvgKey != null && existingFig.svg?.take(200) == incomingSvgKey)
+            }
+            if (matchIndex >= 0) {
+                val existingFig = merged[matchIndex]
+                val promoted = existingFig.copy(
+                    href = existingFig.href ?: incoming.href,
+                    svg = existingFig.svg ?: incoming.svg,
+                    caption = if (existingFig.caption.isBlank()) incoming.caption else existingFig.caption,
+                    imageBytes = existingFig.imageBytes ?: incoming.imageBytes,
+                    charOffset = existingFig.charOffset ?: incoming.charOffset,
+                )
+                if (promoted != existingFig) {
+                    merged[matchIndex] = promoted
+                    changed = true
+                }
+            } else {
+                merged += incoming.copy(order = merged.size)
+                changed = true
+            }
+        }
+        if (!changed) return existing.toDomain()
+        val deviceId = deviceIdStore.getOrCreate()
+        val now = clock()
+        val updated = existing.copy(
+            embeddedFigures = merged.toEntityJson(),
+            updatedAt = now,
+            lastModifiedByDeviceId = deviceId,
+        )
+        dao.upsert(updated)
+        return updated.toDomain()
+    }
+
     override suspend fun delete(id: String) {
         dao.tombstone(id, updatedAt = clock(), deviceId = deviceIdStore.getOrCreate())
     }
@@ -215,6 +297,17 @@ class AnnotationStoreImpl(
         imageSvg: String?,
     ): Annotation? =
         dao.findImageForFigure(sourceId, itemId, chapterHref, imageHref, imageSvg)?.toDomain()
+}
+
+/**
+ * Filename-suffix key for an image href, matching how the reader dedupes figures across the
+ * store/decoration/mergeEnclosedFigures paths (last path segment, stripped of query/fragment).
+ * Inlined here — the app-module `figureHrefFilename` isn't visible from core/data.
+ */
+private fun figureKeyFromHref(href: String): String {
+    val trimmed = href.substringBefore('?').substringBefore('#')
+    val slash = trimmed.lastIndexOf('/')
+    return if (slash >= 0) trimmed.substring(slash + 1) else trimmed
 }
 
 private val embeddedFiguresJson = Json { ignoreUnknownKeys = true }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationW3CCodec.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationW3CCodec.kt
@@ -12,8 +12,10 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.add
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.longOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -171,6 +173,7 @@ object AnnotationW3CCodec {
                 svg = entity.imageSvg,
                 caption = entity.textSnippet,
                 order = null,
+                imageBytes = entity.imageBytes,
             )
         } else {
             bodies += buildJsonObject {
@@ -197,6 +200,8 @@ object AnnotationW3CCodec {
                         svg = figure.svg,
                         caption = figure.caption,
                         order = figure.order,
+                        imageBytes = figure.imageBytes,
+                        charOffset = figure.charOffset,
                     )
                 }
             }
@@ -240,7 +245,14 @@ object AnnotationW3CCodec {
      * Builds a single `riffle:image` Web Annotation body. `order` is only meaningful for figures
      * embedded in a TYPE_HIGHLIGHT range (stable sort key); omitted (null) for TYPE_IMAGE.
      */
-    private fun buildRiffleImageBody(href: String?, svg: String?, caption: String, order: Int?): JsonObject =
+    private fun buildRiffleImageBody(
+        href: String?,
+        svg: String?,
+        caption: String,
+        order: Int?,
+        imageBytes: String? = null,
+        charOffset: Long? = null,
+    ): JsonObject =
         buildJsonObject {
             put("type", "riffle:image")
             put("value", buildJsonObject {
@@ -248,6 +260,11 @@ object AnnotationW3CCodec {
                 if (svg != null) put("svg", svg)
                 put("caption", caption)
                 if (order != null) put("order", JsonPrimitive(order))
+                // Extension fields (2026-07-14): preserve captured raster bytes and the figure's
+                // position-in-range so a sync round-trip doesn't reset local rendering. Older
+                // peers ignore unknown value fields, so this stays backward-compatible.
+                if (imageBytes != null) put("imageBytes", imageBytes)
+                if (charOffset != null) put("charOffset", JsonPrimitive(charOffset))
             })
         }
 
@@ -264,11 +281,17 @@ object AnnotationW3CCodec {
         if (href == null && svg == null) return null
         val caption = value["caption"]?.jsonPrimitive?.content ?: ""
         val order = value["order"]?.jsonPrimitive?.intOrNull ?: fallbackOrder
+        // Extension fields (2026-07-14): default null when the body was written by an older
+        // peer. See [buildRiffleImageBody] for the outbound half.
+        val imageBytes = value["imageBytes"]?.jsonPrimitive?.contentOrNull
+        val charOffset = value["charOffset"]?.jsonPrimitive?.longOrNull
         return EmbeddedFigure(
             href = href,
             svg = if (href != null) null else svg,
             caption = caption,
             order = order,
+            imageBytes = imageBytes,
+            charOffset = charOffset,
         )
     }
 
@@ -306,6 +329,7 @@ object AnnotationW3CCodec {
         embeddedFigures = embeddedFiguresColumnToList(entity.embeddedFigures).ifEmpty { null },
         imageHref = entity.imageHref,
         imageSvg = entity.imageSvg,
+        imageBytes = entity.imageBytes,
     )
 
     /**
@@ -443,6 +467,7 @@ object AnnotationW3CCodec {
             var embeddedFigures: List<EmbeddedFigure>? = null
             var imageHref: String? = null
             var imageSvg: String? = null
+            var imageBytes: String? = null
             if (imageBodies.isNotEmpty()) {
                 if (textBody != null) {
                     type = AnnotationEntity.TYPE_HIGHLIGHT
@@ -457,6 +482,7 @@ object AnnotationW3CCodec {
                     val figure = parseRiffleImageBody(imageBodies.first(), fallbackOrder = 0)
                     imageHref = figure?.href
                     imageSvg = figure?.svg
+                    imageBytes = figure?.imageBytes
                     if (figure != null) {
                         textSnippet = figure.caption
                     }
@@ -504,6 +530,7 @@ object AnnotationW3CCodec {
                 embeddedFigures = embeddedFigures,
                 imageHref = imageHref,
                 imageSvg = imageSvg,
+                imageBytes = imageBytes,
             )
         } catch (_: Exception) {
             return emptyAnnotation()

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationW3CCodecTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationW3CCodecTest.kt
@@ -926,6 +926,78 @@ class AnnotationW3CCodecTest {
     }
 
     @Test
+    fun `charOffset and imageBytes round-trip on TYPE_HIGHLIGHT embeddedFigures`() {
+        // Regression pin for the 2026-07-14 caption-highlight sync fix. Both extension fields
+        // are needed to round-trip: charOffset drives the elided-view figure/caption interleave
+        // order, and imageBytes carries the raster the reader inlines when the annotation
+        // itself lacks captured bytes. Reverting either encoding half flips this red — an
+        // earlier pass shipped only the read half, which silently dropped both fields on push.
+        val figure = EmbeddedFigure(
+            href = "img.jpg",
+            svg = null,
+            caption = "cap",
+            order = 0,
+            imageBytes = "data:image/jpeg;base64,ZZZZ",
+            charOffset = 42L,
+        )
+        val entity = AnnotationEntity(
+            id = "uuid-hl-ext",
+            sourceId = "abs1",
+            itemId = "item1",
+            type = AnnotationEntity.TYPE_HIGHLIGHT,
+            cfi = "epubcfi(/6/4!/4/2,/1:0,/1:100)",
+            color = "yellow",
+            note = null,
+            textSnippet = "cap",
+            chapterHref = "item1",
+            createdAt = 1000L,
+            updatedAt = 1000L,
+            originDeviceId = "device-A",
+            lastModifiedByDeviceId = "device-A",
+            embeddedFigures = embeddedFiguresListToColumn(listOf(figure)),
+        )
+
+        val w3cJson = codec.annotationEntityToW3C(entity)
+        assertTrue("outbound JSON must carry charOffset", w3cJson.contains("\"charOffset\":42"))
+        assertTrue("outbound JSON must carry imageBytes", w3cJson.contains("\"imageBytes\":\"data:image/jpeg;base64,ZZZZ\""))
+
+        val parsed = codec.w3cToAnnotationEntity(w3cJson)
+        val f = parsed.embeddedFigures?.single()
+        assertEquals(42L, f?.charOffset)
+        assertEquals("data:image/jpeg;base64,ZZZZ", f?.imageBytes)
+    }
+
+    @Test
+    fun `TYPE_IMAGE imageBytes round-trips on the annotation body`() {
+        val entity = AnnotationEntity(
+            id = "uuid-img-bytes",
+            sourceId = "abs1",
+            itemId = "item1",
+            type = AnnotationEntity.TYPE_IMAGE,
+            cfi = "epubcfi(/6/4!/4/2)",
+            color = "",
+            note = null,
+            textSnippet = "Figure X",
+            chapterHref = "item1",
+            createdAt = 1000L,
+            updatedAt = 1000L,
+            originDeviceId = "device-A",
+            lastModifiedByDeviceId = "device-A",
+            imageHref = "images/g.png",
+            imageBytes = "data:image/png;base64,QQQQ",
+        )
+
+        val w3cJson = codec.annotationEntityToW3C(entity)
+        assertTrue(
+            "TYPE_IMAGE outbound JSON must carry imageBytes as an extension on the riffle:image body",
+            w3cJson.contains("\"imageBytes\":\"data:image/png;base64,QQQQ\""),
+        )
+
+        val parsed = codec.w3cToAnnotationEntity(w3cJson)
+        assertEquals("data:image/png;base64,QQQQ", parsed.imageBytes)
+    }
+
+    @Test
     fun `TYPE_HIGHLIGHT with null embeddedFigures does not emit riffle_image bodies`() {
         val entity = AnnotationEntity(
             id = "uuid-hl-no-figures",

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationStore.kt
@@ -82,6 +82,36 @@ interface AnnotationStore {
         fontFamily: String,
     ): Int
 
+    /**
+     * Legacy-annotation cleanup: rewrite an existing `TYPE_IMAGE` annotation into a
+     * `TYPE_HIGHLIGHT` covering [textSnippet] with [figure] as its sole embeddedFigure. The
+     * annotation's id is preserved so sync sees the change as an update (bumped updatedAt +
+     * provenance), not a delete/create. Clears `imageHref` / `imageSvg` / `imageBytes` — those
+     * columns are TYPE_HIGHLIGHT-illegal — since the figure now lives in `embeddedFigures`.
+     * Returns the rewritten annotation, or `null` when [id] does not resolve to a live TYPE_IMAGE.
+     */
+    suspend fun upgradeImageToCaptionHighlight(
+        id: String,
+        cfi: String,
+        textSnippet: String,
+        textBefore: String,
+        textAfter: String,
+        figure: EmbeddedFigure,
+    ): Annotation?
+
+    /**
+     * Union [newFigures] into an existing `TYPE_HIGHLIGHT`'s `embeddedFigures`, deduping by
+     * href-filename (raster) and svg-prefix (inline SVG). Preserves the annotation's id, bumps
+     * `updatedAt` + provenance, and returns the merged annotation. Returns `null` when [id] does
+     * not resolve to a live TYPE_HIGHLIGHT. Used to absorb a figure long-press into a highlight
+     * that already covers its caption text (deduping the "caption-highlight duplicate" class of
+     * bug that shipped in the initial 2026-07-14 caption-annotation change).
+     */
+    suspend fun mergeFiguresIntoHighlight(
+        id: String,
+        newFigures: List<EmbeddedFigure>,
+    ): Annotation?
+
     suspend fun delete(id: String)
     suspend fun recolor(id: String, color: String)
     suspend fun updateNote(id: String, note: String?)

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/W3CAnnotation.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/W3CAnnotation.kt
@@ -56,4 +56,8 @@ data class W3CAnnotation(
     val imageHref: String? = null,
     /** Inline SVG markup for a TYPE_IMAGE annotation, when the figure is an SVG. */
     val imageSvg: String? = null,
+    /** Data URI of the captured raster bytes for a TYPE_IMAGE annotation. Carried as an extension
+     *  field on the `riffle:image` body so a sync round-trip doesn't drop the local raster. Null
+     *  when the source didn't rasterize (or the file was written by an older peer). */
+    val imageBytes: String? = null,
 )

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/EmbeddedFigureSerializationTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/EmbeddedFigureSerializationTest.kt
@@ -1,0 +1,28 @@
+package com.riffle.core.domain
+
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Sanity check that a fresh [EmbeddedFigure] with `charOffset = 0L` encodes with the field
+ * present in JSON. Would flip red if kotlinx.serialization surprisingly treated 0L as the
+ * `null` default and dropped the field — which would break [EpubReaderViewModel]'s
+ * caption-highlight interleaver, which discriminates "figure inline" from "figure appended
+ * after text" by whether `charOffset` decodes as null.
+ */
+class EmbeddedFigureSerializationTest {
+
+    @Test
+    fun `charOffset 0L encodes into JSON with encodeDefaults false`() {
+        val json = Json { ignoreUnknownKeys = true }
+        val serializer = ListSerializer(EmbeddedFigure.serializer())
+        val fig = EmbeddedFigure(
+            href = "x.png", svg = null, caption = "", order = 0,
+            imageBytes = null, charOffset = 0L,
+        )
+        val encoded = json.encodeToString(serializer, listOf(fig))
+        assertTrue("charOffset must appear in JSON but was: $encoded", encoded.contains("charOffset"))
+    }
+}


### PR DESCRIPTION
## Summary

Long-press on a figure whose caption resolves in the DOM now creates a `TYPE_HIGHLIGHT` covering the caption text with the figure as its sole `embeddedFigure` — the caption becomes a real annotated span, so tap/select over it routes to the same annotation and a fresh highlight can't land on top. Figure long-press with no resolvable caption still creates `TYPE_IMAGE` as before.

Book-open sweep opportunistically upgrades legacy `TYPE_IMAGE` annotations to the new shape (jsoup mirror of the JS caption resolver), deduplicates same-caption HIGHLIGHTs a prior race produced, and folds a legacy figure into any pre-existing text-selection highlight of the caption. Cleanup phase (annotation-data only, no source HTML) also fires from the Highlights-mode open path.

Elided view now serves figure raster bytes from the local EPUB (`ZipEpubResourceFetcher` opens the downloaded/cached copy directly, bypassing Readium's asset pipeline which Highlights mode never binds). Bytes are encoded once as data URIs and used as the render-time fallback when the annotation itself has no captured `imageBytes`. Figures that previously rendered as `[figure image not captured]` now render the real source-book image.

W3C sync codec extended with `charOffset` and `imageBytes` on each `riffle:image` body, plus `imageBytes` on `W3CAnnotation`. The merge orchestrator preserves local values when the incoming row's are null (older peers).

Renderer's `charOffset==null` fallback detects the caption-highlight shape and emits figure-first-then-caption for natural reading order; text-selection-across-figure highlights keep the v1 text-first-then-figures order. `FigureBorderInjection`'s CSS caption tint is now suppressed only when the highlight's `textSnippet` actually covers the figcaption (so pre-caption-highlight users' body-prose highlights don't lose their figcaption tint).

## What changed

- **New annotation shape**: `TYPE_HIGHLIGHT` + `embeddedFigures=[figure]` for caption-bearing figure long-presses.
- **`CaptionHighlightUpgrader`** (new): jsoup-based sweep with two phases (cleanup duplicate caption HIGHLIGHTs, then upgrade legacy `TYPE_IMAGE`). Runs from both open paths (Highlights-mode gets cleanup-only since it has no source HTML).
- **`ZipEpubResourceFetcher`** (new): raw `ZipFile`-backed resource fetcher that serves EPUB entries directly, with URL-decoding and `readium_package://` scheme stripping.
- **`AnnotationStore.upgradeImageToCaptionHighlight`** + **`mergeFiguresIntoHighlight`**: new store methods for the sweep and per-figure merges.
- **W3C codec**: `charOffset` + `imageBytes` round-trip on `riffle:image` bodies; `imageBytes` field added to `W3CAnnotation`; `AnnotationMergeOrchestrator` preserves local `imageBytes`/`charOffset` when the incoming row lacks them.
- **`HighlightsPublicationFactory`**: `buildHandle` fetches figure bytes via the resource fetcher, encodes them as data URIs, exposes the map on `HighlightsPublicationHandle.figureBytesByHref`, and threads it through `renderChapterHtml` → `appendFigureBlock` / `appendImageAnnotation` as the render-time fallback.
- **Renderer dedup**: `appendInterleavedHighlight` no longer double-emits the caption text; `isCaptionHighlight` detection guarded by an explicit caption-prefix regex so it doesn't misfire on text-highlights enclosing an uncaptioned decorative figure.
- **`FigureBorderInjection`**: gated CSS caption tint (`tintCap` flag on `RasterMark`/`SvgMatch`) — suppressed only when the highlight's `textSnippet` actually covers the caption.
- **Review-round fixes**: two-flag split of `legacyImageUpgradeAttempted` (Highlights-first-then-FullBook now runs both passes); CFI-only dedup in `onFigureLongPress` (avoids "Fig. 1" collisions); percent-decode in `ZipEpubResourceFetcher`; legacy-upgrade map rebuilds after each success so two same-caption legacy rows fold in.

## Test plan

- [x] All JVM unit tests pass (`:app`, `:core:data`, `:core:domain`).
- [x] Verified end-to-end on emulator 5554 with "A Philosophy of Software Design 2e": caption below figure, real image rendered from the source EPUB, no duplicate caption rows, no `[figure image not captured]` placeholders.
- [x] New test files: `CaptionHighlightUpgraderTest.kt`, `ZipEpubResourceFetcherTest.kt`, `EmbeddedFigureSerializationTest.kt`. New cases in `EpubReaderViewModelImageAnnotationTest`, `FigureTapBridgeTest`, `FigureCaptionWalkerTest`, `FigureBorderDecorationTest`, `FigureBorderInjectionTest`, `HighlightsPublicationFactoryImageTest`, `AnnotationW3CCodecTest`.