### PR TITLE
feat(settings): drop dedicated Remove Local Files source button

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/settings/sections/LocalFilesSourceRowTrashTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/settings/sections/LocalFilesSourceRowTrashTest.kt
@@ -122,4 +122,30 @@ class LocalFilesSourceRowTrashTest {
         composeTestRule.onNodeWithText("Remove folder?").assertDoesNotExist()
         assert(removeCallCount == 0) { "onRemoveFolder must not fire when the trash is disabled" }
     }
+
+    /**
+     * Pins the removal of the dedicated "Remove Local Files source" button from the expanded row
+     * body. Whole-source removal now goes through the standard swipe gesture on the row header
+     * (same as every other Source row); re-introducing the in-body button would flip this red.
+     */
+    @Test
+    fun expandedBody_doesNotShowDedicatedRemoveSourceButton() {
+        composeTestRule.setContent {
+            LocalFilesSourceRow(
+                source = source,
+                folders = listOf(folder(1)),
+                folderHealth = emptyMap(),
+                libraryItems = listOf(libraryItem(1, itemCount = 1)),
+                isExpanded = true,
+                onToggleExpanded = {},
+                onAddFolder = {},
+                onRemoveFolder = {},
+                onRemoveSource = {},
+                onSetLibraryVisible = { _, _ -> },
+                onReorderLibraries = {},
+            )
+        }
+
+        composeTestRule.onNodeWithText("Remove Local Files source").assertDoesNotExist()
+    }
 }

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/settings/sections/LocalFilesSourceRowTrashTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/settings/sections/LocalFilesSourceRowTrashTest.kt
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith
 /**
  * Pins the "at least one folder must remain" invariant on the per-folder trash icon in the
  * Local Files source row. If the trash on the last remaining folder becomes tappable, a user can
- * strand the source with zero libraries; the source-wide "Remove Local Files source" action is
+ * strand the source with zero libraries; the swipe-to-remove gesture on the source row header is
  * the correct escape hatch instead.
  */
 @RunWith(AndroidJUnit4::class)

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/sections/SourcesSection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/sections/SourcesSection.kt
@@ -316,7 +316,6 @@ internal fun LocalFilesSourceRow(
     onReorderLibraries: (orderedLibraryIds: List<String>) -> Unit,
 ) {
     var pendingFolderRemoval by remember { mutableStateOf<LocalFilesFolderEntity?>(null) }
-    var pendingSourceRemoval by remember { mutableStateOf(false) }
     val unhealthyCount = folders.count { folderHealth[it.treeUri] == false }
 
     ExpandableSourceRow(
@@ -455,14 +454,6 @@ internal fun LocalFilesSourceRow(
                         )
                     }
                 }
-        TextButton(
-            onClick = { pendingSourceRemoval = true },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 4.dp),
-        ) {
-            Text("Remove Local Files source", color = MaterialTheme.colorScheme.error)
-        }
     }
 
     pendingFolderRemoval?.let { folder ->
@@ -484,22 +475,6 @@ internal fun LocalFilesSourceRow(
             },
             dismissButton = {
                 TextButton(onClick = { pendingFolderRemoval = null }) { Text("Cancel") }
-            },
-        )
-    }
-    if (pendingSourceRemoval) {
-        AlertDialog(
-            onDismissRequest = { pendingSourceRemoval = false },
-            title = { Text("Remove Local Files source?") },
-            text = { Text("Every configured folder and every locally-stored book will be deleted from this device.") },
-            confirmButton = {
-                TextButton(onClick = {
-                    onRemoveSource()
-                    pendingSourceRemoval = false
-                }) { Text("Remove") }
-            },
-            dismissButton = {
-                TextButton(onClick = { pendingSourceRemoval = false }) { Text("Cancel") }
             },
         )
     }


### PR DESCRIPTION
## Summary

The expanded Local Files row in Settings carried a source-wide "Remove Local Files source" `TextButton` at the bottom of its body, plus its own confirmation `AlertDialog`. This duplicated the swipe-to-remove gesture that every other Source row already exposes via `ExpandableSourceRow` → `SwipeToDeleteRow`.

Remove the button, the dialog, and the `pendingSourceRemoval` state so the Local Files row matches the shape of every other Source row. The swipe on the row header remains the escape hatch for removing the whole source.

## Test plan
- [x] New regression test `expandedBody_doesNotShowDedicatedRemoveSourceButton` in `LocalFilesSourceRowTrashTest` asserts the button text is absent from the expanded row — flips red if the button is reintroduced.
- [x] Existing per-folder trash tests still pass (unchanged behaviour).