### PR TITLE
feat(audiobook): show remaining time in system media notification

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audio/TimeFormat.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/TimeFormat.kt
@@ -8,3 +8,16 @@ internal fun formatHms(totalSec: Double): String {
     val sec = s % 60
     return if (h > 0) "%d:%02d:%02d".format(h, m, sec) else "%d:%02d".format(m, sec)
 }
+
+/**
+ * Human-readable remaining-time label for the system media notification / lock-screen player —
+ * e.g. "3h 12m left", "45m left", "Less than a minute left". Whole-minute granularity so we
+ * update the [androidx.media3.common.MediaMetadata] at most once per minute.
+ */
+fun formatRemainingReadable(remainingSec: Double): String {
+    val totalMinutes = (remainingSec / 60.0).toLong().coerceAtLeast(0)
+    if (totalMinutes == 0L) return "Less than a minute left"
+    val h = totalMinutes / 60
+    val m = totalMinutes % 60
+    return if (h > 0) "${h}h ${m}m left" else "${m}m left"
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -5,6 +5,7 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.session.MediaController
 import com.riffle.app.feature.audio.MediaSessionConnector
+import com.riffle.app.feature.audio.formatRemainingReadable
 import com.riffle.app.feature.reader.readaloud.SharedBundle
 import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.AudiobookTrackSpan
@@ -93,6 +94,10 @@ open class AudiobookController @Inject constructor(
     // so it only releases the bundle it set — never one a live Readaloud session owns (e.g. when this
     // player opened a streaming session, or failed to prepare at all, while Readaloud is still playing).
     private var ownsSharedBundle = false
+    // Whole-minute bucket of remaining book time last written to the current MediaItem's metadata.
+    // We `replaceMediaItem` only when this bucket changes, so the system notification's "3h 12m
+    // left" subtitle updates at most once per minute regardless of poll cadence.
+    private var lastRemainingMinuteBucket: Long = -1L
 
     private val listener = object : Player.Listener {
         override fun onEvents(player: Player, events: Player.Events) {
@@ -136,8 +141,11 @@ open class AudiobookController @Inject constructor(
         if (localZipFile != null) SharedBundle.current = localZipFile
         val c = ensureConnected() ?: return
         logger.d(LogChannel.Handoff) { "AB.prepare ensureConnected +${clock.nowMs() - t0}ms" }
+        val initialRemainingSec = (durationSec - startAtSec).coerceAtLeast(0.0)
+        lastRemainingMinuteBucket = (initialRemainingSec / 60.0).toLong()
         val metadata = androidx.media3.common.MediaMetadata.Builder()
             .apply { if (coverUri != null) setArtworkUri(android.net.Uri.parse(coverUri)) }
+            .setArtist(formatRemainingReadable(initialRemainingSec))
             .build()
         val items = trackUrls.map { url ->
             MediaItem.Builder().setMediaId(url).setUri(url).setMediaMetadata(metadata).build()
@@ -279,6 +287,7 @@ open class AudiobookController @Inject constructor(
         ownsSharedBundle = false
         SharedAudiobookContext.spans = emptyList()
         SharedAudiobookContext.totalDurationMs = 0L
+        lastRemainingMinuteBucket = -1L
         _state.value = PlaybackState()
     }
 
@@ -308,6 +317,7 @@ open class AudiobookController @Inject constructor(
         ownsSharedBundle = false
         SharedAudiobookContext.spans = emptyList()
         SharedAudiobookContext.totalDurationMs = 0L
+        lastRemainingMinuteBucket = -1L
         _state.value = PlaybackState()
     }
 
@@ -330,13 +340,37 @@ open class AudiobookController @Inject constructor(
 
     private fun pushState() {
         val c = controller
+        val position = currentAbsoluteSec()
         _state.value = PlaybackState(
             connected = c != null,
             isPlaying = c?.isPlaying == true,
             speed = c?.playbackParameters?.speed ?: 1f,
-            positionSec = currentAbsoluteSec(),
+            positionSec = position,
             durationSec = durationSec,
         )
+        maybeUpdateRemainingMetadata(c, position)
+    }
+
+    /**
+     * Refreshes the current [MediaItem]'s `artist` metadata so the system media notification /
+     * lock-screen player shows "3h 12m left" style remaining-time text under the title. Fires at
+     * most once per whole-minute change; the URI is stripped over the session Binder and rebuilt
+     * by [com.riffle.app.feature.audio.MediaItemRestorerRegistry], so this is a metadata-only
+     * update that does not re-buffer.
+     */
+    private fun maybeUpdateRemainingMetadata(c: MediaController?, positionSec: Double) {
+        if (c == null || !prepared || durationSec <= 0.0) return
+        val remaining = (durationSec - positionSec).coerceAtLeast(0.0)
+        val bucket = (remaining / 60.0).toLong()
+        if (bucket == lastRemainingMinuteBucket) return
+        val index = c.currentMediaItemIndex
+        if (index < 0) return
+        val item = c.currentMediaItem ?: return
+        lastRemainingMinuteBucket = bucket
+        val newMetadata = item.mediaMetadata.buildUpon()
+            .setArtist(formatRemainingReadable(remaining))
+            .build()
+        c.replaceMediaItem(index, item.buildUpon().setMediaMetadata(newMetadata).build())
     }
 
     companion object {

--- a/app/src/test/kotlin/com/riffle/app/feature/audio/TimeFormatTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audio/TimeFormatTest.kt
@@ -1,0 +1,27 @@
+package com.riffle.app.feature.audio
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class TimeFormatTest {
+    @Test fun `remaining under a minute reads as less than a minute`() {
+        assertEquals("Less than a minute left", formatRemainingReadable(0.0))
+        assertEquals("Less than a minute left", formatRemainingReadable(45.0))
+    }
+
+    @Test fun `remaining under an hour is m only`() {
+        assertEquals("1m left", formatRemainingReadable(60.0))
+        assertEquals("45m left", formatRemainingReadable(45 * 60.0))
+        assertEquals("59m left", formatRemainingReadable(59 * 60.0 + 59))
+    }
+
+    @Test fun `remaining at least an hour includes hours and minutes`() {
+        assertEquals("1h 0m left", formatRemainingReadable(60 * 60.0))
+        assertEquals("3h 12m left", formatRemainingReadable(3 * 3600.0 + 12 * 60.0 + 30))
+        assertEquals("12h 5m left", formatRemainingReadable(12 * 3600.0 + 5 * 60.0))
+    }
+
+    @Test fun `negative input clamps to zero`() {
+        assertEquals("Less than a minute left", formatRemainingReadable(-42.0))
+    }
+}


### PR DESCRIPTION
## Summary

The audiobook player's Android system notification / lock-screen player previously set only the cover artwork — no title, no subtitle. This adds a `"3h 12m left"` style remaining-time label so users can see at a glance how much book is left without opening the app.

## How it works

- `formatRemainingReadable(sec)` produces `"3h 12m left"` / `"45m left"` / `"Less than a minute left"` (whole-minute granularity).
- `AudiobookController.prepare()` seeds every track's `MediaMetadata.artist` with the initial label.
- `pushState()` calls a new `maybeUpdateRemainingMetadata()` that fires `MediaController.replaceMediaItem(currentIndex, …)` only when the whole-minute remaining bucket changes — at most one metadata refresh per minute, regardless of the 4 Hz poll cadence.
- URI is stripped over the session Binder and rebuilt by the existing `MediaItemRestorerRegistry`, so this is a metadata-only update and does not re-buffer.
- Bucket state is reset in `stop()` / `releaseForHandoff()` so a subsequent session starts fresh.

Readaloud's notification metadata is unchanged; happy to mirror the pattern into `ReadaloudController` in a follow-up if wanted.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests com.riffle.app.feature.audio.TimeFormatTest` — new `TimeFormatTest` covers under-a-minute, m-only, h+m, and negative clamp.
- [x] `./gradlew :app:compileDebugKotlin :app:compileDebugUnitTestKotlin`.
- [ ] Device verification on AVD (not yet installed) — start audiobook playback, swipe down, confirm subtitle line reads `"Xh Ym left"` and updates as playback progresses.