### PR TITLE
fix(chitanka): fill Gramofonche duration for hour spans and duration-less pages

### DIFF
--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
@@ -219,7 +219,13 @@ class ChitankaCatalog(
         )
         // Layer detail-only fields onto the summary conversion.
         val base = summary.toCatalogItem(root)
+        val resolvedAudioDurationSec = resolveAudioDurationSec(
+            root = root,
+            scraped = base.audioDurationSec,
+            hasDownloads = detail.downloads.isNotEmpty(),
+        ) { tracksFor(detail).sumOf { it.durationSec } }
         return base.copy(
+            audioDurationSec = resolvedAudioDurationSec,
             description = detail.description.ifEmpty { null },
             seriesName = detail.series?.name,
             seriesSequence = detail.series?.sequence?.ifEmpty { null },
@@ -535,19 +541,41 @@ class ChitankaCatalog(
          */
         internal const val GRAMOFONCHE_FALLBACK_BITRATE_BPS: Int = 128_000
 
-        private val GRAMOFONCHE_DURATION_MINUTES_REGEX = Regex("(\\d+)\\s*мин")
+        private val GRAMOFONCHE_HOURS_REGEX = Regex("(\\d+)\\s*часа?")
+        private val GRAMOFONCHE_MINUTES_REGEX = Regex("(\\d+)\\s*мин")
 
         /**
-         * Parses the scraped Gramofonche duration string (e.g. `"45мин"`) into seconds so it can
-         * populate `CatalogItem.audioDurationSec`. `LibraryItemDetailScreen` gates the total-time
-         * line on `audioDurationSec > 0`, so returning 0 for a listing-only value keeps the whole
-         * line hidden until the per-track HEAD probes run at playback time.
+         * Parses the scraped Gramofonche duration string into seconds so it can populate
+         * `CatalogItem.audioDurationSec`. Handles the three shapes the site emits — `"45мин"`,
+         * `"1час 20мин"`, `"2часа"` — by summing whichever hour and minute captures the regex
+         * finds. `LibraryItemDetailScreen` gates the total-time line on `audioDurationSec > 0`;
+         * when both captures miss (page never mentions a duration at all), `getItem` falls back
+         * to summing per-track Xing probes so the line still renders.
          */
+        /**
+         * Picks the effective `audioDurationSec` for a Gramofonche detail page. Prefers the value
+         * scraped from the "..NNмин" line (fast, no network) and falls back to summing per-track
+         * Xing probes only when the scrape yielded 0. Some Gramofonche detail pages (compilations
+         * and older reel-tape rips in particular) simply do not print a duration; without the
+         * fallback, `LibraryItemDetailScreen`'s `audioDurationSec > 0` gate hides the total-time
+         * row entirely. Probing costs one two-range GET per track (see [tracksFor]), so we only
+         * pay it when we have downloads to probe AND nothing better on hand.
+         */
+        internal suspend fun resolveAudioDurationSec(
+            root: String,
+            scraped: Double,
+            hasDownloads: Boolean,
+            fetchProbedTotalSec: suspend () -> Double,
+        ): Double {
+            if (root != ROOT_AUDIOBOOKS || scraped > 0.0 || !hasDownloads) return scraped
+            return runCatching { fetchProbedTotalSec() }.getOrDefault(0.0)
+        }
+
         internal fun parseGramofoncheDurationSeconds(raw: String?): Double {
             if (raw.isNullOrEmpty()) return 0.0
-            val minutes = GRAMOFONCHE_DURATION_MINUTES_REGEX.find(raw)?.groupValues?.get(1)?.toIntOrNull()
-                ?: return 0.0
-            return minutes * 60.0
+            val hours = GRAMOFONCHE_HOURS_REGEX.find(raw)?.groupValues?.get(1)?.toIntOrNull() ?: 0
+            val minutes = GRAMOFONCHE_MINUTES_REGEX.find(raw)?.groupValues?.get(1)?.toIntOrNull() ?: 0
+            return (hours * 3600 + minutes * 60).toDouble()
         }
 
         internal val AUDIO_FACETS: List<CatalogFacet> = listOf(

--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraper.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraper.kt
@@ -261,6 +261,21 @@ internal object GramofoncheScraper {
 
     private val CATEGORY_PATH_PATTERN = Regex("^/(prikazki|pesnicki|zagolemi)/[^/]+/$")
 
+    /**
+     * Captures a Gramofonche duration span in either the listing "..NNмин" line or the detail
+     * page. Supports the three shapes the site uses in the wild:
+     *   - minutes only: `43мин`
+     *   - hours + minutes: `1час 20мин`, `1часа 5 мин`
+     *   - hours only: `2часа`, `1 час`
+     * The parser side ([ChitankaCatalog.parseGramofoncheDurationSeconds]) picks the hour and
+     * minute numbers back out — captured together so the raw span survives the summary→detail
+     * hand-off. Was `(\d+)мин` alone, which silently returned 0 minutes for the (rare but real)
+     * hours-only entries and stripped the hour component from combined spans.
+     */
+    internal val GRAMOFONCHE_DURATION_REGEX = Regex(
+        "(?:\\d+\\s*часа?\\s*)?\\d+\\s*мин|\\d+\\s*часа?",
+    )
+
     fun parseSearchResults(html: String): ChitankaListingResult {
         val doc = Jsoup.parse(html)
         val items = mutableListOf<ChitankaBookSummary>()
@@ -292,7 +307,7 @@ internal object GramofoncheScraper {
                 ChitankaScraper.toAbsolute(imgSrc, "$BASE/") else null
 
             val elText = el.text()
-            val duration = Regex("(\\d+)мин").find(elText)?.let { "${it.groupValues[1]}мин" }
+            val duration = GRAMOFONCHE_DURATION_REGEX.find(elText)?.value
 
             if (title.isNotEmpty() && href.isNotEmpty()) {
                 items += ChitankaBookSummary(
@@ -342,7 +357,7 @@ internal object GramofoncheScraper {
         }
 
         val year = Regex("година:\\s*(\\d{4})").find(contentText)?.groupValues?.get(1).orEmpty()
-        val duration = Regex("(\\d+)мин").find(contentText)?.let { "${it.groupValues[1]}мин" }.orEmpty()
+        val duration = GRAMOFONCHE_DURATION_REGEX.find(contentText)?.value.orEmpty()
 
         val imgSrc = doc.selectFirst("div.kolona_kartinki img")?.attr("src")
         val coverUrl = if (!imgSrc.isNullOrEmpty())

--- a/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
+++ b/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
@@ -446,6 +446,75 @@ class ChitankaCatalogTest {
         assertEquals(9.0 * 60, ChitankaCatalog.parseGramofoncheDurationSeconds("9мин"), 0.0)
     }
 
+    /**
+     * Regression: the parser used to match `(\d+)мин` only, so `"1час 20мин"` yielded 20 minutes
+     * (dropping the hour) and `"2часа"` yielded 0 (hiding the total-duration row entirely). Some
+     * Gramofonche reel-tape rips exceed an hour; both shapes appear in the wild.
+     */
+    @Test fun `parseGramofoncheDurationSeconds sums hours and minutes`() {
+        assertEquals((3600 + 20 * 60).toDouble(), ChitankaCatalog.parseGramofoncheDurationSeconds("1час 20мин"), 0.0)
+        assertEquals((3600 + 5 * 60).toDouble(), ChitankaCatalog.parseGramofoncheDurationSeconds("1часа 5 мин"), 0.0)
+        assertEquals(2 * 3600.0, ChitankaCatalog.parseGramofoncheDurationSeconds("2часа"), 0.0)
+        assertEquals(3600.0, ChitankaCatalog.parseGramofoncheDurationSeconds("1 час"), 0.0)
+    }
+
+    /**
+     * Regression: `getItem` returned scraped duration only. Detail pages with no `"..NNмин"`
+     * line (compilations, some reel-tape rips) yielded audioDurationSec=0, hiding the total-time
+     * row entirely. The fallback must probe per-track Xing headers in that case only — not when
+     * scraping already succeeded (probe is a full HTTP round-trip per track).
+     */
+    @Test fun `resolveAudioDurationSec keeps scraped value and does not probe when nonzero`() = runTest {
+        var probed = 0
+        val result = ChitankaCatalog.resolveAudioDurationSec(
+            root = ChitankaCatalog.ROOT_AUDIOBOOKS,
+            scraped = 2580.0,
+            hasDownloads = true,
+        ) { probed++; 9999.0 }
+        assertEquals(2580.0, result, 0.0)
+        assertEquals(0, probed)
+    }
+
+    @Test fun `resolveAudioDurationSec falls back to per-track probe when scraped is zero`() = runTest {
+        val result = ChitankaCatalog.resolveAudioDurationSec(
+            root = ChitankaCatalog.ROOT_AUDIOBOOKS,
+            scraped = 0.0,
+            hasDownloads = true,
+        ) { 1800.0 + 600.0 }
+        assertEquals(2400.0, result, 0.0)
+    }
+
+    @Test fun `resolveAudioDurationSec skips probe when no downloads to probe`() = runTest {
+        var probed = 0
+        val result = ChitankaCatalog.resolveAudioDurationSec(
+            root = ChitankaCatalog.ROOT_AUDIOBOOKS,
+            scraped = 0.0,
+            hasDownloads = false,
+        ) { probed++; 9999.0 }
+        assertEquals(0.0, result, 0.0)
+        assertEquals(0, probed)
+    }
+
+    @Test fun `resolveAudioDurationSec swallows probe failures and returns zero`() = runTest {
+        val result = ChitankaCatalog.resolveAudioDurationSec(
+            root = ChitankaCatalog.ROOT_AUDIOBOOKS,
+            scraped = 0.0,
+            hasDownloads = true,
+        ) { throw java.io.IOException("boom") }
+        assertEquals(0.0, result, 0.0)
+    }
+
+    @Test fun `resolveAudioDurationSec does not probe for non-audiobook roots`() = runTest {
+        var probed = 0
+        val result = ChitankaCatalog.resolveAudioDurationSec(
+            root = ChitankaCatalog.ROOT_BOOKS,
+            scraped = 0.0,
+            hasDownloads = true,
+        ) { probed++; 9999.0 }
+        assertEquals(0.0, result, 0.0)
+        assertEquals(0, probed)
+    }
+
     @Test fun `parseGramofoncheDurationSeconds returns zero when unknown`() {
         assertEquals(0.0, ChitankaCatalog.parseGramofoncheDurationSeconds(null), 0.0)
         assertEquals(0.0, ChitankaCatalog.parseGramofoncheDurationSeconds(""), 0.0)

--- a/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraperTest.kt
+++ b/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraperTest.kt
@@ -171,4 +171,19 @@ class GramofoncheScraperTest {
             d.narrators.isNotEmpty() && d.narrators.first() == "Георги Кадурин",
         )
     }
+
+    /**
+     * Regression: the duration regex used to be `(\d+)мин` and re-materialised the value as
+     * `"${minutes}мин"`, silently dropping the hour component from combined spans and yielding
+     * an empty string for hour-only entries. Both shapes exist on the live site — pin the
+     * broader `GRAMOFONCHE_DURATION_REGEX` capture so a revert would flip these red.
+     */
+    @Test
+    fun `duration regex captures hours-only and mixed hour-minute spans`() {
+        val re = GramofoncheScraper.GRAMOFONCHE_DURATION_REGEX
+        assertEquals("43мин", re.find("размер: 22M:43мин")?.value)
+        assertEquals("1час 20мин", re.find(".. 1час 20мин\n")?.value)
+        assertEquals("2часа", re.find(".. 2часа\n")?.value)
+        assertEquals("1 час", re.find(".. 1 час\n")?.value)
+    }
 }


### PR DESCRIPTION
## Summary

Some Gramofonche audiobooks still had no total-time row on the details screen after #543 — `LibraryItemDetailScreen` gates that row on `audioDurationSec > 0`, and two shapes still resolved to 0:

- Pages that spell duration as `1час 20мин` or `2часа` (parser only matched `Nмин`, so it dropped the hour on combined spans and returned 0 for hour-only entries).
- Detail pages with no `..NNмин` line at all — compilations and older reel-tape rips print no duration in the HTML. Example: https://gramofonche.chitanka.info/prikazki/barabanchik--duhyt-v-shisheto--baa1831/

## Changes

- Broaden `GRAMOFONCHE_DURATION_REGEX` to capture hours-only and hour+minute spans in both listing and detail scrapes.
- `parseGramofoncheDurationSeconds` now sums the hour and minute captures.
- `getItem` for `ROOT_AUDIOBOOKS` falls back to summing per-track Xing probes (`tracksFor`, from #543) when the scrape yielded 0 and there are downloads to probe. Extracted the conditional into `resolveAudioDurationSec` so it's covered by unit tests.

## Test plan

- [x] `./gradlew :core:catalog-chitanka:test` — new tests fail on revert of each change:
  - `parseGramofoncheDurationSeconds sums hours and minutes` (asserts `1час 20мин` → 4800s, `2часа` → 7200s)
  - `duration regex captures hours-only and mixed hour-minute spans`
  - `resolveAudioDurationSec falls back to per-track probe when scraped is zero` (+ four sibling cases pinning the no-probe branches)