### PR TITLE
feat(audiobook): visualize buffer-ahead on the player seek bar

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
@@ -88,6 +88,10 @@ data class PlayerSurfaceState(
     val speed: Float = 1f,
     val positionSec: Double = 0.0,
     val durationSec: Double = 0.0,
+    // Book-absolute buffered-ahead position. Rendered as a lighter band between the played fill and
+    // the base track; a value ≤ [positionSec] draws nothing extra. Readaloud (local-bundle audio)
+    // leaves this at 0 — the band simply doesn't appear.
+    val bufferedPositionSec: Double = 0.0,
     val currentChapterTitle: String? = null,
     val chapterStartsSec: List<Double> = emptyList(),
     // Absolute positions (seconds, global timeline) of the user's bookmarks, drawn as thin ticks on
@@ -276,6 +280,7 @@ private fun PlayerControls(state: PlayerSurfaceState, actions: PlayerSurfaceActi
         ChapterSeekBar(
             positionSec = state.positionSec,
             durationSec = state.durationSec,
+            bufferedPositionSec = state.bufferedPositionSec,
             chapterStartsSec = state.chapterStartsSec,
             bookmarkPositionsSec = state.bookmarkPositionsSec,
             onSeek = actions.onSeek,
@@ -424,12 +429,16 @@ private fun DualTime(state: PlayerSurfaceState) {
 private fun ChapterSeekBar(
     positionSec: Double,
     durationSec: Double,
+    bufferedPositionSec: Double,
     chapterStartsSec: List<Double>,
     bookmarkPositionsSec: List<Double>,
     onSeek: (Double) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val accent = MaterialTheme.colorScheme.primary
+    // Buffered-ahead band: same hue as the played fill, muted so it reads as "loaded, not played yet"
+    // against the accent-filled portion below the playhead and the base-track above it.
+    val buffered = accent.copy(alpha = 0.35f)
     val track = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.16f)
     val tickColor = MaterialTheme.colorScheme.background
     // Bookmark ticks read over both the filled and unfilled track; onSurfaceVariant contrasts with
@@ -475,6 +484,17 @@ private fun ChapterSeekBar(
             val frac = if (durationSec > 0) (displayedSec / durationSec).coerceIn(0.0, 1.0).toFloat() else 0f
             // base track
             drawRoundRect(color = track, size = size, cornerRadius = CornerRadius(h / 2, h / 2))
+            // buffered-ahead band (rendered under the filled portion so its right edge extends past
+            // the playhead; hidden when nothing is buffered past the current position, which keeps
+            // Readaloud's local-bundle player free of a stray band).
+            if (durationSec > 0 && bufferedPositionSec > displayedSec) {
+                val bufFrac = (bufferedPositionSec / durationSec).coerceIn(0.0, 1.0).toFloat()
+                drawRoundRect(
+                    color = buffered,
+                    size = Size(w * bufFrac, h),
+                    cornerRadius = CornerRadius(h / 2, h / 2),
+                )
+            }
             // filled portion
             drawRoundRect(
                 color = accent,

--- a/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
@@ -89,8 +89,7 @@ data class PlayerSurfaceState(
     val positionSec: Double = 0.0,
     val durationSec: Double = 0.0,
     // Book-absolute buffered-ahead position. Rendered as a lighter band between the played fill and
-    // the base track; a value ≤ [positionSec] draws nothing extra. Readaloud (local-bundle audio)
-    // leaves this at 0 — the band simply doesn't appear.
+    // the base track; a value ≤ [positionSec] draws nothing extra (so the default 0 is inert).
     val bufferedPositionSec: Double = 0.0,
     val currentChapterTitle: String? = null,
     val chapterStartsSec: List<Double> = emptyList(),
@@ -485,8 +484,7 @@ private fun ChapterSeekBar(
             // base track
             drawRoundRect(color = track, size = size, cornerRadius = CornerRadius(h / 2, h / 2))
             // buffered-ahead band (rendered under the filled portion so its right edge extends past
-            // the playhead; hidden when nothing is buffered past the current position, which keeps
-            // Readaloud's local-bundle player free of a stray band).
+            // the playhead; hidden when nothing is buffered past the current position).
             if (durationSec > 0 && bufferedPositionSec > displayedSec) {
                 val bufFrac = (bufferedPositionSec / durationSec).coerceIn(0.0, 1.0).toFloat()
                 drawRoundRect(

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AbsolutePositionPlayer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AbsolutePositionPlayer.kt
@@ -14,9 +14,10 @@ import com.riffle.core.domain.AudiobookTracks
  * When no audiobook is active ([SharedAudiobookContext.spans] is empty) every call passes through
  * to the delegate unchanged, so Readaloud playback is unaffected.
  *
- * The three overrides are mutually consistent:
- * - [getCurrentPosition] → book-absolute milliseconds
- * - [getDuration]        → total book duration in milliseconds
+ * The four overrides are mutually consistent:
+ * - [getCurrentPosition]  → book-absolute milliseconds
+ * - [getBufferedPosition] → book-absolute milliseconds (buffered-ahead frontier)
+ * - [getDuration]         → total book duration in milliseconds
  * - [seekTo] (single-arg) → resolves absolute ms → (track index, in-track offset) and delegates
  *
  * The two-argument [seekTo](mediaItemIndex, positionMs) is intentionally NOT overridden: the
@@ -32,6 +33,16 @@ class AbsolutePositionPlayer(private val exoPlayer: ExoPlayer) : ForwardingPlaye
         return (AudiobookTracks.absoluteSec(
             exoPlayer.currentMediaItemIndex,
             exoPlayer.currentPosition / 1000.0,
+            spans,
+        ) * 1000.0).toLong()
+    }
+
+    override fun getBufferedPosition(): Long {
+        val spans = SharedAudiobookContext.spans
+        if (spans.isEmpty()) return exoPlayer.bufferedPosition
+        return (AudiobookTracks.absoluteSec(
+            exoPlayer.currentMediaItemIndex,
+            exoPlayer.bufferedPosition / 1000.0,
             spans,
         ) * 1000.0).toLong()
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -60,6 +60,9 @@ open class AudiobookController @Inject constructor(
         val speed: Float = 1f,
         val positionSec: Double = 0.0,
         val durationSec: Double = 0.0,
+        // Book-absolute position up to which ExoPlayer has buffered ahead of [positionSec].
+        // Projected through [AbsolutePositionPlayer.getBufferedPosition], so no offset math here.
+        val bufferedSec: Double = 0.0,
     )
 
     // Main.immediate is required for Media3 MediaController calls; the survivable Job tree comes from
@@ -336,6 +339,7 @@ open class AudiobookController @Inject constructor(
             speed = c?.playbackParameters?.speed ?: 1f,
             positionSec = currentAbsoluteSec(),
             durationSec = durationSec,
+            bufferedSec = (c?.bufferedPosition ?: 0L) / 1000.0,
         )
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -224,6 +224,7 @@ fun AudiobookPlayerScreen(
                             speed = state.speed,
                             positionSec = state.positionSec,
                             durationSec = state.durationSec,
+                            bufferedPositionSec = state.bufferedPositionSec,
                             currentChapterTitle = state.currentChapterTitle,
                             chapterStartsSec = state.chapterStartsSec,
                             bookmarkPositionsSec = state.bookmarks.map { it.positionSec },

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -133,6 +133,9 @@ data class AudiobookPlayerUiState(
     val speed: Float = 1f,
     val positionSec: Double = 0.0,
     val durationSec: Double = 0.0,
+    // Book-absolute position up to which audio has buffered ahead of [positionSec]. Rendered as a
+    // lighter fill on the seek bar, YouTube/Spotify-style.
+    val bufferedPositionSec: Double = 0.0,
     val currentChapterTitle: String? = null,
     val chapterStartsSec: List<Double> = emptyList(),
     // The full chapter list + the index of the chapter the playhead is in, for the Chapters sheet.
@@ -316,6 +319,7 @@ class AudiobookPlayerViewModel @Inject constructor(
                 speed = playback.speed,
                 positionSec = pos,
                 durationSec = if (playback.durationSec > 0) playback.durationSec else m.durationSec,
+                bufferedPositionSec = playback.bufferedSec,
                 currentChapterTitle = chapter?.title,
                 chapterStartsSec = timeline.chapters.map { it.startSec },
                 chapters = timeline.chapters,

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AbsolutePositionPlayerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AbsolutePositionPlayerTest.kt
@@ -1,0 +1,52 @@
+package com.riffle.app.feature.audiobook
+
+import androidx.media3.exoplayer.ExoPlayer
+import com.riffle.core.domain.AudiobookTrackSpan
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Buffer projection: [AbsolutePositionPlayer.getBufferedPosition] must add the current track's
+ * `startOffsetSec` when [SharedAudiobookContext] has spans, and pass through otherwise. The parallel
+ * of the well-known [getCurrentPosition] double-count trap — a plain forwarding delegate would
+ * return per-track ms and the seek-bar buffered band would appear to sit before the playhead.
+ */
+class AbsolutePositionPlayerTest {
+
+    @After
+    fun tearDown() {
+        SharedAudiobookContext.spans = emptyList()
+        SharedAudiobookContext.totalDurationMs = 0L
+    }
+
+    @Test
+    fun `getBufferedPosition adds current track startOffset when spans are set`() {
+        SharedAudiobookContext.spans = listOf(
+            AudiobookTrackSpan(index = 0, startOffsetSec = 0.0, durationSec = 600.0),
+            AudiobookTrackSpan(index = 1, startOffsetSec = 600.0, durationSec = 600.0),
+        )
+        val exo = mockk<ExoPlayer>(relaxed = true) {
+            every { currentMediaItemIndex } returns 1
+            every { bufferedPosition } returns 30_000L
+        }
+
+        val projected = AbsolutePositionPlayer(exo).bufferedPosition
+
+        // 600s (track 1 startOffset) + 30s (in-track buffered) = 630_000 ms.
+        assertEquals(630_000L, projected)
+    }
+
+    @Test
+    fun `getBufferedPosition passes through when no audiobook is active`() {
+        // Readaloud path: spans empty → return ExoPlayer's raw per-track value untouched.
+        SharedAudiobookContext.spans = emptyList()
+        val exo = mockk<ExoPlayer>(relaxed = true) {
+            every { bufferedPosition } returns 12_345L
+        }
+
+        assertEquals(12_345L, AbsolutePositionPlayer(exo).bufferedPosition)
+    }
+}


### PR DESCRIPTION
## Summary

Draws a lighter accent-tinted band on the audiobook seek bar showing how far ExoPlayer has buffered ahead of the playhead (YouTube/Spotify-style), so streaming stalls and prefetch progress become visible.

## Changes

- **AbsolutePositionPlayer** — added \`getBufferedPosition\` override so ExoPlayer's per-track buffered ms is projected to book-absolute ms, mirroring the existing \`getCurrentPosition\` projection (same class of trap noted in the audiobook-position double-count history).
- **AudiobookController** — added \`bufferedSec\` to \`PlaybackState\`; \`pushState()\` reads \`controller.bufferedPosition\` on the existing 250 ms poll (no new plumbing).
- **AudiobookPlayerViewModel / AudiobookPlayerScreen** — threaded \`bufferedPositionSec\` through the UI state.
- **PlayerSurface.ChapterSeekBar** — draws a 35%-alpha accent band between the base track and the played fill. Hidden when \`bufferedPositionSec ≤ displayedSec\`, so the default 0 is inert.

## Tests

- \`AbsolutePositionPlayerTest\` — pins the projection: on track index 1 with \`startOffsetSec=600\` and in-track buffered=30 s, \`bufferedPosition\` must return 630 000 ms. Reverting the override flips the assertion red. Also covers the spans-empty pass-through path.

## Test plan

- [x] JVM unit tests pass (\`:app:testDebugUnitTest\`)
- [ ] Visual verification against ABS streaming — buffer band should grow ahead of the playhead as ExoPlayer buffers, contract on seek, and cap at the current chapter boundary
- [ ] No visual regression on the seek bar in normal playback / drag-to-seek