### PR TITLE
fix(library): hide empty To Read / Annotations tabs on web-source screens

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryTabVisibilityObserver.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryTabVisibilityObserver.kt
@@ -1,0 +1,100 @@
+package com.riffle.app.feature.library
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.riffle.core.data.AnnotationsLibraryRepository
+import com.riffle.core.data.ToReadRepository
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.SourceRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Source-agnostic feed of [LibraryTabVisibility] for a given library. The four optional tabs
+ * (To Read, Series, Collections, Annotations) are visible iff their underlying data is non-empty
+ * — no source-type or Catalog-capability gating.
+ *
+ * Any screen with a `libraryId` can wire tab visibility with one line via
+ * [LibraryTabVisibilityViewModel]; a new source doesn't need to reinvent (or copy-paste) the
+ * per-flow "is this list empty?" plumbing. `LibraryItemsViewModel` (ABS/Komga) still owns its
+ * own bespoke computation because it also folds the offline/search filters into visibility —
+ * that filter-awareness is server-source-specific and doesn't belong in this shared observer.
+ */
+@Singleton
+class LibraryTabVisibilityObserver @Inject constructor(
+    private val libraryObserver: LibraryObserver,
+    private val toReadRepository: ToReadRepository,
+    private val annotationsLibraryRepository: AnnotationsLibraryRepository,
+    private val sourceRepository: SourceRepository,
+) {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun observe(libraryId: String): Flow<LibraryTabVisibility> {
+        // "Has at least one item on the To Read list AND already in this library." Mirrors the
+        // web-source `toReadItems` join — a queued id whose `library_items` row hasn't been
+        // upserted yet shouldn't reveal the tab, since the tab content itself would render empty.
+        val hasToRead = combine(
+            toReadRepository.observeToReadItemIds(libraryId),
+            libraryObserver.observeAllBooks(libraryId),
+        ) { ids, all -> all.any { it.id in ids } }
+
+        val activeSourceId: Flow<String?> = sourceRepository.observeAll()
+            .map { sources -> sources.firstOrNull { it.isActive }?.id }
+            .distinctUntilChanged()
+
+        // Same query the Annotations tab content uses
+        // ([com.riffle.app.feature.annotations.AnnotationsListViewModel]) so tab visibility can't
+        // disagree with what the tab would render.
+        val hasAnnotations = activeSourceId.flatMapLatest { sourceId ->
+            if (sourceId == null) flowOf(false)
+            else annotationsLibraryRepository.observeAnnotatedBooks(sourceId, libraryId)
+                .map { it.isNotEmpty() }
+        }
+
+        return combine(
+            hasToRead,
+            libraryObserver.observeSeries(libraryId),
+            libraryObserver.observeCollections(libraryId),
+            hasAnnotations,
+        ) { toRead, series, collections, annotations ->
+            LibraryTabVisibility(
+                toRead = toRead,
+                series = series.isNotEmpty(),
+                collections = collections.isNotEmpty(),
+                annotations = annotations,
+            )
+        }.distinctUntilChanged()
+    }
+}
+
+/**
+ * Thin Hilt-scoped wrapper that reads `libraryId` from `SavedStateHandle` and exposes the
+ * observer's flow as a lifecycle-bound `StateFlow`. Any screen — server-source or web-source —
+ * can wire tab visibility in one line:
+ *
+ * ```
+ * val visibility by hiltViewModel<LibraryTabVisibilityViewModel>().visibility.collectAsState()
+ * ```
+ */
+@HiltViewModel
+class LibraryTabVisibilityViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    observer: LibraryTabVisibilityObserver,
+) : ViewModel() {
+
+    private val libraryId: String = savedStateHandle.get<String>("libraryId") ?: ""
+
+    val visibility: StateFlow<LibraryTabVisibility> = observer.observe(libraryId)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), LibraryTabVisibility.Empty)
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
@@ -108,10 +108,22 @@ fun ChitankaBrowseScreen(
     val isAudioRoot = viewModel.rootId == ChitankaCatalog.ROOT_AUDIOBOOKS
     var searchOpen by remember { mutableStateOf(false) }
 
-    // Clamp if a rememberSaveable-restored selectedTab lands on Annotations after process
-    // death when we're now on the audiobook root (where that tab is hidden).
-    LaunchedEffect(isAudioRoot) {
-        if (isAudioRoot && selectedTab == TAB_ANNOTATIONS) selectedTab = TAB_HOME
+    val visibility by hiltViewModel<com.riffle.app.feature.library.LibraryTabVisibilityViewModel>()
+        .visibility.collectAsState()
+    // Annotations are anchored to ebook text — Gramofonche (the audiobook root) can never surface
+    // any, so hide the tab there on top of the generic emptiness gate.
+    val annotationsTabVisible = visibility.annotations && !isAudioRoot
+
+    // Clamp if a rememberSaveable-restored selectedTab lands on a tab that is currently hidden —
+    // either the audiobook root (Annotations always hidden there) or an empty To Read / Annotations
+    // list. Matches the LibraryTabBar clamp on the ABS/Komga side.
+    LaunchedEffect(visibility.toRead, annotationsTabVisible) {
+        val hidden = when (selectedTab) {
+            TAB_TO_READ -> !visibility.toRead
+            TAB_ANNOTATIONS -> !annotationsTabVisible
+            else -> false
+        }
+        if (hidden) selectedTab = TAB_HOME
     }
 
     Scaffold(
@@ -146,14 +158,16 @@ fun ChitankaBrowseScreen(
                     onClick = { selectedTab = TAB_HOME },
                     icon = { Icon(Icons.Filled.Home, contentDescription = "Home") },
                 )
-                NavigationBarItem(
-                    selected = selectedTab == TAB_TO_READ,
-                    onClick = { selectedTab = TAB_TO_READ },
-                    icon = { Icon(RiffleIcons.ToReadFilled, contentDescription = "To Read") },
-                )
-                // Annotations are anchored to ebook text — Gramofonche (the audiobook root)
-                // can never surface any. Hide the tab there so it isn't dead UI.
-                if (!isAudioRoot) {
+                if (visibility.toRead) {
+                    NavigationBarItem(
+                        selected = selectedTab == TAB_TO_READ,
+                        onClick = { selectedTab = TAB_TO_READ },
+                        icon = { Icon(RiffleIcons.ToReadFilled, contentDescription = "To Read") },
+                    )
+                }
+                // Annotations are anchored to ebook text — Gramofonche (the audiobook root) can
+                // never surface any, and an empty list makes the tab dead UI either way.
+                if (annotationsTabVisible) {
                     NavigationBarItem(
                         selected = selectedTab == TAB_ANNOTATIONS,
                         onClick = { selectedTab = TAB_ANNOTATIONS },

--- a/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
@@ -87,8 +87,22 @@ fun GutenbergBrowseScreen(
     var selectedTab by rememberSaveable(key = "gutenberg_selected_tab_v1") { mutableIntStateOf(TAB_HOME) }
     var searchOpen by remember { mutableStateOf(false) }
 
+    val visibility by hiltViewModel<com.riffle.app.feature.library.LibraryTabVisibilityViewModel>()
+        .visibility.collectAsState()
+
     LaunchedEffect(viewModel) {
         viewModel.openDetailEvents.collect { event -> onOpenDetail(event.itemId) }
+    }
+
+    // Clamp if a rememberSaveable-restored selectedTab lands on a tab that is currently hidden
+    // (empty To Read or Annotations list). Matches the LibraryTabBar clamp on the ABS/Komga side.
+    LaunchedEffect(visibility.toRead, visibility.annotations) {
+        val hidden = when (selectedTab) {
+            TAB_TO_READ -> !visibility.toRead
+            TAB_ANNOTATIONS -> !visibility.annotations
+            else -> false
+        }
+        if (hidden) selectedTab = TAB_HOME
     }
 
     Scaffold(
@@ -123,16 +137,20 @@ fun GutenbergBrowseScreen(
                     onClick = { selectedTab = TAB_HOME },
                     icon = { Icon(Icons.Filled.Home, contentDescription = "Home") },
                 )
-                NavigationBarItem(
-                    selected = selectedTab == TAB_TO_READ,
-                    onClick = { selectedTab = TAB_TO_READ },
-                    icon = { Icon(RiffleIcons.ToReadFilled, contentDescription = "To Read") },
-                )
-                NavigationBarItem(
-                    selected = selectedTab == TAB_ANNOTATIONS,
-                    onClick = { selectedTab = TAB_ANNOTATIONS },
-                    icon = { Icon(RiffleIcons.Annotations, contentDescription = "Annotations") },
-                )
+                if (visibility.toRead) {
+                    NavigationBarItem(
+                        selected = selectedTab == TAB_TO_READ,
+                        onClick = { selectedTab = TAB_TO_READ },
+                        icon = { Icon(RiffleIcons.ToReadFilled, contentDescription = "To Read") },
+                    )
+                }
+                if (visibility.annotations) {
+                    NavigationBarItem(
+                        selected = selectedTab == TAB_ANNOTATIONS,
+                        onClick = { selectedTab = TAB_ANNOTATIONS },
+                        icon = { Icon(RiffleIcons.Annotations, contentDescription = "Annotations") },
+                    )
+                }
                 NavigationBarItem(
                     selected = selectedTab == TAB_LIBRARY,
                     onClick = { selectedTab = TAB_LIBRARY },

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryTabVisibilityObserverTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryTabVisibilityObserverTest.kt
@@ -1,0 +1,194 @@
+package com.riffle.app.feature.library
+
+import com.riffle.core.data.AnnotatedBook
+import com.riffle.core.data.AnnotationsLibraryRepository
+import com.riffle.core.data.ToReadRepository
+import com.riffle.core.domain.Collection
+import com.riffle.core.domain.EbookFormat
+import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.Series
+import com.riffle.core.domain.Source
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.SourceType
+import com.riffle.core.domain.SourceUrl
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pins [LibraryTabVisibilityObserver] — the source-agnostic feed screens use to hide the
+ * To Read / Series / Collections / Annotations tabs when their underlying lists are empty.
+ * Regression coverage for the bottom-nav bug where the To Read and Annotations tabs stayed
+ * visible on Chitanka/Gutenberg even when both lists were empty; the fix is a shared observer
+ * both web-source screens (and any future one) consume via `LibraryTabVisibilityViewModel`.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class LibraryTabVisibilityObserverTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before fun setUp() { Dispatchers.setMain(dispatcher) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    private val activeSource = Source(
+        id = "src-1",
+        url = SourceUrl.parse("https://example.com")!!,
+        isActive = true,
+        insecureConnectionAllowed = false,
+        username = "",
+        type = SourceType.CHITANKA,
+    )
+
+    @Test
+    fun `everything empty hides every optional tab`() = runTest(dispatcher) {
+        val observer = buildObserver()
+        assertEquals(LibraryTabVisibility.Empty, awaitVisibility(observer))
+    }
+
+    @Test
+    fun `to-read only visible when a queued id also has a library row`() = runTest(dispatcher) {
+        // A queued id whose library_items row hasn't been upserted must NOT show the tab — the
+        // tab content itself filters against `observeAllBooks`, so leaving it visible produces a
+        // dead tab with nothing in it.
+        val observer = buildObserver(
+            toReadIds = MutableStateFlow(setOf("book-1")),
+            allBooks = MutableStateFlow(emptyList()),
+        )
+        assertEquals(false, awaitVisibility(observer).toRead)
+
+        val observerWithRow = buildObserver(
+            toReadIds = MutableStateFlow(setOf("book-1")),
+            allBooks = MutableStateFlow(listOf(libItem("book-1"))),
+        )
+        assertEquals(true, awaitVisibility(observerWithRow).toRead)
+    }
+
+    @Test
+    fun `series tab visibility mirrors observeSeries`() = runTest(dispatcher) {
+        val observer = buildObserver(series = MutableStateFlow(listOf(series("s-1"))))
+        assertEquals(true, awaitVisibility(observer).series)
+    }
+
+    @Test
+    fun `collections tab visibility mirrors observeCollections`() = runTest(dispatcher) {
+        val observer = buildObserver(collections = MutableStateFlow(listOf(collection("c-1"))))
+        assertEquals(true, awaitVisibility(observer).collections)
+    }
+
+    @Test
+    fun `annotations tab visible when the active source has any annotated book`() = runTest(dispatcher) {
+        val observer = buildObserver(annotated = MutableStateFlow(listOf(annotatedBook("book-1"))))
+        assertEquals(true, awaitVisibility(observer).annotations)
+    }
+
+    @Test
+    fun `annotations tab hidden when no source is active`() = runTest(dispatcher) {
+        // No active source ⇒ no annotations query is issued, so the tab can never show — even if
+        // an annotated-books flow was set up. Pins the null-active-source branch.
+        val observer = buildObserver(
+            active = null,
+            annotated = MutableStateFlow(listOf(annotatedBook("book-1"))),
+        )
+        assertEquals(false, awaitVisibility(observer).annotations)
+    }
+
+    // ---- helpers -----------------------------------------------------------------
+
+    private fun TestScope.awaitVisibility(observer: LibraryTabVisibilityObserver): LibraryTabVisibility {
+        var latest: LibraryTabVisibility = LibraryTabVisibility.Empty
+        val job = (this as CoroutineScope).launch {
+            observer.observe(LIB).collect { latest = it }
+        }
+        advanceUntilIdle()
+        job.cancel()
+        return latest
+    }
+
+    private fun libItem(id: String) = LibraryItem(
+        id = id,
+        libraryId = LIB,
+        title = id,
+        author = "A",
+        coverUrl = null,
+        readingProgress = 0f,
+        isCached = false,
+        isDownloaded = false,
+        ebookFormat = EbookFormat.Epub,
+        sourceId = "src-1",
+    )
+
+    private fun series(id: String) =
+        Series(id = id, libraryId = LIB, name = id, coverUrl = null, bookCount = 1)
+
+    private fun collection(id: String) =
+        Collection(id = id, libraryId = LIB, name = id, bookCount = 1)
+
+    private fun annotatedBook(itemId: String) = AnnotatedBook(
+        sourceId = "src-1",
+        itemId = itemId,
+        title = itemId,
+        author = "A",
+        coverUrl = null,
+        highlightCount = 1,
+        latestUpdatedAt = 0L,
+    )
+
+    private fun fakeSourceRepo(active: Source?): SourceRepository = object : SourceRepository {
+        override fun observeAll() = flowOf(listOfNotNull(active))
+        override suspend fun getActive(): Source? = active
+        override suspend fun commit(
+            pending: com.riffle.core.domain.PendingSource,
+            hiddenLibraryIds: Set<String>,
+        ) = throw UnsupportedOperationException()
+        override suspend fun setActive(sourceId: String) { }
+        override suspend fun remove(sourceId: String) { }
+        override suspend fun getSourceVersion(sourceId: String): String? = null
+    }
+
+    private fun buildObserver(
+        active: Source? = activeSource,
+        toReadIds: MutableStateFlow<Set<String>> = MutableStateFlow(emptySet()),
+        allBooks: MutableStateFlow<List<LibraryItem>> = MutableStateFlow(emptyList()),
+        series: MutableStateFlow<List<Series>> = MutableStateFlow(emptyList()),
+        collections: MutableStateFlow<List<Collection>> = MutableStateFlow(emptyList()),
+        annotated: MutableStateFlow<List<AnnotatedBook>> = MutableStateFlow(emptyList()),
+    ): LibraryTabVisibilityObserver {
+        val libraryObserver = mockk<LibraryObserver>(relaxed = true).also {
+            every { it.observeAllBooks(LIB) } returns allBooks
+            every { it.observeSeries(LIB) } returns series
+            every { it.observeCollections(LIB) } returns collections
+        }
+        val toReadRepo = mockk<ToReadRepository>(relaxed = true).also {
+            every { it.observeToReadItemIds(LIB) } returns toReadIds
+        }
+        val annotationsRepo = mockk<AnnotationsLibraryRepository>(relaxed = true).also {
+            every { it.observeAnnotatedBooks(any(), LIB) } returns annotated
+        }
+        return LibraryTabVisibilityObserver(
+            libraryObserver = libraryObserver,
+            toReadRepository = toReadRepo,
+            annotationsLibraryRepository = annotationsRepo,
+            sourceRepository = fakeSourceRepo(active),
+        )
+    }
+
+    private companion object {
+        const val LIB = "library-1"
+    }
+}


### PR DESCRIPTION
## Summary

On Chitanka and Gutenberg the To Read and Annotations bottom-nav items were rendered unconditionally, so users saw them even when both lists were empty. ABS/Komga hide those tabs via `LibraryItemsViewModel.tabVisibility`; web sources didn't have the equivalent gate.

Rather than copy that logic per source (which would need to be re-copied for every new web source), this change introduces a shared, source-agnostic feed:

- **`LibraryTabVisibilityObserver`** — for a given `libraryId`, produces a `Flow<LibraryTabVisibility>` (`toRead`, `series`, `collections`, `annotations`) based on whether each backing list is empty.
- **`LibraryTabVisibilityViewModel`** — thin Hilt wrapper reading `libraryId` from `SavedStateHandle` and exposing the observer as a `StateFlow`.
- `ChitankaBrowseScreen` / `GutenbergBrowseScreen` now gate their nav items on `visibility.toRead` / `visibility.annotations` and clamp a `rememberSaveable`-restored `selectedTab` that lands on a now-hidden tab back to Home — mirroring the ABS/Komga `LibraryTabBar` behavior.

Adding a third web source in the future is two lines: collect the flow, wrap the nav items in `if (visibility.x)`.

`LibraryItemsViewModel` (ABS/Komga) keeps its own bespoke `tabVisibility` because it also folds in the offline-banner and search-query filters via `LibraryProjection` — server-source-specific concerns that don't belong in the generic observer. Called out in the observer's KDoc.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` green
- [x] New `LibraryTabVisibilityObserverTest` (6 tests): all-empty ⇒ nothing visible; To Read only shows when a queued id also has a library row; Series / Collections / Annotations mirror their flows; no active source ⇒ Annotations hidden
- [ ] Manual: open Chitanka with an empty library — only Home + All Books tabs visible in bottom nav
- [ ] Manual: mark a Chitanka book as To Read — To Read tab appears; unmark — tab disappears
- [ ] Manual: highlight a Chitanka book — Annotations tab appears
- [ ] Manual: same three checks for Gutenberg
- [ ] Manual: on Chitanka's Gramofonche (audiobook) root, Annotations tab stays hidden even if the source has annotations elsewhere