### PR TITLE
fix(reader): suppress double-paint on caption-highlight figcaptions

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecoration.kt
@@ -115,13 +115,26 @@ internal object FigureBorderDecoration {
      * enclose a figure — the figcaption sits below the range and only the CSS tint can reach
      * it). Normalizes whitespace on both sides so the check matches how the text-content walks
      * on the two rendering paths collapse.
+     *
+     * Blank `figure.caption` is the shape written by the caption-highlight code paths
+     * (`EpubReaderViewModel.onFigureLongPress` and `CaptionHighlightUpgrader`), which deliberately
+     * store an empty string to avoid an unrelated elided-view double-render. In that case the
+     * highlight's own `textSnippet` IS the caption, so falling back to false would let the CSS
+     * tint stack on top of Readium's decoration (~2x opacity — the "duplicated" look). Detect the
+     * shape via the same canonical caption prefix used by
+     * `HighlightsPublicationFactory.appendInterleavedHighlight` and treat it as covered.
      */
     private fun highlightCoversCaption(annotation: Annotation, figure: com.riffle.core.domain.EmbeddedFigure): Boolean {
-        if (figure.caption.isBlank()) return false
-        val normalizedCaption = figure.caption.replace(Regex("\\s+"), " ").trim()
         val normalizedSnippet = annotation.textSnippet.replace(Regex("\\s+"), " ").trim()
+        if (figure.caption.isBlank()) {
+            return CAPTION_HIGHLIGHT_PREFIX_REGEX.containsMatchIn(normalizedSnippet)
+        }
+        val normalizedCaption = figure.caption.replace(Regex("\\s+"), " ").trim()
         return normalizedSnippet.contains(normalizedCaption)
     }
+
+    private val CAPTION_HIGHLIGHT_PREFIX_REGEX =
+        Regex("^\\s*(Figure|Fig\\.?|Table|Chart)\\s+\\d", RegexOption.IGNORE_CASE)
 
     /**
      * One entry per SVG annotation covering the current document. Newest-wins by `updatedAt` when

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecorationTest.kt
@@ -153,6 +153,54 @@ class FigureBorderDecorationTest {
     }
 
     @Test
+    fun `caption-highlight with blank figure caption still suppresses CSS tint`() {
+        // Regression pin for the "visually duplicated" bug (2026-07-14): the caption-highlight
+        // path in EpubReaderViewModel.onFigureLongPress writes EmbeddedFigure(caption="") to keep
+        // the elided-view renderer clean, so highlightCoversCaption must NOT fall back to
+        // tintCaption=true when the annotation's textSnippet is itself the caption. Otherwise
+        // Readium's highlight decoration and the CSS tint both paint the <figcaption>, stacking
+        // to ~2x opacity. Detects the caption-highlight shape via the same canonical caption
+        // prefix (Figure|Fig.|Table|Chart + digit) used by HighlightsPublicationFactory.
+        val captionHighlightRaster = highlightAnnotation(
+            id = "hl-raster",
+            color = "yellow",
+            embedded = listOf(EmbeddedFigure(href = "g.png", svg = null, caption = "", order = 0)),
+            textSnippet = "Figure 20.2: The original code for allocating new space at the end of a Buffer.",
+        )
+        val rasters = FigureBorderDecoration.buildRasterMarks(listOf(captionHighlightRaster))
+        assertFalse(
+            "caption-highlight with blank figure.caption must not request CSS tint (would double-paint)",
+            rasters.single().tintCaption,
+        )
+
+        val captionHighlightSvg = highlightAnnotation(
+            id = "hl-svg",
+            color = "yellow",
+            embedded = listOf(EmbeddedFigure(href = null, svg = "<svg id=\"c\"></svg>", caption = "", order = 0)),
+            textSnippet = "Table 3: Comparative results across all six datasets.",
+        )
+        val svgs = FigureBorderDecoration.buildSvgMatches(listOf(captionHighlightSvg))
+        assertFalse(
+            "SVG caption-highlight with blank figure.caption must not request CSS tint",
+            svgs.single().tintCaption,
+        )
+
+        // Legacy decorative-figure shape (blank caption, non-caption textSnippet) still keeps the
+        // CSS tint — the prefix check protects the pre-caption-highlight body-prose case.
+        val legacyDecorative = highlightAnnotation(
+            id = "hl-legacy",
+            color = "yellow",
+            embedded = listOf(EmbeddedFigure(href = "d.png", svg = null, caption = "", order = 0)),
+            textSnippet = "This paragraph discusses the surrounding topic and the diagram is decorative.",
+        )
+        val legacyRasters = FigureBorderDecoration.buildRasterMarks(listOf(legacyDecorative))
+        assertTrue(
+            "legacy decorative-figure highlight (no caption prefix in snippet) still requests CSS tint",
+            legacyRasters.single().tintCaption,
+        )
+    }
+
+    @Test
     fun `rule includes the annotation color`() {
         val a = imageAnnotation(id = "a", imageHref = "g.png", color = "blue")
 


### PR DESCRIPTION
## Summary

Caption-highlight annotations (long-press on a figure with a resolvable caption) rendered with a visibly darker highlight than a normal one — the `<figcaption>` background was being painted twice.

Root cause: the caption-highlight code paths in `EpubReaderViewModel.onFigureLongPress` and `CaptionHighlightUpgrader` deliberately store `EmbeddedFigure(caption = "")` to keep the elided-view renderer clean. But `FigureBorderDecoration.highlightCoversCaption` short-circuited to `false` the moment `figure.caption` was blank, so `tintCaption` stayed `true` and the render-side JS (`FigureBorderInjection.tintCaptionFor`) painted the `<figcaption>` background with `!important` CSS on top of Readium's own highlight decoration — two paints stacking to ~2x opacity (the "duplicated" look reported today).

Fix: when `figure.caption` is blank, use the same canonical caption prefix (`Figure`/`Fig.`/`Table`/`Chart` + digit) already used by `HighlightsPublicationFactory.appendInterleavedHighlight` to recognize the caption-highlight shape and treat it as already covered by Readium. Legacy decorative-figure highlights (blank caption, body-prose snippet) still get the CSS tint via the prefix guard.

## Test plan

- [x] New unit test `caption-highlight with blank figure caption still suppresses CSS tint` pins:
  - Raster caption-highlight (`caption=""`, `Figure 20.2: ...` snippet) → `tintCaption=false`
  - SVG caption-highlight (`caption=""`, `Table 3: ...` snippet) → `tintCaption=false`
  - Legacy decorative-figure (`caption=""`, non-caption snippet) → `tintCaption=true` (inverse)
- [x] `./gradlew :app:testDebugUnitTest --tests FigureBorderDecorationTest` green
- [ ] Reader visual check: annotate a figure via long-press, confirm caption highlight is the standard translucent shade, not the doubled-up dark shade