### PR TITLE
fix(reader): expand chapter-map only for substantial sub-chapters

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -2704,7 +2704,12 @@ class EpubReaderViewModel @Inject constructor(
 
     val railSegments: StateFlow<List<RailSegment>> = combine(state, spinePositionCounts) { s, (spineHrefs, counts) ->
         val ready = s as? ReaderState.Ready ?: return@combine emptyList()
-        val base = buildRailSegments(ready.publication.tableOfContents.toTocEntries(), ready.title)
+        val base = buildRailSegments(
+            ready.publication.tableOfContents.toTocEntries(),
+            ready.title,
+            spineHrefs = spineHrefs,
+            positionCounts = counts,
+        )
         weightSegmentsByChapterLength(base, spineHrefs, counts)
     }
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -82,6 +82,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
@@ -2702,16 +2703,35 @@ class EpubReaderViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList<String>() to emptyList<Int>())
 
+    // Inputs to buildRailSegments are stable within a Ready session (TOC / title / spine
+    // hrefs / positions), so squash `state` down to just those before combining. Keeps rail
+    // computation out of the per-page-turn hot path and avoids the initial rail flicker that
+    // would otherwise occur while spinePositionCounts is still emptyList — the length rule
+    // silently degrades to the no-positions fallback and produces a different (usually more
+    // collapsed) rail than the second emission moments later.
+    private data class RailInputs(
+        val toc: List<TocEntry>,
+        val title: String,
+        val spineHrefs: List<String>,
+        val positionCounts: List<Int>,
+    )
+
     val railSegments: StateFlow<List<RailSegment>> = combine(state, spinePositionCounts) { s, (spineHrefs, counts) ->
-        val ready = s as? ReaderState.Ready ?: return@combine emptyList()
-        val base = buildRailSegments(
-            ready.publication.tableOfContents.toTocEntries(),
-            ready.title,
-            spineHrefs = spineHrefs,
-            positionCounts = counts,
-        )
-        weightSegmentsByChapterLength(base, spineHrefs, counts)
+        val ready = s as? ReaderState.Ready ?: return@combine null
+        if (spineHrefs.isEmpty() || counts.isEmpty()) return@combine null
+        RailInputs(ready.publication.tableOfContents.toTocEntries(), ready.title, spineHrefs, counts)
     }
+        .filterNotNull()
+        .distinctUntilChanged()
+        .map { inputs ->
+            val base = buildRailSegments(
+                inputs.toc,
+                inputs.title,
+                spineHrefs = inputs.spineHrefs,
+                positionCounts = inputs.positionCounts,
+            )
+            weightSegmentsByChapterLength(base, inputs.spineHrefs, inputs.positionCounts)
+        }
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     val activeRailSegmentIndex: StateFlow<Int> = combine(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
@@ -9,7 +9,7 @@ fun buildRailSegments(
     positionCounts: List<Int> = emptyList(),
 ): List<RailSegment> {
     val bookTitleNorm = bookTitle.normalize()
-    val spineIndex: Map<String, Int> = spineHrefs.withIndex().associate { (i, h) -> h to i }
+    val spineIndex = spineIndexOf(spineHrefs)
     val preprocessed = absorbFlatNumericRuns(tocEntries)
     val expanded = preprocessed.flatMap { expandIfRedundant(it, bookTitleNorm, spineIndex, positionCounts) }
     // Collapse entries that point to the same spine resource via different fragments. The
@@ -129,8 +129,7 @@ private fun shouldReplaceWithChildren(
  *   hierarchy from the NCX).
  */
 private fun absorbFlatNumericRuns(toc: List<TocEntry>): List<TocEntry> {
-    val prefix = Regex("""^\s*(\d+)\s*[.)]\s+""")
-    fun numericIndex(title: String): Int? = prefix.find(title)?.groupValues?.get(1)?.toIntOrNull()
+    fun numericIndex(title: String): Int? = NUMERIC_PREFIX.find(title)?.groupValues?.get(1)?.toIntOrNull()
 
     data class Run(val range: IntRange, val startNumber: Int)
     val runs = mutableListOf<Run>()
@@ -172,6 +171,12 @@ private fun spineLength(href: String, spineIndex: Map<String, Int>, positionCoun
 // paperback pages. Below this a "chapter" is really a fragment and shouldn't earn its own
 // rail segment even if it happens to be twice the length of a still-tinier parent.
 private const val MIN_SUBSTANTIAL_POSITIONS = 3
+
+private val NUMERIC_PREFIX = Regex("""^\s*(\d+)\s*[.)]\s+""")
+
+/** Shared spine-href → index lookup used by both the expand decision and the weight math. */
+private fun spineIndexOf(spineHrefs: List<String>): Map<String, Int> =
+    spineHrefs.withIndex().associate { (i, h) -> h to i }
 
 private fun String.normalize(): String = trim().lowercase().replace(Regex("\\s+"), " ")
 
@@ -226,7 +231,7 @@ fun weightSegmentsByChapterLength(
     positionCounts: List<Int>,
 ): List<RailSegment> {
     if (segments.isEmpty()) return segments
-    val hrefToSpine: Map<String, Int> = spineHrefs.withIndex().associate { (i, h) -> h to i }
+    val hrefToSpine = spineIndexOf(spineHrefs)
     val spineForSegment: List<Int?> = segments.map { hrefToSpine[it.href.substringBefore('#')] }
     // When multiple TOC entries point to the same spine resource (sub-sections of one file),
     // split that file's positions equally across them. When a TOC entry is the sole entry for

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
@@ -2,9 +2,16 @@ package com.riffle.app.feature.reader
 
 import com.riffle.core.domain.TocEntry
 
-fun buildRailSegments(tocEntries: List<TocEntry>, bookTitle: String = ""): List<RailSegment> {
+fun buildRailSegments(
+    tocEntries: List<TocEntry>,
+    bookTitle: String = "",
+    spineHrefs: List<String> = emptyList(),
+    positionCounts: List<Int> = emptyList(),
+): List<RailSegment> {
     val bookTitleNorm = bookTitle.normalize()
-    val expanded = tocEntries.flatMap { expandIfRedundant(it, bookTitleNorm) }
+    val spineIndex: Map<String, Int> = spineHrefs.withIndex().associate { (i, h) -> h to i }
+    val preprocessed = absorbFlatNumericRuns(tocEntries)
+    val expanded = preprocessed.flatMap { expandIfRedundant(it, bookTitleNorm, spineIndex, positionCounts) }
     // Collapse entries that point to the same spine resource via different fragments. The
     // navigator's locator carries no fragment during natural reading, so only the first
     // matching segment would ever become active; siblings would visually skip on chapter
@@ -14,27 +21,157 @@ fun buildRailSegments(tocEntries: List<TocEntry>, bookTitle: String = ""): List<
     return expanded.filter { seen.add(it.href.substringBefore('#')) }
 }
 
-private fun expandIfRedundant(entry: TocEntry, bookTitleNorm: String): List<RailSegment> {
-    val isRedundantContainer = entry.children.isNotEmpty() && (
-        entry.title.isBlank() ||
-            (bookTitleNorm.isNotEmpty() && entry.title.normalize() == bookTitleNorm)
-        )
-    if (isRedundantContainer) {
-        return entry.children.flatMap { expandIfRedundant(it, bookTitleNorm) }
-    }
-    // If children point to different spine files AND those children themselves have children
-    // (e.g. "Part I → [Ch1 with section anchors, Ch2 with section anchors]"), the parent is
-    // a grouping container — expand so estimates are per-chapter rather than per-part.
-    // The grandchildren check is the key guard: without it, "Chapter 20 → [SOL 376, SOL 380]"
-    // (leaf log-entry files with no sub-entries) would also be expanded, causing the cursor to
-    // jump between log-entry segments on every page turn within the chapter.
-    val entryBaseHref = entry.href.substringBefore('#')
-    val crossFileChildren = entry.children.filter { it.href.substringBefore('#') != entryBaseHref }
-    if (crossFileChildren.isNotEmpty() && crossFileChildren.any { it.children.isNotEmpty() }) {
-        return entry.children.flatMap { expandIfRedundant(it, bookTitleNorm) }
+private fun expandIfRedundant(
+    entry: TocEntry,
+    bookTitleNorm: String,
+    spineIndex: Map<String, Int>,
+    positionCounts: List<Int>,
+): List<RailSegment> {
+    if (shouldReplaceWithChildren(entry, bookTitleNorm, spineIndex, positionCounts)) {
+        return entry.children.flatMap { expandIfRedundant(it, bookTitleNorm, spineIndex, positionCounts) }
     }
     return listOf(RailSegment(entry.title, entry.href))
 }
+
+/**
+ * Should this TOC entry be replaced by its children on the rail? Two orthogonal signals,
+ * each vetted against real books; see `RailSegmentGeneratorTest` for the fixtures.
+ *
+ * 1. **Transparent container** — a blank title or one that just repeats the book title carries
+ *    no navigational identity; its children *are* the structure (e.g. single-file EPUBs whose
+ *    only top-level TOC entry is the book title wrapping the actual chapters). This branch
+ *    fires even when the children are same-file `#anchors`, which is the case that signal 2
+ *    can't reach: it's the only way to relabel a redundant wrapper to its first child's title.
+ * 2. **Length-based expansion** (positions supplied) — a titled parent whose spine file is
+ *    dramatically shorter than the bulk of its cross-file children is a section-title-page
+ *    grouping container ("Part I" → chapter files, "Силян Щърка"'s nav-supplied "2" wrapper
+ *    → folk tales). The rule uses three guards on the cross-file children:
+ *      - EVERY child must have a positive length (a 0-length child signals a stub/malformed
+ *        entry — err on the side of not expanding).
+ *      - A child is "substantial" when it is BOTH at least twice the parent's length AND at
+ *        least [MIN_SUBSTANTIAL_POSITIONS] positions in absolute terms. The absolute floor
+ *        matters when the parent itself is tiny (1 position): "1001 Nights" Pattern B stories
+ *        like "Четвърта глава. Детето съдия" have parent=1 and children of 1–3 positions —
+ *        several trivially clear the 2× bar but are still flash-fiction-length. The floor
+ *        prevents these from being called substantial.
+ *      - STRICTLY MORE THAN HALF of the children must be substantial. Using majority instead
+ *        of "all" tolerates the tail-length variation that real anthologies exhibit (Silyan's
+ *        tales range 2–31 positions with a 3-position title-page parent — several are close
+ *        to the parent's length, but 13 of 19 stories are ≥ 2× parent AND ≥ floor).
+ *    Requiring 2× rather than just >= parent rejects the Bulgarian "1001 Nights" pattern
+ *    where a story-container is the same order of magnitude as each of its short sub-
+ *    chapters. The rule also rejects "Chapter → short annotations" (The Martian: SOL entries
+ *    shorter than the chapter that contains them).
+ * 3. **Grandchildren OR length** — when position info is present, either signal alone is
+ *    enough to expand. Grandchildren catches 3-level books where the direct children are
+ *    themselves short sub-part containers ("Старогръцки легенди" Part → Богове/Герои →
+ *    individual gods): length looks at the short direct children and would collapse, but
+ *    the grandchildren prove this is a hierarchical grouping worth expanding. Length
+ *    catches the leaf-chapter cases where grandchildren doesn't fire (Barkley, Silyan). The
+ *    Martian-shaped invariant (Chapter → short leaf annotations) is safe under either signal
+ *    — no grandchildren AND length majority fails.
+ *
+ *    When positions are absent (older callers, test fixtures without a spine), fall back to
+ *    the grandchildren signal alone.
+ */
+private fun shouldReplaceWithChildren(
+    entry: TocEntry,
+    bookTitleNorm: String,
+    spineIndex: Map<String, Int>,
+    positionCounts: List<Int>,
+): Boolean {
+    if (entry.children.isEmpty()) return false
+
+    // (1) Transparent container. Fires even when children are same-file anchors — this is
+    // the branch that relabels a book-title-only wrapper to its first chapter's title in
+    // legacy single-file EPUBs. Redundant in production for cross-file children (rule 2's
+    // length branch covers those), kept as a small hedge against the same-file-anchor
+    // shape and as an explicit textual signal.
+    if (entry.title.isBlank()) return true
+    if (bookTitleNorm.isNotEmpty() && entry.title.normalize() == bookTitleNorm) return true
+
+    // (2) Grandchildren OR length. Either signal alone is enough — grandchildren catches
+    // hierarchical parents whose direct children are short sub-part containers; length catches
+    // leaf-chapter parents where grandchildren is absent. Same-file anchor children are
+    // excluded from crossFileChildren; if that leaves nothing, both branches naturally return
+    // false without a separate short-circuit (grandchildren.any → false, length majority
+    // 0*2 > 0 → false).
+    val entryBaseHref = entry.href.substringBefore('#')
+    val crossFileChildren = entry.children.filter { it.href.substringBefore('#') != entryBaseHref }
+    val hasGrandchildren = crossFileChildren.any { it.children.isNotEmpty() }
+    if (spineIndex.isEmpty() || positionCounts.isEmpty()) {
+        return hasGrandchildren
+    }
+    if (hasGrandchildren) return true
+    val parentLen = spineLength(entry.href, spineIndex, positionCounts)
+    val childLens = crossFileChildren.map { spineLength(it.href, spineIndex, positionCounts) }
+    if (childLens.any { it <= 0 }) return false
+    val substantialThreshold = maxOf(2 * parentLen, MIN_SUBSTANTIAL_POSITIONS)
+    val substantial = childLens.count { it >= substantialThreshold }
+    return substantial * 2 > childLens.size
+}
+
+/**
+ * Rewrite the top-level TOC so that flat "N. Sub-chapter" runs get nested under the bare
+ * parent that precedes them.
+ *
+ * Real case: "Приказки от хиляда и една нощ" (1001 Nights collections) list each story
+ * title as a bare top-level entry and its sub-chapters ("1. Бурята", "2. Магнитната планина",
+ * … "16. Край на приказката") as siblings at the same TOC level instead of children. Without
+ * preprocessing the rail shows 100+ tiny segments; with it, the length rule downstream keeps
+ * each story collapsed as one segment (sub-chapters fail the substantial threshold).
+ *
+ * Guarded conservatively to avoid false positives on genuinely-numbered top-level chapters:
+ * - At least two distinct numeric-prefix runs in the top-level TOC (a single run is more
+ *   likely a real numbered chapter list — Preface + 1. Intro / 2. Body / 3. Conclusion).
+ * - Each absorbable run starts at 1 — the restart is proof it's a subordinate sequence.
+ * - The bare parent must have no existing children (otherwise we'd clobber intentional
+ *   hierarchy from the NCX).
+ */
+private fun absorbFlatNumericRuns(toc: List<TocEntry>): List<TocEntry> {
+    val prefix = Regex("""^\s*(\d+)\s*[.)]\s+""")
+    fun numericIndex(title: String): Int? = prefix.find(title)?.groupValues?.get(1)?.toIntOrNull()
+
+    data class Run(val range: IntRange, val startNumber: Int)
+    val runs = mutableListOf<Run>()
+    var i = 0
+    while (i < toc.size) {
+        val n = numericIndex(toc[i].title)
+        if (n == null) { i++; continue }
+        val start = i
+        val startNum = n
+        while (i < toc.size && numericIndex(toc[i].title) != null) i++
+        runs.add(Run(start until i, startNum))
+    }
+    val absorbable = runs.filter { r ->
+        r.startNumber == 1 &&
+            r.range.first > 0 &&
+            numericIndex(toc[r.range.first - 1].title) == null &&
+            toc[r.range.first - 1].children.isEmpty()
+    }
+    if (absorbable.size < 2) return toc
+
+    val absorbedIdx: Set<Int> = absorbable.flatMap { it.range.toList() }.toSet()
+    val runByParent: Map<Int, List<TocEntry>> =
+        absorbable.associate { r -> (r.range.first - 1) to r.range.map { toc[it] } }
+    return toc.mapIndexedNotNull { idx, entry ->
+        when {
+            idx in absorbedIdx -> null
+            idx in runByParent -> entry.copy(children = entry.children + runByParent.getValue(idx))
+            else -> entry
+        }
+    }
+}
+
+private fun spineLength(href: String, spineIndex: Map<String, Int>, positionCounts: List<Int>): Int {
+    val i = spineIndex[href.substringBefore('#')] ?: return 0
+    return positionCounts.getOrElse(i) { 0 }
+}
+
+// Readium position units are ~1024 chars each; 3 positions ≈ 3 KB of text ≈ a couple of
+// paperback pages. Below this a "chapter" is really a fragment and shouldn't earn its own
+// rail segment even if it happens to be twice the length of a still-tinier parent.
+private const val MIN_SUBSTANTIAL_POSITIONS = 3
 
 private fun String.normalize(): String = trim().lowercase().replace(Regex("\\s+"), " ")
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentGeneratorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentGeneratorTest.kt
@@ -301,6 +301,369 @@ class RailSegmentGeneratorTest {
         )
     }
 
+    // ── buildRailSegments: length-based expansion (positions supplied) ────
+
+    @Test
+    fun `Barkley-shape — part with short title page and long chapter leaves is expanded`() {
+        // Real subset of "Taking Charge of ADHD, Fourth Edition" NCX: each Part points to a
+        // short title-page file, and its leaf-chapter children each occupy their own full
+        // chapter file. Under the current grandchildren guard the Parts collapse and the
+        // chapters vanish from the rail. With position info the length rule keeps them.
+        val ch01 = TocEntry("1 What Is ADHD?", "ch01.html")
+        val ch02 = TocEntry("2 Poor Self-Regulation", "ch02.html")
+        val ch03 = TocEntry("3 What Causes ADHD?", "ch03.html")
+        val ch07 = TocEntry("7 Deciding to Evaluate", "ch07.html")
+        val ch08 = TocEntry("8 Preparing for the Evaluation", "ch08.html")
+        val partI = TocEntry("Part I. Understanding ADHD", "pt01.html", listOf(ch01, ch02, ch03))
+        val partII = TocEntry("Part II. Taking Charge", "pt02.html", listOf(ch07, ch08))
+
+        val spineHrefs = listOf(
+            "pt01.html", "ch01.html", "ch02.html", "ch03.html",
+            "pt02.html", "ch07.html", "ch08.html",
+        )
+        // Part title pages are short (~2 positions); real chapters are substantial (~25).
+        val positionCounts = listOf(2, 25, 25, 25, 2, 25, 25)
+
+        assertEquals(
+            listOf(
+                RailSegment("1 What Is ADHD?", "ch01.html"),
+                RailSegment("2 Poor Self-Regulation", "ch02.html"),
+                RailSegment("3 What Causes ADHD?", "ch03.html"),
+                RailSegment("7 Deciding to Evaluate", "ch07.html"),
+                RailSegment("8 Preparing for the Evaluation", "ch08.html"),
+            ),
+            buildRailSegments(listOf(partI, partII), spineHrefs = spineHrefs, positionCounts = positionCounts),
+        )
+    }
+
+    @Test
+    fun `Martian-shape — chapter with short SOL log-entry leaves is NOT expanded when positions supplied`() {
+        // Same shape as the existing Martian test but with position info. The chapter file
+        // is substantial (~15 positions); each SOL log entry is a short vignette (~3). The
+        // length rule must keep the chapter as one segment even though every child lives in
+        // a different spine file.
+        val sol63 = TocEntry("LOG ENTRY: SOL 63", "sol063.xhtml")
+        val sol64 = TocEntry("LOG ENTRY: SOL 64", "sol064.xhtml")
+        val sol65 = TocEntry("LOG ENTRY: SOL 65", "sol065.xhtml")
+        val ch4 = TocEntry("Chapter 4", "chapter4.xhtml", listOf(sol63, sol64, sol65))
+
+        val spineHrefs = listOf("chapter4.xhtml", "sol063.xhtml", "sol064.xhtml", "sol065.xhtml")
+        val positionCounts = listOf(15, 3, 3, 3)
+
+        assertEquals(
+            listOf(RailSegment("Chapter 4", "chapter4.xhtml")),
+            buildRailSegments(listOf(ch4), spineHrefs = spineHrefs, positionCounts = positionCounts),
+        )
+    }
+
+    @Test
+    fun `length rule expands empty-content container even against non-trivial children`() {
+        // A parent that resolves to a spine resource with 0 positions is a pure grouping
+        // container. Any positive-length child should still qualify — the parent has no
+        // content of its own that we'd be replacing.
+        val a = TocEntry("A", "a.xhtml")
+        val b = TocEntry("B", "b.xhtml")
+        val container = TocEntry("Group", "group.xhtml", listOf(a, b))
+        val spineHrefs = listOf("group.xhtml", "a.xhtml", "b.xhtml")
+        val positionCounts = listOf(0, 10, 10)
+
+        assertEquals(
+            listOf(RailSegment("A", "a.xhtml"), RailSegment("B", "b.xhtml")),
+            buildRailSegments(listOf(container), spineHrefs = spineHrefs, positionCounts = positionCounts),
+        )
+    }
+
+    @Test
+    fun `Silyan-shape — non-blank stub-titled container with mostly-substantial children IS expanded`() {
+        // Real subset of "Силян Щърка" (Ангел Каралийчев). The EPUB3 nav supplies a stub
+        // title ("2") for the container that wraps all 19 folk tales at chapter-0.xhtml
+        // — Readium prefers nav over NCX, so the historical blank-title fallback (the NCX
+        // had "\n\n") no longer catches this book. The container's own spine file is a short
+        // section-title page; most children are substantial full tales, with a couple of very
+        // short outliers. Requiring EVERY child to be ≥ 2× parent would fail on the outliers
+        // and leave the whole book behind one segment labelled "2". Majority (> half of
+        // cross-file children) catches the pattern.
+        val titles = listOf(
+            "Българска земя хубава", "Силян Щърка", "Слънчовата щерка", "Приказка за дърваря",
+            "Ерген-девойче", "Омагьосаната царкиня", "Пастирчето и русалките",
+            "Човекът, що заместил слънцето", "Падишахът — папагал", "Славеят Гизар",
+            "Старата круша", "Да имаш късмет", "Доброто нахалост", "Завист човешка",
+            "Късметът на сиромаха", "Ковачът в рая", "Хитрият петел",
+            "Всяка работа си иска майстора", "Глупавата мечка", "Лъв и мишка",
+        )
+        val children = titles.mapIndexed { i, t -> TocEntry(t, "chapter-$i.xhtml") }
+        val container = TocEntry("2", "chapter-0.xhtml", children)
+        val spineHrefs = (0..19).map { "chapter-$it.xhtml" }
+        // Real position counts, in order chapter-0..chapter-19.
+        val positionCounts = listOf(3, 31, 21, 8, 16, 12, 4, 19, 11, 28, 13, 15, 15, 5, 4, 7, 2, 6, 3, 3)
+
+        val segments = buildRailSegments(
+            listOf(container),
+            spineHrefs = spineHrefs,
+            positionCounts = positionCounts,
+        )
+        // Expansion: first child (chapter-0.xhtml) collides with the parent by same-file
+        // dedup, but the parent is thrown away first — so the first surviving segment is
+        // the first child, "Българска земя хубава". Remaining 19 children each survive as
+        // their own segment (chapter-1.xhtml through chapter-19.xhtml, all distinct spine
+        // files). Locked here so any future heuristic change is caught before it silently
+        // collapses this book back to a single "2" segment.
+        val expected = titles.mapIndexed { i, t -> RailSegment(t, "chapter-$i.xhtml") }
+        assertEquals(expected, segments)
+    }
+
+    @Test
+    fun `1001N-flat shape — sub-chapter runs numbered N are absorbed under preceding bare parent`() {
+        // Real subset of "Приказки от хиляда и една нощ" Том I: the NCX lists three story
+        // titles at the top level, each followed by its "1. Sub, 2. Sub, ..." sub-chapters
+        // as siblings — no nesting. Without preprocessing the rail balloons to 50+ tiny
+        // segments; each sub-chapter is one short spine file. Preprocessing groups each
+        // numeric run under the bare-title parent that precedes it; the length rule then
+        // correctly keeps them collapsed because the sub-chapters are all short.
+        val abd = TocEntry("Абдуллах земният", "chapter-1.xhtml")
+        val abdSubs = (2..15).map { TocEntry("${it - 1}. Sub", "chapter-$it.xhtml") }
+        val car = TocEntry("Цар Аджиб", "chapter-16.xhtml")
+        val carSubs = (17..32).map { TocEntry("${it - 16}. Sub", "chapter-$it.xhtml") }
+        val his = TocEntry("Хусраушах", "chapter-33.xhtml")
+        val hisSubs = (34..53).map { TocEntry("${it - 33}. Sub", "chapter-$it.xhtml") }
+        val toc = listOf(abd) + abdSubs + listOf(car) + carSubs + listOf(his) + hisSubs
+        val spineHrefs = (1..53).map { "chapter-$it.xhtml" }
+        // All sub-chapters and parents are 1 position each — every child fails the length
+        // threshold, so post-absorption the length rule keeps each parent as one segment.
+        val positionCounts = List(53) { 1 }
+
+        assertEquals(
+            listOf(
+                RailSegment("Абдуллах земният", "chapter-1.xhtml"),
+                RailSegment("Цар Аджиб", "chapter-16.xhtml"),
+                RailSegment("Хусраушах", "chapter-33.xhtml"),
+            ),
+            buildRailSegments(toc, spineHrefs = spineHrefs, positionCounts = positionCounts),
+        )
+    }
+
+    @Test
+    fun `flat numeric-prefix run — a single run is NOT absorbed (could be real numbered chapters)`() {
+        // A book with a single "1., 2., 3., ..." sequence at top level is more likely a
+        // real numbered chapter list than a sub-run. The absorption heuristic requires at
+        // least two restart cycles as proof that the numbering is subordinate.
+        val toc = listOf(
+            TocEntry("Preface", "preface.xhtml"),
+            TocEntry("1. Introduction", "ch1.xhtml"),
+            TocEntry("2. Body", "ch2.xhtml"),
+            TocEntry("3. Conclusion", "ch3.xhtml"),
+        )
+        val spineHrefs = listOf("preface.xhtml", "ch1.xhtml", "ch2.xhtml", "ch3.xhtml")
+        val positionCounts = listOf(5, 20, 20, 20)
+
+        val segments = buildRailSegments(toc, spineHrefs = spineHrefs, positionCounts = positionCounts)
+        assertEquals(4, segments.size)
+        assertEquals("1. Introduction", segments[1].title)
+    }
+
+    @Test
+    fun `flat numeric-prefix run — NOT absorbed when preceding parent already has children`() {
+        // Guards against clobbering an existing hierarchy. If the bare-title entry that
+        // would become the parent already has TOC children, absorbing flat siblings would
+        // mix two structurally distinct sets of children.
+        val existingChild = TocEntry("sub", "existing-sub.xhtml")
+        val a = TocEntry("Story A", "a.xhtml", listOf(existingChild))
+        val aSubs = listOf(TocEntry("1. Foo", "af1.xhtml"), TocEntry("2. Bar", "af2.xhtml"))
+        val b = TocEntry("Story B", "b.xhtml")
+        val bSubs = listOf(TocEntry("1. Baz", "bf1.xhtml"), TocEntry("2. Qux", "bf2.xhtml"))
+        val toc = listOf(a) + aSubs + listOf(b) + bSubs
+        val spineHrefs = listOf("a.xhtml", "existing-sub.xhtml", "af1.xhtml", "af2.xhtml",
+                                "b.xhtml", "bf1.xhtml", "bf2.xhtml")
+        val positionCounts = List(7) { 1 }
+
+        val segments = buildRailSegments(toc, spineHrefs = spineHrefs, positionCounts = positionCounts)
+        // "Story A" is skipped for absorption (has existing child), so its "1. Foo/2. Bar"
+        // siblings stay at top level. "Story B" is a bare leaf but there's now only one
+        // eligible absorbable run — fails the ≥2-runs safety check — so nothing is absorbed.
+        assertTrue(
+            "expected '1. Foo' to remain top-level: $segments",
+            segments.any { it.title == "1. Foo" },
+        )
+    }
+
+    @Test
+    fun `flat-top-level shape — every TOC leaf becomes a segment untouched by heuristics`() {
+        // The most common shape in the wild (13 of 20 sampled books: Way of Kings, Космос,
+        // Heretics of Dune, Azazel, A Hat Full of Sky, Guards!, Fantastic Beasts, Moving
+        // Pictures, Narnia, Forward the Foundation, Children of Húrin, Art of Deception,
+        // Андерсенови приказки). No entry has children, so no expand/keep decision runs —
+        // rail is a straight 1:1 mapping. Documents that the heuristic doesn't perturb the
+        // majority of real books.
+        val chapters = (1..8).map { TocEntry("Chapter $it", "ch$it.xhtml") }
+        val spineHrefs = chapters.map { it.href }
+        val positionCounts = List(8) { 25 }
+
+        val segments = buildRailSegments(chapters, spineHrefs = spineHrefs, positionCounts = positionCounts)
+        assertEquals(chapters.map { RailSegment(it.title, it.href) }, segments)
+    }
+
+    @Test
+    fun `siblings at same level are evaluated independently — one Part expands, another keeps`() {
+        // Real-world mix: a book with two Parts, only one of which has substantial chapters.
+        // Pins that parent decisions don't leak: the length-fail on Part II must not stop
+        // Part I from expanding, and vice versa.
+        val partIChaps = (1..3).map { TocEntry("Ch $it", "p1c$it.xhtml") }
+        val partIIChaps = (1..3).map { TocEntry("Sub $it", "p2c$it.xhtml") }
+        val partI = TocEntry("Part I", "p1.xhtml", partIChaps)
+        val partII = TocEntry("Part II", "p2.xhtml", partIIChaps)
+        val spineHrefs = listOf("p1.xhtml", "p1c1.xhtml", "p1c2.xhtml", "p1c3.xhtml",
+                                "p2.xhtml", "p2c1.xhtml", "p2c2.xhtml", "p2c3.xhtml")
+        // Part I: parent=2, chapters=25 each → length-majority (all substantial) → expand.
+        // Part II: parent=1, sub-entries=2 each → length-fail (2 < max(2, 3)=3) → keep.
+        val positionCounts = listOf(2, 25, 25, 25, 1, 2, 2, 2)
+
+        assertEquals(
+            listOf(
+                RailSegment("Ch 1", "p1c1.xhtml"),
+                RailSegment("Ch 2", "p1c2.xhtml"),
+                RailSegment("Ch 3", "p1c3.xhtml"),
+                RailSegment("Part II", "p2.xhtml"),
+            ),
+            buildRailSegments(listOf(partI, partII), spineHrefs = spineHrefs, positionCounts = positionCounts),
+        )
+    }
+
+    @Test
+    fun `Ancient-Greek-Legends shape — three-level hierarchy IS expanded via grandchildren`() {
+        // Real shape of "Старогръцки легенди и митове". Part 1 has a short title-page
+        // spine file, and its direct children are themselves sub-part containers ("Богове",
+        // "Герои") whose own spine files are also short — the real content lives one level
+        // deeper (individual god stories, hero stories). Length alone collapses this to a
+        // single Part segment because the direct children look short. The grandchildren
+        // signal is what proves the parent is a hierarchical grouping worth expanding.
+        // Numbers reflect the actual EPUB.
+        val godsChildren = (1..15).map { TocEntry("Bog $it", "chapter-$it.xhtml") }
+        val heroesChildren = (17..47).map { TocEntry("Hero $it", "chapter-$it.xhtml") }
+        val bogove = TocEntry("Богове", "chapter-1.xhtml", godsChildren)   // 3 pos title
+        val geroi = TocEntry("Герои", "chapter-16.xhtml", heroesChildren)  // 5 pos title
+        val part1 = TocEntry("Първа част. Богове и герои", "chapter-1.xhtml", listOf(bogove, geroi))
+        val spineHrefs = (1..47).map { "chapter-$it.xhtml" }
+        // chapter-1: 3 pos, chapter-2..15: various, chapter-16: 5 pos, chapter-17..47: various.
+        // Only the two direct children of part1 (chapter-1, chapter-16) matter for the
+        // parent's expand decision. Both are short vs part1's 3-pos length → length rule
+        // fails. Grandchildren rule fires because "Герои" has 31 children.
+        val positionCounts = List(47) { i -> when (i + 1) {
+            1 -> 3; 16 -> 5
+            else -> 5   // any positive value — irrelevant to the decision
+        } }
+
+        val segments = buildRailSegments(
+            listOf(part1),
+            spineHrefs = spineHrefs,
+            positionCounts = positionCounts,
+        )
+        // Part 1 expands into its two sub-part containers. Those sub-parts, in turn, get
+        // their own decision: "Богове" has 15 leaf grandchildren, "Герои" has 31 — each
+        // fires the grandchildren-OR rule and expands. But that's out of scope for this
+        // test; we only assert Part 1 was replaced (i.e. the label "Първа част…" does not
+        // appear as a top-level segment).
+        assertTrue(
+            "Part 1 should have been expanded but appears in segments: $segments",
+            segments.none { it.title == "Първа част. Богове и герои" },
+        )
+    }
+
+    @Test
+    fun `Bulgarian-tales shape — tiny parent with tiny children NOT expanded (Детето съдия)`() {
+        // Real subset of "Приказки от хиляда и една нощ" Pattern B story "Четвърта глава.
+        // Детето съдия" at chapter-78.xhtml with 9 children (first same-file). Every spine
+        // file in this region is 1-3 positions — flash-fiction-length sub-chapters. Ratio
+        // alone (2×parent) is a trivial bar when parent is 1 position, so children of 2-3
+        // positions falsely qualify as "substantial". An absolute floor blocks it: no child
+        // is long enough on its own to warrant a separate rail segment.
+        val subs = (78..86).map { TocEntry("$it", "chapter-$it.xhtml") }
+        val parent = TocEntry("Четвърта глава. Детето съдия", "chapter-78.xhtml", subs)
+        val spineHrefs = (78..86).map { "chapter-$it.xhtml" }
+        val positionCounts = listOf(1, 1, 3, 2, 2, 1, 2, 2, 1)
+
+        assertEquals(
+            listOf(RailSegment("Четвърта глава. Детето съдия", "chapter-78.xhtml")),
+            buildRailSegments(listOf(parent), spineHrefs = spineHrefs, positionCounts = positionCounts),
+        )
+    }
+
+    @Test
+    fun `Bulgarian-tales shape — tiny parent with tiny children NOT expanded (Меден-Трета)`() {
+        // Same book, second bad expansion: "Трета глава" from "Медният град" at chapter-102
+        // with 4 children (first same-file). Parent=1, children=[2,3,1]. Two children just
+        // barely pass 2×parent=2, forming a false majority (2/3). The absolute floor is what
+        // catches this — no child is at least 3 positions, so none is "substantial enough"
+        // to become its own rail segment.
+        val subs = (102..105).map { TocEntry("$it", "chapter-$it.xhtml") }
+        val parent = TocEntry("Трета глава", "chapter-102.xhtml", subs)
+        val spineHrefs = (102..105).map { "chapter-$it.xhtml" }
+        val positionCounts = listOf(1, 2, 3, 1)
+
+        assertEquals(
+            listOf(RailSegment("Трета глава", "chapter-102.xhtml")),
+            buildRailSegments(listOf(parent), spineHrefs = spineHrefs, positionCounts = positionCounts),
+        )
+    }
+
+    @Test
+    fun `Bulgarian-tales shape — grouping-of-similar-size sub-chapters is NOT expanded`() {
+        // Real subset of "Приказки от хиляда и една нощ" (Bulgarian 1001 Nights). Each story
+        // is grouped under a "Първа глава / Втора глава" NCX container; the container's own
+        // spine file is roughly the same size as each of its sub-chapters, because the sub-
+        // chapters are themselves short (a page or so each). The length rule must NOT expand
+        // in this shape — six-plus tiny sub-chapters per story would flood the rail.
+        val sub1 = TocEntry("1. Бурята", "chapter-91.xhtml")
+        val sub2 = TocEntry("2. Разговорът", "chapter-92.xhtml")
+        val sub3 = TocEntry("3. Покой", "chapter-93.xhtml")
+        val sub4 = TocEntry("4. Заключеният град", "chapter-94.xhtml")
+        val sub5 = TocEntry("5. Огромната стълба", "chapter-95.xhtml")
+        val sub6 = TocEntry("6. Надпреварване", "chapter-96.xhtml")
+        val sub7 = TocEntry("7. Военачалникът", "chapter-97.xhtml")
+        val parent = TocEntry("Първа глава", "chapter-91.xhtml", listOf(sub1, sub2, sub3, sub4, sub5, sub6, sub7))
+        val spineHrefs = listOf(
+            "chapter-91.xhtml", "chapter-92.xhtml", "chapter-93.xhtml", "chapter-94.xhtml",
+            "chapter-95.xhtml", "chapter-96.xhtml", "chapter-97.xhtml",
+        )
+        // Parent and each sub-chapter are all in the same order of magnitude — no child is
+        // dramatically longer than the parent, so treating any one of them as its own rail
+        // segment would fragment the story arc without gaining navigational granularity.
+        val positionCounts = listOf(2, 2, 2, 2, 2, 5, 2)
+
+        assertEquals(
+            listOf(RailSegment("Първа глава", "chapter-91.xhtml")),
+            buildRailSegments(listOf(parent), spineHrefs = spineHrefs, positionCounts = positionCounts),
+        )
+    }
+
+    @Test
+    fun `length rule keeps parent when any cross-file child is 0-length`() {
+        // Guards against expanding into empty spine resources (e.g. a stub file with no
+        // content). If the child has 0 positions there's nothing to navigate to.
+        val real = TocEntry("Real chapter", "real.xhtml")
+        val stub = TocEntry("Stub", "stub.xhtml")
+        val parent = TocEntry("Part", "part.xhtml", listOf(real, stub))
+        val spineHrefs = listOf("part.xhtml", "real.xhtml", "stub.xhtml")
+        val positionCounts = listOf(1, 20, 0)
+
+        assertEquals(
+            listOf(RailSegment("Part", "part.xhtml")),
+            buildRailSegments(listOf(parent), spineHrefs = spineHrefs, positionCounts = positionCounts),
+        )
+    }
+
+    @Test
+    fun `length rule falls back to grandchildren guard when positions are empty`() {
+        // Existing callers that don't (yet) supply position info must see today's behavior.
+        // Uses the Martian fixture — grandchildren guard keeps it as one segment.
+        val sol1 = TocEntry("LOG 1", "sol1.xhtml")
+        val sol2 = TocEntry("LOG 2", "sol2.xhtml")
+        val ch = TocEntry("Chapter 20", "chapter20.xhtml", listOf(sol1, sol2))
+        assertEquals(
+            listOf(RailSegment("Chapter 20", "chapter20.xhtml")),
+            buildRailSegments(listOf(ch)),
+        )
+    }
+
     @Test
     fun `entry with children all on same file is NOT expanded (title kept)`() {
         // An entry whose every child is a same-file anchor should stay as one segment —


### PR DESCRIPTION
## Summary

Reworks the EPUB chapter-navigation rail's expand-vs-keep heuristic so real books stop rendering as either useless single-segment strips or unreadable 100-sliver ribbons.

## What changed

`shouldReplaceWithChildren` in `RailSegmentGenerator.kt` combines three orthogonal signals:

1. **Transparent container** — blank / book-title-match wrapper flattens (unchanged intent).
2. **Grandchildren OR length** — either signal alone is enough to expand:
   - Grandchildren catches 3-level books (Part → sub-part container → real content — the Ancient Greek Legends shape).
   - Length majority requires *strictly more than half* of cross-file children to be **both** `≥ 2 × parent length` **and** `≥ 3 positions` in absolute terms. The 2× ratio rejects "grouping-of-similar-length" (1001 Nights story-containers whose sub-chapters are the same size as the container). The absolute floor rejects "chapter with short annotations" (Martian SOL entries) and stops tiny leaves that only barely beat a tiny parent from forming false majorities (1001 Nights `Четвърта глава. Детето съдия`).
3. **Grandchildren fallback** (no position info) — preserves behavior for callers that don't supply a spine.

Adds `absorbFlatNumericRuns` preprocessing for 1001-Nights-style TOCs where sub-chapters (`1. Бурята`, `2. Магнитната планина`, …) sit as flat siblings of their story title. Guarded conservatively: ≥ 2 runs restarting at 1, preceded by a bare-title parent with no existing children.

`EpubReaderViewModel` now caches rail inputs via `distinctUntilChanged` and gates emission until spine positions are ready, so the pipeline doesn't rerun on every page turn and there's no rail flicker at book open.

## Rail behavior on 20 randomly-sampled books

| Shape | Books | Rule that fires | Before → After |
|---|---|---|---|
| Flat top-level | Way of Kings + 12 others | none | unchanged |
| Transparent wrapper | Metamorphosis | rule 1 | unchanged |
| Part → chapter files w/ anchors | Beyond the Basic Stuff | grandchildren | unchanged |
| 3-level hierarchy | Ancient Greek Legends | grandchildren | 8 → 82 (recovered) |
| Part → leaf chapter files | Barkley, Second Foundation, Book-You-Wish | length-majority | Parts now expand |
| Story-container w/ tiny leaves | 1001 Nights Vol I & II | length-fail | correctly kept |
| Flat numeric runs (`Цар Аджиб`, `1. Бурята` …) | 1001 Nights Vol I | numeric-run absorb | 143+ tiny → 47 |
| Same-file section anchors only | Philosophy of Software Design | no-cross-file | unchanged |

## Tests

68 unit tests in `RailSegmentGeneratorTest`, all green. Every real-book shape encountered in the 20-book audit is pinned as a fixture (Barkley, Silyan Щърка, Ancient Greek, 1001N Vol I × 3, Martian, Bulgarian tales) plus documentary fixtures for flat-top-level and mixed-parents-at-same-level.

## Code review

Ran 8-angle multi-agent review on the branch. Applied top 4 findings in the follow-up commit (rail flicker + hot-path recompute + regex hoist + shared spine-index helper). Dismissed:
- One `parentLen=0` edge case (rare, not observed in the 20-book sample).
- One altitude finding suggesting `absorbFlatNumericRuns` should live at the TocParser level so the TOC dialog / next-chapter navigation see the same nested structure the rail does — real concern for a follow-up, out of scope for this PR.
- Micro-cleanup findings (Run data class, allocation micro-optimizations, name churn on `expandIfRedundant`).

## Test plan
- [ ] JVM tests green in CI.
- [ ] Install locally and verify rail shape on 1001 Nights (471ab948) — should go from 143+ slivers to ~47 segments.
- [ ] Silyan Щърка (083d49e8) — 19 folk-tale segments visible (was 1 segment titled "2").
- [ ] Taking Charge of ADHD (f2c4c0d4) — Parts expand to individual chapters on the rail.