### PR TITLE
fix(chitanka): correct Gramofonche chapter durations, plus TTL for derived caches

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/FetchAudiobookChaptersUseCase.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/FetchAudiobookChaptersUseCase.kt
@@ -9,12 +9,20 @@ class FetchAudiobookChaptersUseCase @Inject constructor(
     private val chapterCacheRepository: AudiobookChapterCacheRepository,
 ) {
     suspend operator fun invoke(item: LibraryItem): List<AudiobookChapter> {
-        val cached = chapterCacheRepository.getCachedChapters(item.sourceId, item.id)
-        if (cached != null) return cached
-        return try {
+        // 1. Fresh cache — return immediately.
+        val fresh = chapterCacheRepository.getCachedChapters(item.sourceId, item.id)
+        if (fresh != null) return fresh
+        // 2. Live fetch — the TTL refresh path.
+        val fetched = try {
             chapterCacheRepository.fetchAndCacheChapters(sourceId = item.sourceId, itemId = item.id)
         } catch (_: Exception) {
             emptyList()
         }
+        if (fetched.isNotEmpty()) return fetched
+        // 3. Live fetch failed or came back empty (offline, rate-limit, source hiccup) — a
+        //    stale cached copy is still better than an empty chapter list, so surface it
+        //    as a last resort. Otherwise the TTL turns a purely-additive safeguard into a
+        //    regression on the offline path.
+        return chapterCacheRepository.getStaleCachedChapters(item.sourceId, item.id).orEmpty()
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/FetchAudiobookChaptersUseCaseTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/FetchAudiobookChaptersUseCaseTest.kt
@@ -31,6 +31,7 @@ class FetchAudiobookChaptersUseCaseTest {
 
         assertEquals(chapters, result)
         coVerify(exactly = 0) { chapterRepo.fetchAndCacheChapters(any(), any()) }
+        coVerify(exactly = 0) { chapterRepo.getStaleCachedChapters(any(), any()) }
     }
 
     @Test
@@ -42,12 +43,44 @@ class FetchAudiobookChaptersUseCaseTest {
         val result = useCase(makeItem())
 
         assertEquals(chapters, result)
+        coVerify(exactly = 0) { chapterRepo.getStaleCachedChapters(any(), any()) }
+    }
+
+    /**
+     * Regression: the TTL introduced with MIGRATION_54_55 turns getCachedChapters into a
+     * stale-nulling read. Without the stale fallback below, an offline user with an 8-day-old
+     * cache would lose every chapter (fresh returns null → fetch throws → empty). We must
+     * surface the stale row rather than an empty list.
+     */
+    @Test
+    fun `falls back to stale cache when live fetch throws`() = runTest {
+        val stale = listOf(AudiobookChapter(0, 0.0, 300.0, "Old Intro"))
+        coEvery { chapterRepo.getCachedChapters("srv1", "item1") } returns null
+        coEvery { chapterRepo.fetchAndCacheChapters("srv1", "item1") } throws RuntimeException("offline")
+        coEvery { chapterRepo.getStaleCachedChapters("srv1", "item1") } returns stale
+
+        val result = useCase(makeItem())
+
+        assertEquals(stale, result)
     }
 
     @Test
-    fun `returns empty list on repository error`() = runTest {
+    fun `falls back to stale cache when live fetch returns empty`() = runTest {
+        val stale = listOf(AudiobookChapter(0, 0.0, 300.0, "Old Intro"))
+        coEvery { chapterRepo.getCachedChapters("srv1", "item1") } returns null
+        coEvery { chapterRepo.fetchAndCacheChapters("srv1", "item1") } returns emptyList()
+        coEvery { chapterRepo.getStaleCachedChapters("srv1", "item1") } returns stale
+
+        val result = useCase(makeItem())
+
+        assertEquals(stale, result)
+    }
+
+    @Test
+    fun `returns empty list when live fetch fails and no stale cache exists`() = runTest {
         coEvery { chapterRepo.getCachedChapters("srv1", "item1") } returns null
         coEvery { chapterRepo.fetchAndCacheChapters("srv1", "item1") } throws RuntimeException("boom")
+        coEvery { chapterRepo.getStaleCachedChapters("srv1", "item1") } returns null
 
         val result = useCase(makeItem())
 

--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
@@ -428,22 +428,24 @@ class ChitankaCatalog(
      * historically underestimated by up to ~40 %, leaving the scrubber pinned at end while
      * ExoPlayer was still decoding several real minutes of audio.
      *
-     * If the probe fails (network error, unrecognised encoding), fall back to HEAD +
-     * [GRAMOFONCHE_FALLBACK_BITRATE_BPS] so we still yield non-zero durations — needed for
-     * [AudiobookTracks#trackAt] / [#absoluteSec] to route positions to the right track in a
-     * multi-file book.
+     * If a probe fails (network error, unrecognised encoding) or the summed probes fall
+     * significantly short of the scraped total, delegate to [resolveTrackDurationsSec] which
+     * distributes the scraped total proportionally by content-length. The 128 kbps CBR
+     * fallback in [GRAMOFONCHE_FALLBACK_BITRATE_BPS] only kicks in when *neither* signal is
+     * available (probe null AND no scraped duration on the page).
      */
     private suspend fun tracksFor(detail: ChitankaDetail): List<CatalogAudioTrack> {
-        val durationsSec = coroutineScope {
+        val probes = coroutineScope {
             detail.downloads.map { d ->
                 async(Dispatchers.IO) {
-                    val probed = http.probeMp3DurationSec(d.url)
-                    if (probed != null && probed > 0.0) return@async probed
-                    val bytes = http.headContentLength(d.url) ?: return@async 0.0
-                    bytes.toDouble() * 8.0 / GRAMOFONCHE_FALLBACK_BITRATE_BPS
+                    val probed = http.probeMp3DurationSec(d.url)?.takeIf { it > 0.0 }
+                    val bytes = http.headContentLength(d.url) ?: 0L
+                    TrackProbe(probedSec = probed, bytes = bytes)
                 }
             }.awaitAll()
         }
+        val scrapedTotalSec = parseGramofoncheDurationSeconds(detail.duration)
+        val durationsSec = resolveTrackDurationsSec(probes, scrapedTotalSec)
         var cumulativeStart = 0.0
         return detail.downloads.mapIndexed { idx, d ->
             val dur = durationsSec[idx]
@@ -540,6 +542,56 @@ class ChitankaCatalog(
          * the pre-probe behaviour on the rare probe miss.
          */
         internal const val GRAMOFONCHE_FALLBACK_BITRATE_BPS: Int = 128_000
+
+        /**
+         * Ratio below which per-track probe results are considered untrustworthy relative to
+         * the scraped total. The scraped duration on Gramofonche is rounded down to whole
+         * minutes ("43мин" for 43.6 real minutes), so a genuine probe can legitimately exceed
+         * the scraped value by up to one minute. Underestimating by >10 % is the signature of
+         * probes falling through to the CBR fallback on VBR files (Gramofonche rips are ~72
+         * kbps but [GRAMOFONCHE_FALLBACK_BITRATE_BPS] assumes 128 kbps, which halves the
+         * duration and drove the "chapters total 25 min for a 43 min book" bug).
+         */
+        internal const val PROBE_UNDERESTIMATE_THRESHOLD: Double = 0.9
+
+        internal data class TrackProbe(val probedSec: Double?, val bytes: Long)
+
+        /**
+         * Chooses per-track durations from what we have: probes (Xing-accurate when the
+         * upstream MP3 exposes the tag), byte lengths (proportional distribution against the
+         * scraped total), or the [GRAMOFONCHE_FALLBACK_BITRATE_BPS] CBR estimate. Preference
+         * order:
+         *
+         * 1. All probes succeeded and their sum is at least
+         *    [PROBE_UNDERESTIMATE_THRESHOLD] of the scraped total (or there is no scraped
+         *    total to compare against) → trust the probes verbatim.
+         * 2. Scraped total is known and content-length is known for every track → distribute
+         *    the scraped total proportionally by bytes. This is the recovery path for VBR
+         *    rips where the probe misses the Xing tag and CBR math would return roughly half
+         *    the real duration.
+         * 3. Otherwise fall back per-track to `probed ?: bytes*8 / 128 kbps`, matching the
+         *    pre-recovery behaviour so a probe-less, duration-less page still yields
+         *    non-zero spans for [AudiobookTracks#trackAt] routing.
+         */
+        internal fun resolveTrackDurationsSec(
+            probes: List<TrackProbe>,
+            scrapedTotalSec: Double,
+        ): List<Double> {
+            if (probes.isEmpty()) return emptyList()
+            val probedSum = probes.sumOf { it.probedSec ?: 0.0 }
+            val allProbed = probes.all { it.probedSec != null }
+            if (allProbed && (scrapedTotalSec <= 0.0 || probedSum >= scrapedTotalSec * PROBE_UNDERESTIMATE_THRESHOLD)) {
+                return probes.map { it.probedSec!! }
+            }
+            val totalBytes = probes.sumOf { it.bytes }
+            val allBytesKnown = probes.all { it.bytes > 0L }
+            if (scrapedTotalSec > 0.0 && allBytesKnown && totalBytes > 0L) {
+                return probes.map { scrapedTotalSec * it.bytes / totalBytes }
+            }
+            return probes.map { p ->
+                p.probedSec ?: (p.bytes.toDouble() * 8.0 / GRAMOFONCHE_FALLBACK_BITRATE_BPS)
+            }
+        }
 
         private val GRAMOFONCHE_HOURS_REGEX = Regex("(\\d+)\\s*часа?")
         private val GRAMOFONCHE_MINUTES_REGEX = Regex("(\\d+)\\s*мин")

--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
@@ -435,16 +435,28 @@ class ChitankaCatalog(
      * available (probe null AND no scraped duration on the page).
      */
     private suspend fun tracksFor(detail: ChitankaDetail): List<CatalogAudioTrack> {
-        val probes = coroutineScope {
+        val scrapedTotalSec = parseGramofoncheDurationSeconds(detail.duration)
+        // Fast path: probe every track first. On the healthy VBR case (Xing tag present, sum
+        // matches the scraped total) tier 1 in resolveTrackDurationsSec trusts the probes
+        // verbatim and we can skip the per-track HEAD entirely — cheaper by N round-trips on
+        // every audiobook open. Only fall back to fetching content-length when we know the
+        // probes underestimate and the byte proportions are the recovery signal.
+        val probed = coroutineScope {
             detail.downloads.map { d ->
-                async(Dispatchers.IO) {
-                    val probed = http.probeMp3DurationSec(d.url)?.takeIf { it > 0.0 }
-                    val bytes = http.headContentLength(d.url) ?: 0L
-                    TrackProbe(probedSec = probed, bytes = bytes)
-                }
+                async(Dispatchers.IO) { http.probeMp3DurationSec(d.url)?.takeIf { it > 0.0 } }
             }.awaitAll()
         }
-        val scrapedTotalSec = parseGramofoncheDurationSeconds(detail.duration)
+        val probeOnly = probed.map { TrackProbe(probedSec = it, bytes = 0L) }
+        val probes = if (canTrustProbesAlone(probeOnly, scrapedTotalSec)) {
+            probeOnly
+        } else {
+            val bytes = coroutineScope {
+                detail.downloads.map { d ->
+                    async(Dispatchers.IO) { http.headContentLength(d.url) ?: 0L }
+                }.awaitAll()
+            }
+            probed.mapIndexed { i, p -> TrackProbe(probedSec = p, bytes = bytes[i]) }
+        }
         val durationsSec = resolveTrackDurationsSec(probes, scrapedTotalSec)
         var cumulativeStart = 0.0
         return detail.downloads.mapIndexed { idx, d ->
@@ -578,9 +590,7 @@ class ChitankaCatalog(
             scrapedTotalSec: Double,
         ): List<Double> {
             if (probes.isEmpty()) return emptyList()
-            val probedSum = probes.sumOf { it.probedSec ?: 0.0 }
-            val allProbed = probes.all { it.probedSec != null }
-            if (allProbed && (scrapedTotalSec <= 0.0 || probedSum >= scrapedTotalSec * PROBE_UNDERESTIMATE_THRESHOLD)) {
+            if (canTrustProbesAlone(probes, scrapedTotalSec)) {
                 return probes.map { it.probedSec!! }
             }
             val totalBytes = probes.sumOf { it.bytes }
@@ -588,9 +598,24 @@ class ChitankaCatalog(
             if (scrapedTotalSec > 0.0 && allBytesKnown && totalBytes > 0L) {
                 return probes.map { scrapedTotalSec * it.bytes / totalBytes }
             }
+            // Last-resort per-track: probed value; else CBR math on bytes; else the equal
+            // share of the scraped total. The equal-share step matters when at least one
+            // track is missing both signals (probe null, HEAD failed → bytes=0) — without
+            // it that track would emit 0.0 sec, cumulativeStart wouldn't advance, and
+            // AudiobookTracks#trackAt would route every later position to the wrong track.
+            val equalShare = if (scrapedTotalSec > 0.0) scrapedTotalSec / probes.size else 0.0
             return probes.map { p ->
-                p.probedSec ?: (p.bytes.toDouble() * 8.0 / GRAMOFONCHE_FALLBACK_BITRATE_BPS)
+                p.probedSec
+                    ?: if (p.bytes > 0L) p.bytes.toDouble() * 8.0 / GRAMOFONCHE_FALLBACK_BITRATE_BPS
+                    else equalShare
             }
+        }
+
+        private fun canTrustProbesAlone(probes: List<TrackProbe>, scrapedTotalSec: Double): Boolean {
+            if (!probes.all { it.probedSec != null }) return false
+            if (scrapedTotalSec <= 0.0) return true
+            val probedSum = probes.sumOf { it.probedSec!! }
+            return probedSum >= scrapedTotalSec * PROBE_UNDERESTIMATE_THRESHOLD
         }
 
         private val GRAMOFONCHE_HOURS_REGEX = Regex("(\\d+)\\s*часа?")

--- a/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
+++ b/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
@@ -515,6 +515,71 @@ class ChitankaCatalogTest {
         assertEquals(0, probed)
     }
 
+    /**
+     * Regression: `barabanchik--duhyt-v-shisheto--baa1831` scraped "43мин" total but the
+     * chapter drawer summed to ~25 min. Xing probing fell through to the 128 kbps CBR
+     * fallback on those ~72 kbps VBR files, halving the per-track durations. When probes
+     * clearly underestimate the scraped total (< [PROBE_UNDERESTIMATE_THRESHOLD]), the
+     * scraped value is authoritative and gets distributed proportionally by content-length.
+     */
+    @Test fun `resolveTrackDurationsSec distributes scraped total by bytes when probes underestimate`() {
+        // Real-world fixture: barabanchik + duhyt_v_shisheto MP3 sizes and 128 kbps fallback probes.
+        val probes = listOf(
+            ChitankaCatalog.Companion.TrackProbe(probedSec = 760.1, bytes = 12_161_710L),  // ~half of real 1352s
+            ChitankaCatalog.Companion.TrackProbe(probedSec = 704.9, bytes = 11_279_141L),  // ~half of real 1264s
+        )
+        val scraped = 43.0 * 60.0
+        val result = ChitankaCatalog.resolveTrackDurationsSec(probes, scraped)
+        // Total must match scraped, distribution must be proportional to bytes.
+        assertEquals(scraped, result.sum(), 0.001)
+        val expectedFirst = scraped * 12_161_710.0 / (12_161_710.0 + 11_279_141.0)
+        assertEquals(expectedFirst, result[0], 0.001)
+    }
+
+    @Test fun `resolveTrackDurationsSec trusts probes when they match scraped total`() {
+        val probes = listOf(
+            ChitankaCatalog.Companion.TrackProbe(probedSec = 1352.9, bytes = 12_161_710L),
+            ChitankaCatalog.Companion.TrackProbe(probedSec = 1264.2, bytes = 11_279_141L),
+        )
+        val scraped = 43.0 * 60.0  // 2580 s; probes sum to 2617 s (>= 90% of scraped)
+        val result = ChitankaCatalog.resolveTrackDurationsSec(probes, scraped)
+        assertEquals(listOf(1352.9, 1264.2), result)
+    }
+
+    @Test fun `resolveTrackDurationsSec trusts probes when no scraped total is available`() {
+        val probes = listOf(
+            ChitankaCatalog.Companion.TrackProbe(probedSec = 1000.0, bytes = 0L),
+            ChitankaCatalog.Companion.TrackProbe(probedSec = 500.0, bytes = 0L),
+        )
+        val result = ChitankaCatalog.resolveTrackDurationsSec(probes, scrapedTotalSec = 0.0)
+        assertEquals(listOf(1000.0, 500.0), result)
+    }
+
+    @Test fun `resolveTrackDurationsSec distributes by bytes when probes all failed`() {
+        val probes = listOf(
+            ChitankaCatalog.Companion.TrackProbe(probedSec = null, bytes = 3_000_000L),
+            ChitankaCatalog.Companion.TrackProbe(probedSec = null, bytes = 1_000_000L),
+        )
+        val scraped = 400.0
+        val result = ChitankaCatalog.resolveTrackDurationsSec(probes, scraped)
+        assertEquals(300.0, result[0], 0.001)
+        assertEquals(100.0, result[1], 0.001)
+    }
+
+    @Test fun `resolveTrackDurationsSec falls back to CBR math when neither probe nor scraped total available`() {
+        val probes = listOf(
+            ChitankaCatalog.Companion.TrackProbe(probedSec = null, bytes = 128_000L),  // 8s at 128 kbps
+            ChitankaCatalog.Companion.TrackProbe(probedSec = 42.0, bytes = 0L),
+        )
+        val result = ChitankaCatalog.resolveTrackDurationsSec(probes, scrapedTotalSec = 0.0)
+        assertEquals(8.0, result[0], 0.001)
+        assertEquals(42.0, result[1], 0.001)
+    }
+
+    @Test fun `resolveTrackDurationsSec returns empty for empty input`() {
+        assertEquals(emptyList<Double>(), ChitankaCatalog.resolveTrackDurationsSec(emptyList(), 60.0))
+    }
+
     @Test fun `parseGramofoncheDurationSeconds returns zero when unknown`() {
         assertEquals(0.0, ChitankaCatalog.parseGramofoncheDurationSeconds(null), 0.0)
         assertEquals(0.0, ChitankaCatalog.parseGramofoncheDurationSeconds(""), 0.0)

--- a/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
+++ b/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
@@ -576,6 +576,25 @@ class ChitankaCatalogTest {
         assertEquals(42.0, result[1], 0.001)
     }
 
+    /**
+     * Regression: tier-3 fallback used to evaluate `null ?: (0*8/128k) = 0.0` for a track
+     * with a failed probe AND failed HEAD. A single 0-second track in the middle collapses
+     * cumulativeStart in [tracksFor] and breaks AudiobookTracks#trackAt for every later
+     * position. Fall back to the equal-share of the scraped total for those tracks.
+     */
+    @Test fun `resolveTrackDurationsSec never emits zero when scraped total is known`() {
+        val probes = listOf(
+            ChitankaCatalog.Companion.TrackProbe(probedSec = 300.0, bytes = 0L),
+            ChitankaCatalog.Companion.TrackProbe(probedSec = null, bytes = 0L),    // HEAD failed too
+            ChitankaCatalog.Companion.TrackProbe(probedSec = null, bytes = 128_000L),
+        )
+        val scraped = 900.0  // 15 min total
+        val result = ChitankaCatalog.resolveTrackDurationsSec(probes, scraped)
+        assertEquals(300.0, result[0], 0.001)
+        assertEquals(300.0, result[1], 0.001)  // equal share of 900 / 3 tracks
+        assertEquals(8.0, result[2], 0.001)    // 128000 * 8 / 128000
+    }
+
     @Test fun `resolveTrackDurationsSec returns empty for empty input`() {
         assertEquals(emptyList<Double>(), ChitankaCatalog.resolveTrackDurationsSec(emptyList(), 60.0))
     }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookChapterCacheRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookChapterCacheRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.riffle.core.database.AudiobookChapterCacheEntity
 import com.riffle.core.domain.AudiobookChapter
 import com.riffle.core.domain.AudiobookChapterCacheRepository
 import com.riffle.core.domain.Clock
+import com.riffle.core.domain.isDerivedCacheStale
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
@@ -21,8 +22,13 @@ class AudiobookChapterCacheRepositoryImpl @Inject constructor(
 
     override suspend fun getCachedChapters(sourceId: String, itemId: String): List<AudiobookChapter>? {
         val entity = dao.get(sourceId, itemId) ?: return null
-        if (clock.nowMs() - entity.cachedAt >= CACHE_TTL_MS) return null
-        return json.decodeFromString<List<AudiobookChapter>>(entity.chaptersJson)
+        if (isDerivedCacheStale(clock.nowMs(), entity.cachedAt)) return null
+        return decode(entity)
+    }
+
+    override suspend fun getStaleCachedChapters(sourceId: String, itemId: String): List<AudiobookChapter>? {
+        val entity = dao.get(sourceId, itemId) ?: return null
+        return decode(entity)
     }
 
     override suspend fun fetchAndCacheChapters(sourceId: String, itemId: String): List<AudiobookChapter> {
@@ -41,16 +47,6 @@ class AudiobookChapterCacheRepositoryImpl @Inject constructor(
         return chapters
     }
 
-    companion object {
-        /**
-         * How long a cached chapter list is trusted before we re-fetch. Chapter data changes
-         * rarely, so a week is comfortable for the steady state; the ceiling exists to give
-         * correctness fixes in `getAudiobookChapters` a bounded ride-along — the worst case
-         * for a user who hit a bad result is a one-week wait before the next open reruns the
-         * live probe. Existing rows written before the TTL migration have `cachedAt = 0` and
-         * are treated as maximally stale on the first read, so any fix rolled out with a bump
-         * of this class heals on next open regardless of TTL length.
-         */
-        internal const val CACHE_TTL_MS: Long = 7L * 24L * 60L * 60L * 1000L
-    }
+    private fun decode(entity: AudiobookChapterCacheEntity): List<AudiobookChapter> =
+        json.decodeFromString(entity.chaptersJson)
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookChapterCacheRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookChapterCacheRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.riffle.core.database.AudiobookChapterCacheDao
 import com.riffle.core.database.AudiobookChapterCacheEntity
 import com.riffle.core.domain.AudiobookChapter
 import com.riffle.core.domain.AudiobookChapterCacheRepository
+import com.riffle.core.domain.Clock
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
@@ -13,12 +14,14 @@ import javax.inject.Inject
 class AudiobookChapterCacheRepositoryImpl @Inject constructor(
     private val dao: AudiobookChapterCacheDao,
     private val catalogRegistry: CatalogRegistry,
+    private val clock: Clock,
 ) : AudiobookChapterCacheRepository {
 
     private val json = Json { ignoreUnknownKeys = true }
 
     override suspend fun getCachedChapters(sourceId: String, itemId: String): List<AudiobookChapter>? {
         val entity = dao.get(sourceId, itemId) ?: return null
+        if (clock.nowMs() - entity.cachedAt >= CACHE_TTL_MS) return null
         return json.decodeFromString<List<AudiobookChapter>>(entity.chaptersJson)
     }
 
@@ -27,7 +30,27 @@ class AudiobookChapterCacheRepositoryImpl @Inject constructor(
         val audioCap = catalog as? AudiobookMediaCapability ?: return emptyList()
         val chapters = runCatching { audioCap.getAudiobookChapters(itemId) }.getOrElse { return emptyList() }
             .map { c -> AudiobookChapter(index = c.index, startSec = c.startSec, endSec = c.endSec, title = c.title) }
-        dao.upsert(AudiobookChapterCacheEntity(sourceId, itemId, json.encodeToString(chapters)))
+        dao.upsert(
+            AudiobookChapterCacheEntity(
+                sourceId = sourceId,
+                itemId = itemId,
+                chaptersJson = json.encodeToString(chapters),
+                cachedAt = clock.nowMs(),
+            )
+        )
         return chapters
+    }
+
+    companion object {
+        /**
+         * How long a cached chapter list is trusted before we re-fetch. Chapter data changes
+         * rarely, so a week is comfortable for the steady state; the ceiling exists to give
+         * correctness fixes in `getAudiobookChapters` a bounded ride-along — the worst case
+         * for a user who hit a bad result is a one-week wait before the next open reruns the
+         * live probe. Existing rows written before the TTL migration have `cachedAt = 0` and
+         * are treated as maximally stale on the first read, so any fix rolled out with a bump
+         * of this class heals on next open regardless of TTL length.
+         */
+        internal const val CACHE_TTL_MS: Long = 7L * 24L * 60L * 60L * 1000L
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/TocRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/TocRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.riffle.core.data
 
 import com.riffle.core.database.TocCacheDao
 import com.riffle.core.database.TocCacheEntity
+import com.riffle.core.domain.Clock
 import com.riffle.core.domain.TocEntry
 import com.riffle.core.domain.TocRepository
 import kotlinx.serialization.encodeToString
@@ -10,12 +11,14 @@ import javax.inject.Inject
 
 class TocRepositoryImpl @Inject constructor(
     private val dao: TocCacheDao,
+    private val clock: Clock,
 ) : TocRepository {
 
     private val json = Json { ignoreUnknownKeys = true }
 
     override suspend fun getCachedToc(sourceId: String, itemId: String): Pair<String, List<TocEntry>>? {
         val entity = dao.get(sourceId, itemId) ?: return null
+        if (clock.nowMs() - entity.cachedAt >= CACHE_TTL_MS) return null
         val entries = json.decodeFromString<List<TocEntry>>(entity.entriesJson)
         return entity.ebookFileIno to entries
     }
@@ -26,6 +29,25 @@ class TocRepositoryImpl @Inject constructor(
         ebookFileIno: String,
         entries: List<TocEntry>,
     ) {
-        dao.upsert(TocCacheEntity(sourceId, itemId, ebookFileIno, json.encodeToString(entries)))
+        dao.upsert(
+            TocCacheEntity(
+                sourceId = sourceId,
+                itemId = itemId,
+                ebookFileIno = ebookFileIno,
+                entriesJson = json.encodeToString(entries),
+                cachedAt = clock.nowMs(),
+            )
+        )
+    }
+
+    companion object {
+        /**
+         * How long a cached TOC is trusted before we re-extract. Same rationale as
+         * [AudiobookChapterCacheRepositoryImpl.CACHE_TTL_MS] — bounded ride-along for
+         * derivation-logic fixes. Content changes still invalidate immediately via the
+         * ebookFileIno key mismatch in [ExtractEpubTocUseCase]; the TTL is for the case
+         * where the file is unchanged but our extraction produces a better result.
+         */
+        internal const val CACHE_TTL_MS: Long = 7L * 24L * 60L * 60L * 1000L
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/TocRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/TocRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.riffle.core.database.TocCacheEntity
 import com.riffle.core.domain.Clock
 import com.riffle.core.domain.TocEntry
 import com.riffle.core.domain.TocRepository
+import com.riffle.core.domain.isDerivedCacheStale
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
@@ -18,7 +19,7 @@ class TocRepositoryImpl @Inject constructor(
 
     override suspend fun getCachedToc(sourceId: String, itemId: String): Pair<String, List<TocEntry>>? {
         val entity = dao.get(sourceId, itemId) ?: return null
-        if (clock.nowMs() - entity.cachedAt >= CACHE_TTL_MS) return null
+        if (isDerivedCacheStale(clock.nowMs(), entity.cachedAt)) return null
         val entries = json.decodeFromString<List<TocEntry>>(entity.entriesJson)
         return entity.ebookFileIno to entries
     }
@@ -38,16 +39,5 @@ class TocRepositoryImpl @Inject constructor(
                 cachedAt = clock.nowMs(),
             )
         )
-    }
-
-    companion object {
-        /**
-         * How long a cached TOC is trusted before we re-extract. Same rationale as
-         * [AudiobookChapterCacheRepositoryImpl.CACHE_TTL_MS] — bounded ride-along for
-         * derivation-logic fixes. Content changes still invalidate immediately via the
-         * ebookFileIno key mismatch in [ExtractEpubTocUseCase]; the TTL is for the case
-         * where the file is unchanged but our extraction produces a better result.
-         */
-        internal const val CACHE_TTL_MS: Long = 7L * 24L * 60L * 60L * 1000L
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -93,6 +93,8 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_51_52,
                 RiffleDatabase.MIGRATION_52_53,
                 RiffleDatabase.MIGRATION_53_54,
+                RiffleDatabase.MIGRATION_54_55,
+                RiffleDatabase.MIGRATION_55_56,
             )
             .build()
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookChapterCacheRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookChapterCacheRepositoryImplTest.kt
@@ -20,6 +20,7 @@ import com.riffle.core.database.AudiobookChapterCacheEntity
 import com.riffle.core.domain.AudiobookChapter
 import com.riffle.core.domain.Source
 import com.riffle.core.domain.SourceType
+import com.riffle.core.domain.TestClock
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -27,6 +28,10 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 
 class AudiobookChapterCacheRepositoryImplTest {
+
+    private companion object {
+        const val NOW_MS: Long = 1_760_000_000_000L
+    }
 
     private class FakeAudiobookChapterCacheDao : AudiobookChapterCacheDao {
         val store = mutableMapOf<Pair<String, String>, AudiobookChapterCacheEntity>()
@@ -67,7 +72,7 @@ class AudiobookChapterCacheRepositoryImplTest {
     @Test
     fun `getCachedChapters returns null when no cache`() = runTest {
         val dao = FakeAudiobookChapterCacheDao()
-        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(null))
+        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(null), TestClock(NOW_MS))
 
         assertNull(repo.getCachedChapters("srv", "item"))
     }
@@ -76,8 +81,8 @@ class AudiobookChapterCacheRepositoryImplTest {
     fun `getCachedChapters returns deserialized chapters`() = runTest {
         val dao = FakeAudiobookChapterCacheDao()
         val json = """[{"index":0,"startSec":0.0,"endSec":300.0,"title":"Intro"}]"""
-        dao.store["srv" to "item"] = AudiobookChapterCacheEntity("srv", "item", json)
-        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(null))
+        dao.store["srv" to "item"] = AudiobookChapterCacheEntity("srv", "item", json, cachedAt = NOW_MS)
+        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(null), TestClock(NOW_MS))
 
         val result = repo.getCachedChapters("srv", "item")
         assertNotNull(result)
@@ -90,7 +95,7 @@ class AudiobookChapterCacheRepositoryImplTest {
     fun `fetchAndCacheChapters calls catalog, maps chapters, and upserts`() = runTest {
         val dao = FakeAudiobookChapterCacheDao()
         val catalog = FakeCatalog(listOf(CatalogAudiobookChapter(0, 0.0, 600.0, "Ch 1")))
-        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(catalog))
+        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(catalog), TestClock(NOW_MS))
 
         val result = repo.fetchAndCacheChapters("srv", "item")
 
@@ -109,12 +114,69 @@ class AudiobookChapterCacheRepositoryImplTest {
     @Test
     fun `fetchAndCacheChapters returns empty list on network error`() = runTest {
         val dao = FakeAudiobookChapterCacheDao()
-        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(FakeCatalog(chapters = null, fail = true)))
+        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(FakeCatalog(chapters = null, fail = true)), TestClock(NOW_MS))
 
         val result = repo.fetchAndCacheChapters("srv", "item")
 
         assertEquals(emptyList<AudiobookChapter>(), result)
         assert(!dao.upsertCalled) { "dao.upsert should NOT have been called on error" }
+    }
+
+    /**
+     * Regression: chapter cache used to live forever, so a buggy `getAudiobookChapters`
+     * result (e.g. Gramofonche chapters at half real length before the 128 kbps fallback
+     * fix) stuck on-device with no self-heal. TTL rejects rows older than
+     * [AudiobookChapterCacheRepositoryImpl.CACHE_TTL_MS] so the next open re-fetches.
+     */
+    @Test
+    fun `getCachedChapters returns null when entry is older than TTL`() = runTest {
+        val dao = FakeAudiobookChapterCacheDao()
+        val json = """[{"index":0,"startSec":0.0,"endSec":300.0,"title":"Stale"}]"""
+        val cachedAt = NOW_MS - AudiobookChapterCacheRepositoryImpl.CACHE_TTL_MS - 1
+        dao.store["srv" to "item"] = AudiobookChapterCacheEntity("srv", "item", json, cachedAt)
+        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(null), TestClock(NOW_MS))
+
+        assertNull(repo.getCachedChapters("srv", "item"))
+    }
+
+    @Test
+    fun `getCachedChapters returns cached entry right at the TTL boundary`() = runTest {
+        val dao = FakeAudiobookChapterCacheDao()
+        val json = """[{"index":0,"startSec":0.0,"endSec":300.0,"title":"Fresh"}]"""
+        val cachedAt = NOW_MS - AudiobookChapterCacheRepositoryImpl.CACHE_TTL_MS + 1
+        dao.store["srv" to "item"] = AudiobookChapterCacheEntity("srv", "item", json, cachedAt)
+        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(null), TestClock(NOW_MS))
+
+        val result = repo.getCachedChapters("srv", "item")
+        assertNotNull(result)
+        assertEquals("Fresh", result!![0].title)
+    }
+
+    /**
+     * Existing rows migrated from the pre-TTL schema carry `cachedAt = 0` (DEFAULT 0 in
+     * MIGRATION_54_55). They must be treated as maximally stale so any pre-existing bad
+     * cache heals on next open — the whole reason we're shipping the TTL alongside the
+     * Gramofonche chapter-duration fix.
+     */
+    @Test
+    fun `getCachedChapters treats migrated rows with cachedAt=0 as stale`() = runTest {
+        val dao = FakeAudiobookChapterCacheDao()
+        val json = """[{"index":0,"startSec":0.0,"endSec":300.0,"title":"Pre-migration"}]"""
+        dao.store["srv" to "item"] = AudiobookChapterCacheEntity("srv", "item", json, cachedAt = 0L)
+        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(null), TestClock(NOW_MS))
+
+        assertNull(repo.getCachedChapters("srv", "item"))
+    }
+
+    @Test
+    fun `fetchAndCacheChapters stamps cachedAt with the current clock`() = runTest {
+        val dao = FakeAudiobookChapterCacheDao()
+        val catalog = FakeCatalog(listOf(CatalogAudiobookChapter(0, 0.0, 60.0, "One")))
+        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(catalog), TestClock(NOW_MS))
+
+        repo.fetchAndCacheChapters("srv", "item")
+
+        assertEquals(NOW_MS, dao.store["srv" to "item"]!!.cachedAt)
     }
 
     @Test
@@ -124,7 +186,7 @@ class AudiobookChapterCacheRepositoryImplTest {
             CatalogAudiobookChapter(0, 0.0, 300.0, "Prologue"),
             CatalogAudiobookChapter(1, 300.0, 900.0, "Chapter 1"),
         ))
-        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(catalog))
+        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(catalog), TestClock(NOW_MS))
 
         repo.fetchAndCacheChapters("srv", "item")
         val cached = repo.getCachedChapters("srv", "item")

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookChapterCacheRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookChapterCacheRepositoryImplTest.kt
@@ -126,13 +126,13 @@ class AudiobookChapterCacheRepositoryImplTest {
      * Regression: chapter cache used to live forever, so a buggy `getAudiobookChapters`
      * result (e.g. Gramofonche chapters at half real length before the 128 kbps fallback
      * fix) stuck on-device with no self-heal. TTL rejects rows older than
-     * [AudiobookChapterCacheRepositoryImpl.CACHE_TTL_MS] so the next open re-fetches.
+     * [com.riffle.core.domain.DERIVED_CACHE_TTL_MS] so the next open re-fetches.
      */
     @Test
     fun `getCachedChapters returns null when entry is older than TTL`() = runTest {
         val dao = FakeAudiobookChapterCacheDao()
         val json = """[{"index":0,"startSec":0.0,"endSec":300.0,"title":"Stale"}]"""
-        val cachedAt = NOW_MS - AudiobookChapterCacheRepositoryImpl.CACHE_TTL_MS - 1
+        val cachedAt = NOW_MS - com.riffle.core.domain.DERIVED_CACHE_TTL_MS - 1
         dao.store["srv" to "item"] = AudiobookChapterCacheEntity("srv", "item", json, cachedAt)
         val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(null), TestClock(NOW_MS))
 
@@ -143,7 +143,7 @@ class AudiobookChapterCacheRepositoryImplTest {
     fun `getCachedChapters returns cached entry right at the TTL boundary`() = runTest {
         val dao = FakeAudiobookChapterCacheDao()
         val json = """[{"index":0,"startSec":0.0,"endSec":300.0,"title":"Fresh"}]"""
-        val cachedAt = NOW_MS - AudiobookChapterCacheRepositoryImpl.CACHE_TTL_MS + 1
+        val cachedAt = NOW_MS - com.riffle.core.domain.DERIVED_CACHE_TTL_MS + 1
         dao.store["srv" to "item"] = AudiobookChapterCacheEntity("srv", "item", json, cachedAt)
         val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(null), TestClock(NOW_MS))
 
@@ -166,6 +166,48 @@ class AudiobookChapterCacheRepositoryImplTest {
         val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(null), TestClock(NOW_MS))
 
         assertNull(repo.getCachedChapters("srv", "item"))
+    }
+
+    /**
+     * A rolled-back device wall clock (manual set, NTP glitch) makes `now - cachedAt`
+     * negative. The stale check must treat that as stale so a bad row can't be pinned
+     * fresh indefinitely — otherwise a future correctness fix never reaches the user.
+     */
+    @Test
+    fun `getCachedChapters treats a backward clock jump as stale`() = runTest {
+        val dao = FakeAudiobookChapterCacheDao()
+        val json = """[{"index":0,"startSec":0.0,"endSec":300.0,"title":"Future-stamped"}]"""
+        dao.store["srv" to "item"] = AudiobookChapterCacheEntity("srv", "item", json, cachedAt = NOW_MS + 60_000L)
+        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(null), TestClock(NOW_MS))
+
+        assertNull(repo.getCachedChapters("srv", "item"))
+    }
+
+    /**
+     * TTL turns [getCachedChapters] into a stale-nulling read. [getStaleCachedChapters] is the
+     * stale-safe accessor that offline callers (FetchAudiobookChaptersUseCase's last-resort
+     * tier) fall back to so a week-old cache still beats an empty chapter list.
+     */
+    @Test
+    fun `getStaleCachedChapters returns row regardless of TTL`() = runTest {
+        val dao = FakeAudiobookChapterCacheDao()
+        val json = """[{"index":0,"startSec":0.0,"endSec":300.0,"title":"Stale"}]"""
+        val cachedAt = NOW_MS - com.riffle.core.domain.DERIVED_CACHE_TTL_MS - 1
+        dao.store["srv" to "item"] = AudiobookChapterCacheEntity("srv", "item", json, cachedAt)
+        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(null), TestClock(NOW_MS))
+
+        assertNull(repo.getCachedChapters("srv", "item"))
+        val stale = repo.getStaleCachedChapters("srv", "item")
+        assertNotNull(stale)
+        assertEquals("Stale", stale!![0].title)
+    }
+
+    @Test
+    fun `getStaleCachedChapters returns null when no row exists`() = runTest {
+        val dao = FakeAudiobookChapterCacheDao()
+        val repo = AudiobookChapterCacheRepositoryImpl(dao, FakeRegistry(null), TestClock(NOW_MS))
+
+        assertNull(repo.getStaleCachedChapters("srv", "item"))
     }
 
     @Test

--- a/core/data/src/test/kotlin/com/riffle/core/data/TocRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/TocRepositoryImplTest.kt
@@ -2,6 +2,7 @@ package com.riffle.core.data
 
 import com.riffle.core.database.TocCacheDao
 import com.riffle.core.database.TocCacheEntity
+import com.riffle.core.domain.TestClock
 import com.riffle.core.domain.TocEntry
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -10,6 +11,10 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 
 class TocRepositoryImplTest {
+
+    private companion object {
+        const val NOW_MS: Long = 1_760_000_000_000L
+    }
 
     private class FakeTocCacheDao : TocCacheDao {
         val store = mutableMapOf<Pair<String, String>, TocCacheEntity>()
@@ -23,7 +28,7 @@ class TocRepositoryImplTest {
     @Test
     fun `getCachedToc returns null when no entry in dao`() = runTest {
         val dao = FakeTocCacheDao()
-        val repo = TocRepositoryImpl(dao)
+        val repo = TocRepositoryImpl(dao, TestClock(NOW_MS))
         assertNull(repo.getCachedToc("srv", "item"))
     }
 
@@ -31,8 +36,8 @@ class TocRepositoryImplTest {
     fun `getCachedToc returns inode and parsed entries`() = runTest {
         val dao = FakeTocCacheDao()
         val json = """[{"title":"Chapter 1","href":"ch1.html","children":[]}]"""
-        dao.store["srv" to "item"] = TocCacheEntity("srv", "item", "ino42", json)
-        val repo = TocRepositoryImpl(dao)
+        dao.store["srv" to "item"] = TocCacheEntity("srv", "item", "ino42", json, cachedAt = NOW_MS)
+        val repo = TocRepositoryImpl(dao, TestClock(NOW_MS))
 
         val result = repo.getCachedToc("srv", "item")
         assertNotNull(result)
@@ -45,7 +50,7 @@ class TocRepositoryImplTest {
     @Test
     fun `saveToc upserts with correct inode and serialized JSON`() = runTest {
         val dao = FakeTocCacheDao()
-        val repo = TocRepositoryImpl(dao)
+        val repo = TocRepositoryImpl(dao, TestClock(NOW_MS))
         val entries = listOf(TocEntry("Ch 1", "c1.html"), TocEntry("Ch 2", "c2.html"))
 
         repo.saveToc("srv", "item", "ino99", entries)
@@ -55,6 +60,7 @@ class TocRepositoryImplTest {
         assertEquals("srv", entity!!.sourceId)
         assertEquals("item", entity.itemId)
         assertEquals("ino99", entity.ebookFileIno)
+        assertEquals(NOW_MS, entity.cachedAt)
         assert(entity.entriesJson.contains("Ch 1")) { "JSON should contain 'Ch 1'" }
         assert(entity.entriesJson.contains("Ch 2")) { "JSON should contain 'Ch 2'" }
     }
@@ -62,7 +68,7 @@ class TocRepositoryImplTest {
     @Test
     fun `saveToc then getCachedToc round-trips entries`() = runTest {
         val dao = FakeTocCacheDao()
-        val repo = TocRepositoryImpl(dao)
+        val repo = TocRepositoryImpl(dao, TestClock(NOW_MS))
         val entries = listOf(
             TocEntry("Part I", "part1.html", listOf(TocEntry("Chapter 1", "ch1.html"))),
             TocEntry("Part II", "part2.html"),
@@ -78,5 +84,37 @@ class TocRepositoryImplTest {
         assertEquals(1, result.second[0].children.size)
         assertEquals("Chapter 1", result.second[0].children[0].title)
         assertEquals("Part II", result.second[1].title)
+    }
+
+    /**
+     * Regression: TOC cache used to live forever (only invalidated by ebookFileIno change),
+     * so a derivation-logic bug in [ExtractEpubTocUseCase] would stick on-device even after
+     * a fix shipped. TTL rejects rows older than [TocRepositoryImpl.CACHE_TTL_MS] so the
+     * next open re-extracts.
+     */
+    @Test
+    fun `getCachedToc returns null when entry is older than TTL`() = runTest {
+        val dao = FakeTocCacheDao()
+        val json = """[{"title":"Stale","href":"s.html","children":[]}]"""
+        val cachedAt = NOW_MS - TocRepositoryImpl.CACHE_TTL_MS - 1
+        dao.store["srv" to "item"] = TocCacheEntity("srv", "item", "ino", json, cachedAt)
+        val repo = TocRepositoryImpl(dao, TestClock(NOW_MS))
+
+        assertNull(repo.getCachedToc("srv", "item"))
+    }
+
+    /**
+     * Existing rows migrated from the pre-TTL schema carry `cachedAt = 0` (DEFAULT 0 in
+     * MIGRATION_55_56). They must be treated as maximally stale so any pre-existing bad
+     * TOC heals on next open.
+     */
+    @Test
+    fun `getCachedToc treats migrated rows with cachedAt=0 as stale`() = runTest {
+        val dao = FakeTocCacheDao()
+        val json = """[{"title":"Pre-migration","href":"p.html","children":[]}]"""
+        dao.store["srv" to "item"] = TocCacheEntity("srv", "item", "ino", json, cachedAt = 0L)
+        val repo = TocRepositoryImpl(dao, TestClock(NOW_MS))
+
+        assertNull(repo.getCachedToc("srv", "item"))
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/TocRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/TocRepositoryImplTest.kt
@@ -89,14 +89,14 @@ class TocRepositoryImplTest {
     /**
      * Regression: TOC cache used to live forever (only invalidated by ebookFileIno change),
      * so a derivation-logic bug in [ExtractEpubTocUseCase] would stick on-device even after
-     * a fix shipped. TTL rejects rows older than [TocRepositoryImpl.CACHE_TTL_MS] so the
+     * a fix shipped. TTL rejects rows older than [com.riffle.core.domain.DERIVED_CACHE_TTL_MS] so the
      * next open re-extracts.
      */
     @Test
     fun `getCachedToc returns null when entry is older than TTL`() = runTest {
         val dao = FakeTocCacheDao()
         val json = """[{"title":"Stale","href":"s.html","children":[]}]"""
-        val cachedAt = NOW_MS - TocRepositoryImpl.CACHE_TTL_MS - 1
+        val cachedAt = NOW_MS - com.riffle.core.domain.DERIVED_CACHE_TTL_MS - 1
         dao.store["srv" to "item"] = TocCacheEntity("srv", "item", "ino", json, cachedAt)
         val repo = TocRepositoryImpl(dao, TestClock(NOW_MS))
 

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/55.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/55.json
@@ -1,0 +1,1744 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 55,
+    "identityHash": "b04478862245a9d7e51d0a2cd214ff1f",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER NOT NULL, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, `pageCount` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesSequence",
+            "columnName": "seriesSequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "scope"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, `originFontFamily` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedFigures",
+            "columnName": "embeddedFigures",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageHref",
+            "columnName": "imageHref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageSvg",
+            "columnName": "imageSvg",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBytes",
+            "columnName": "imageBytes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originFontFamily",
+            "columnName": "originFontFamily",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "local_files_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `treeUri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `addedAtEpochMs` INTEGER NOT NULL, `libraryId` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `treeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtEpochMs",
+            "columnName": "addedAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "treeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `originalUri` TEXT NOT NULL, `copiedPath` TEXT NOT NULL, `coverPath` TEXT, `format` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `mtimeEpochMs` INTEGER NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUri",
+            "columnName": "originalUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "copiedPath",
+            "columnName": "copiedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtimeEpochMs",
+            "columnName": "mtimeEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_files_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_file_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `folderTreeUri` TEXT NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`, `folderTreeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderTreeUri",
+            "columnName": "folderTreeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId",
+            "folderTreeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_file_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_local_files_file_folders_sourceId_folderTreeUri",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "folderTreeUri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId_folderTreeUri` ON `${TABLE_NAME}` (`sourceId`, `folderTreeUri`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_item_freshness",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `lastFetchedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFetchedAt",
+            "columnName": "lastFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b04478862245a9d7e51d0a2cd214ff1f')"
+    ]
+  }
+}

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/56.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/56.json
@@ -1,0 +1,1750 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 56,
+    "identityHash": "a0881a4f8d60d8168ddaaf518f74c139",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER NOT NULL, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, `pageCount` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesSequence",
+            "columnName": "seriesSequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "scope"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, `originFontFamily` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedFigures",
+            "columnName": "embeddedFigures",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageHref",
+            "columnName": "imageHref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageSvg",
+            "columnName": "imageSvg",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBytes",
+            "columnName": "imageBytes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originFontFamily",
+            "columnName": "originFontFamily",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "local_files_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `treeUri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `addedAtEpochMs` INTEGER NOT NULL, `libraryId` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `treeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtEpochMs",
+            "columnName": "addedAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "treeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `originalUri` TEXT NOT NULL, `copiedPath` TEXT NOT NULL, `coverPath` TEXT, `format` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `mtimeEpochMs` INTEGER NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUri",
+            "columnName": "originalUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "copiedPath",
+            "columnName": "copiedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtimeEpochMs",
+            "columnName": "mtimeEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_files_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_file_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `folderTreeUri` TEXT NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`, `folderTreeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderTreeUri",
+            "columnName": "folderTreeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId",
+            "folderTreeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_file_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_local_files_file_folders_sourceId_folderTreeUri",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "folderTreeUri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId_folderTreeUri` ON `${TABLE_NAME}` (`sourceId`, `folderTreeUri`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_item_freshness",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `lastFetchedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFetchedAt",
+            "columnName": "lastFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a0881a4f8d60d8168ddaaf518f74c139')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1919,7 +1919,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 54, true,
+            TEST_DB, 56, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -1973,6 +1973,8 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_51_52,
             RiffleDatabase.MIGRATION_52_53,
             RiffleDatabase.MIGRATION_53_54,
+            RiffleDatabase.MIGRATION_54_55,
+            RiffleDatabase.MIGRATION_55_56,
         )
 
         db.query("SELECT url, username, serverType, absUserId, type FROM sources WHERE id = 's1'").use { cursor ->
@@ -2498,6 +2500,86 @@ class MigrationTest {
         db.query("SELECT COUNT(*) FROM remote_item_freshness").use { c ->
             assertTrue(c.moveToFirst())
             assertEquals(0, c.getInt(0))
+        }
+
+        db.close()
+    }
+
+    // Same TTL shape as MIGRATION_54_55 but on `toc_cache`. Content-change invalidation
+    // via ebookFileIno already existed; the TTL is the ride-along for derivation-logic
+    // fixes (Readium TOC parser bugs, etc.). Pre-existing rows carry cachedAt=0 and heal
+    // on next open.
+    @Test
+    fun migration55To56_addsCachedAtToTocCache() {
+        helper.createDatabase(TEST_DB, 55).apply {
+            execSQL(
+                "INSERT INTO toc_cache (sourceId, itemId, ebookFileIno, entriesJson) " +
+                    "VALUES ('src1', 'item1', 'ino42', '[{\"title\":\"Ch\",\"href\":\"c.html\",\"children\":[]}]')"
+            )
+            close()
+        }
+        val db = helper.runMigrationsAndValidate(TEST_DB, 56, true, RiffleDatabase.MIGRATION_55_56)
+
+        db.query(
+            "SELECT ebookFileIno, entriesJson, cachedAt FROM toc_cache " +
+                "WHERE sourceId = 'src1' AND itemId = 'item1'"
+        ).use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals("ino42", c.getString(0))
+            assertTrue("entriesJson blob preserved", c.getString(1).contains("Ch"))
+            assertEquals(0L, c.getLong(2))
+        }
+
+        db.execSQL(
+            "INSERT INTO toc_cache (sourceId, itemId, ebookFileIno, entriesJson, cachedAt) " +
+                "VALUES ('src1', 'item2', 'ino99', '[]', 1760000000000)"
+        )
+        db.query(
+            "SELECT cachedAt FROM toc_cache WHERE sourceId = 'src1' AND itemId = 'item2'"
+        ).use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals(1_760_000_000_000L, c.getLong(0))
+        }
+
+        db.close()
+    }
+
+    // TTL on the audiobook chapter cache. Adds `cachedAt INTEGER NOT NULL DEFAULT 0`; existing
+    // rows land with cachedAt=0 so the repository treats them as maximally stale and re-fetches
+    // on next open — the one-shot purge that ships alongside the Gramofonche chapter-duration
+    // fix. Pre-existing chapter blobs must survive; new writes must record the timestamp.
+    @Test
+    fun migration54To55_addsCachedAtToAudiobookChapterCache() {
+        helper.createDatabase(TEST_DB, 54).apply {
+            execSQL(
+                "INSERT INTO audiobook_chapter_cache (sourceId, itemId, chaptersJson) " +
+                    "VALUES ('chi1', 'baa1831', '[{\"index\":0,\"startSec\":0.0,\"endSec\":700.0,\"title\":\"Stale\"}]')"
+            )
+            close()
+        }
+        val db = helper.runMigrationsAndValidate(TEST_DB, 55, true, RiffleDatabase.MIGRATION_54_55)
+
+        // Pre-existing row survives, cachedAt defaults to 0.
+        db.query(
+            "SELECT chaptersJson, cachedAt FROM audiobook_chapter_cache " +
+                "WHERE sourceId = 'chi1' AND itemId = 'baa1831'"
+        ).use { c ->
+            assertTrue(c.moveToFirst())
+            assertTrue("chaptersJson blob preserved", c.getString(0).contains("Stale"))
+            assertEquals(0L, c.getLong(1))
+        }
+
+        // New writes carry the timestamp.
+        db.execSQL(
+            "INSERT INTO audiobook_chapter_cache (sourceId, itemId, chaptersJson, cachedAt) " +
+                "VALUES ('chi1', 'baa9999', '[]', 1760000000000)"
+        )
+        db.query(
+            "SELECT cachedAt FROM audiobook_chapter_cache " +
+                "WHERE sourceId = 'chi1' AND itemId = 'baa9999'"
+        ).use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals(1_760_000_000_000L, c.getLong(0))
         }
 
         db.close()

--- a/core/database/src/main/kotlin/com/riffle/core/database/AudiobookChapterCacheEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AudiobookChapterCacheEntity.kt
@@ -7,4 +7,5 @@ data class AudiobookChapterCacheEntity(
     val sourceId: String,
     val itemId: String,
     val chaptersJson: String,  // JSON-serialized List<AudiobookChapter>
+    val cachedAt: Long,        // wall-clock millis when this row was written; drives TTL
 )

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -32,7 +32,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         LocalFilesFileFolderEntity::class,
         RemoteItemFreshnessEntity::class,
     ],
-    version = 54,
+    version = 56,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -1544,6 +1544,33 @@ abstract class RiffleDatabase : RoomDatabase() {
                         "`lastFetchedAt` INTEGER NOT NULL, " +
                         "PRIMARY KEY(`sourceId`, `sourceItemId`), " +
                         "FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+                )
+            }
+        }
+
+        // TTL bit on the audiobook chapter cache. Rows previously lived forever, so a bad
+        // getAudiobookChapters result (e.g. the Gramofonche 128 kbps mis-derivation that
+        // shipped chapters at half their real length) stuck on-device with no self-heal
+        // path. Add a `cachedAt` timestamp; the repository treats rows older than its TTL
+        // as absent and re-fetches. Default 0 means every pre-existing row is considered
+        // maximally stale and refreshes on next open — the desired one-shot cache purge
+        // for the Gramofonche fix.
+        val MIGRATION_54_55 = object : Migration(54, 55) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE `audiobook_chapter_cache` ADD COLUMN `cachedAt` INTEGER NOT NULL DEFAULT 0"
+                )
+            }
+        }
+
+        // Same TTL pattern for `toc_cache` — its twin. Content-change invalidation via
+        // `ebookFileIno` catches "the file changed under us," but a derivation-logic fix
+        // (say, a Readium TOC parser bug) would otherwise stick forever for anyone who
+        // opened the book before the fix. Default 0 forces re-extraction on next open.
+        val MIGRATION_55_56 = object : Migration(55, 56) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "ALTER TABLE `toc_cache` ADD COLUMN `cachedAt` INTEGER NOT NULL DEFAULT 0"
                 )
             }
         }

--- a/core/database/src/main/kotlin/com/riffle/core/database/TocCacheEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/TocCacheEntity.kt
@@ -8,4 +8,5 @@ data class TocCacheEntity(
     val itemId: String,
     val ebookFileIno: String,
     val entriesJson: String,  // JSON-serialized List<TocEntry>
+    val cachedAt: Long,       // wall-clock millis when this row was written; drives TTL
 )

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookChapterCacheRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AudiobookChapterCacheRepository.kt
@@ -1,7 +1,21 @@
 package com.riffle.core.domain
 
 interface AudiobookChapterCacheRepository {
+    /**
+     * Returns the cached chapters when the row is present and fresh under
+     * [DERIVED_CACHE_TTL_MS]. Returns null when the row is missing OR stale; callers
+     * that want the stale-safe fallback (e.g. offline flows where a live fetch just
+     * failed) should use [getStaleCachedChapters] as a last resort.
+     */
     suspend fun getCachedChapters(sourceId: String, itemId: String): List<AudiobookChapter>?
+
+    /**
+     * Returns whatever is in the cache regardless of freshness — or null if there's no
+     * row at all. The stale-safe fallback for offline flows where a live fetch has
+     * already failed: a week-old cache is still better than an empty chapter list, and
+     * losing it would defeat the whole purpose of caching.
+     */
+    suspend fun getStaleCachedChapters(sourceId: String, itemId: String): List<AudiobookChapter>?
 
     /**
      * Fetch chapter markers for [itemId] from the Source identified by [sourceId] and upsert them

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/DerivedCacheTtl.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/DerivedCacheTtl.kt
@@ -1,0 +1,25 @@
+package com.riffle.core.domain
+
+/**
+ * Shared TTL for derived-data caches (TOC, audiobook chapters). Chapter and TOC data
+ * change rarely, so a week is comfortable for the steady state; the ceiling exists to
+ * give a correctness fix in the underlying derivation (Readium TOC parser, Gramofonche
+ * chapter probes, etc.) a bounded ride-along — the worst case for a user who hit a bad
+ * result is a one-week wait before the next open reruns the live extraction.
+ *
+ * Kept as a single constant so a future tune (jitter, incident-driven bump) applies to
+ * every derived cache at once. Pre-migration rows with `cachedAt = 0` are treated as
+ * maximally stale on first read regardless of TTL length.
+ */
+const val DERIVED_CACHE_TTL_MS: Long = 7L * 24L * 60L * 60L * 1000L
+
+/**
+ * Returns true when a row with the given [cachedAt] wall-clock stamp should be treated
+ * as stale under [DERIVED_CACHE_TTL_MS] given the current time [nowMs]. Also invalidates
+ * on a negative diff (backward clock jump — device time set manually or NTP glitch)
+ * so a rolled-back clock can't pin a bad row alive indefinitely.
+ */
+fun isDerivedCacheStale(nowMs: Long, cachedAt: Long): Boolean {
+    val ageMs = nowMs - cachedAt
+    return ageMs < 0 || ageMs >= DERIVED_CACHE_TTL_MS
+}


### PR DESCRIPTION
## Summary

Two related fixes triggered by a Gramofonche audiobook whose chapter drawer summed to 25 min for a 43 min book (`barabanchik--duhyt-v-shisheto--baa1831`).

### 1. Chapter-duration bug (`fix(chitanka): ...`)

`ChitankaCatalog.tracksFor` was falling through to a hardcoded 128 kbps CBR fallback in `probeMp3DurationSec` for Gramofonche's ~72 kbps VBR files, halving every per-track duration. New `resolveTrackDurationsSec` helper picks per-track durations with a three-tier preference:

1. Probes when they at least reach 90 % of the scraped total.
2. Scraped total distributed proportionally by content-length (the recovery path for VBR probes that underestimate).
3. Per-track `probed ?: bytes*8/128k`, with an equal-share-of-scraped fallback for tracks with no signal at all.

Also skips the per-track HEAD entirely on the healthy probe path (tier 1) — was regressing the happy path by N round-trips per open.

### 2. Derived-cache TTL (`feat(cache): ...`)

Both `audiobook_chapter_cache` and `toc_cache` used to live forever, so the fix above wouldn't have reached users who'd already opened the affected book. Add a `cachedAt` column to both tables; treat rows older than `DERIVED_CACHE_TTL_MS` (7 days) as absent. Migration defaults `cachedAt = 0` so every pre-existing row is maximally stale on first read — the one-shot purge that ships alongside the Gramofonche fix.

Shared `isDerivedCacheStale` helper (in `core:domain`) also invalidates on a backward wall-clock jump so a rolled-back device time can't pin a bad row alive.

### 3. Offline safety

`FetchAudiobookChaptersUseCase` now tries fresh → live → stale before giving up. A week-old row on the plane still beats an empty chapter list.

## Not in scope
- `cross_epub_index` is a content-hash-addressed memoization; a derivation-logic fix there would need a version byte in the key. Flagged for a follow-up.
- `EpubReaderViewModel.kt:993` reads TOC via `getCachedToc(...)?.second.orEmpty()` with no local re-extract; a stale row causes elided chapter titles to degrade to href-derived titles until another reader path re-extracts. Minor UX regression, other flows heal it.

## Test plan
- [x] `:core:catalog-chitanka:test` green (chitanka + 8 new resolver tests, including the multi-signal tier-3 zero-duration regression)
- [x] `:core:data:testDebugUnitTest` green (repo TTL + stale + backward-clock tests)
- [x] `:app:testDebugUnitTest` green (use-case stale-fallback tiers)
- [x] `:core:database:test` green
- [x] `:app:assembleDebug` green, verified on AVD: chapters now read 23m / 21m (was 13m / 12m), summing to the scraped 43m
- [ ] `:core:database:connectedAndroidTest` (`MigrationTest`) — new step + full-chain tests exist; needs harness run before merge