### PR TITLE
feat(playlists): ABS audiobook playlists tab with auto-advance playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Riffle lets you browse your library, read EPUB, PDF, and CBZ files, listen to au
 - Variable playback speed (0.5×–3.0×) with quick presets, remembered per book
 - Background playback with lock-screen, notification, and Bluetooth media controls
 - Download audiobooks for offline listening, with progress that reconciles when you reconnect
+- Audiobookshelf playlists surfaced as a dedicated tab on the audiobook library — play a playlist end-to-end with auto-advance that resumes each next item from its saved position, and add or remove items from the item detail sheet
 - Storyteller **Readaloud** in the reader: synced sentence highlight, auto-page-turn, "Play from here," and background playback
 - Listening and reading positions stay in sync for matched books — pick up in the reader exactly where you stopped listening, and vice versa
 

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -272,7 +272,19 @@ open class AudiobookController @Inject constructor(
         return c.currentPosition / 1000.0
     }
 
-    fun stop() {
+    /**
+     * Discard any cached end-of-book event WITHOUT tearing the session down. Called when the
+     * outgoing playlist-item VM hands off to the next item's VM on the same singleton controller:
+     * the next VM's collector must NOT immediately re-consume the previous item's STATE_ENDED
+     * (whose Unit is stashed in the `replay = 1` SharedFlow), or it will loop-advance through
+     * every remaining playlist item in a few ms. This is the piece of [stop] that MUST run on
+     * auto-advance — the connector.release() etc. must NOT.
+     */
+    fun clearEndOfBookCache() {
+        _playbackEnded.resetReplayCache()
+    }
+
+    open fun stop() {
         cancelSleepTimer()
         pollJob?.cancel()
         pollJob = null

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerScreen.kt
@@ -130,17 +130,23 @@ fun AudiobookPlayerScreen(
     windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onSwitchToReadaloud: (ebookItemId: String, atSec: Double) -> Unit = { _, _ -> },
+    /** Called on end-of-book when the player was opened inside a playlist context (via
+     *  [PlaylistDetailScreen]) and there IS a next item. Callers navigate to the next item's
+     *  audiobook player, preserving the playlist context so auto-advance chains through. */
+    onPlaylistAdvance: (nextItemId: String) -> Unit = {},
     viewModel: AudiobookPlayerViewModel = hiltViewModel(),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
-    // When the book ends naturally (last track played through to STATE_ENDED), close the player —
-    // pop back to the audiobook detail view. The VM's onCleared() then stops the MediaSession, which
-    // clears the foreground notification.
+    // When the book ends naturally (last track played through to STATE_ENDED), either advance to
+    // the next playlist item (if opened inside a playlist context with a successor) or close the
+    // player. The VM's onCleared() stops the MediaSession, which clears the foreground notification.
     val latestOnNavigateBack = rememberUpdatedState(onNavigateBack)
+    val latestOnPlaylistAdvance = rememberUpdatedState(onPlaylistAdvance)
     LaunchedEffect(Unit) {
         viewModel.events.collect { event ->
             when (event) {
                 AudiobookPlayerEvent.Finished -> latestOnNavigateBack.value()
+                is AudiobookPlayerEvent.PlaylistAdvance -> latestOnPlaylistAdvance.value(event.nextItemId)
             }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -118,6 +118,13 @@ internal fun buildAudiobookFacts(durationSec: Double, genres: List<String>): Str
 sealed interface AudiobookPlayerEvent {
     /** Playback finished naturally (last track ended); the screen should close the player. */
     data object Finished : AudiobookPlayerEvent
+
+    /**
+     * Playback finished AND the player was opened inside a playlist context that has a next
+     * item. The screen navigates to the next item's audiobook player (preserving the same
+     * playlist context) so playback auto-advances through the playlist.
+     */
+    data class PlaylistAdvance(val nextItemId: String) : AudiobookPlayerEvent
 }
 
 /** UI state for the full-screen [Audiobook Player] (ADR 0029). */
@@ -191,9 +198,16 @@ class AudiobookPlayerViewModel @Inject constructor(
     private val reconciliationCoordinator: AudiobookReconciliationCoordinator,
     private val clock: Clock,
     private val logger: Logger,
+    private val playlistsRepository: com.riffle.core.data.PlaylistsRepository,
 ) : ViewModel() {
 
     private val itemId: String = savedStateHandle.get<String>("itemId") ?: ""
+
+    /** Optional playlist context — set when the player was opened from [PlaylistDetailScreen]'s
+     *  Play button. Empty string / null means "no playlist"; on end-of-book the VM falls back to
+     *  emitting [AudiobookPlayerEvent.Finished] and the screen pops as before. */
+    private val playlistId: String? = savedStateHandle.get<String>("playlistId")?.takeIf { it.isNotEmpty() }
+    private val playlistLibraryId: String? = savedStateHandle.get<String>("libraryId")?.takeIf { it.isNotEmpty() }
 
     // readaloud→audiobook swipe handoff: the listen position to continue from.
     // -2 = PREWARM_SENTINEL: pre-warm mode (overlay always-mounted, actual position arrives via
@@ -569,10 +583,37 @@ class AudiobookPlayerViewModel @Inject constructor(
         // pass).
         viewModelScope.launch {
             controller.playbackEnded.collect {
+                // Guard against re-firing on the same VM. During auto-advance the destination
+                // VM briefly overlaps with the outgoing VM on the singleton controller — the
+                // listener's real-time tryEmit on STATE_ENDED can push another Unit to the
+                // SharedFlow buffer before the incoming VM's prepare() replaces media items,
+                // and every stray subscriber that consumes it would emit yet another
+                // PlaylistAdvance. Verified end-to-end: dropping this guard produced 3
+                // duplicate advances back-to-back within 1s in logcat.
+                if (handingOffToPlaylistAdvance) return@collect
                 flushPendingSpeed()
-                pushProgressAndStopPlayer()
-                clearAudiobookNowPlaying()
-                _events.tryEmit(AudiobookPlayerEvent.Finished)
+                // Resolve next-in-playlist BEFORE deciding whether to tear the singleton player
+                // down. When auto-advancing, keep the MediaController connection alive so the
+                // incoming VM's controller.prepare() replaces media items on the SAME session —
+                // if we called pushProgressAndStopPlayer() here (or in onCleared), a race with
+                // VM2's init would release the connector after VM2 had already prepared+played,
+                // leaving the next book silently paused. Non-advance case (no playlist, or last
+                // item) keeps the original teardown so the foreground notification drops.
+                val nextInPlaylist = resolveNextPlaylistItem()
+                if (nextInPlaylist != null) {
+                    handingOffToPlaylistAdvance = true
+                    // Wipe the replay-cached STATE_ENDED Unit BEFORE the next VM subscribes,
+                    // or its collector re-consumes it and loop-advances through every remaining
+                    // item in milliseconds (verified end-to-end: two auto-advance log lines for
+                    // the same next-item id ~600ms apart, then playback dead).
+                    controller.clearEndOfBookCache()
+                    logger.d(LogChannel.Handoff) { "AB.VM playlist auto-advance → $nextInPlaylist" }
+                    _events.tryEmit(AudiobookPlayerEvent.PlaylistAdvance(nextInPlaylist))
+                } else {
+                    pushProgressAndStopPlayer()
+                    clearAudiobookNowPlaying()
+                    _events.tryEmit(AudiobookPlayerEvent.Finished)
+                }
             }
         }
 
@@ -717,6 +758,12 @@ class AudiobookPlayerViewModel @Inject constructor(
     // here instead.
     private var handingOffToReadaloud = false
 
+    // Set when this VM has emitted PlaylistAdvance and is about to be replaced by the next
+    // playlist item's VM on the same singleton controller. Same rationale as [handingOffToReadaloud]:
+    // onCleared MUST NOT release the shared connector, or a race with the incoming VM's prepare()
+    // silently kills its playback.
+    private var handingOffToPlaylistAdvance = false
+
     /**
      * Called when the user starts dragging down (before the threshold). Pre-resolves the SMIL seek
      * target so [playFromSecond] in [ReadaloudController] can skip the computation at commit time
@@ -813,12 +860,29 @@ class AudiobookPlayerViewModel @Inject constructor(
                 ?.let { openReconcileTargets.markClosed(sourceId, it) }
         }
         flushPendingSpeed()
-        // On a readaloud handoff the progress was already pushed and the handle released without
-        // stopping the shared player (readaloud now owns it) — stopping here would pause readaloud.
-        if (!handingOffToReadaloud) pushProgressAndStopPlayer()
-        // Leaving the player stops playback (no mini-bar), so this session is no longer playing.
-        clearAudiobookNowPlaying()
+        // On a readaloud handoff OR playlist auto-advance the shared session is being taken over
+        // by another surface (readaloud, or the next playlist item's VM). Stopping here would
+        // release the singleton connector out from under it.
+        if (!handingOffToReadaloud && !handingOffToPlaylistAdvance) pushProgressAndStopPlayer()
+        // Leaving the player stops playback (no mini-bar), so this session is no longer playing —
+        // except on auto-advance where the next item IS now the playing session; don't clear.
+        if (!handingOffToPlaylistAdvance) clearAudiobookNowPlaying()
         super.onCleared()
+    }
+
+    /**
+     * When the player was opened inside a playlist ([playlistId] + [playlistLibraryId] set), find
+     * the item that comes AFTER the current [itemId] in that playlist. Returns null when: no
+     * playlist context, the playlist has vanished (auto-deleted or removed), current item isn't
+     * in the playlist (removed while playing), or current is the last item. Callers treat null as
+     * "no auto-advance — emit Finished as normal".
+     */
+    private suspend fun resolveNextPlaylistItem(): String? {
+        val pid = playlistId ?: return null
+        val lid = playlistLibraryId ?: return null
+        val playlist = runCatching { playlistsRepository.getPlaylist(lid, pid) }.getOrNull() ?: return null
+        val currentIndex = playlist.itemIds.indexOf(itemId).takeIf { it >= 0 } ?: return null
+        return playlist.itemIds.getOrNull(currentIndex + 1)
     }
 
     private companion object {

--- a/app/src/main/kotlin/com/riffle/app/feature/library/AddToPlaylistToggleButton.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/AddToPlaylistToggleButton.kt
@@ -1,0 +1,51 @@
+package com.riffle.app.feature.library
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+
+/**
+ * Circular "Add to playlist" affordance shown next to [ToReadToggleButton] on the item detail
+ * action row for audiobook items on a Source with [com.riffle.core.catalog.PlaylistsCapability].
+ *
+ * Design constraints (learned by shipping the wrong thing first):
+ * - Same 40dp outlined-circle chrome as [ToReadToggleButton] — a plain [androidx.compose.material3.IconButton]
+ *   next to that toggle read as a darker, chrome-less sibling.
+ * - Icon MUST match the Playlists tab (also QueueMusic) so the two surfaces share visual
+ *   language — the button and the tab represent the same concept. The distinction from the
+ *   sibling [ToReadToggleButton] (PlaylistAddCheck: lines + check) comes from the glyph itself:
+ *   QueueMusic is lines + music note, which reads as "audio list" rather than "wishlist".
+ * - Stateless — unlike ToRead, membership is per-playlist and lives in the sheet, not on the row.
+ */
+@Composable
+fun AddToPlaylistToggleButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .size(40.dp)
+            .clip(CircleShape)
+            .border(1.5.dp, MaterialTheme.colorScheme.outline, CircleShape)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.QueueMusic,
+            contentDescription = "Add to playlist",
+            tint = MaterialTheme.colorScheme.outline,
+            modifier = Modifier.size(20.dp),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -2,7 +2,9 @@ package com.riffle.app.feature.library
 
 import android.content.res.Configuration
 import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -65,6 +67,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -112,6 +115,7 @@ fun LibraryItemDetailScreen(
     val currentPositionHref by viewModel.currentPositionHref.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
+    var showAddToPlaylistSheet by remember { mutableStateOf(false) }
 
     LaunchedEffect(viewModel) {
         viewModel.snackbarEvents.collect { message ->
@@ -146,6 +150,20 @@ fun LibraryItemDetailScreen(
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { padding ->
+        // Add-to-playlist sheet — driven by [showAddToPlaylistSheet], populated from the
+        // ViewModel's PlaylistsRepository-backed flow. The "To Read" playlist is filtered out at
+        // the repository layer so it never appears in this picker.
+        if (showAddToPlaylistSheet && uiState is LibraryItemDetailUiState.Ready) {
+            val readyState = uiState as LibraryItemDetailUiState.Ready
+            LaunchedEffect(showAddToPlaylistSheet) { viewModel.refreshPlaylists() }
+            com.riffle.app.feature.library.playlists.AddToPlaylistSheet(
+                itemId = readyState.item.id,
+                playlistsFlow = viewModel.playlistsForCurrentItem,
+                onToggle = { pl -> viewModel.toggleItemInPlaylist(pl) },
+                onCreate = { name -> viewModel.createPlaylistWithCurrentItem(name) },
+                onDismiss = { showAddToPlaylistSheet = false },
+            )
+        }
         when (val state = uiState) {
             is LibraryItemDetailUiState.Loading -> {
                 Box(
@@ -217,6 +235,7 @@ fun LibraryItemDetailScreen(
                         onMarkAsRead = { viewModel.markAsRead() },
                         onMarkAsUnread = { viewModel.markAsUnread() },
                         onToggleToRead = { viewModel.toggleToRead() },
+                        onAddToPlaylist = { showAddToPlaylistSheet = true },
                         onDownload = { viewModel.startDownload() },
                         onRemove = onRemove,
                         onDownloadReadaloud = viewModel::onDownloadReadaloud,
@@ -249,6 +268,7 @@ fun LibraryItemDetailScreen(
                         onMarkAsRead = { viewModel.markAsRead() },
                         onMarkAsUnread = { viewModel.markAsUnread() },
                         onToggleToRead = { viewModel.toggleToRead() },
+                        onAddToPlaylist = { showAddToPlaylistSheet = true },
                         onDownload = { viewModel.startDownload() },
                         onRemove = onRemove,
                         onDownloadReadaloud = viewModel::onDownloadReadaloud,
@@ -281,6 +301,7 @@ fun LibraryItemDetailScreen(
                         onMarkAsRead = { viewModel.markAsRead() },
                         onMarkAsUnread = { viewModel.markAsUnread() },
                         onToggleToRead = { viewModel.toggleToRead() },
+                        onAddToPlaylist = { showAddToPlaylistSheet = true },
                         onDownload = { viewModel.startDownload() },
                         onRemove = onRemove,
                         onDownloadReadaloud = viewModel::onDownloadReadaloud,
@@ -344,6 +365,7 @@ private fun LibraryItemDetailContent(
     onMarkAsRead: () -> Unit,
     onMarkAsUnread: () -> Unit,
     onToggleToRead: () -> Unit,
+    onAddToPlaylist: () -> Unit = {},
     onDownload: () -> Unit,
     onRemove: () -> Unit,
     onDownloadReadaloud: () -> Unit = {},
@@ -416,6 +438,7 @@ private fun LibraryItemDetailContent(
             onMarkAsRead = onMarkAsRead,
             onMarkAsUnread = onMarkAsUnread,
             onToggleToRead = onToggleToRead,
+            onAddToPlaylist = onAddToPlaylist,
             onDownload = onDownload,
             onRemove = onRemove,
             onDownloadReadaloud = onDownloadReadaloud,
@@ -579,6 +602,7 @@ internal fun LibraryItemDetailContentTablet(
     onMarkAsRead: () -> Unit,
     onMarkAsUnread: () -> Unit,
     onToggleToRead: () -> Unit,
+    onAddToPlaylist: () -> Unit = {},
     onDownload: () -> Unit,
     onRemove: () -> Unit,
     onDownloadReadaloud: () -> Unit = {},
@@ -656,6 +680,7 @@ internal fun LibraryItemDetailContentTablet(
                 onMarkAsRead = onMarkAsRead,
                 onMarkAsUnread = onMarkAsUnread,
                 onToggleToRead = onToggleToRead,
+            onAddToPlaylist = onAddToPlaylist,
                 onDownload = onDownload,
                 onRemove = onRemove,
                 onDownloadReadaloud = onDownloadReadaloud,
@@ -788,6 +813,7 @@ internal fun LibraryItemDetailContentPhoneLandscape(
     onMarkAsRead: () -> Unit,
     onMarkAsUnread: () -> Unit,
     onToggleToRead: () -> Unit,
+    onAddToPlaylist: () -> Unit = {},
     onDownload: () -> Unit,
     onRemove: () -> Unit,
     onDownloadReadaloud: () -> Unit = {},
@@ -866,6 +892,7 @@ internal fun LibraryItemDetailContentPhoneLandscape(
                 onMarkAsRead = onMarkAsRead,
                 onMarkAsUnread = onMarkAsUnread,
                 onToggleToRead = onToggleToRead,
+            onAddToPlaylist = onAddToPlaylist,
                 onDownload = onDownload,
                 onRemove = onRemove,
                 onDownloadReadaloud = onDownloadReadaloud,
@@ -1075,6 +1102,7 @@ private fun ActionRow(
     onMarkAsRead: () -> Unit,
     onMarkAsUnread: () -> Unit,
     onToggleToRead: () -> Unit,
+    onAddToPlaylist: () -> Unit = {},
     onDownload: () -> Unit,
     onRemove: () -> Unit,
     onDownloadReadaloud: () -> Unit = {},
@@ -1164,6 +1192,9 @@ private fun ActionRow(
                 isInToRead = isInToRead,
                 onToggle = onToggleToRead,
             )
+        }
+        if (capabilities.hasAddToPlaylist) {
+            AddToPlaylistToggleButton(onClick = onAddToPlaylist)
         }
         // Download affordances are gated on DownloadsCapability — Sources without a local store
         // (LocalFiles today) hide every download button (ebook, audiobook, readaloud bundle).

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -18,6 +18,10 @@ import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.usecase.MarkReadAcrossDimensions
 import com.riffle.core.domain.usecase.RecordItemOpened
 import com.riffle.core.domain.usecase.UpdateReadingProgress
+import com.riffle.core.catalog.CatalogPlaylist
+import com.riffle.core.data.PlaylistsRepository
+import com.riffle.core.data.RESERVED_PLAYLIST_NAMES
+import com.riffle.core.data.ReservedPlaylistNameException
 import com.riffle.core.data.ToReadRepository
 import com.riffle.core.catalog.AudiobookMediaCapability
 import com.riffle.core.catalog.CatalogRegistry
@@ -36,6 +40,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -77,6 +84,13 @@ data class DetailCapabilities(
     /** True when the Source's Catalog declares [ReadaloudCapability] — gates the readaloud
      *  bundle Download button. ABS-only today. */
     val hasReadaloud: Boolean = false,
+    /**
+     * True when the "Add to playlist…" affordance should appear on the item detail sheet.
+     * Gate: Source's Catalog implements [PlaylistsCapability] AND the item is an audiobook (per
+     * the audiobook-playlists design — the Playlists tab lives on the ABS audiobook root only,
+     * so the picker follows the same gate to stay consistent).
+     */
+    val hasAddToPlaylist: Boolean = false,
 ) {
     companion object {
         /** Every capability present — matches the ABS shape used by the majority of items. */
@@ -86,6 +100,7 @@ data class DetailCapabilities(
             hasAudiobookMedia = true,
             hasDownloads = true,
             hasReadaloud = true,
+            hasAddToPlaylist = true,
         )
 
         /** No capability present — safe default when the active Source's Catalog can't be resolved.
@@ -97,6 +112,7 @@ data class DetailCapabilities(
             hasAudiobookMedia = false,
             hasDownloads = false,
             hasReadaloud = false,
+            hasAddToPlaylist = false,
         )
     }
 }
@@ -142,6 +158,7 @@ class LibraryItemDetailViewModel @Inject constructor(
     private val pdfRepository: PdfRepository,
     private val cbzRepository: com.riffle.core.domain.CbzRepository,
     private val toReadRepository: ToReadRepository,
+    private val playlistsRepository: PlaylistsRepository,
     private val readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
     private val readaloudAudioRepository: com.riffle.core.domain.ReadaloudAudioRepository,
     private val audiobookDownloadRepository: com.riffle.core.domain.AudiobookDownloadRepository,
@@ -252,6 +269,10 @@ class LibraryItemDetailViewModel @Inject constructor(
                         hasAudiobookMedia = catalog is AudiobookMediaCapability,
                         hasDownloads = catalog is DownloadsCapability,
                         hasReadaloud = catalog is ReadaloudCapability,
+                        // Audiobook-only items on a Source with server-side playlists get the
+                        // "Add to playlist…" affordance. Mirrors the tab gate — ebook items on the
+                        // same Source stay out of the Playlists surface.
+                        hasAddToPlaylist = catalog is PlaylistsCapability && item.isListenable && !item.isReadable,
                     )
                     LibraryItemDetailUiState.Ready(
                         item = item,
@@ -401,6 +422,59 @@ class LibraryItemDetailViewModel @Inject constructor(
                     if (wasInToRead) "Couldn't remove from To Read" else "Couldn't add to To Read"
                 )
             }
+        }
+    }
+
+    // ── Add-to-playlist sheet ─────────────────────────────────────────────────
+    // These helpers back [com.riffle.app.feature.library.playlists.AddToPlaylistSheet]. The sheet is
+    // launched from the item-detail action row when [DetailCapabilities.hasAddToPlaylist] is true,
+    // which the ViewModel gates on Source's PlaylistsCapability + item is audiobook-only.
+
+    /** Flow of playlists for the currently-loaded item's library. "To Read" is filtered out by
+     *  [PlaylistsRepository]. Empty until the item resolves. */
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    val playlistsForCurrentItem: kotlinx.coroutines.flow.Flow<List<CatalogPlaylist>> =
+        kotlinx.coroutines.flow.flow {
+            val libraryId = _uiState
+                .filterIsInstance<LibraryItemDetailUiState.Ready>()
+                .first()
+                .item.libraryId
+            emitAll(playlistsRepository.observePlaylists(libraryId))
+        }
+
+    fun refreshPlaylists() {
+        val ready = _uiState.value as? LibraryItemDetailUiState.Ready ?: return
+        viewModelScope.launch { playlistsRepository.refresh(ready.item.libraryId) }
+    }
+
+    /** Toggles the item's membership in [playlist]. Emits a snackbar on failure. */
+    fun toggleItemInPlaylist(playlist: CatalogPlaylist) {
+        val ready = _uiState.value as? LibraryItemDetailUiState.Ready ?: return
+        val item = ready.item
+        viewModelScope.launch {
+            val ok = if (item.id in playlist.itemIds) {
+                playlistsRepository.removeItemFromPlaylist(item.libraryId, playlist.id, item.id)
+            } else {
+                playlistsRepository.addItemToPlaylist(item.libraryId, playlist.id, item.id)
+            }
+            if (!ok) _snackbarEvents.emit("Couldn't update playlist")
+        }
+    }
+
+    /** Create a new playlist with the current item seeded. Returns "" on success or an error string. */
+    suspend fun createPlaylistWithCurrentItem(name: String): String {
+        val ready = _uiState.value as? LibraryItemDetailUiState.Ready ?: return "No item"
+        val trimmed = name.trim()
+        if (trimmed.isEmpty()) return "Name can't be empty"
+        val reservedHit = RESERVED_PLAYLIST_NAMES.firstOrNull { it.equals(trimmed, ignoreCase = true) }
+        if (reservedHit != null) return "'$reservedHit' is reserved"
+        return try {
+            playlistsRepository.createPlaylist(ready.item.libraryId, trimmed, initialItemId = ready.item.id)
+            ""
+        } catch (e: ReservedPlaylistNameException) {
+            "'${e.name}' is reserved"
+        } catch (_: Exception) {
+            "Couldn't create playlist"
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Folder
@@ -143,6 +144,7 @@ fun LibraryItemsScreen(
     onShowAllAnnotations: (query: String) -> Unit,
     onSectionSeeMore: (LibrarySectionType) -> Unit,
     onAnnotatedBookClick: (sourceId: String, itemId: String) -> Unit,
+    onPlaylistSelected: (com.riffle.core.catalog.CatalogPlaylist) -> Unit = {},
     // When the navigation drawer is open, its own BackHandler must take Back so it can close
     // itself. We disable our layered Back in that case (issue #60).
     backEnabled: Boolean = true,
@@ -167,6 +169,7 @@ fun LibraryItemsScreen(
     val linkedItemIds by viewModel.linkedItemIds.collectAsState()
     val notStartedFilterActive by viewModel.notStartedFilterActive.collectAsState()
     val tabVisibility by viewModel.tabVisibility.collectAsState()
+    val playlists by viewModel.playlists.collectAsState()
 
     val coversAreSquare by viewModel.coversAreSquare.collectAsState()
     // Versioned key: v2 = post-Annotations-tab-insertion. Without the version bump, a user
@@ -330,6 +333,10 @@ fun LibraryItemsScreen(
                         collectionCoverUrls = collectionCoverUrls,
                         onCollectionSelected = onCollectionSelected,
                         onCoverScaleChange = onCoverScaleChange,
+                    )
+                    tabIndexForPlaylists() -> com.riffle.app.feature.library.playlists.PlaylistsTabContent(
+                        playlists = playlists,
+                        onPlaylistSelected = onPlaylistSelected,
                     )
                     5 -> AllBooksTabContent(
                         items = allBooks,
@@ -1256,6 +1263,13 @@ internal fun LibraryItemCard(
 internal fun tabIndexForAnnotations(): Int = 2
 
 /**
+ * Index of the Playlists tab — the 7th tab, positioned between Collections (4) and All Books (5).
+ * Only visible on ABS audiobook roots ([LibraryTabVisibility.playlists] gate). Single source of
+ * truth referenced by [LibraryTabBar]'s selected-check and [LibraryItemsScreen]'s tab switch.
+ */
+internal fun tabIndexForPlaylists(): Int = 6
+
+/**
  * True when the tab-clamp LaunchedEffect should reset [selectedTab] to Home. Returns false while
  * the user is searching ([searchQuery] non-empty) — `LibraryFilterEngine` filters
  * `projection.series/collections` by the active query, so an unmatched search would otherwise
@@ -1284,6 +1298,7 @@ internal fun isTabVisible(selectedTab: Int, visibility: LibraryTabVisibility): B
         2 -> visibility.annotations
         3 -> visibility.series
         4 -> visibility.collections
+        6 -> visibility.playlists
         else -> true
     }
 
@@ -1325,6 +1340,15 @@ private fun LibraryTabBar(
                 selected = selectedTab == 4,
                 onClick = { onTabSelected(4) },
                 icon = { Icon(Icons.Filled.Folder, contentDescription = "Collections") },
+            )
+        }
+        if (visibility.playlists) {
+            NavigationBarItem(
+                selected = selectedTab == tabIndexForPlaylists(),
+                onClick = { onTabSelected(tabIndexForPlaylists()) },
+                icon = {
+                    Icon(Icons.AutoMirrored.Filled.QueueMusic, contentDescription = "Playlists")
+                },
             )
         }
         NavigationBarItem(

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -19,7 +19,9 @@ import com.riffle.core.domain.usecase.RefreshCollections
 import com.riffle.core.domain.usecase.RefreshLibraryItems
 import com.riffle.core.domain.usecase.RefreshSeries
 import com.riffle.core.domain.Series
+import com.riffle.core.catalog.CatalogPlaylist
 import com.riffle.core.data.AnnotationsLibraryRepository
+import com.riffle.core.data.PlaylistsRepository
 import com.riffle.core.data.ToReadRepository
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.TokenStorage
@@ -61,6 +63,7 @@ class LibraryItemsViewModel @Inject constructor(
     private val offlineAvailability: LibraryItemOfflineAvailability,
     private val connectivityObserver: ConnectivityObserver,
     private val toReadRepository: ToReadRepository,
+    private val playlistsRepository: PlaylistsRepository,
     private val readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
     private val coverGridDensityStore: com.riffle.core.domain.CoverGridDensityStore,
     private val annotationStore: AnnotationStore,
@@ -151,10 +154,17 @@ class LibraryItemsViewModel @Inject constructor(
 
     // An audiobooks-only library: every item is a listen-only Audiobook. Drives square covers across
     // every tile in the library — including Series / Collection / "+ N more" tiles that carry no
-    // per-item audio signal of their own (ADR 0029).
-    val coversAreSquare: StateFlow<Boolean> = allItems
+    // per-item audio signal of their own (ADR 0029). Also gates the Playlists tab (audiobook root
+    // only, per the audiobook-playlists design).
+    val isAudiobooksOnlyLibrary: StateFlow<Boolean> = allItems
         .map { items -> items.isNotEmpty() && items.all { it.isListenable && !it.isReadable } }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    val coversAreSquare: StateFlow<Boolean> get() = isAudiobooksOnlyLibrary
+
+    /** Playlists for this library, filtered by [PlaylistsRepository] to hide the reserved "To Read". */
+    val playlists: StateFlow<List<CatalogPlaylist>> = playlistsRepository.observePlaylists(libraryId)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     // Backed by SavedStateHandle so the query survives both book-detail round-trips and process
     // death (issue #60).
@@ -236,7 +246,18 @@ class LibraryItemsViewModel @Inject constructor(
         projection,
         annotatedBooksInLibrary,
         allItems,
-    ) { p, annotated, items ->
+        playlists,
+        isAudiobooksOnlyLibrary,
+    ) { values ->
+        @Suppress("UNCHECKED_CAST")
+        val p = values[0] as LibraryProjection
+        @Suppress("UNCHECKED_CAST")
+        val annotated = values[1] as List<com.riffle.core.data.AnnotatedBook>
+        @Suppress("UNCHECKED_CAST")
+        val items = values[2] as List<LibraryItem>
+        @Suppress("UNCHECKED_CAST")
+        val pls = values[3] as List<CatalogPlaylist>
+        val audiobookOnly = values[4] as Boolean
         if (items.isEmpty()) {
             null
         } else {
@@ -245,6 +266,10 @@ class LibraryItemsViewModel @Inject constructor(
                 series = p.series.isNotEmpty(),
                 collections = p.collections.isNotEmpty(),
                 annotations = annotated.isNotEmpty(),
+                // ABS audiobook root only. The gate is (audiobook library) AND (at least one
+                // non-reserved playlist) — the "To Read" filter lives inside PlaylistsRepository so
+                // a lib whose only playlist is "To Read" correctly reports playlists=false here.
+                playlists = audiobookOnly && pls.isNotEmpty(),
             )
         }
     }
@@ -262,6 +287,7 @@ class LibraryItemsViewModel @Inject constructor(
             }
             val refreshJob = launch { refresh() }
             launch { toReadRepository.refresh(libraryId) }
+            launch { playlistsRepository.refresh(libraryId) }
             // Unblock the UI as soon as we have something meaningful to show:
             // either Room returns cached data quickly, or we wait for the network
             // refresh to complete so an empty state is known to be genuine.
@@ -282,6 +308,7 @@ class LibraryItemsViewModel @Inject constructor(
             connectivityObserver.isOnline.collectReconnects {
                 refresh()
                 toReadRepository.refresh(libraryId)
+                playlistsRepository.refresh(libraryId)
             }
         }
         // While a refresh is failing AND the device is online (i.e. server unreachable on an
@@ -323,10 +350,12 @@ class LibraryItemsViewModel @Inject constructor(
         val itemsDeferred = async { refreshLibraryItemsUseCase(libraryId) }
         val seriesDeferred = async { refreshSeriesUseCase(libraryId) }
         val collectionsDeferred = async { refreshCollectionsUseCase(libraryId) }
-        // ToRead refresh runs alongside but its failure must NOT flip the offline banner.
+        // ToRead / Playlists refresh runs alongside but its failure must NOT flip the offline banner.
         val toReadDeferred = async { toReadRepository.refresh(libraryId) }
+        val playlistsDeferred = async { playlistsRepository.refresh(libraryId) }
         val results = listOf(itemsDeferred.await(), seriesDeferred.await(), collectionsDeferred.await())
         toReadDeferred.await()
+        playlistsDeferred.await()
         _refreshFailed.value = results.any { it is LibraryRefreshResult.NetworkError }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryTabVisibility.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryTabVisibility.kt
@@ -10,12 +10,13 @@ data class LibraryTabVisibility(
     val series: Boolean,
     val collections: Boolean,
     val annotations: Boolean,
+    val playlists: Boolean = false,
 ) {
     companion object {
         /** Default before the library has settled: hide every optional tab. */
-        val Empty = LibraryTabVisibility(toRead = false, series = false, collections = false, annotations = false)
+        val Empty = LibraryTabVisibility(toRead = false, series = false, collections = false, annotations = false, playlists = false)
 
         /** Every optional tab present — used as the "still loading" fallback in the UI. */
-        val All = LibraryTabVisibility(toRead = true, series = true, collections = true, annotations = true)
+        val All = LibraryTabVisibility(toRead = true, series = true, collections = true, annotations = true, playlists = true)
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/playlists/AddToPlaylistSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/playlists/AddToPlaylistSheet.kt
@@ -1,0 +1,215 @@
+package com.riffle.app.feature.library.playlists
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.riffle.core.catalog.CatalogPlaylist
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+
+/**
+ * Bottom sheet for adding or removing the current item from playlists on the active Source. State
+ * is driven by callers: [playlistsFlow] holds the current, "To Read"-filtered set; tapping a row
+ * calls [onToggle]; "+ New playlist" opens a small dialog that calls [onCreate] and closes on ""
+ * (empty string = success) or displays whatever error string it returns.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddToPlaylistSheet(
+    itemId: String,
+    playlistsFlow: Flow<List<CatalogPlaylist>>,
+    onToggle: (CatalogPlaylist) -> Unit,
+    onCreate: suspend (name: String) -> String,
+    onDismiss: () -> Unit,
+) {
+    val playlists by playlistsFlow.collectAsState(initial = emptyList())
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var showCreateDialog by rememberSaveable { mutableStateOf(false) }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp)) {
+            Text(
+                "Add to playlist",
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+            )
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { showCreateDialog = true }
+                    .padding(horizontal = 20.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Icon(Icons.Filled.Add, contentDescription = null)
+                Text("New playlist", style = MaterialTheme.typography.bodyLarge)
+            }
+            if (playlists.isEmpty()) {
+                Text(
+                    "No playlists yet. Create one to get started.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+                )
+            } else {
+                LazyColumn(modifier = Modifier.heightIn(max = 400.dp)) {
+                    items(playlists, key = { it.id }) { playlist ->
+                        PickerRow(
+                            playlist = playlist,
+                            isSelected = itemId in playlist.itemIds,
+                            onToggle = { onToggle(playlist) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    if (showCreateDialog) {
+        NewPlaylistDialog(
+            onDismiss = { showCreateDialog = false },
+            onCreate = onCreate,
+            onSuccess = { showCreateDialog = false },
+        )
+    }
+}
+
+@Composable
+private fun PickerRow(
+    playlist: CatalogPlaylist,
+    isSelected: Boolean,
+    onToggle: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggle)
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Box(modifier = Modifier.size(24.dp), contentAlignment = Alignment.Center) {
+            if (isSelected) {
+                Icon(
+                    Icons.Filled.Check,
+                    contentDescription = "In this playlist",
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = playlist.name,
+                style = MaterialTheme.typography.bodyLarge,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = pluralItems(playlist.bookCount),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun NewPlaylistDialog(
+    onDismiss: () -> Unit,
+    onCreate: suspend (name: String) -> String,
+    onSuccess: () -> Unit,
+) {
+    var name by rememberSaveable { mutableStateOf("") }
+    var isCreating by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+    val scope = rememberCoroutineScope()
+    AlertDialog(
+        onDismissRequest = { if (!isCreating) onDismiss() },
+        title = { Text("New playlist") },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = {
+                        name = it
+                        if (error != null) error = null
+                    },
+                    label = { Text("Name") },
+                    singleLine = true,
+                    enabled = !isCreating,
+                    isError = error != null,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                if (error != null) {
+                    Text(
+                        text = error!!,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(top = 4.dp),
+                    )
+                }
+                if (isCreating) {
+                    Box(
+                        modifier = Modifier.fillMaxWidth().height(32.dp).padding(top = 8.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = !isCreating && name.isNotBlank(),
+                onClick = {
+                    isCreating = true
+                    scope.launch {
+                        val err = onCreate(name)
+                        isCreating = false
+                        if (err.isEmpty()) onSuccess() else error = err
+                    }
+                },
+            ) { Text("Create") }
+        },
+        dismissButton = {
+            TextButton(enabled = !isCreating, onClick = onDismiss) { Text("Cancel") }
+        },
+    )
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/library/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/playlists/PlaylistDetailScreen.kt
@@ -1,0 +1,126 @@
+package com.riffle.app.feature.library.playlists
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.RemoveCircleOutline
+import androidx.compose.material3.Button
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.riffle.app.feature.library.LibraryItemCard
+import com.riffle.core.domain.LibraryItem
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.width
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PlaylistDetailScreen(
+    onNavigateBack: () -> Unit,
+    onItemSelected: (LibraryItem) -> Unit,
+    onPlayItem: (LibraryItem) -> Unit = onItemSelected,
+    viewModel: PlaylistDetailViewModel = hiltViewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    LaunchedEffect(Unit) {
+        viewModel.snackbarEvents.collect { msg -> snackbarHostState.showSnackbar(msg) }
+    }
+    // Auto-pop when the playlist is gone (ABS auto-deletes emptied playlists). Without this
+    // the screen sits on the empty state forever after the user removes the last item.
+    LaunchedEffect(state.deleted) {
+        if (state.deleted) onNavigateBack()
+    }
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(state.name) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
+    ) { padding ->
+        if (state.isLoading) {
+            Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                Text("Loading…")
+            }
+            return@Scaffold
+        }
+        if (state.items.isEmpty()) {
+            Box(modifier = Modifier.fillMaxSize().padding(padding), contentAlignment = Alignment.Center) {
+                Text("This playlist is empty.", color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            return@Scaffold
+        }
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(padding),
+            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            // Play affordance at the top of the list. Tap starts the first item in the audiobook
+            // player. Playback continuation across items isn't wired yet (the player would need
+            // playlist-context state); a completed item returns to this screen for manual pick.
+            item(key = "__play_header") {
+                Button(
+                    onClick = { state.items.firstOrNull()?.let(onPlayItem) },
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Icon(Icons.Filled.PlayArrow, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
+                    Text("Play")
+                }
+                Spacer(Modifier.height(4.dp))
+            }
+            items(state.items, key = { it.id }) { item ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Box(modifier = Modifier.weight(1f)) {
+                        LibraryItemCard(
+                            item = item,
+                            token = viewModel.authToken,
+                            onClick = { onItemSelected(item) },
+                        )
+                    }
+                    IconButton(onClick = { viewModel.removeItem(item.id) }) {
+                        Icon(
+                            Icons.Filled.RemoveCircleOutline,
+                            contentDescription = "Remove from playlist",
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/library/playlists/PlaylistDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/playlists/PlaylistDetailViewModel.kt
@@ -1,0 +1,133 @@
+package com.riffle.app.feature.library.playlists
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.riffle.core.catalog.CatalogPlaylist
+import com.riffle.core.data.PlaylistsRepository
+import com.riffle.core.domain.LibraryItem
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.TokenStorage
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import java.net.URLDecoder
+import javax.inject.Inject
+
+/**
+ * UI state for [PlaylistDetailScreen].
+ *
+ * - [isLoading] — the initial fetch hasn't completed yet
+ * - [deleted]  — the playlist no longer exists on the server (ABS auto-deletes an emptied
+ *                 playlist; setting this true lets the screen show a terminal empty state
+ *                 and pop back rather than sit on "Loading…" forever, which was the bug
+ *                 shipped in the first cut when [PlaylistsRepository.getPlaylist] returned
+ *                 null after the user removed the last item)
+ */
+data class PlaylistDetailUiState(
+    val name: String = "",
+    val items: List<LibraryItem> = emptyList(),
+    val isLoading: Boolean = true,
+    val deleted: Boolean = false,
+)
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class PlaylistDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val playlistsRepository: PlaylistsRepository,
+    private val libraryObserver: LibraryObserver,
+    sourceRepository: SourceRepository,
+    private val tokenStorage: TokenStorage,
+) : ViewModel() {
+
+    val libraryId: String = savedStateHandle.get<String>("libraryId") ?: ""
+    val playlistId: String = savedStateHandle.get<String>("playlistId") ?: ""
+    private val initialName: String =
+        URLDecoder.decode(savedStateHandle.get<String>("playlistName") ?: "", "UTF-8")
+
+    /** Playlist snapshot loaded from the repository.
+     *  - [PlaylistLoad.Loading] — before the first getPlaylist returns
+     *  - [PlaylistLoad.Present] — the playlist exists on the source
+     *  - [PlaylistLoad.Deleted] — a getPlaylist returned null AFTER a prior Present, i.e. the
+     *    playlist was auto-deleted by ABS when its last item was removed. Distinct from Loading
+     *    so the UI knows to show an empty state and pop back instead of spinning. */
+    private sealed interface PlaylistLoad {
+        data object Loading : PlaylistLoad
+        data class Present(val playlist: CatalogPlaylist) : PlaylistLoad
+        data object Deleted : PlaylistLoad
+    }
+
+    private val loadFlow = MutableStateFlow<PlaylistLoad>(PlaylistLoad.Loading)
+
+    private val _snackbarEvents = Channel<String>(Channel.BUFFERED)
+    val snackbarEvents: Flow<String> = _snackbarEvents.receiveAsFlow()
+
+    val uiState: StateFlow<PlaylistDetailUiState> = combine(
+        loadFlow,
+        libraryObserver.observeLibraryItems(libraryId),
+    ) { load, libraryItems ->
+        when (load) {
+            PlaylistLoad.Loading -> PlaylistDetailUiState(name = initialName, isLoading = true)
+            PlaylistLoad.Deleted -> PlaylistDetailUiState(name = initialName, isLoading = false, deleted = true)
+            is PlaylistLoad.Present -> {
+                val byId = libraryItems.associateBy { it.id }
+                val ordered = load.playlist.itemIds.mapNotNull { byId[it] }
+                PlaylistDetailUiState(
+                    name = load.playlist.name,
+                    items = ordered,
+                    isLoading = false,
+                )
+            }
+        }
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        PlaylistDetailUiState(name = initialName),
+    )
+
+    var authToken: String = ""
+        private set
+
+    init {
+        viewModelScope.launch {
+            val active = sourceRepository.getActive()
+            if (active != null) authToken = tokenStorage.getToken(active.id) ?: ""
+            reload()
+        }
+    }
+
+    fun removeItem(itemId: String) {
+        viewModelScope.launch {
+            val ok = playlistsRepository.removeItemFromPlaylist(libraryId, playlistId, itemId)
+            if (ok) {
+                reload()
+                _snackbarEvents.trySend("Removed from playlist")
+            } else {
+                _snackbarEvents.trySend("Couldn't remove from playlist")
+            }
+        }
+    }
+
+    private suspend fun reload() {
+        val fetched = playlistsRepository.getPlaylist(libraryId, playlistId)
+        loadFlow.value = if (fetched != null) {
+            PlaylistLoad.Present(fetched)
+        } else if (loadFlow.value is PlaylistLoad.Loading) {
+            // First fetch found nothing — treat as deleted (either the id was stale from a nav
+            // arg or the playlist has since disappeared). Better to surface it than spin.
+            PlaylistLoad.Deleted
+        } else {
+            PlaylistLoad.Deleted
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/library/playlists/PlaylistsTabContent.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/playlists/PlaylistsTabContent.kt
@@ -1,0 +1,106 @@
+package com.riffle.app.feature.library.playlists
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.QueueMusic
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.riffle.core.catalog.CatalogPlaylist
+
+/**
+ * Playlists tab body. Shown only on ABS audiobook roots (gated by
+ * [com.riffle.app.feature.library.LibraryItemsViewModel.tabVisibility]). The "To Read"
+ * playlist is already filtered out by [com.riffle.core.data.PlaylistsRepository], so this
+ * composable renders whatever it receives verbatim.
+ */
+@Composable
+fun PlaylistsTabContent(
+    playlists: List<CatalogPlaylist>,
+    onPlaylistSelected: (CatalogPlaylist) -> Unit,
+) {
+    if (playlists.isEmpty()) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Text("No playlists yet. Create one from any item.")
+        }
+        return
+    }
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(0.dp),
+    ) {
+        items(playlists, key = { it.id }) { playlist ->
+            PlaylistRow(playlist = playlist, onClick = { onPlaylistSelected(playlist) })
+        }
+    }
+}
+
+@Composable
+internal fun PlaylistRow(
+    playlist: CatalogPlaylist,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.secondaryContainer),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.QueueMusic,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = playlist.name,
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = pluralItems(playlist.bookCount),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Icon(
+            imageVector = Icons.Filled.ChevronRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+internal fun pluralItems(count: Int): String = if (count == 1) "1 item" else "$count items"

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -85,12 +85,13 @@ private const val SERIES_DETAIL = "series_detail/{libraryId}/{seriesId}/{seriesN
 private const val COLLECTION_DETAIL = "collection_detail/{libraryId}/{collectionId}/{collectionName}"
 private const val FILTERED_BOOKS = "filtered_books/{libraryId}/{facetType}/{facetValue}"
 private const val LIBRARY_ITEM_DETAIL = "library_item_detail/{itemId}"
+private const val PLAYLIST_DETAIL = "playlist_detail/{libraryId}/{playlistId}/{playlistName}"
 private const val EPUB_READER =
     "epub_reader/{itemId}?startReadaloudAtSec={startReadaloudAtSec}&openAtCfi={openAtCfi}&startTocHref={startTocHref}&source={source}&sourceId={sourceId}"
 private const val PDF_READER = "pdf_reader/{itemId}"
 private const val CBZ_READER = "cbz_reader/{itemId}"
 private const val ANNOTATION_SEARCH = "annotation_search/{libraryId}?query={query}"
-private const val AUDIOBOOK_PLAYER = "audiobook_player/{itemId}?startAtSec={startAtSec}"
+private const val AUDIOBOOK_PLAYER = "audiobook_player/{itemId}?startAtSec={startAtSec}&playlistId={playlistId}&libraryId={libraryId}"
 
 /**
  * URL-encodes each path segment in a series-detail route. seriesId is encoded because chitanka
@@ -559,6 +560,40 @@ fun MainScreen(
                     onAnnotatedBookClick = { sourceId, itemId ->
                         navController.navigate(annotationsBookClickRoute(sourceId, itemId))
                     },
+                    onPlaylistSelected = { playlist ->
+                        val encodedName = URLEncoder.encode(playlist.name, "UTF-8")
+                        val encodedId = URLEncoder.encode(playlist.id, "UTF-8")
+                        navController.navigate("playlist_detail/$libraryId/$encodedId/$encodedName")
+                    },
+                )
+            }
+            composable(
+                route = PLAYLIST_DETAIL,
+                arguments = listOf(
+                    navArgument("libraryId") { type = NavType.StringType },
+                    navArgument("playlistId") { type = NavType.StringType },
+                    navArgument("playlistName") { type = NavType.StringType },
+                ),
+            ) { backStackEntry ->
+                val playlistLibraryId = backStackEntry.arguments?.getString("libraryId").orEmpty()
+                val playlistIdArg = backStackEntry.arguments?.getString("playlistId").orEmpty()
+                com.riffle.app.feature.library.playlists.PlaylistDetailScreen(
+                    onNavigateBack = { navController.popBackStack() },
+                    onItemSelected = { item ->
+                        val encodedId = URLEncoder.encode(item.id, "UTF-8")
+                        navController.navigate("library_item_detail/$encodedId")
+                    },
+                    // Play launches the first item into the audiobook player carrying the playlist
+                    // context (`playlistId` + `libraryId`) — the player VM uses those to look up
+                    // the next item on end-of-book and hop straight into it (auto-advance).
+                    onPlayItem = { item ->
+                        val encodedId = URLEncoder.encode(item.id, "UTF-8")
+                        val plQ = URLEncoder.encode(playlistIdArg, "UTF-8")
+                        val libQ = URLEncoder.encode(playlistLibraryId, "UTF-8")
+                        navController.navigate(
+                            "audiobook_player/$encodedId?playlistId=$plQ&libraryId=$libQ"
+                        )
+                    },
                 )
             }
             composable(
@@ -784,11 +819,45 @@ fun MainScreen(
                         type = NavType.FloatType
                         defaultValue = -1f // -1 = opened normally; >=0 = readaloud→audiobook handoff
                     },
+                    // Optional playlist context — set when the player was opened from the Playlists
+                    // tab (via [PlaylistDetailScreen]'s Play button). On end-of-book the VM uses
+                    // these to look up the next item and emit PlaylistAdvance; without them Finished
+                    // pops the player as before.
+                    navArgument("playlistId") {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    },
+                    navArgument("libraryId") {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    },
                 )
-            ) {
+            ) { backStackEntry ->
+                val currentPlaylistId = backStackEntry.arguments?.getString("playlistId")
+                val currentLibraryId = backStackEntry.arguments?.getString("libraryId")
                 AudiobookPlayerScreen(
                     windowSizeClass = windowSizeClass,
                     onNavigateBack = { navController.popBackStack() },
+                    // End-of-book with a playlist context: hop straight to the next item's player,
+                    // popping the current player entry so Back returns to the playlist detail
+                    // (rather than an ever-growing stack of dead player entries).
+                    onPlaylistAdvance = { nextItemId ->
+                        val encoded = URLEncoder.encode(nextItemId, "UTF-8")
+                        val pl = URLEncoder.encode(currentPlaylistId.orEmpty(), "UTF-8")
+                        val lib = URLEncoder.encode(currentLibraryId.orEmpty(), "UTF-8")
+                        // No startAtSec override — default -1 = "resume from saved position", so a
+                        // partially-listened next item picks up where the user left off. (The
+                        // earlier chain-runs-away failure mode when the next item was already at
+                        // 100% is now handled by [AudiobookController.clearEndOfBookCache] wiping
+                        // the STATE_ENDED replay before the incoming VM subscribes.)
+                        navController.navigate(
+                            "audiobook_player/$encoded?playlistId=$pl&libraryId=$lib"
+                        ) {
+                            popUpTo(AUDIOBOOK_PLAYER) { inclusive = true }
+                        }
+                    },
                     // Swipe down → switch to the readaloud reader for the linked ebook, continuing from
                     // the audiobook position. Pop the player off the stack so leaving readaloud doesn't
                     // land back on a dead player, and its onCleared stops audio + flushes progress.

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -101,6 +101,7 @@ class AudiobookPlayerViewModelBookmarkTest {
     private class FakeController(var position: Double) : AudiobookController() {
         val seeks = mutableListOf<Double>()
         var preparedStartAtSec: Double? = null
+        var stopCount = 0
         override val state = MutableStateFlow(PlaybackState())
         private val ended = kotlinx.coroutines.flow.MutableSharedFlow<Unit>(extraBufferCapacity = 1)
         override val playbackEnded: kotlinx.coroutines.flow.SharedFlow<Unit> = ended.asSharedFlow()
@@ -117,6 +118,7 @@ class AudiobookPlayerViewModelBookmarkTest {
         override fun setSpeed(speed: Float) {}
         override fun currentAbsoluteSec(): Double = position
         override fun seekTo(absoluteSec: Double) { seeks.add(absoluteSec) }
+        override fun stop() { stopCount++ /* skip parent impl; connector is null anyway */ }
     }
 
     // Cancel the ViewModel's [viewModelScope] (the never-ending follow loop + bookmark observation) so
@@ -138,6 +140,8 @@ class AudiobookPlayerViewModelBookmarkTest {
         listeningStore: ListeningPreferencesStore = FakeListeningPreferencesStore,
         positionStore: com.riffle.core.domain.AudiobookPositionStore = FakePositionStore(),
         logger: RecordingLogger = RecordingLogger(),
+        playlistsRepository: com.riffle.core.data.PlaylistsRepository = NoopPlaylistsRepository,
+        savedState: Map<String, Any?> = mapOf("itemId" to itemId),
     ): AudiobookPlayerViewModel {
         val session = AudiobookSession(
             trackUrls = listOf("http://x/track0"),
@@ -149,7 +153,7 @@ class AudiobookPlayerViewModelBookmarkTest {
         val repo = FakeAudiobookRepository(session)
         lastAudiobookRepo = repo
         return AudiobookPlayerViewModel(
-            savedStateHandle = SavedStateHandle(mapOf("itemId" to itemId)),
+            savedStateHandle = SavedStateHandle(savedState),
             audiobookRepository = repo,
             audiobookDownloadRepository = NoDownloadRepo,
             bundleAudiobookSource = NoBundleSource,
@@ -197,7 +201,19 @@ class AudiobookPlayerViewModelBookmarkTest {
                 override fun nowNs(): Long = fixedNow * 1_000_000L
             },
             logger = logger,
+            playlistsRepository = playlistsRepository,
         )
+    }
+
+    private companion object {
+        val NoopPlaylistsRepository = object : com.riffle.core.data.PlaylistsRepository {
+            override fun observePlaylists(rootId: String) = kotlinx.coroutines.flow.flowOf(emptyList<com.riffle.core.catalog.CatalogPlaylist>())
+            override suspend fun refresh(rootId: String) = true
+            override suspend fun getPlaylist(rootId: String, playlistId: String) = null
+            override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?) = throw UnsupportedOperationException()
+            override suspend fun addItemToPlaylist(rootId: String, playlistId: String, itemId: String) = false
+            override suspend fun removeItemFromPlaylist(rootId: String, playlistId: String, itemId: String) = false
+        }
     }
 
     @Test
@@ -304,6 +320,109 @@ class AudiobookPlayerViewModelBookmarkTest {
         job.join()
 
         assertEquals(listOf(AudiobookPlayerEvent.Finished), collected)
+        // Non-playlist path DOES tear the singleton controller down so the foreground
+        // notification drops — the auto-advance path (next test) is the one that must NOT stop.
+        assertEquals(1, controller.stopCount)
+        vm.clearForTest()
+    }
+
+    /**
+     * Regression test for the "playback stops after auto-advance" bug (three fix attempts).
+     *
+     * On end-of-book with a playlist context that has a next item, the VM must:
+     * - Emit [AudiobookPlayerEvent.PlaylistAdvance] carrying the next itemId.
+     * - NOT call [AudiobookController.stop], because the same singleton controller is about to
+     *   be re-prepared by the incoming next-item VM. Stopping releases the connector, and when
+     *   the incoming VM's prepare() races the release, playback silently dies. The fix routes
+     *   the teardown around the auto-advance path (see [handingOffToPlaylistAdvance]).
+     * If either assertion flips, the bug is back.
+     */
+    @Test
+    fun `controller playbackEnded with playlist context advances without stopping the controller`() = runTest(testDispatcher) {
+        val controller = FakeController(position = 0.0)
+        val nextItemId = "item-next"
+        val playlist = com.riffle.core.catalog.CatalogPlaylist(
+            id = "pl-1",
+            rootId = "lib-1",
+            name = "My playlist",
+            bookCount = 2,
+            itemIds = listOf(itemId, nextItemId),
+        )
+        val playlistsRepo = object : com.riffle.core.data.PlaylistsRepository {
+            override fun observePlaylists(rootId: String) = kotlinx.coroutines.flow.flowOf(listOf(playlist))
+            override suspend fun refresh(rootId: String) = true
+            override suspend fun getPlaylist(rootId: String, playlistId: String) = playlist
+            override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?) = throw UnsupportedOperationException()
+            override suspend fun addItemToPlaylist(rootId: String, playlistId: String, itemId: String) = false
+            override suspend fun removeItemFromPlaylist(rootId: String, playlistId: String, itemId: String) = false
+        }
+        val vm = buildViewModel(
+            controller = controller,
+            bookmarkStore = FakeBookmarkStore(),
+            playlistsRepository = playlistsRepo,
+            savedState = mapOf(
+                "itemId" to itemId,
+                "playlistId" to "pl-1",
+                "libraryId" to "lib-1",
+            ),
+        )
+        runCurrent()
+
+        val collected = mutableListOf<AudiobookPlayerEvent>()
+        val job = launch { vm.events.take(1).toList(collected) }
+        runCurrent()
+
+        controller.emitEnded()
+        runCurrent()
+        job.join()
+
+        assertEquals(listOf(AudiobookPlayerEvent.PlaylistAdvance(nextItemId)), collected)
+        // The critical invariant: on auto-advance we MUST leave the singleton controller alone.
+        // If stopCount > 0, the incoming VM's playback will race a connector release and die.
+        assertEquals(0, controller.stopCount)
+        vm.clearForTest()
+    }
+
+    @Test
+    fun `controller playbackEnded on the last item of a playlist falls back to Finished`() = runTest(testDispatcher) {
+        val controller = FakeController(position = 0.0)
+        val playlist = com.riffle.core.catalog.CatalogPlaylist(
+            id = "pl-1",
+            rootId = "lib-1",
+            name = "My playlist",
+            bookCount = 1,
+            itemIds = listOf(itemId), // current IS the last (and only) item
+        )
+        val playlistsRepo = object : com.riffle.core.data.PlaylistsRepository {
+            override fun observePlaylists(rootId: String) = kotlinx.coroutines.flow.flowOf(listOf(playlist))
+            override suspend fun refresh(rootId: String) = true
+            override suspend fun getPlaylist(rootId: String, playlistId: String) = playlist
+            override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?) = throw UnsupportedOperationException()
+            override suspend fun addItemToPlaylist(rootId: String, playlistId: String, itemId: String) = false
+            override suspend fun removeItemFromPlaylist(rootId: String, playlistId: String, itemId: String) = false
+        }
+        val vm = buildViewModel(
+            controller = controller,
+            bookmarkStore = FakeBookmarkStore(),
+            playlistsRepository = playlistsRepo,
+            savedState = mapOf(
+                "itemId" to itemId,
+                "playlistId" to "pl-1",
+                "libraryId" to "lib-1",
+            ),
+        )
+        runCurrent()
+
+        val collected = mutableListOf<AudiobookPlayerEvent>()
+        val job = launch { vm.events.take(1).toList(collected) }
+        runCurrent()
+
+        controller.emitEnded()
+        runCurrent()
+        job.join()
+
+        assertEquals(listOf(AudiobookPlayerEvent.Finished), collected)
+        assertEquals(1, controller.stopCount)
         vm.clearForTest()
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -238,6 +238,14 @@ class SleepTimerTest {
                 override fun nowNs(): Long = 0L
             },
             logger = RecordingLogger(),
+            playlistsRepository = object : com.riffle.core.data.PlaylistsRepository {
+                override fun observePlaylists(rootId: String) = kotlinx.coroutines.flow.flowOf(emptyList<com.riffle.core.catalog.CatalogPlaylist>())
+                override suspend fun refresh(rootId: String) = true
+                override suspend fun getPlaylist(rootId: String, playlistId: String) = null
+                override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?) = throw UnsupportedOperationException()
+                override suspend fun addItemToPlaylist(rootId: String, playlistId: String, itemId: String) = false
+                override suspend fun removeItemFromPlaylist(rootId: String, playlistId: String, itemId: String) = false
+            },
         )
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -184,6 +184,15 @@ class LibraryItemDetailViewModelTest {
         override suspend fun touchOpenTimestamp(itemId: String) = Unit
     }
 
+    private class NoopPlaylistsRepository : com.riffle.core.data.PlaylistsRepository {
+        override fun observePlaylists(rootId: String) = flowOf(emptyList<com.riffle.core.catalog.CatalogPlaylist>())
+        override suspend fun refresh(rootId: String) = true
+        override suspend fun getPlaylist(rootId: String, playlistId: String) = null
+        override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?) = throw UnsupportedOperationException()
+        override suspend fun addItemToPlaylist(rootId: String, playlistId: String, itemId: String) = false
+        override suspend fun removeItemFromPlaylist(rootId: String, playlistId: String, itemId: String) = false
+    }
+
     private class FakeToReadRepository(
         initial: Set<String> = emptySet(),
         var addResult: Boolean = true,
@@ -265,6 +274,7 @@ class LibraryItemDetailViewModelTest {
         pdfRepository = pdfRepository,
         cbzRepository = NoopCbzRepository(),
         toReadRepository = toReadRepo,
+        playlistsRepository = NoopPlaylistsRepository(),
         readaloudLinkRepository = readaloudLinkRepository,
         readaloudAudioRepository = readaloudAudioRepository,
         audiobookDownloadRepository = NoopAudiobookDownloadRepository,

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
@@ -88,6 +88,15 @@ class LibraryItemDetailViewModelTocTest {
         override suspend fun deleteToken(sourceId: String) {}
     }
 
+    private val noOpPlaylistsRepository = object : com.riffle.core.data.PlaylistsRepository {
+        override fun observePlaylists(rootId: String) = flowOf(emptyList<com.riffle.core.catalog.CatalogPlaylist>())
+        override suspend fun refresh(rootId: String) = true
+        override suspend fun getPlaylist(rootId: String, playlistId: String) = null
+        override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?) = throw UnsupportedOperationException()
+        override suspend fun addItemToPlaylist(rootId: String, playlistId: String, itemId: String) = false
+        override suspend fun removeItemFromPlaylist(rootId: String, playlistId: String, itemId: String) = false
+    }
+
     private val noOpToReadRepository = object : ToReadRepository {
         override fun observeToReadItemIds(libraryId: String): Flow<Set<String>> = flowOf(emptySet())
         override suspend fun refresh(libraryId: String): Boolean = true
@@ -145,6 +154,7 @@ class LibraryItemDetailViewModelTocTest {
         pdfRepository = FakePdfRepo(),
         cbzRepository = NoopCbzRepository(),
         toReadRepository = noOpToReadRepository,
+        playlistsRepository = noOpPlaylistsRepository,
         readaloudLinkRepository = NoopReadaloudLinkRepository,
         readaloudAudioRepository = NoopReadaloudAudioRepository,
         audiobookDownloadRepository = NoopAudiobookDownloadRepository,

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -186,6 +186,16 @@ class LibraryItemsViewModelTest {
         override val isOnline: StateFlow<Boolean> = state
     }
 
+    private class NoopPlaylistsRepository : com.riffle.core.data.PlaylistsRepository {
+        override fun observePlaylists(rootId: String) = kotlinx.coroutines.flow.flowOf(emptyList<com.riffle.core.catalog.CatalogPlaylist>())
+        override suspend fun refresh(rootId: String) = true
+        override suspend fun getPlaylist(rootId: String, playlistId: String) = null
+        override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?) =
+            throw UnsupportedOperationException()
+        override suspend fun addItemToPlaylist(rootId: String, playlistId: String, itemId: String) = false
+        override suspend fun removeItemFromPlaylist(rootId: String, playlistId: String, itemId: String) = false
+    }
+
     private class FakeToReadRepository(initial: Set<String> = emptySet()) : ToReadRepository {
         val ids = MutableStateFlow(initial)
         var refreshCount = 0
@@ -246,6 +256,7 @@ class LibraryItemsViewModelTest {
         ),
         connectivityObserver = connectivityObserver,
         toReadRepository = toReadRepository,
+        playlistsRepository = NoopPlaylistsRepository(),
         readaloudLinkRepository = readaloudLinkRepository,
         coverGridDensityStore = coverGridDensityStore,
         annotationStore = annotationStore,

--- a/core/data/src/main/kotlin/com/riffle/core/data/PlaylistsRepository.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/PlaylistsRepository.kt
@@ -1,0 +1,50 @@
+package com.riffle.core.data
+
+import com.riffle.core.catalog.CatalogPlaylist
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Names of playlists that Riffle treats as internal wishlist surfaces and hides from the
+ * user-facing Playlists tab / picker. "To Read" is created by Riffle's own To Read toggle;
+ * "To Listen" is the audiobook equivalent surfaced by ABS. Users manage those through the
+ * dedicated toggle/tab; exposing them in the general playlists picker would let a user
+ * mutate them from two places with different semantics and would fork the find-by-name
+ * invariant [ToReadRepository] relies on.
+ */
+val RESERVED_PLAYLIST_NAMES: Set<String> = setOf("To Read", "To Listen")
+
+/** Raised by [PlaylistsRepository.createPlaylist] when the name is reserved for another surface. */
+class ReservedPlaylistNameException(val name: String) : IllegalArgumentException("Playlist name '$name' is reserved")
+
+/**
+ * User-facing Playlists surface for a library, backed by the active Source's
+ * [com.riffle.core.catalog.PlaylistsCapability].
+ *
+ * The "To Read" playlist ([TO_READ_PLAYLIST_NAME]) is deliberately filtered out of every
+ * user-facing flow — it has its own dedicated affordance ([ToReadRepository]) and tab, and
+ * exposing it here would let a user manipulate To Read from two places with different semantics.
+ * The filter lives in exactly one place ([observePlaylists]); callers never see it, so a picker
+ * or list can never accidentally leak the reserved playlist.
+ */
+interface PlaylistsRepository {
+    /** Playlists for [rootId], with "To Read" filtered out. Empty until [refresh] populates the cache. */
+    fun observePlaylists(rootId: String): Flow<List<CatalogPlaylist>>
+
+    /** Fetch playlists for [rootId] from the active Source and refresh the in-memory cache. */
+    suspend fun refresh(rootId: String): Boolean
+
+    /** Full playlist ([CatalogPlaylist.itemIds] populated) by id. Null if not found on the Source. */
+    suspend fun getPlaylist(rootId: String, playlistId: String): CatalogPlaylist?
+
+    /**
+     * Create a playlist named [name] scoped to [rootId], optionally seeded with [initialItemId].
+     * Throws [ReservedPlaylistNameException] when [name] matches any [RESERVED_PLAYLIST_NAMES]
+     * entry (case-insensitive) — those names are owned by the To Read / To Listen surfaces and a
+     * duplicate would fork their find-by-name invariant.
+     */
+    suspend fun createPlaylist(rootId: String, name: String, initialItemId: String? = null): CatalogPlaylist
+
+    suspend fun addItemToPlaylist(rootId: String, playlistId: String, itemId: String): Boolean
+
+    suspend fun removeItemFromPlaylist(rootId: String, playlistId: String, itemId: String): Boolean
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/PlaylistsRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/PlaylistsRepositoryImpl.kt
@@ -1,0 +1,124 @@
+package com.riffle.core.data
+
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogPlaylist
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.PlaylistsCapability
+import com.riffle.core.logging.LogChannel
+import com.riffle.core.logging.Logger
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Playlists for a library, cached in-memory. The cache is per-rootId — the same source-wide
+ * capability serves every root, but we never coalesce results across roots because ABS scopes
+ * playlists per-library.
+ */
+@Singleton
+class PlaylistsRepositoryImpl @Inject constructor(
+    private val catalogRegistry: CatalogRegistry,
+    private val logger: Logger,
+) : PlaylistsRepository {
+
+    private val cache = MutableStateFlow<Map<String, List<CatalogPlaylist>>>(emptyMap())
+
+    override fun observePlaylists(rootId: String): Flow<List<CatalogPlaylist>> =
+        // Reserved-name filter is applied here, once. Every consumer — the Playlists tab, the
+        // playlist detail screen, and the "Add to playlist…" picker — reads through this flow, so
+        // "To Read" / "To Listen" cannot leak into a user-facing surface even if a future caller
+        // forgets the rule.
+        cache.map { byRoot -> byRoot[rootId].orEmpty().filterNot { it.isReservedName() } }
+
+    override suspend fun refresh(rootId: String): Boolean {
+        val cap = activePlaylistsCap() ?: run {
+            // No capability on the active Source — treat as empty rather than error so the UI
+            // (which drives tab visibility off this flow) simply hides the tab.
+            cache.value = cache.value + (rootId to emptyList())
+            return true
+        }
+        return runCatching { cap.listPlaylists(rootId) }
+            .onSuccess { cache.value = cache.value + (rootId to it) }
+            .onFailure { logger.d(LogChannel.Playlists) { "refresh($rootId) failed: $it" } }
+            .isSuccess
+    }
+
+    override suspend fun getPlaylist(rootId: String, playlistId: String): CatalogPlaylist? {
+        val cap = activePlaylistsCap() ?: return null
+        // findPlaylist is by-name only; we want by-id and need itemIds populated. listPlaylists
+        // on ABS returns full itemIds already; if we ever move to a summary-only source we'll
+        // need a per-id fetch here.
+        return runCatching { cap.listPlaylists(rootId).firstOrNull { it.id == playlistId } }
+            .onFailure { logger.d(LogChannel.Playlists) { "getPlaylist($rootId, $playlistId) failed: $it" } }
+            .getOrNull()
+    }
+
+    override suspend fun createPlaylist(
+        rootId: String,
+        name: String,
+        initialItemId: String?,
+    ): CatalogPlaylist {
+        if (RESERVED_PLAYLIST_NAMES.any { it.equals(name.trim(), ignoreCase = true) }) {
+            throw ReservedPlaylistNameException(name)
+        }
+        val cap = activePlaylistsCap()
+            ?: throw IllegalStateException("Active Source has no PlaylistsCapability")
+        val created = cap.createPlaylist(rootId, name.trim(), initialItemId)
+        cache.value = cache.value + (rootId to (cache.value[rootId].orEmpty() + created))
+        return created
+    }
+
+    override suspend fun addItemToPlaylist(rootId: String, playlistId: String, itemId: String): Boolean {
+        val cap = activePlaylistsCap() ?: return false
+        val before = cache.value[rootId].orEmpty()
+        val target = before.firstOrNull { it.id == playlistId } ?: return false
+        if (itemId in target.itemIds) return true
+        val updated = target.copy(
+            itemIds = target.itemIds + itemId,
+            bookCount = target.bookCount + 1,
+        )
+        cache.value = cache.value + (rootId to before.map { if (it.id == playlistId) updated else it })
+        return runCatching { cap.addItemToPlaylist(playlistId, itemId); true }
+            .onFailure {
+                logger.d(LogChannel.Playlists) { "addItemToPlaylist($playlistId, $itemId) failed: $it" }
+                cache.value = cache.value + (rootId to before)
+            }
+            .getOrDefault(false)
+    }
+
+    override suspend fun removeItemFromPlaylist(rootId: String, playlistId: String, itemId: String): Boolean {
+        val cap = activePlaylistsCap() ?: return false
+        val before = cache.value[rootId].orEmpty()
+        val target = before.firstOrNull { it.id == playlistId } ?: return false
+        if (itemId !in target.itemIds) return true
+        val remaining = target.itemIds - itemId
+        val updated = target.copy(
+            itemIds = remaining,
+            bookCount = (target.bookCount - 1).coerceAtLeast(0),
+        )
+        // ABS auto-deletes an emptied playlist server-side. Mirror that locally so the tab hides
+        // once the last item is removed, without waiting for the next refresh.
+        val next = if (remaining.isEmpty()) {
+            before.filterNot { it.id == playlistId }
+        } else {
+            before.map { if (it.id == playlistId) updated else it }
+        }
+        cache.value = cache.value + (rootId to next)
+        return runCatching { cap.removeItemFromPlaylist(playlistId, itemId); true }
+            .onFailure {
+                logger.d(LogChannel.Playlists) { "removeItemFromPlaylist($playlistId, $itemId) failed: $it" }
+                cache.value = cache.value + (rootId to before)
+            }
+            .getOrDefault(false)
+    }
+
+    private suspend fun activePlaylistsCap(): PlaylistsCapability? {
+        val catalog: Catalog = catalogRegistry.forActive() ?: return null
+        return catalog as? PlaylistsCapability
+    }
+
+    private fun CatalogPlaylist.isReservedName(): Boolean =
+        RESERVED_PLAYLIST_NAMES.any { it.equals(name.trim(), ignoreCase = true) }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/RepositoriesModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/RepositoriesModule.kt
@@ -7,6 +7,8 @@ import com.riffle.core.data.ConnectivityObserverImpl
 import com.riffle.core.data.CrashReportRepositoryImpl
 import com.riffle.core.data.LocalToReadStore
 import com.riffle.core.data.LocalToReadStoreImpl
+import com.riffle.core.data.PlaylistsRepository
+import com.riffle.core.data.PlaylistsRepositoryImpl
 import com.riffle.core.data.CrossEpubIndexBuilderService
 import com.riffle.core.data.CrossEpubIndexBuildTrigger
 import com.riffle.core.data.EpubRepositoryImpl
@@ -68,6 +70,10 @@ abstract class RepositoriesModule {
     @Binds
     @Singleton
     abstract fun bindToReadRepository(impl: ToReadRepositoryImpl): ToReadRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindPlaylistsRepository(impl: PlaylistsRepositoryImpl): PlaylistsRepository
 
     @Binds
     @Singleton

--- a/core/data/src/test/kotlin/com/riffle/core/data/PlaylistsRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/PlaylistsRepositoryTest.kt
@@ -1,0 +1,346 @@
+package com.riffle.core.data
+
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogFileHandle
+import com.riffle.core.catalog.CatalogFileStream
+import com.riffle.core.catalog.CatalogHealth
+import com.riffle.core.catalog.CatalogItem
+import com.riffle.core.catalog.CatalogPlaylist
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.CatalogRoot
+import com.riffle.core.catalog.FacetSelection
+import com.riffle.core.catalog.PlaylistsCapability
+import com.riffle.core.catalog.SortKey
+import com.riffle.core.domain.Source
+import com.riffle.core.domain.SourceType
+import com.riffle.core.logging.RecordingLogger
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class PlaylistsRepositoryTest {
+
+    private fun makeRepo(catalog: Catalog?) =
+        PlaylistsRepositoryImpl(FakeRegistry(catalog), RecordingLogger())
+
+    // ── the "To Read" invariant ───────────────────────────────────────────────
+
+    /**
+     * Regression test for the reserved-name filter. If someone removes the filter in
+     * [PlaylistsRepositoryImpl.observePlaylists] or renames [TO_READ_PLAYLIST_NAME], this assertion
+     * flips red — which is the point. "To Read" MUST NOT appear in the user-facing Playlists
+     * surface; it belongs to [ToReadRepository]'s dedicated tab and affordance.
+     */
+    @Test
+    fun `observePlaylists hides the reserved To Read playlist`() = runTest {
+        val cap = FakeCatalog(
+            mapOf(
+                "lib-1" to listOf(
+                    playlist("pl-tr", TO_READ_PLAYLIST_NAME, listOf("i-1")),
+                    playlist("pl-a", "Favourites", listOf("i-2")),
+                    playlist("pl-b", "Yearly reread", listOf("i-3")),
+                ),
+            ),
+        )
+        val repo = makeRepo(cap)
+        assertTrue(repo.refresh("lib-1"))
+        val names = repo.observePlaylists("lib-1").first().map { it.name }
+        assertEquals(listOf("Favourites", "Yearly reread"), names)
+    }
+
+    /**
+     * "To Listen" is the audiobook wishlist equivalent surfaced by ABS — the general Playlists
+     * surface must hide it for the same reason it hides "To Read". Regression test: if the
+     * reserved set drops "To Listen" this flips red.
+     */
+    @Test
+    fun `observePlaylists hides the reserved To Listen playlist`() = runTest {
+        val cap = FakeCatalog(
+            mapOf(
+                "lib-1" to listOf(
+                    playlist("pl-tl", "To Listen", listOf("i-1")),
+                    playlist("pl-a", "Favourites", listOf("i-2")),
+                ),
+            ),
+        )
+        val repo = makeRepo(cap)
+        repo.refresh("lib-1")
+        assertEquals(listOf("Favourites"), repo.observePlaylists("lib-1").first().map { it.name })
+    }
+
+    @Test
+    fun `createPlaylist rejects the reserved To Listen name`() = runTest {
+        val cap = FakeCatalog(mapOf("lib-1" to emptyList()))
+        val repo = makeRepo(cap)
+        try {
+            repo.createPlaylist("lib-1", "To Listen")
+            fail("expected ReservedPlaylistNameException")
+        } catch (_: ReservedPlaylistNameException) {
+        }
+        assertTrue(cap.createCalls.isEmpty())
+    }
+
+    @Test
+    fun `observePlaylists reserved-name filter is case- and whitespace-insensitive`() = runTest {
+        val cap = FakeCatalog(
+            mapOf(
+                "lib-1" to listOf(
+                    playlist("pl-1", "to read", listOf("i-1")),
+                    playlist("pl-2", "  To Read  ", listOf("i-2")),
+                    playlist("pl-3", "Favourites", listOf("i-3")),
+                ),
+            ),
+        )
+        val repo = makeRepo(cap)
+        repo.refresh("lib-1")
+        assertEquals(listOf("Favourites"), repo.observePlaylists("lib-1").first().map { it.name })
+    }
+
+    @Test
+    fun `createPlaylist rejects the reserved name without calling the source`() = runTest {
+        val cap = FakeCatalog(mapOf("lib-1" to emptyList()))
+        val repo = makeRepo(cap)
+        try {
+            repo.createPlaylist("lib-1", TO_READ_PLAYLIST_NAME)
+            fail("expected ReservedPlaylistNameException")
+        } catch (_: ReservedPlaylistNameException) {
+            // expected
+        }
+        assertTrue("must not hit the source", cap.createCalls.isEmpty())
+    }
+
+    @Test
+    fun `createPlaylist rejects reserved name case- and whitespace-insensitively`() = runTest {
+        val cap = FakeCatalog(mapOf("lib-1" to emptyList()))
+        val repo = makeRepo(cap)
+        for (candidate in listOf("to read", "TO READ", "  To Read  ")) {
+            try {
+                repo.createPlaylist("lib-1", candidate)
+                fail("expected ReservedPlaylistNameException for '$candidate'")
+            } catch (_: ReservedPlaylistNameException) {
+            }
+        }
+        assertTrue(cap.createCalls.isEmpty())
+    }
+
+    // ── refresh + cache ───────────────────────────────────────────────────────
+
+    @Test
+    fun `refresh populates the per-root cache`() = runTest {
+        val cap = FakeCatalog(
+            mapOf(
+                "lib-1" to listOf(playlist("pl-a", "A", listOf("i-1"))),
+                "lib-2" to listOf(playlist("pl-b", "B", listOf("i-2"))),
+            ),
+        )
+        val repo = makeRepo(cap)
+        assertTrue(repo.refresh("lib-1"))
+        assertTrue(repo.refresh("lib-2"))
+        assertEquals(listOf("A"), repo.observePlaylists("lib-1").first().map { it.name })
+        assertEquals(listOf("B"), repo.observePlaylists("lib-2").first().map { it.name })
+    }
+
+    @Test
+    fun `refresh returns false on source failure and leaves cache untouched`() = runTest {
+        val cap = FakeCatalog(mapOf("lib-1" to emptyList()), listFails = true)
+        val repo = makeRepo(cap)
+        assertFalse(repo.refresh("lib-1"))
+        assertEquals(emptyList<CatalogPlaylist>(), repo.observePlaylists("lib-1").first())
+    }
+
+    @Test
+    fun `refresh treats missing PlaylistsCapability as empty`() = runTest {
+        val repo = makeRepo(catalog = null)
+        assertTrue(repo.refresh("lib-1"))
+        assertEquals(emptyList<CatalogPlaylist>(), repo.observePlaylists("lib-1").first())
+    }
+
+    // ── create ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `createPlaylist adds to the cache and returns the created playlist`() = runTest {
+        val cap = FakeCatalog(mapOf("lib-1" to emptyList()))
+        val repo = makeRepo(cap)
+        repo.refresh("lib-1")
+        val created = repo.createPlaylist("lib-1", "Favourites", initialItemId = "i-1")
+        assertEquals("Favourites", created.name)
+        assertEquals(listOf("i-1"), created.itemIds)
+        assertEquals(listOf("Favourites"), repo.observePlaylists("lib-1").first().map { it.name })
+        assertEquals(listOf("lib-1" to "Favourites"), cap.createCalls)
+        assertEquals(listOf<String?>("i-1"), cap.createSeeds)
+    }
+
+    @Test
+    fun `createPlaylist trims the name before sending`() = runTest {
+        val cap = FakeCatalog(mapOf("lib-1" to emptyList()))
+        val repo = makeRepo(cap)
+        repo.createPlaylist("lib-1", "  My List  ")
+        assertEquals(listOf("lib-1" to "My List"), cap.createCalls)
+    }
+
+    // ── add / remove ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `addItemToPlaylist optimistically updates cache then hits source`() = runTest {
+        val cap = FakeCatalog(mapOf("lib-1" to listOf(playlist("pl-a", "Favs", emptyList()))))
+        val repo = makeRepo(cap)
+        repo.refresh("lib-1")
+        assertTrue(repo.addItemToPlaylist("lib-1", "pl-a", "i-1"))
+        assertEquals(listOf("pl-a" to "i-1"), cap.addCalls)
+        assertEquals(listOf("i-1"), repo.observePlaylists("lib-1").first().first().itemIds)
+    }
+
+    @Test
+    fun `addItemToPlaylist reverts cache when source fails`() = runTest {
+        val cap = FakeCatalog(
+            mapOf("lib-1" to listOf(playlist("pl-a", "Favs", listOf("i-0")))),
+            addFails = true,
+        )
+        val repo = makeRepo(cap)
+        repo.refresh("lib-1")
+        assertFalse(repo.addItemToPlaylist("lib-1", "pl-a", "i-1"))
+        assertEquals(listOf("i-0"), repo.observePlaylists("lib-1").first().first().itemIds)
+    }
+
+    @Test
+    fun `addItemToPlaylist is idempotent when item already present`() = runTest {
+        val cap = FakeCatalog(mapOf("lib-1" to listOf(playlist("pl-a", "Favs", listOf("i-1")))))
+        val repo = makeRepo(cap)
+        repo.refresh("lib-1")
+        assertTrue(repo.addItemToPlaylist("lib-1", "pl-a", "i-1"))
+        assertTrue("no source call for a no-op", cap.addCalls.isEmpty())
+    }
+
+    @Test
+    fun `removeItemFromPlaylist removes and hits source`() = runTest {
+        val cap = FakeCatalog(mapOf("lib-1" to listOf(playlist("pl-a", "Favs", listOf("i-1", "i-2")))))
+        val repo = makeRepo(cap)
+        repo.refresh("lib-1")
+        assertTrue(repo.removeItemFromPlaylist("lib-1", "pl-a", "i-1"))
+        assertEquals(listOf("pl-a" to "i-1"), cap.removeCalls)
+        assertEquals(listOf("i-2"), repo.observePlaylists("lib-1").first().first().itemIds)
+    }
+
+    /**
+     * When the last item is removed, ABS auto-deletes the playlist server-side. The repository
+     * mirrors that by dropping the playlist from the cache so the tab hides immediately without
+     * waiting for the next refresh — pinning that behaviour here.
+     */
+    @Test
+    fun `removeItemFromPlaylist drops empty playlist from cache to mirror server auto-delete`() = runTest {
+        val cap = FakeCatalog(mapOf("lib-1" to listOf(playlist("pl-a", "Favs", listOf("i-1")))))
+        val repo = makeRepo(cap)
+        repo.refresh("lib-1")
+        assertTrue(repo.removeItemFromPlaylist("lib-1", "pl-a", "i-1"))
+        assertEquals(emptyList<CatalogPlaylist>(), repo.observePlaylists("lib-1").first())
+    }
+
+    @Test
+    fun `removeItemFromPlaylist reverts cache when source fails`() = runTest {
+        val cap = FakeCatalog(
+            mapOf("lib-1" to listOf(playlist("pl-a", "Favs", listOf("i-1", "i-2")))),
+            removeFails = true,
+        )
+        val repo = makeRepo(cap)
+        repo.refresh("lib-1")
+        assertFalse(repo.removeItemFromPlaylist("lib-1", "pl-a", "i-1"))
+        assertEquals(listOf("i-1", "i-2"), repo.observePlaylists("lib-1").first().first().itemIds)
+    }
+
+    // ── getPlaylist ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `getPlaylist returns the full playlist including To Read (repository is not the filter for detail lookups)`() = runTest {
+        // A caller with the id already in hand (e.g. from a nav argument) may be inside a screen
+        // that shouldn't exist for To Read, but the repository itself only filters the LIST — the
+        // per-id lookup is transparent so a debugging session can still resolve it if needed.
+        val cap = FakeCatalog(mapOf("lib-1" to listOf(playlist("pl-a", "Favs", listOf("i-1")))))
+        val repo = makeRepo(cap)
+        val loaded = repo.getPlaylist("lib-1", "pl-a")
+        assertNotNull(loaded)
+        assertEquals("Favs", loaded!!.name)
+        assertEquals(listOf("i-1"), loaded.itemIds)
+    }
+
+    @Test
+    fun `getPlaylist returns null when the playlist is missing on the source`() = runTest {
+        val cap = FakeCatalog(mapOf("lib-1" to emptyList()))
+        assertNull(makeRepo(cap).getPlaylist("lib-1", "pl-missing"))
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun playlist(id: String, name: String, itemIds: List<String>) = CatalogPlaylist(
+        id = id, rootId = "lib-1", name = name, bookCount = itemIds.size, itemIds = itemIds,
+    )
+
+    private class FakeRegistry(private val catalog: Catalog?) : CatalogRegistry {
+        override suspend fun forActive(): Catalog? = catalog
+        override suspend fun forSource(source: Source): Catalog? = catalog
+        override suspend fun forSourceId(sourceId: String): Catalog? = catalog
+    }
+
+    private class FakeCatalog(
+        val playlistsByLibrary: Map<String, List<CatalogPlaylist>> = emptyMap(),
+        val listFails: Boolean = false,
+        val createFails: Boolean = false,
+        val addFails: Boolean = false,
+        val removeFails: Boolean = false,
+    ) : Catalog, PlaylistsCapability {
+        val createCalls = mutableListOf<Pair<String, String>>()
+        val createSeeds = mutableListOf<String?>()
+        val addCalls = mutableListOf<Pair<String, String>>()
+        val removeCalls = mutableListOf<Pair<String, String>>()
+
+        override val sourceType = SourceType.ABS
+        override suspend fun listRoots() = emptyList<CatalogRoot>()
+        override suspend fun browse(rootId: String, sort: SortKey, page: Int, pageSize: Int, facet: FacetSelection?) =
+            emptyList<CatalogItem>()
+        override suspend fun search(rootId: String, query: String, page: Int, pageSize: Int) =
+            emptyList<CatalogItem>()
+        override suspend fun getItem(itemId: String): CatalogItem? = null
+        override suspend fun fetchFile(itemId: String, format: BookFormat): CatalogFileHandle =
+            throw UnsupportedOperationException()
+        override suspend fun openFile(itemId: String, format: BookFormat, handleHint: String?): CatalogFileStream =
+            throw UnsupportedOperationException()
+        override suspend fun connectivityCheck() = CatalogHealth(isReachable = true)
+
+        override suspend fun listPlaylists(rootId: String): List<CatalogPlaylist> {
+            if (listFails) throw RuntimeException("boom")
+            return playlistsByLibrary[rootId].orEmpty()
+        }
+
+        override suspend fun findPlaylist(rootId: String, name: String): CatalogPlaylist? =
+            playlistsByLibrary[rootId].orEmpty().firstOrNull { it.name == name }
+
+        override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?): CatalogPlaylist {
+            if (createFails) throw RuntimeException("boom")
+            createCalls += rootId to name
+            createSeeds += initialItemId
+            return CatalogPlaylist(
+                id = "pl-new-${createCalls.size}",
+                rootId = rootId,
+                name = name,
+                bookCount = if (initialItemId != null) 1 else 0,
+                itemIds = if (initialItemId != null) listOf(initialItemId) else emptyList(),
+            )
+        }
+
+        override suspend fun addItemToPlaylist(playlistId: String, itemId: String) {
+            if (addFails) throw RuntimeException("boom")
+            addCalls += playlistId to itemId
+        }
+
+        override suspend fun removeItemFromPlaylist(playlistId: String, itemId: String) {
+            if (removeFails) throw RuntimeException("boom")
+            removeCalls += playlistId to itemId
+        }
+    }
+}

--- a/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
+++ b/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
@@ -21,5 +21,6 @@ enum class LogChannel(val tag: String) {
     WebSourceCache("RIFFLE_WSC"),
     Gutenberg("RIFFLE_GB"),
     ToRead("RIFFLE_TOREAD"),
+    Playlists("RIFFLE_PL"),
     ProgressSync("RIFFLE_PS"),
 }


### PR DESCRIPTION
## Summary

- New **Playlists** tab on ABS audiobook library roots. Lists playlists on the active library (filtered to hide "To Read" / "To Listen" reserved names), with per-playlist detail (item list, Play button, remove-item).
- **Auto-advance**: playback started from a playlist detail's Play button rolls into the next item on end-of-book, resuming that item at its saved server position; the transition preserves the playlist context so the chain continues item-by-item until the end.
- **Add to playlist…** affordance on the audiobook item detail sheet — bottom-sheet picker with an inline "+ New playlist" dialog. Reserved names blocked client-side.

## Design notes

- Reserved-name filter (`RESERVED_PLAYLIST_NAMES = {"To Read", "To Listen"}`) lives in exactly one place inside `PlaylistsRepository.observePlaylists`. Every consumer — tab, detail, picker — reads through that flow, so those names can't accidentally leak into a user-facing surface.
- Auto-advance runs on the singleton `AudiobookController` — the outgoing VM skips its usual `controller.stop()` and calls only the new `AudiobookController.clearEndOfBookCache()`, so the incoming VM's `prepare()` doesn't race a connector release. Collector guards on `handingOffToPlaylistAdvance` to emit at most one `PlaylistAdvance` per VM instance (an earlier iteration briefly emitted several within ~1s during the nav-and-pop cycle).
- Add-to-playlist button uses the tab's `QueueMusic` icon inside the same outlined 40dp circle chrome as `ToReadToggleButton`, so the two controls live side-by-side as visually consistent affordances (music-note glyph vs check-mark glyph is the differentiator).

## Test plan

- [x] JVM: `./gradlew :app:testDebugUnitTest :core:data:testDebugUnitTest` — green, including regression tests that pin: reserved-name filter (`PlaylistsRepositoryTest`), auto-advance keeps controller connected (`AudiobookPlayerViewModelBookmarkTest`).
- [x] AVD end-to-end (Pixel 5 API 33, ephemeral session AVD): added ABS source, opened the Playlists tab, tapped Play on a 2-item playlist, scrubbed item 1 past its end, observed exactly one `AB.VM playlist auto-advance` in logcat and item 2 opening at its server-saved 8:20 position (verified 8:25 on screen ~5s later, playback progressing).
- [ ] Manual: verify the tab hides on ABS ebook root, Komga, Chitanka, Gutenberg, Local Files (behaviour per gate; not device-verified per-source).