### PR TITLE
fix(audiobook): stop seek bar blinking on track-crossing rewind

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -102,6 +102,8 @@ open class AudiobookController @Inject constructor(
     // left" subtitle updates at most once per minute regardless of poll cadence.
     private var lastRemainingMinuteBucket: Long = -1L
 
+    private val pendingSeek = PendingSeekGate()
+
     private val listener = object : Player.Listener {
         override fun onEvents(player: Player, events: Player.Events) {
             if (events.containsAny(Player.EVENT_PLAYBACK_STATE_CHANGED, Player.EVENT_IS_PLAYING_CHANGED)) {
@@ -110,6 +112,9 @@ open class AudiobookController @Inject constructor(
             if (events.contains(Player.EVENT_PLAYBACK_STATE_CHANGED)
                 && player.playbackState == Player.STATE_ENDED) {
                 _playbackEnded.tryEmit(Unit)
+            }
+            if (events.contains(Player.EVENT_POSITION_DISCONTINUITY)) {
+                pendingSeek.onDiscontinuity()
             }
             maybeStart(player)
             pushState()
@@ -254,6 +259,7 @@ open class AudiobookController @Inject constructor(
         val clamped = absoluteSec.coerceIn(0.0, if (durationSec > 0) durationSec else absoluteSec)
         val index = AudiobookTracks.trackIndexAt(clamped, spans)
         val offset = AudiobookTracks.offsetInTrackSec(clamped, spans)
+        pendingSeek.onSeekIssued(clamped)
         controller?.seekTo(index, (offset * 1000).toLong())
         pushState()
     }
@@ -269,7 +275,7 @@ open class AudiobookController @Inject constructor(
     // track 0 and inflates the displayed position past durationSec (e.g. 19:56 books reading 27:50+).
     open fun currentAbsoluteSec(): Double {
         val c = controller ?: return 0.0
-        return c.currentPosition / 1000.0
+        return pendingSeek.sample { c.currentPosition / 1000.0 }
     }
 
     fun stop() {
@@ -291,6 +297,7 @@ open class AudiobookController @Inject constructor(
         SharedAudiobookContext.spans = emptyList()
         SharedAudiobookContext.totalDurationMs = 0L
         lastRemainingMinuteBucket = -1L
+        pendingSeek.reset()
         _state.value = PlaybackState()
     }
 
@@ -321,6 +328,7 @@ open class AudiobookController @Inject constructor(
         SharedAudiobookContext.spans = emptyList()
         SharedAudiobookContext.totalDurationMs = 0L
         lastRemainingMinuteBucket = -1L
+        pendingSeek.reset()
         _state.value = PlaybackState()
     }
 
@@ -344,13 +352,18 @@ open class AudiobookController @Inject constructor(
     private fun pushState() {
         val c = controller
         val position = currentAbsoluteSec()
+        // While a seek is pending the client's [MediaController.bufferedPosition] mirror also holds the
+        // raw local offsetMs we just issued; treating that as absolute would paint a phantom
+        // buffer band. Pin it to the pending target (== "nothing loaded past the seek yet") until the
+        // discontinuity lands and the server rebroadcasts the real projected value.
+        val bufferedSec = if (pendingSeek.pendingSec != null) position else (c?.bufferedPosition ?: 0L) / 1000.0
         _state.value = PlaybackState(
             connected = c != null,
             isPlaying = c?.isPlaying == true,
             speed = c?.playbackParameters?.speed ?: 1f,
             positionSec = position,
             durationSec = durationSec,
-            bufferedSec = (c?.bufferedPosition ?: 0L) / 1000.0,
+            bufferedSec = bufferedSec,
         )
         maybeUpdateRemainingMetadata(c, position)
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/PendingSeekGate.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/PendingSeekGate.kt
@@ -1,0 +1,20 @@
+package com.riffle.app.feature.audiobook
+
+/**
+ * Suppresses the client-side [androidx.media3.session.MediaController] position mirror during the
+ * window between a seek command being issued and the server relaying the position discontinuity
+ * that confirms it landed. After [onSeekIssued] the client mirror snaps to the raw local-track
+ * `offsetMs` we just sent — projecting that as book-absolute time (the caller does that further up)
+ * would paint the seek bar at a bogus early position for one poll tick after every track-crossing
+ * seek. [sample] returns the held target until [onDiscontinuity] clears it.
+ */
+internal class PendingSeekGate {
+    var pendingSec: Double? = null
+        private set
+
+    fun onSeekIssued(absoluteSec: Double) { pendingSec = absoluteSec }
+    fun onDiscontinuity() { pendingSec = null }
+    fun reset() { pendingSec = null }
+
+    inline fun sample(fallback: () -> Double): Double = pendingSec ?: fallback()
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/PendingSeekGateTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/PendingSeekGateTest.kt
@@ -1,0 +1,43 @@
+package com.riffle.app.feature.audiobook
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Regression coverage for the "seek bar blinks to zero for one frame after a track-crossing rewind"
+ * bug: after [PendingSeekGate.onSeekIssued], [sample] must return the pending target — NOT the
+ * fallback (which, in the real controller, reads the client-side [MediaController] mirror that has
+ * optimistically snapped to the raw local-track offsetMs and would be projected as an absurdly early
+ * absolute position). If someone reverts the gate, [pendingSampleWinsOverFallback] flips red.
+ */
+class PendingSeekGateTest {
+
+    @Test
+    fun pendingSampleWinsOverFallback() {
+        val gate = PendingSeekGate()
+        gate.onSeekIssued(absoluteSec = 10_217.0) // ~2:50:17 into a 2:50:45 book
+        // Fallback mirrors the raw client-side offsetMs / 1000 (~5:55 into the last track).
+        assertEquals(10_217.0, gate.sample { 355.0 }, 0.0)
+    }
+
+    @Test
+    fun fallbackReturnsAfterDiscontinuity() {
+        val gate = PendingSeekGate()
+        gate.onSeekIssued(10_217.0)
+        gate.onDiscontinuity()
+        assertNull(gate.pendingSec)
+        assertEquals(10_217.0, gate.sample { 10_217.0 }, 0.0)
+        // Confirm subsequent samples read the fallback each time.
+        assertEquals(10_218.5, gate.sample { 10_218.5 }, 0.0)
+    }
+
+    @Test
+    fun resetClearsPending() {
+        val gate = PendingSeekGate()
+        gate.onSeekIssued(42.0)
+        gate.reset()
+        assertNull(gate.pendingSec)
+        assertEquals(1.0, gate.sample { 1.0 }, 0.0)
+    }
+}


### PR DESCRIPTION
## Summary

Reproduced in a screen recording of a -15 s rewind on an audiobook that crosses a track boundary: the entire seek bar collapses to ~0 for one frame before snapping back.

Root cause is in `AudiobookController.currentAbsoluteSec()`. After `controller.seekTo(mediaItemIndex, offsetMs)` the client-side `MediaController` optimistically mirrors `currentPosition = offsetMs` (raw local-track ms) before the server-side `AbsolutePositionPlayer.getCurrentPosition` rebroadcasts the projected absolute value. `pushState()` runs synchronously right after `seekTo` and samples the raw local offset; the UI interprets it as absolute, so for one poll tick the position reads as e.g. 5:55 (offset in the last track) instead of 2:50:17 (absolute), and `frac ≈ 0` collapses the fill.

Fix: a small `PendingSeekGate` records the absolute seek target on `seekTo` and makes `currentAbsoluteSec` + the buffered-band value return the target until `EVENT_POSITION_DISCONTINUITY` confirms the seek has landed. The gate resets on `stop()` / `releaseForHandoff()` so state doesn't leak across sessions.

## Test plan

- [x] `PendingSeekGateTest` — regression test that pins the state machine (issue → hold → discontinuity → fall through). Flips red if the gate is removed.
- [x] `./gradlew :app:testDebugUnitTest` green.
- [ ] Manual verify on device: rewind (-15) from near end of an audiobook so it crosses a track boundary; seek bar no longer blinks.