### PR TITLE
fix(audiobook): snap Gramofonche progress to 100% at end of book

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -41,10 +41,17 @@ import javax.inject.Inject
 /**
  * Maps a book-absolute listen position to the unified 0..1 `readingProgress` fraction the library
  * and detail screens render (ADR 0029). Returns 0 when the duration isn't known yet (so a not-yet-
- * prepared player never writes a bogus 100%).
+ * prepared player never writes a bogus 100%). Snaps to 1f within [AUDIOBOOK_FINISHED_EPS_SEC] of
+ * the end so a book listened all the way through displays 100%, not 99% — LAME encoder-delay/
+ * padding samples and the silent Xing/Info frame leave the reported position a hair short of the
+ * Xing-derived total, and integer truncation at the display sites would otherwise render "99%".
  */
 internal fun audiobookProgressFraction(positionSec: Double, durationSec: Double): Float =
-    if (durationSec > 0.0) (positionSec / durationSec).toFloat().coerceIn(0f, 1f) else 0f
+    when {
+        durationSec <= 0.0 -> 0f
+        positionSec >= durationSec - AUDIOBOOK_FINISHED_EPS_SEC -> 1f
+        else -> (positionSec / durationSec).toFloat().coerceIn(0f, 1f)
+    }
 
 /**
  * The book-absolute resume position. When NO position was tracked at all ([hadTrackedPosition] false —

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookProgressFractionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookProgressFractionTest.kt
@@ -29,4 +29,21 @@ class AudiobookProgressFractionTest {
     fun `start of book is zero`() {
         assertEquals(0f, audiobookProgressFraction(positionSec = 0.0, durationSec = 300.0), 0f)
     }
+
+    // A book listened to the end sits a hair below the Xing-derived total (LAME encoder-delay/
+    // padding + silent Xing frame). Without the finished-eps snap the raw fraction is ~0.999,
+    // which the "${(p*100).toInt()}%" display sites truncate to 99%.
+    @Test
+    fun `snaps to one when within finished-eps of duration`() {
+        val duration = 12345.0
+        assertEquals(1f, audiobookProgressFraction(positionSec = duration - 0.2, durationSec = duration), 0f)
+        assertEquals(1f, audiobookProgressFraction(positionSec = duration - AUDIOBOOK_FINISHED_EPS_SEC, durationSec = duration), 0f)
+    }
+
+    @Test
+    fun `just outside finished-eps stays below one`() {
+        val duration = 12345.0
+        val fraction = audiobookProgressFraction(positionSec = duration - AUDIOBOOK_FINISHED_EPS_SEC - 0.01, durationSec = duration)
+        assertEquals(true, fraction < 1f)
+    }
 }


### PR DESCRIPTION
## Problem

When a Gramofonche audiobook is listened all the way to the end, the library/detail screens display "99% listened" instead of "100%".

## Root cause

Before commit bc6d774f9 (Xing-derived Gramofonche durations), `SharedAudiobookContext.totalDurationMs` under-estimated the true duration (flat `Content-Length / 128 kbps`), so ExoPlayer's actual position always overshot the fake total and `.coerceIn(0f, 1f)` clamped to `1.0f` = 100%.

With real Xing-derived durations, the reported book-absolute position at end-of-book lands ~0.999 of the total — LAME encoder-delay/padding samples, the single silent Xing/Info frame, and truncating `.toLong()` at `AbsolutePositionPlayer.kt:36` together leave a sub-second gap. The display sites use `"${(progress * 100).toInt()}%"` (`LibraryItemDetailScreen.kt:1235`, `LibraryItemsScreen.kt:1238`), which truncates 0.999 → **99**.

## Fix

`audiobookProgressFraction` now snaps to `1f` when position sits within `AUDIOBOOK_FINISHED_EPS_SEC` (1.0s) of duration — the same threshold `audiobookStartSec` already uses on the resume side to recognise a finished book.

## Tests

Two new unit tests in `AudiobookProgressFractionTest`:
- `snaps to one when within finished-eps of duration` — the regression test; asserts 1f both 0.2s and exactly `EPS` short of the end. Fails on revert (returns ~0.999f).
- `just outside finished-eps stays below one` — pins the boundary so future edits can't over-broaden the snap.