### PR TITLE
fix(reader): close formatting sheet on Back instead of exiting the book

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderSettingsSheetCapabilitiesTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderSettingsSheetCapabilitiesTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.riffle.app.feature.reader.formatting.RenderCapabilities
 import com.riffle.core.domain.FormattingPreferences
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -80,5 +81,24 @@ class ReaderSettingsSheetCapabilitiesTest {
         composeTestRule.onNodeWithText("Theme").assertIsDisplayed()
         composeTestRule.onNodeWithText("Current chapter label").assertIsDisplayed()
         composeTestRule.onNodeWithText("Time remaining").assertIsDisplayed()
+    }
+
+    @Test
+    fun backPress_invokesOnDismiss_insteadOfPoppingReader() {
+        var dismissed = false
+        composeTestRule.setContent {
+            ReaderSettingsSheet(
+                prefs = FormattingPreferences(),
+                capabilities = RenderCapabilities.EPUB,
+                hasBookOverrides = false,
+                onPrefsChange = {}, onReset = {}, onDismiss = { dismissed = true },
+                keepScreenOn = false, onKeepScreenOnChange = {},
+                volumeKeyNavigationEnabled = false, onVolumeKeyNavigationEnabledChange = {},
+                invertVolumeKeys = false, onInvertVolumeKeysChange = {},
+            )
+        }
+        composeTestRule.activity.onBackPressedDispatcher.onBackPressed()
+        composeTestRule.waitForIdle()
+        assertTrue("Back press while sheet is open must invoke onDismiss", dismissed)
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsSheet.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.reader
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -55,6 +56,8 @@ fun ReaderSettingsSheet(
 ) {
     val tabs = listOf("Formatting", "Display", "Behavior")
     var selectedTab by remember { mutableIntStateOf(0) }
+
+    BackHandler(onBack = onDismiss)
 
     Box(modifier = Modifier.fillMaxSize()) {
         // Tap-catcher above the sheet dismisses; reader pane stays visible to preview changes.


### PR DESCRIPTION
## Summary

When the reader's formatting sheet (Aa panel) was open, pressing the system Back button popped the whole reader out of the book instead of just closing the sheet.

`ReaderSettingsSheet` had no `BackHandler`, so Back propagated to the NavHost. This fix registers a `BackHandler(onBack = onDismiss)` at the top of the composable, so Back dismisses the sheet whenever it is composed. Applies to both EPUB and PDF readers since they share the sheet.

## Test plan

- [x] New instrumentation test `backPress_invokesOnDismiss_insteadOfPoppingReader` in `ReaderSettingsSheetCapabilitiesTest` renders the sheet, dispatches Back via the activity's `onBackPressedDispatcher`, and asserts `onDismiss` fires. Reverting the `BackHandler` line makes it flip red.
- [ ] Manual: open a book → tap Aa → press system Back → sheet closes, book stays open.