### PR TITLE
refactor(reader): unified slider for formatting + pacing controls

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingSection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingSection.kt
@@ -1,20 +1,26 @@
 package com.riffle.app.feature.reader
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.unit.dp
 import com.riffle.app.feature.reader.formatting.RenderCapabilities
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.ReaderFontFamily
+import java.util.Locale
 
 /**
  * Text + page typography controls. Reused by the in-reader settings sheet (Formatting tab)
@@ -35,13 +41,18 @@ fun FormattingSection(
         }
 
         if (capabilities.supportsTextTypography) {
-            Text("Font size", style = MaterialTheme.typography.labelMedium)
-            StepperRow(
-                label = "%.0f%%".format(prefs.fontSize * 100),
-                onDecrement = { onPrefsChange(prefs.copy(fontSize = (prefs.fontSize - 0.1f).coerceAtLeast(0.5f).round1())) },
-                onIncrement = { onPrefsChange(prefs.copy(fontSize = (prefs.fontSize + 0.1f).coerceAtMost(2.5f).round1())) },
-                decrementDescription = "Decrease font size",
-                incrementDescription = "Increase font size",
+            UnifiedSliderRow(
+                title = "Font size",
+                caption = "%.0f%%".format(Locale.ROOT, prefs.fontSize * 100),
+                value = prefs.fontSize,
+                onValueChange = { onPrefsChange(prefs.copy(fontSize = it.round1())) },
+                valueRange = 0.5f..2.5f,
+                steps = 19,
+                majorEvery = 0.5f,
+                edgeLeft = { Text("A", style = MaterialTheme.typography.labelMedium) },
+                edgeRight = { Text("A", style = MaterialTheme.typography.titleLarge) },
+                bubbleLabel = ::fontSizeBubble,
+                contentDescription = "Font size",
             )
             Spacer(Modifier.height(16.dp))
         }
@@ -63,13 +74,18 @@ fun FormattingSection(
             }
             Spacer(Modifier.height(16.dp))
 
-            Text("Line spacing", style = MaterialTheme.typography.labelMedium)
-            StepperRow(
-                label = "${lineSpacingWord(prefs.lineSpacing)} · %.1f×".format(prefs.lineSpacing),
-                onDecrement = { onPrefsChange(prefs.copy(lineSpacing = (prefs.lineSpacing - 0.1f).coerceAtLeast(1.0f).round1())) },
-                onIncrement = { onPrefsChange(prefs.copy(lineSpacing = (prefs.lineSpacing + 0.1f).coerceAtMost(2.0f).round1())) },
-                decrementDescription = "Decrease line spacing",
-                incrementDescription = "Increase line spacing",
+            UnifiedSliderRow(
+                title = "Line spacing",
+                caption = "${lineSpacingWord(prefs.lineSpacing)} · %.1f×".format(Locale.ROOT, prefs.lineSpacing),
+                value = prefs.lineSpacing,
+                onValueChange = { onPrefsChange(prefs.copy(lineSpacing = it.round1())) },
+                valueRange = 1.0f..2.0f,
+                steps = 9,
+                majorEvery = 0.2f,
+                edgeLeft = { TightLinesIcon() },
+                edgeRight = { LooseLinesIcon() },
+                bubbleLabel = ::lineSpacingBubble,
+                contentDescription = "Line spacing",
             )
             Spacer(Modifier.height(20.dp))
         }
@@ -80,13 +96,78 @@ fun FormattingSection(
             Text("Page", style = MaterialTheme.typography.labelMedium)
             Spacer(Modifier.height(8.dp))
         }
-        Text("Margins", style = MaterialTheme.typography.labelMedium)
-        StepperRow(
-            label = "${marginsWord(prefs.margins)} · %.1f×".format(prefs.margins),
-            onDecrement = { onPrefsChange(prefs.copy(margins = (prefs.margins - 0.1f).coerceAtLeast(0.2f).round1())) },
-            onIncrement = { onPrefsChange(prefs.copy(margins = (prefs.margins + 0.1f).coerceAtMost(3.0f).round1())) },
-            decrementDescription = "Decrease margins",
-            incrementDescription = "Increase margins",
+        UnifiedSliderRow(
+            title = "Margins",
+            caption = "${marginsWord(prefs.margins)} · %.1f×".format(Locale.ROOT, prefs.margins),
+            value = prefs.margins,
+            onValueChange = { onPrefsChange(prefs.copy(margins = it.round1())) },
+            valueRange = 0.2f..3.0f,
+            steps = 27,
+            majorEvery = 0.5f,
+            edgeLeft = { NarrowMarginsIcon() },
+            edgeRight = { WideMarginsIcon() },
+            bubbleLabel = ::marginsBubble,
+            contentDescription = "Margins",
         )
+    }
+}
+
+@Composable
+private fun TightLinesIcon() {
+    val c = MaterialTheme.colorScheme.onSurfaceVariant
+    Canvas(Modifier.size(18.dp)) {
+        val stroke = size.width * 0.10f
+        val pad = size.width * 0.15f
+        val w = size.width - pad * 2
+        listOf(0.35f, 0.50f, 0.65f).forEach { y ->
+            drawRect(color = c, topLeft = Offset(pad, size.height * y - stroke / 2), size = Size(w, stroke))
+        }
+    }
+}
+
+@Composable
+private fun LooseLinesIcon() {
+    val c = MaterialTheme.colorScheme.onSurfaceVariant
+    Canvas(Modifier.size(18.dp)) {
+        val stroke = size.width * 0.10f
+        val pad = size.width * 0.15f
+        val w = size.width - pad * 2
+        listOf(0.20f, 0.50f, 0.80f).forEach { y ->
+            drawRect(color = c, topLeft = Offset(pad, size.height * y - stroke / 2), size = Size(w, stroke))
+        }
+    }
+}
+
+@Composable
+private fun NarrowMarginsIcon() {
+    val c = MaterialTheme.colorScheme.onSurfaceVariant
+    Canvas(Modifier.size(18.dp)) {
+        val stroke = size.width * 0.08f
+        drawRect(color = c, topLeft = Offset(0f, 0f), size = size, style = Stroke(width = stroke))
+        val innerPad = size.width * 0.15f
+        listOf(0.35f, 0.55f, 0.75f).forEach { y ->
+            drawRect(
+                color = c,
+                topLeft = Offset(innerPad, size.height * y - stroke),
+                size = Size(size.width - innerPad * 2, stroke * 1.5f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun WideMarginsIcon() {
+    val c = MaterialTheme.colorScheme.onSurfaceVariant
+    Canvas(Modifier.size(18.dp)) {
+        val stroke = size.width * 0.08f
+        drawRect(color = c, topLeft = Offset(0f, 0f), size = size, style = Stroke(width = stroke))
+        val innerPad = size.width * 0.30f
+        listOf(0.40f, 0.60f).forEach { y ->
+            drawRect(
+                color = c,
+                topLeft = Offset(innerPad, size.height * y - stroke),
+                size = Size(size.width - innerPad * 2, stroke * 1.5f),
+            )
+        }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsControls.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsControls.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilterChip
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
@@ -46,7 +45,6 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.riffle.core.domain.ReaderFontFamily
 import com.riffle.core.domain.ReaderOrientation
@@ -54,42 +52,6 @@ import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.ThemeSchedule
 import java.time.LocalTime
 import kotlin.math.roundToInt
-
-@Composable
-internal fun StepperRow(
-    label: String,
-    onDecrement: () -> Unit,
-    onIncrement: () -> Unit,
-    decrementDescription: String,
-    incrementDescription: String,
-) {
-    Surface(
-        shape = RoundedCornerShape(percent = 50),
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.height(48.dp),
-        ) {
-            IconButton(
-                onClick = onDecrement,
-                modifier = Modifier.semantics { contentDescription = decrementDescription },
-            ) { Text("−", style = MaterialTheme.typography.titleLarge) }
-            Text(
-                label,
-                style = MaterialTheme.typography.bodyLarge,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.weight(1f),
-            )
-            IconButton(
-                onClick = onIncrement,
-                modifier = Modifier.semantics { contentDescription = incrementDescription },
-            ) { Text("+", style = MaterialTheme.typography.titleLarge) }
-        }
-    }
-}
 
 @Composable
 internal fun ThemeSwatch(theme: ReaderTheme, schedule: ThemeSchedule) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
@@ -149,17 +149,22 @@ private fun SliderTrack(
             val cy = size.height / 2f
             val trackHeightPx = with(density) { 6.dp.toPx() }
             val corner = trackHeightPx / 2f
+            // Match the M3 Slider's thumb travel: the thumb centre only ranges from
+            // [thumbHalf, width - thumbHalf], so the track and ticks must live inside
+            // that same inset — otherwise the filled portion drifts away from the thumb.
+            val thumbHalfPx = with(density) { 10.dp.toPx() }
+            val usableWidth = size.width - thumbHalfPx * 2f
             drawRoundRect(
                 color = trackBaseColor,
-                topLeft = Offset(0f, cy - trackHeightPx / 2f),
-                size = Size(size.width, trackHeightPx),
+                topLeft = Offset(thumbHalfPx, cy - trackHeightPx / 2f),
+                size = Size(usableWidth, trackHeightPx),
                 cornerRadius = CornerRadius(corner, corner),
             )
             val filledFrac = ((value - min) / span).coerceIn(0f, 1f)
             drawRoundRect(
                 color = fillColor,
-                topLeft = Offset(0f, cy - trackHeightPx / 2f),
-                size = Size(size.width * filledFrac, trackHeightPx),
+                topLeft = Offset(thumbHalfPx, cy - trackHeightPx / 2f),
+                size = Size(usableWidth * filledFrac, trackHeightPx),
                 cornerRadius = CornerRadius(corner, corner),
             )
             if (steps > 0) {
@@ -167,7 +172,7 @@ private fun SliderTrack(
                     val v = min + i * step
                     val isMajor = majorEvery != null && isMajorTick(v, majorEvery)
                     if (!showMinors && !isMajor) continue
-                    val x = size.width * ((v - min) / span)
+                    val x = thumbHalfPx + usableWidth * ((v - min) / span)
                     val tickH = if (isMajor) with(density) { 12.dp.toPx() } else with(density) { 8.dp.toPx() }
                     val tickW = with(density) { 2.dp.toPx() }
                     val color = if (isMajor) fillColor else minorTickColor
@@ -183,7 +188,7 @@ private fun SliderTrack(
 
         if (interacting && trackWidthPx > 0) {
             val frac = ((value - min) / span).coerceIn(0f, 1f)
-            val thumbHalfPx = with(density) { 12.dp.toPx() }
+            val thumbHalfPx = with(density) { 10.dp.toPx() }
             val usable = trackWidthPx - thumbHalfPx * 2f
             val xPx = thumbHalfPx + frac * usable
             Box(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
@@ -227,7 +227,11 @@ private fun SliderTrack(
                         .background(MaterialTheme.colorScheme.primary, CircleShape),
                 )
             },
-            track = { /* We draw the track ourselves above; keep this slot empty. */ },
+            // Do NOT override `track` with an empty slot — that collapses the M3 Slider's
+            // internal width to the thumb, killing drag. The default track fills width and
+            // draws transparent because both activeTrackColor and inactiveTrackColor are
+            // Color.Transparent in the SliderColors above, so nothing is painted on top of
+            // our custom Canvas.
             modifier = Modifier
                 .fillMaxWidth()
                 .semantics { this.contentDescription = contentDescription },

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
@@ -3,7 +3,7 @@
 package com.riffle.app.feature.reader
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -210,6 +209,7 @@ private fun SliderTrack(
             activeTickColor = Color.Transparent,
             inactiveTickColor = Color.Transparent,
         )
+        val interactionSource = remember { MutableInteractionSource() }
         Slider(
             value = value,
             onValueChange = { new ->
@@ -220,11 +220,14 @@ private fun SliderTrack(
             valueRange = valueRange,
             steps = steps,
             colors = sliderColors,
+            interactionSource = interactionSource,
             thumb = {
-                Box(
-                    modifier = Modifier
-                        .size(20.dp)
-                        .background(MaterialTheme.colorScheme.primary, CircleShape),
+                // Use M3's own Thumb sized down — keeps the layout math consistent with
+                // SliderImpl so the thumb sits at the correct fraction of the track.
+                SliderDefaults.Thumb(
+                    interactionSource = interactionSource,
+                    colors = sliderColors,
+                    thumbSize = androidx.compose.ui.unit.DpSize(20.dp, 20.dp),
                 )
             },
             // Do NOT override `track` with an empty slot — that collapses the M3 Slider's

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
@@ -170,7 +170,8 @@ private fun SliderTrack(
                 for (i in 0..(steps + 1)) {
                     val v = min + i * step
                     val isMajor = majorEvery != null && isMajorTick(v, majorEvery)
-                    if (!showMinors && !isMajor) continue
+                    val isEndpoint = i == 0 || i == steps + 1
+                    if (!showMinors && !isMajor && !isEndpoint) continue
                     val x = thumbHalfPx + usableWidth * ((v - min) / span)
                     val tickH = if (isMajor) with(density) { 12.dp.toPx() } else with(density) { 8.dp.toPx() }
                     val tickW = with(density) { 2.dp.toPx() }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
@@ -1,0 +1,232 @@
+package com.riffle.app.feature.reader
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import java.util.Locale
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+internal fun fontSizeBubble(v: Float): String = "${(v * 100).roundToInt()}%"
+internal fun lineSpacingBubble(v: Float): String = "%.1f×".format(Locale.ROOT, v)
+internal fun marginsBubble(v: Float): String = "%.1f×".format(Locale.ROOT, v)
+internal fun wpmBubble(v: Float): String = "${v.roundToInt()}"
+
+/**
+ * True when [value] is an integer multiple of [majorEvery], within [epsilon].
+ * Majors line up on natural round numbers (100 wpm, 1.0×, …) regardless of where the range starts.
+ */
+internal fun isMajorTick(
+    value: Float,
+    majorEvery: Float,
+    epsilon: Float = 1e-3f,
+): Boolean {
+    val k = value / majorEvery
+    return abs(k - k.roundToInt()) < epsilon
+}
+
+@Composable
+internal fun UnifiedSliderRow(
+    title: String,
+    caption: String,
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int,
+    majorEvery: Float?,
+    edgeLeft: @Composable () -> Unit,
+    edgeRight: @Composable () -> Unit,
+    bubbleLabel: (Float) -> String,
+    modifier: Modifier = Modifier,
+    contentDescription: String = title,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                title,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                caption,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Spacer(Modifier.height(4.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+        ) {
+            Box(Modifier.size(28.dp), contentAlignment = Alignment.Center) { edgeLeft() }
+            Spacer(Modifier.width(8.dp))
+            SliderTrack(
+                value = value,
+                onValueChange = onValueChange,
+                valueRange = valueRange,
+                steps = steps,
+                majorEvery = majorEvery,
+                bubbleLabel = bubbleLabel,
+                contentDescription = contentDescription,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(Modifier.width(8.dp))
+            Box(Modifier.size(28.dp), contentAlignment = Alignment.Center) { edgeRight() }
+        }
+    }
+}
+
+@Composable
+private fun SliderTrack(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int,
+    majorEvery: Float?,
+    bubbleLabel: (Float) -> String,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+) {
+    val min = valueRange.start
+    val max = valueRange.endInclusive
+    val span = max - min
+    val trackBaseColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.25f)
+    val minorTickColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+    val fillColor = MaterialTheme.colorScheme.primary
+    val step = if (steps <= 0) span else span / (steps + 1)
+    val showMinors = steps <= 40
+    var trackWidthPx by remember { mutableStateOf(0) }
+    val density = LocalDensity.current
+    var interacting by remember { mutableStateOf(false) }
+
+    Box(
+        modifier = modifier
+            .height(56.dp)
+            .onSizeChanged { trackWidthPx = it.width },
+        contentAlignment = Alignment.Center,
+    ) {
+        Canvas(modifier = Modifier.fillMaxWidth().height(20.dp)) {
+            val cy = size.height / 2f
+            val trackHeightPx = with(density) { 6.dp.toPx() }
+            val corner = trackHeightPx / 2f
+            drawRoundRect(
+                color = trackBaseColor,
+                topLeft = Offset(0f, cy - trackHeightPx / 2f),
+                size = Size(size.width, trackHeightPx),
+                cornerRadius = CornerRadius(corner, corner),
+            )
+            val filledFrac = ((value - min) / span).coerceIn(0f, 1f)
+            drawRoundRect(
+                color = fillColor,
+                topLeft = Offset(0f, cy - trackHeightPx / 2f),
+                size = Size(size.width * filledFrac, trackHeightPx),
+                cornerRadius = CornerRadius(corner, corner),
+            )
+            if (steps > 0) {
+                for (i in 0..(steps + 1)) {
+                    val v = min + i * step
+                    val isMajor = majorEvery != null && isMajorTick(v, majorEvery)
+                    if (!showMinors && !isMajor) continue
+                    val x = size.width * ((v - min) / span)
+                    val tickH = if (isMajor) with(density) { 12.dp.toPx() } else with(density) { 8.dp.toPx() }
+                    val tickW = with(density) { 2.dp.toPx() }
+                    val color = if (isMajor) fillColor else minorTickColor
+                    drawRoundRect(
+                        color = color,
+                        topLeft = Offset(x - tickW / 2f, cy - tickH / 2f),
+                        size = Size(tickW, tickH),
+                        cornerRadius = CornerRadius(1f, 1f),
+                    )
+                }
+            }
+        }
+
+        if (interacting && trackWidthPx > 0) {
+            val frac = ((value - min) / span).coerceIn(0f, 1f)
+            val thumbHalfPx = with(density) { 12.dp.toPx() }
+            val usable = trackWidthPx - thumbHalfPx * 2f
+            val xPx = thumbHalfPx + frac * usable
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 28.dp),
+                contentAlignment = Alignment.BottomStart,
+            ) {
+                Box(
+                    modifier = Modifier.graphicsLayer { translationX = xPx - 24f },
+                ) { Bubble(bubbleLabel(value)) }
+            }
+        }
+
+        Slider(
+            value = value,
+            onValueChange = { new ->
+                interacting = true
+                onValueChange(new)
+            },
+            onValueChangeFinished = { interacting = false },
+            valueRange = valueRange,
+            steps = steps,
+            colors = SliderDefaults.colors(
+                thumbColor = MaterialTheme.colorScheme.primary,
+                activeTrackColor = Color.Transparent,
+                inactiveTrackColor = Color.Transparent,
+                activeTickColor = Color.Transparent,
+                inactiveTickColor = Color.Transparent,
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { this.contentDescription = contentDescription },
+        )
+    }
+}
+
+@Composable
+private fun Bubble(text: String) {
+    Surface(
+        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.inverseSurface,
+        contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+    ) {
+        Text(
+            text,
+            style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier.padding(horizontal = 9.dp, vertical = 4.dp),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
@@ -1,6 +1,9 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 package com.riffle.app.feature.reader
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,7 +13,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
@@ -193,6 +198,13 @@ private fun SliderTrack(
             }
         }
 
+        val sliderColors = SliderDefaults.colors(
+            thumbColor = MaterialTheme.colorScheme.primary,
+            activeTrackColor = Color.Transparent,
+            inactiveTrackColor = Color.Transparent,
+            activeTickColor = Color.Transparent,
+            inactiveTickColor = Color.Transparent,
+        )
         Slider(
             value = value,
             onValueChange = { new ->
@@ -202,13 +214,15 @@ private fun SliderTrack(
             onValueChangeFinished = { interacting = false },
             valueRange = valueRange,
             steps = steps,
-            colors = SliderDefaults.colors(
-                thumbColor = MaterialTheme.colorScheme.primary,
-                activeTrackColor = Color.Transparent,
-                inactiveTrackColor = Color.Transparent,
-                activeTickColor = Color.Transparent,
-                inactiveTickColor = Color.Transparent,
-            ),
+            colors = sliderColors,
+            thumb = {
+                Box(
+                    modifier = Modifier
+                        .size(20.dp)
+                        .background(MaterialTheme.colorScheme.primary, CircleShape),
+                )
+            },
+            track = { /* We draw the track ourselves above; keep this slot empty. */ },
             modifier = Modifier
                 .fillMaxWidth()
                 .semantics { this.contentDescription = contentDescription },

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/panels/PacingPanelBits.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/panels/PacingPanelBits.kt
@@ -1,10 +1,12 @@
 package com.riffle.app.feature.settings.panels
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -14,23 +16,28 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import com.riffle.app.feature.reader.UnifiedSliderRow
+import com.riffle.app.feature.reader.wpmBubble
 import com.riffle.core.domain.HighlightColor
 import com.riffle.core.domain.autoscroll.AutoScrollSpeed
 
 /**
  * Shared WPM slider — Cadence and Auto-Scroll use the same 80–600 wpm, step 10, default 250 range
  * per issue #403 (both reuse [AutoScrollSpeed]'s constants). Snapping happens inside
- * [AutoScrollSpeed.of] so the caller can't emit a mid-step value.
+ * [AutoScrollSpeed.of] so the caller can't emit a mid-step value. Renders through
+ * [UnifiedSliderRow] so it visually matches the typography sliders in the Formatting sheet.
  */
 @Composable
 internal fun WpmSliderRow(
@@ -39,23 +46,57 @@ internal fun WpmSliderRow(
     wpm: Int,
     onWpmChange: (Int) -> Unit,
 ) {
-    Text(
-        text = "$label — $wpm wpm",
-        style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.padding(top = 8.dp, bottom = 4.dp),
-    )
-    Slider(
-        value = wpm.toFloat(),
-        onValueChange = { onWpmChange(AutoScrollSpeed.of(it.toInt()).wpm) },
-        valueRange = AutoScrollSpeed.MIN_WPM.toFloat()..AutoScrollSpeed.MAX_WPM.toFloat(),
-        steps = (AutoScrollSpeed.MAX_WPM - AutoScrollSpeed.MIN_WPM) / AutoScrollSpeed.STEP_WPM - 1,
-    )
-    Text(
-        text = helper,
-        style = MaterialTheme.typography.labelSmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
-        modifier = Modifier.padding(bottom = 8.dp),
-    )
+    Column(modifier = Modifier.padding(top = 8.dp, bottom = 8.dp)) {
+        UnifiedSliderRow(
+            title = label,
+            caption = "$wpm wpm",
+            value = wpm.toFloat(),
+            onValueChange = { onWpmChange(AutoScrollSpeed.of(it.toInt()).wpm) },
+            valueRange = AutoScrollSpeed.MIN_WPM.toFloat()..AutoScrollSpeed.MAX_WPM.toFloat(),
+            steps = (AutoScrollSpeed.MAX_WPM - AutoScrollSpeed.MIN_WPM) / AutoScrollSpeed.STEP_WPM - 1,
+            majorEvery = 100f,
+            edgeLeft = { SlowIcon() },
+            edgeRight = { FastIcon() },
+            bubbleLabel = ::wpmBubble,
+            contentDescription = "$label speed",
+        )
+        Text(
+            text = helper,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+    }
+}
+
+@Composable
+private fun SlowIcon() {
+    val c = MaterialTheme.colorScheme.onSurfaceVariant
+    Canvas(Modifier.size(20.dp)) {
+        val stroke = size.width * 0.10f
+        drawCircle(color = c, radius = size.minDimension / 2f - stroke / 2f, style = Stroke(width = stroke))
+        // Notch pointing left → "slower".
+        drawRect(
+            color = c,
+            topLeft = Offset(size.width * 0.20f, size.height / 2f - stroke / 2f),
+            size = Size(size.width * 0.30f, stroke),
+        )
+    }
+}
+
+@Composable
+private fun FastIcon() {
+    val c = MaterialTheme.colorScheme.onSurfaceVariant
+    Canvas(Modifier.size(20.dp)) {
+        val stroke = size.width * 0.10f
+        drawCircle(color = c, radius = size.minDimension / 2f - stroke / 2f, style = Stroke(width = stroke))
+        // Notch pointing right → "faster".
+        drawRect(
+            color = c,
+            topLeft = Offset(size.width * 0.50f, size.height / 2f - stroke / 2f),
+            size = Size(size.width * 0.30f, stroke),
+        )
+    }
 }
 
 /**

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/panels/PacingPanelBits.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/panels/PacingPanelBits.kt
@@ -72,30 +72,31 @@ internal fun WpmSliderRow(
 @Composable
 private fun SlowIcon() {
     val c = MaterialTheme.colorScheme.onSurfaceVariant
+    // A stubby left-pointing chevron — reads as "slower / rewind".
     Canvas(Modifier.size(20.dp)) {
-        val stroke = size.width * 0.10f
-        drawCircle(color = c, radius = size.minDimension / 2f - stroke / 2f, style = Stroke(width = stroke))
-        // Notch pointing left → "slower".
-        drawRect(
-            color = c,
-            topLeft = Offset(size.width * 0.20f, size.height / 2f - stroke / 2f),
-            size = Size(size.width * 0.30f, stroke),
-        )
+        val stroke = size.width * 0.14f
+        val cx = size.width * 0.35f
+        val yMid = size.height / 2f
+        val yTop = size.height * 0.22f
+        val yBot = size.height * 0.78f
+        drawLine(color = c, start = Offset(cx + size.width * 0.30f, yTop), end = Offset(cx, yMid), strokeWidth = stroke, cap = androidx.compose.ui.graphics.StrokeCap.Round)
+        drawLine(color = c, start = Offset(cx, yMid), end = Offset(cx + size.width * 0.30f, yBot), strokeWidth = stroke, cap = androidx.compose.ui.graphics.StrokeCap.Round)
     }
 }
 
 @Composable
 private fun FastIcon() {
     val c = MaterialTheme.colorScheme.onSurfaceVariant
+    // Two right-pointing chevrons — reads as "faster / fast-forward".
     Canvas(Modifier.size(20.dp)) {
-        val stroke = size.width * 0.10f
-        drawCircle(color = c, radius = size.minDimension / 2f - stroke / 2f, style = Stroke(width = stroke))
-        // Notch pointing right → "faster".
-        drawRect(
-            color = c,
-            topLeft = Offset(size.width * 0.50f, size.height / 2f - stroke / 2f),
-            size = Size(size.width * 0.30f, stroke),
-        )
+        val stroke = size.width * 0.14f
+        val yTop = size.height * 0.22f
+        val yMid = size.height / 2f
+        val yBot = size.height * 0.78f
+        listOf(size.width * 0.18f, size.width * 0.50f).forEach { cx ->
+            drawLine(color = c, start = Offset(cx, yTop), end = Offset(cx + size.width * 0.30f, yMid), strokeWidth = stroke, cap = androidx.compose.ui.graphics.StrokeCap.Round)
+            drawLine(color = c, start = Offset(cx + size.width * 0.30f, yMid), end = Offset(cx, yBot), strokeWidth = stroke, cap = androidx.compose.ui.graphics.StrokeCap.Round)
+        }
     }
 }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/UnifiedSliderLabelsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/UnifiedSliderLabelsTest.kt
@@ -1,0 +1,60 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UnifiedSliderLabelsTest {
+
+    @Test fun fontSizeBubbleRoundsToPercent() {
+        assertEquals("50%", fontSizeBubble(0.5f))
+        assertEquals("100%", fontSizeBubble(1.0f))
+        assertEquals("120%", fontSizeBubble(1.2f))
+        assertEquals("250%", fontSizeBubble(2.5f))
+    }
+
+    @Test fun lineSpacingBubbleFormatsOneDecimal() {
+        assertEquals("1.0×", lineSpacingBubble(1.0f))
+        assertEquals("1.4×", lineSpacingBubble(1.4f))
+        assertEquals("2.0×", lineSpacingBubble(2.0f))
+    }
+
+    @Test fun marginsBubbleFormatsOneDecimal() {
+        assertEquals("0.2×", marginsBubble(0.2f))
+        assertEquals("1.0×", marginsBubble(1.0f))
+        assertEquals("3.0×", marginsBubble(3.0f))
+    }
+
+    @Test fun wpmBubbleShowsInteger() {
+        assertEquals("80", wpmBubble(80f))
+        assertEquals("250", wpmBubble(250.4f))
+        assertEquals("600", wpmBubble(600f))
+    }
+
+    @Test fun isMajorTickTrueAtIntegerMultiples() {
+        // WPM majors every 100 → 100, 200, 300, …
+        assertTrue(isMajorTick(value = 100f, majorEvery = 100f))
+        assertTrue(isMajorTick(value = 500f, majorEvery = 100f))
+        // Font majors every 0.5 → 0.5, 1.0, 1.5, 2.0, 2.5
+        assertTrue(isMajorTick(value = 1.0f, majorEvery = 0.5f))
+        assertTrue(isMajorTick(value = 2.5f, majorEvery = 0.5f))
+        // Spacing majors every 0.2 → 1.0, 1.2, 1.4, …
+        assertTrue(isMajorTick(value = 1.4f, majorEvery = 0.2f))
+    }
+
+    @Test fun isMajorTickFalseAtMinorSteps() {
+        assertFalse(isMajorTick(value = 0.6f, majorEvery = 0.5f))
+        assertFalse(isMajorTick(value = 1.3f, majorEvery = 0.2f))
+        assertFalse(isMajorTick(value = 190f, majorEvery = 100f))
+        // 80 wpm is the range floor but NOT an integer multiple of 100 — the design intentionally
+        // draws only 100, 200, …, 600 as majors on the wpm slider.
+        assertFalse(isMajorTick(value = 80f, majorEvery = 100f))
+    }
+
+    @Test fun isMajorTickToleratesFloatDrift() {
+        // 0.1 arithmetic in Float drifts; 0.2 * 5 lands near 1.0 but not exactly.
+        val drifted = 0.2f + 0.2f + 0.2f + 0.2f + 0.2f
+        assertTrue(isMajorTick(drifted, majorEvery = 0.2f))
+    }
+}

--- a/docs/superpowers/plans/2026-07-17-formatting-unified-slider.md
+++ b/docs/superpowers/plans/2026-07-17-formatting-unified-slider.md
@@ -1,0 +1,774 @@
+# Unified Slider Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace typography steppers with sliders and unify auto-scroll / cadence sliders under one `UnifiedSlider` composable, styled per prototype A.
+
+**Architecture:** Add a `UnifiedSlider(...)` + `UnifiedSliderRow(...)` composable in the reader feature package. It draws a custom track with tick notches (minors every step, majors every `majorEvery`), an edge-icon slot on either side, and a value bubble anchored above the thumb, on top of an M3 `Slider` for interaction/a11y. Migrate call sites in `FormattingSection.kt` (font size / line spacing / margins) and `PacingPanelBits.kt::WpmSliderRow` (auto-scroll + cadence). Delete `StepperRow`.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material3, JUnit 4.
+
+## Global Constraints
+
+- Value ranges and defaults are locked to the current values — do not shift them.
+  - Font size: `0.5f..2.5f`, step `0.1f`, majors every `0.5f`.
+  - Line spacing: `1.0f..2.0f`, step `0.1f`, majors every `0.2f`.
+  - Margins: `0.2f..3.0f`, step `0.1f`, majors every `0.5f`.
+  - WPM (auto-scroll + cadence): `AutoScrollSpeed.MIN_WPM..MAX_WPM` (80..600), step `AutoScrollSpeed.STEP_WPM` (10), majors every `100f`.
+- All rounding to 1 dp goes through `Float.round1()` (already in `ReaderSettingsControls.kt:241`).
+- WPM snapping stays inside `AutoScrollSpeed.of(...)`.
+- Do not touch `FormattingPreferences` shape or `AutoScrollSpeed` constants.
+- Use Material `Icons.Outlined.*` where possible; fall back to inline vector drawables only when needed.
+- No feature flag. Single PR to `main`. PR title uses Conventional Commits (`feat(reader):` / `refactor(reader):`).
+
+---
+
+### Task 1: Add `UnifiedSlider` composable and label helpers
+
+**Files:**
+- Create: `app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt`
+- Create: `app/src/test/kotlin/com/riffle/app/feature/reader/UnifiedSliderLabelsTest.kt`
+
+**Interfaces produced:**
+- `internal fun UnifiedSliderRow(title: String, caption: String, value: Float, onValueChange: (Float) -> Unit, valueRange: ClosedFloatingPointRange<Float>, steps: Int, majorEvery: Float?, edgeLeft: @Composable () -> Unit, edgeRight: @Composable () -> Unit, bubbleLabel: (Float) -> String, modifier: Modifier = Modifier)`
+- `internal fun isMajorTick(value: Float, min: Float, majorEvery: Float, epsilon: Float = 1e-3f): Boolean`
+- `internal fun fontSizeBubble(v: Float): String = "${(v * 100).roundToInt()}%"`
+- `internal fun lineSpacingBubble(v: Float): String = "%.1f×".format(v)`
+- `internal fun marginsBubble(v: Float): String = "%.1f×".format(v)`
+- `internal fun wpmBubble(v: Float): String = "${v.roundToInt()}"`
+
+- [ ] **Step 1: Write failing tests for label/predicate helpers**
+
+Create `app/src/test/kotlin/com/riffle/app/feature/reader/UnifiedSliderLabelsTest.kt`:
+
+```kotlin
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UnifiedSliderLabelsTest {
+
+    @Test fun fontSizeBubbleRoundsToPercent() {
+        assertEquals("50%", fontSizeBubble(0.5f))
+        assertEquals("100%", fontSizeBubble(1.0f))
+        assertEquals("120%", fontSizeBubble(1.2f))
+        assertEquals("250%", fontSizeBubble(2.5f))
+    }
+
+    @Test fun lineSpacingBubbleFormatsOneDecimal() {
+        assertEquals("1.0×", lineSpacingBubble(1.0f))
+        assertEquals("1.4×", lineSpacingBubble(1.4f))
+        assertEquals("2.0×", lineSpacingBubble(2.0f))
+    }
+
+    @Test fun marginsBubbleFormatsOneDecimal() {
+        assertEquals("0.2×", marginsBubble(0.2f))
+        assertEquals("1.0×", marginsBubble(1.0f))
+        assertEquals("3.0×", marginsBubble(3.0f))
+    }
+
+    @Test fun wpmBubbleShowsInteger() {
+        assertEquals("80", wpmBubble(80f))
+        assertEquals("250", wpmBubble(250.4f))
+        assertEquals("600", wpmBubble(600f))
+    }
+
+    @Test fun isMajorTickTrueAtMajorSteps() {
+        assertTrue(isMajorTick(value = 1.0f, min = 0.5f, majorEvery = 0.5f))
+        assertTrue(isMajorTick(value = 2.5f, min = 0.5f, majorEvery = 0.5f))
+        assertTrue(isMajorTick(value = 200f, min = 80f, majorEvery = 100f))
+        assertTrue(isMajorTick(value = 500f, min = 80f, majorEvery = 100f))
+    }
+
+    @Test fun isMajorTickFalseAtMinorSteps() {
+        assertFalse(isMajorTick(value = 0.6f, min = 0.5f, majorEvery = 0.5f))
+        assertFalse(isMajorTick(value = 1.3f, min = 1.0f, majorEvery = 0.2f))
+        assertFalse(isMajorTick(value = 190f, min = 80f, majorEvery = 100f))
+    }
+
+    @Test fun isMajorTickToleratesFloatDrift() {
+        // 1.0 - 0.5 in Float lands at 0.5000001 or so on some JVMs; guard against
+        // the (v - min) % majorEvery ~= 0 comparison silently flipping.
+        val drifted = 0.5f + 0.1f + 0.1f + 0.1f + 0.1f + 0.1f  // ~= 1.0
+        assertTrue(isMajorTick(drifted, min = 0.5f, majorEvery = 0.5f))
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify FAIL**
+
+```
+JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home \
+  ./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.reader.UnifiedSliderLabelsTest"
+```
+
+Expected: FAIL with unresolved references to the helper functions.
+
+- [ ] **Step 3: Create `UnifiedSlider.kt` with helpers + composable**
+
+Create `app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt`:
+
+```kotlin
+package com.riffle.app.feature.reader
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlin.math.abs
+import kotlin.math.roundToInt
+
+internal fun fontSizeBubble(v: Float): String = "${(v * 100).roundToInt()}%"
+internal fun lineSpacingBubble(v: Float): String = "%.1f×".format(v)
+internal fun marginsBubble(v: Float): String = "%.1f×".format(v)
+internal fun wpmBubble(v: Float): String = "${v.roundToInt()}"
+
+/**
+ * True when [value] sits on a major tick — i.e. `(value - min) / majorEvery` is (near-)integer.
+ * Uses float-tolerant rounding because 0.1 arithmetic in Float drifts across ranges like 0.5..2.5.
+ */
+internal fun isMajorTick(
+    value: Float,
+    min: Float,
+    majorEvery: Float,
+    epsilon: Float = 1e-3f,
+): Boolean {
+    val k = (value - min) / majorEvery
+    return abs(k - k.roundToInt()) < epsilon
+}
+
+/**
+ * Unified typography/pacing slider row. See `docs/superpowers/specs/2026-07-17-formatting-unified-slider-design.md`.
+ *
+ * Draws:
+ *  - Title (left) + live caption (right).
+ *  - Edge icon slots (28.dp), a custom tick-notched track, a value bubble on the thumb.
+ *  - An M3 [Slider] on top provides interaction, snapping, focus + a11y.
+ */
+@Composable
+internal fun UnifiedSliderRow(
+    title: String,
+    caption: String,
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int,
+    majorEvery: Float?,
+    edgeLeft: @Composable () -> Unit,
+    edgeRight: @Composable () -> Unit,
+    bubbleLabel: (Float) -> String,
+    modifier: Modifier = Modifier,
+    contentDescription: String = title,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                title,
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                caption,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Spacer(Modifier.height(4.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(56.dp),
+        ) {
+            Box(
+                Modifier.size(28.dp),
+                contentAlignment = Alignment.Center,
+            ) { edgeLeft() }
+            Spacer(Modifier.width(8.dp))
+            SliderTrack(
+                value = value,
+                onValueChange = onValueChange,
+                valueRange = valueRange,
+                steps = steps,
+                majorEvery = majorEvery,
+                bubbleLabel = bubbleLabel,
+                contentDescription = contentDescription,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(Modifier.width(8.dp))
+            Box(
+                Modifier.size(28.dp),
+                contentAlignment = Alignment.Center,
+            ) { edgeRight() }
+        }
+    }
+}
+
+@Composable
+private fun SliderTrack(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int,
+    majorEvery: Float?,
+    bubbleLabel: (Float) -> String,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+) {
+    val min = valueRange.start
+    val max = valueRange.endInclusive
+    val span = max - min
+    val tickColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.45f)
+    val majorColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.85f)
+    val step = if (steps <= 0) span else span / (steps + 1)
+    // Skip minor ticks when there are too many to read comfortably (WPM has 52 stops).
+    val showMinors = steps <= 40
+    var trackWidthPx by remember { mutableStateOf(0) }
+    val density = LocalDensity.current
+    var interacting by remember { mutableStateOf(false) }
+
+    Box(
+        modifier = modifier
+            .height(56.dp)
+            .onSizeChanged { trackWidthPx = it.width },
+        contentAlignment = Alignment.Center,
+    ) {
+        Canvas(modifier = Modifier.fillMaxWidth().height(20.dp)) {
+            val h = size.height
+            val cy = h / 2f
+            val trackHeightPx = with(density) { 6.dp.toPx() }
+            val corner = trackHeightPx / 2f
+            // Base track.
+            drawRoundRect(
+                color = tickColor.copy(alpha = 0.3f),
+                topLeft = Offset(0f, cy - trackHeightPx / 2f),
+                size = Size(size.width, trackHeightPx),
+                cornerRadius = androidx.compose.ui.geometry.CornerRadius(corner, corner),
+            )
+            // Filled portion.
+            val filledFrac = ((value - min) / span).coerceIn(0f, 1f)
+            drawRoundRect(
+                color = majorColor,
+                topLeft = Offset(0f, cy - trackHeightPx / 2f),
+                size = Size(size.width * filledFrac, trackHeightPx),
+                cornerRadius = androidx.compose.ui.geometry.CornerRadius(corner, corner),
+            )
+            // Ticks.
+            if (steps > 0) {
+                for (i in 0..(steps + 1)) {
+                    val v = min + i * step
+                    val isMajor = majorEvery != null && isMajorTick(v, min, majorEvery)
+                    if (!showMinors && !isMajor) continue
+                    val x = size.width * ((v - min) / span)
+                    val tickH = if (isMajor) with(density) { 12.dp.toPx() } else with(density) { 8.dp.toPx() }
+                    val tickW = with(density) { 2.dp.toPx() }
+                    val color = if (isMajor) majorColor else tickColor
+                    drawRoundRect(
+                        color = color,
+                        topLeft = Offset(x - tickW / 2f, cy - tickH / 2f),
+                        size = Size(tickW, tickH),
+                        cornerRadius = androidx.compose.ui.geometry.CornerRadius(1f, 1f),
+                    )
+                }
+            }
+        }
+
+        // Bubble above the thumb — visible only during interaction.
+        if (interacting && trackWidthPx > 0) {
+            val frac = ((value - min) / span).coerceIn(0f, 1f)
+            val thumbHalfPx = with(density) { 12.dp.toPx() }
+            val usable = trackWidthPx - thumbHalfPx * 2f
+            val xPx = thumbHalfPx + frac * usable
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 28.dp),
+                contentAlignment = Alignment.BottomStart,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .graphicsLayer {
+                            translationX = xPx - 24f
+                            compositingStrategy = CompositingStrategy.Offscreen
+                        },
+                ) {
+                    Bubble(bubbleLabel(value))
+                }
+            }
+        }
+
+        Slider(
+            value = value,
+            onValueChange = { new ->
+                interacting = true
+                onValueChange(new)
+            },
+            onValueChangeFinished = { interacting = false },
+            valueRange = valueRange,
+            steps = steps,
+            colors = SliderDefaults.colors(
+                thumbColor = MaterialTheme.colorScheme.primary,
+                activeTrackColor = Color.Transparent,
+                inactiveTrackColor = Color.Transparent,
+                activeTickColor = Color.Transparent,
+                inactiveTickColor = Color.Transparent,
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { this.contentDescription = contentDescription },
+        )
+    }
+}
+
+@Composable
+private fun Bubble(text: String) {
+    androidx.compose.material3.Surface(
+        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.inverseSurface,
+        contentColor = MaterialTheme.colorScheme.inverseOnSurface,
+    ) {
+        Text(
+            text,
+            style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier.padding(horizontal = 9.dp, vertical = 4.dp),
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify PASS**
+
+```
+JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home \
+  ./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.reader.UnifiedSliderLabelsTest"
+```
+
+Expected: 7 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt \
+        app/src/test/kotlin/com/riffle/app/feature/reader/UnifiedSliderLabelsTest.kt
+git commit -m "feat(reader): add UnifiedSlider composable + label helpers"
+```
+
+---
+
+### Task 2: Migrate FormattingSection to UnifiedSlider
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/FormattingSection.kt`
+
+**Interfaces consumed:** `UnifiedSliderRow`, `fontSizeBubble`, `lineSpacingBubble`, `marginsBubble`, `lineSpacingWord`, `marginsWord`, `Float.round1()`.
+
+- [ ] **Step 1: Rewrite the three stepper blocks as `UnifiedSliderRow` calls**
+
+In `FormattingSection.kt`, replace the "Font size", "Line spacing", and "Margins" blocks. The full replacement composable body:
+
+```kotlin
+Column {
+    if (capabilities.supportsTextTypography || capabilities.supportsFontFamily) {
+        Text("Text", style = MaterialTheme.typography.labelMedium)
+        Spacer(Modifier.height(8.dp))
+    }
+
+    if (capabilities.supportsTextTypography) {
+        UnifiedSliderRow(
+            title = "Font size",
+            caption = "%.0f%%".format(prefs.fontSize * 100),
+            value = prefs.fontSize,
+            onValueChange = { onPrefsChange(prefs.copy(fontSize = it.round1())) },
+            valueRange = 0.5f..2.5f,
+            steps = 19, // (2.5 - 0.5) / 0.1 - 1
+            majorEvery = 0.5f,
+            edgeLeft = { Text("A", style = MaterialTheme.typography.labelMedium) },
+            edgeRight = { Text("A", style = MaterialTheme.typography.titleLarge) },
+            bubbleLabel = ::fontSizeBubble,
+            contentDescription = "Font size",
+        )
+        Spacer(Modifier.height(16.dp))
+    }
+
+    if (capabilities.supportsFontFamily) {
+        Text("Font", style = MaterialTheme.typography.labelMedium)
+        val genericFonts = listOf(ReaderFontFamily.Original, ReaderFontFamily.Serif, ReaderFontFamily.SansSerif, ReaderFontFamily.Monospace)
+        val bundledFonts = listOf(ReaderFontFamily.Literata, ReaderFontFamily.Merriweather, ReaderFontFamily.OpenDyslexic)
+        FontChipRow(genericFonts, prefs.fontFamily) { onPrefsChange(prefs.copy(fontFamily = it)) }
+        Spacer(Modifier.height(4.dp))
+        FontChipRow(bundledFonts, prefs.fontFamily) { onPrefsChange(prefs.copy(fontFamily = it)) }
+        Spacer(Modifier.height(12.dp))
+    }
+
+    if (capabilities.supportsTextTypography) {
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+            Text("Justify text", style = MaterialTheme.typography.bodyLarge, modifier = Modifier.weight(1f))
+            Switch(checked = prefs.justifyText, onCheckedChange = { onPrefsChange(prefs.copy(justifyText = it)) })
+        }
+        Spacer(Modifier.height(16.dp))
+
+        UnifiedSliderRow(
+            title = "Line spacing",
+            caption = "${lineSpacingWord(prefs.lineSpacing)} · %.1f×".format(prefs.lineSpacing),
+            value = prefs.lineSpacing,
+            onValueChange = { onPrefsChange(prefs.copy(lineSpacing = it.round1())) },
+            valueRange = 1.0f..2.0f,
+            steps = 9,
+            majorEvery = 0.2f,
+            edgeLeft = { TightLinesIcon() },
+            edgeRight = { LooseLinesIcon() },
+            bubbleLabel = ::lineSpacingBubble,
+            contentDescription = "Line spacing",
+        )
+        Spacer(Modifier.height(20.dp))
+    }
+
+    if (capabilities.supportsTextTypography || capabilities.supportsFontFamily) {
+        Text("Page", style = MaterialTheme.typography.labelMedium)
+        Spacer(Modifier.height(8.dp))
+    }
+    UnifiedSliderRow(
+        title = "Margins",
+        caption = "${marginsWord(prefs.margins)} · %.1f×".format(prefs.margins),
+        value = prefs.margins,
+        onValueChange = { onPrefsChange(prefs.copy(margins = it.round1())) },
+        valueRange = 0.2f..3.0f,
+        steps = 27,
+        majorEvery = 0.5f,
+        edgeLeft = { NarrowMarginsIcon() },
+        edgeRight = { WideMarginsIcon() },
+        bubbleLabel = ::marginsBubble,
+        contentDescription = "Margins",
+    )
+}
+```
+
+- [ ] **Step 2: Add the four inline vector edge-icon composables at the bottom of `FormattingSection.kt`**
+
+```kotlin
+@Composable
+private fun TightLinesIcon() {
+    val c = MaterialTheme.colorScheme.onSurfaceVariant
+    Canvas(Modifier.size(18.dp)) {
+        val stroke = size.width * 0.10f
+        val pad = size.width * 0.15f
+        val w = size.width - pad * 2
+        listOf(0.35f, 0.50f, 0.65f).forEach { y ->
+            drawRect(color = c, topLeft = Offset(pad, size.height * y - stroke / 2), size = Size(w, stroke))
+        }
+    }
+}
+
+@Composable
+private fun LooseLinesIcon() {
+    val c = MaterialTheme.colorScheme.onSurfaceVariant
+    Canvas(Modifier.size(18.dp)) {
+        val stroke = size.width * 0.10f
+        val pad = size.width * 0.15f
+        val w = size.width - pad * 2
+        listOf(0.20f, 0.50f, 0.80f).forEach { y ->
+            drawRect(color = c, topLeft = Offset(pad, size.height * y - stroke / 2), size = Size(w, stroke))
+        }
+    }
+}
+
+@Composable
+private fun NarrowMarginsIcon() {
+    val c = MaterialTheme.colorScheme.onSurfaceVariant
+    Canvas(Modifier.size(18.dp)) {
+        val stroke = size.width * 0.08f
+        drawRect(color = c, topLeft = Offset(0f, 0f), size = size, style = Stroke(width = stroke))
+        val innerPad = size.width * 0.15f
+        listOf(0.35f, 0.55f, 0.75f).forEach { y ->
+            drawRect(
+                color = c,
+                topLeft = Offset(innerPad, size.height * y - stroke),
+                size = Size(size.width - innerPad * 2, stroke * 1.5f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun WideMarginsIcon() {
+    val c = MaterialTheme.colorScheme.onSurfaceVariant
+    Canvas(Modifier.size(18.dp)) {
+        val stroke = size.width * 0.08f
+        drawRect(color = c, topLeft = Offset(0f, 0f), size = size, style = Stroke(width = stroke))
+        val innerPad = size.width * 0.30f
+        listOf(0.40f, 0.60f).forEach { y ->
+            drawRect(
+                color = c,
+                topLeft = Offset(innerPad, size.height * y - stroke),
+                size = Size(size.width - innerPad * 2, stroke * 1.5f),
+            )
+        }
+    }
+}
+```
+
+Add the imports `import androidx.compose.foundation.Canvas`, `import androidx.compose.ui.geometry.Offset`, `import androidx.compose.ui.geometry.Size`, `import androidx.compose.ui.graphics.drawscope.Stroke`, `import androidx.compose.foundation.layout.size`.
+
+- [ ] **Step 3: Run compile + tests**
+
+```
+JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest
+```
+
+Expected: green.
+
+- [ ] **Step 4: Commit**
+
+```
+git add app/src/main/kotlin/com/riffle/app/feature/reader/FormattingSection.kt
+git commit -m "refactor(reader): switch typography controls to UnifiedSlider"
+```
+
+---
+
+### Task 3: Migrate `WpmSliderRow` to UnifiedSlider
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/settings/panels/PacingPanelBits.kt`
+
+- [ ] **Step 1: Rewrite `WpmSliderRow` on top of `UnifiedSliderRow`**
+
+Full replacement (keep the existing `HighlightColorRow` untouched):
+
+```kotlin
+package com.riffle.app.feature.settings.panels
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.riffle.app.feature.reader.UnifiedSliderRow
+import com.riffle.app.feature.reader.wpmBubble
+import com.riffle.core.domain.HighlightColor
+import com.riffle.core.domain.autoscroll.AutoScrollSpeed
+
+@Composable
+internal fun WpmSliderRow(
+    label: String,
+    helper: String,
+    wpm: Int,
+    onWpmChange: (Int) -> Unit,
+) {
+    Column {
+        UnifiedSliderRow(
+            title = label,
+            caption = "$wpm wpm",
+            value = wpm.toFloat(),
+            onValueChange = { onWpmChange(AutoScrollSpeed.of(it.toInt()).wpm) },
+            valueRange = AutoScrollSpeed.MIN_WPM.toFloat()..AutoScrollSpeed.MAX_WPM.toFloat(),
+            steps = (AutoScrollSpeed.MAX_WPM - AutoScrollSpeed.MIN_WPM) / AutoScrollSpeed.STEP_WPM - 1,
+            majorEvery = 100f,
+            edgeLeft = { TurtleIcon() },
+            edgeRight = { HareIcon() },
+            bubbleLabel = ::wpmBubble,
+            contentDescription = "$label speed",
+        )
+        Text(
+            text = helper,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 4.dp, bottom = 8.dp),
+        )
+    }
+}
+
+@Composable
+private fun TurtleIcon() {
+    val c = MaterialTheme.colorScheme.onSurfaceVariant
+    Canvas(Modifier.size(20.dp)) {
+        val stroke = size.width * 0.10f
+        // A very simple "slow" glyph: a circle with a small notch — reads as a dial pointing left.
+        drawCircle(color = c, radius = size.minDimension / 2f - stroke / 2f, style = Stroke(width = stroke))
+        drawRect(
+            color = c,
+            topLeft = Offset(size.width * 0.20f, size.height / 2f - stroke / 2f),
+            size = Size(size.width * 0.30f, stroke),
+        )
+    }
+}
+
+@Composable
+private fun HareIcon() {
+    val c = MaterialTheme.colorScheme.onSurfaceVariant
+    Canvas(Modifier.size(20.dp)) {
+        val stroke = size.width * 0.10f
+        drawCircle(color = c, radius = size.minDimension / 2f - stroke / 2f, style = Stroke(width = stroke))
+        drawRect(
+            color = c,
+            topLeft = Offset(size.width * 0.50f, size.height / 2f - stroke / 2f),
+            size = Size(size.width * 0.30f, stroke),
+        )
+    }
+}
+
+/**
+ * Colour-swatch picker for Cadence's highlight — mirrors the Readaloud picker to keep the visual
+ * pattern identical (issue #403: "Independent from Readaloud. Same palette."). Selected swatch
+ * carries a contrast ring + a check glyph so the pick is unambiguous in screenshots.
+ */
+@Composable
+internal fun HighlightColorRow(
+    selected: HighlightColor,
+    onSelectedChange: (HighlightColor) -> Unit,
+) {
+    ListItem(
+        headlineContent = { Text("Highlight color") },
+        supportingContent = { Text("Independent from Readaloud. Same palette.") },
+        trailingContent = {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                HighlightColor.entries.forEach { color ->
+                    val isSelected = selected == color
+                    val swatchColor = Color(color.argb.toLong() and 0xFFFFFFFFL)
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier
+                            .size(36.dp)
+                            .clip(CircleShape)
+                            .clickable { onSelectedChange(color) }
+                            .then(
+                                if (isSelected)
+                                    Modifier.border(2.dp, MaterialTheme.colorScheme.onSurface, CircleShape)
+                                else Modifier,
+                            )
+                            .padding(4.dp)
+                            .clip(CircleShape)
+                            .background(swatchColor)
+                            .semantics {
+                                contentDescription = color.name.lowercase()
+                                    .replaceFirstChar { it.uppercase() } +
+                                    " highlight" + if (isSelected) ", selected" else ""
+                            },
+                    ) {
+                        if (isSelected) {
+                            Icon(imageVector = Icons.Default.Check, contentDescription = null)
+                        }
+                    }
+                }
+            }
+        },
+    )
+}
+```
+
+- [ ] **Step 2: Run compile + tests**
+
+```
+JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest
+```
+
+Expected: green.
+
+- [ ] **Step 3: Commit**
+
+```
+git add app/src/main/kotlin/com/riffle/app/feature/settings/panels/PacingPanelBits.kt
+git commit -m "refactor(settings): route WpmSliderRow through UnifiedSlider"
+```
+
+---
+
+### Task 4: Drop `StepperRow`
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsControls.kt`
+
+- [ ] **Step 1: Confirm no remaining callers**
+
+```
+grep -rn "StepperRow\b" app/ core/ 2>/dev/null
+```
+
+Expected: only the definition itself.
+
+- [ ] **Step 2: Delete the `StepperRow` composable (lines ~58-92) and its now-unused imports**
+
+Remove `IconButton`, `Surface` (if unused elsewhere in the file — verify first with the file's other functions), and any other imports left dangling.
+
+- [ ] **Step 3: Compile + full app test suite**
+
+```
+JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home ./gradlew :app:compileDebugKotlin :app:testDebugUnitTest
+```
+
+Expected: green.
+
+- [ ] **Step 4: Full-project test run**
+
+```
+JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home ./gradlew test
+```
+
+Expected: no new failures beyond the pre-existing ones in memory (`reference_migration_tests_api25_preexisting_fails`, `reference_flaky_replaceall_emission_tests`, `reference_autofollowjs_paginated_snap_preexisting_fail`).
+
+- [ ] **Step 5: Commit**
+
+```
+git add app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsControls.kt
+git commit -m "refactor(reader): remove obsolete StepperRow"
+```

--- a/docs/superpowers/specs/2026-07-17-formatting-unified-slider-design.md
+++ b/docs/superpowers/specs/2026-07-17-formatting-unified-slider-design.md
@@ -1,0 +1,102 @@
+# Unified slider for typography and pacing controls
+
+**Status:** Design approved (prototype A confirmed 2026-07-17).
+**Prototype:** `.context/formatting-prototype/index.html`.
+
+## Problem
+
+Font size, line spacing, and margins in the Formatting sheet are driven by `StepperRow` — a −/+ pill that requires many taps to sweep across the range. Auto-scroll wpm and readaloud cadence already use sliders, but they are plain `androidx.compose.material3.Slider` calls with no visual affordance for range, no live value bubble, and inconsistent styling versus the rest of the sheet. There is no shared slider primitive, so any future control has to reinvent one.
+
+## Goal
+
+Replace the three typography steppers with sliders, upgrade the two pacing sliders, and factor the whole thing into one shared composable used by all five controls.
+
+## Non-goals
+
+- No change to the underlying value ranges, defaults, or persistence (`AutoScrollSpeed`, `FormattingPreferences`, `Cadence*`).
+- No change to the sheet's tab structure (Formatting / Display / Behavior — merged 2026-07-06 in PR #198).
+- No new controls; this is a replacement, not an expansion.
+- Font family chips and the Justify switch stay as-is.
+
+## Design
+
+### Shared composable
+
+Add `UnifiedSlider` under `app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt` (reader-feature-local; matches where `StepperRow` and `WpmSliderRow` live today). Signature:
+
+```kotlin
+@Composable
+internal fun UnifiedSlider(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int,                 // Material3 semantics: N interior stops
+    majorEvery: Float? = null,  // e.g. 100f for wpm, 0.5f for font, null = all major
+    edgeLeft: @Composable () -> Unit,
+    edgeRight: @Composable () -> Unit,
+    bubbleLabel: (Float) -> String,
+    modifier: Modifier = Modifier,
+)
+```
+
+Renders a Material3 `Slider` on top of a custom track that draws:
+
+- Base track: `surfaceVariant`, 6.dp, rounded.
+- Filled portion left of the thumb: `primary`.
+- Ticks: 2.dp × 8.dp `tick` colour at every step; 2.dp × 12.dp `primary` at every `majorEvery`. Skip minor ticks entirely if step count > 40 to avoid noise on wpm.
+- Value bubble anchored above the thumb (small pill, `inverseSurface` / `inverseOnSurface`, 12sp semibold). Visible during hover, focus, and drag; fades out on release with a short delay.
+- Edge slots: 28.dp wide, centred vertically, `onSurfaceVariant` tint, meant for icons.
+
+Everything else (haptics, keyboard nudge, semantics) comes for free from the underlying M3 `Slider`.
+
+### Row wrapper
+
+`UnifiedSliderRow(title, caption, ...UnifiedSlider params...)` renders:
+
+- Header row: `title` on the left, `caption` on the right (the current live-value line — kept because it's the discoverable label; the bubble is only visible on interaction).
+- Slider beneath.
+- Optional helper text below (used by wpm rows today).
+
+### Call sites
+
+Replace the following in `FormattingSection.kt`:
+
+- **Font size** — range 0.5f..2.5f, step 0.1 (steps=19), `majorEvery=0.5f`. Edges: small serif "A" / large serif "A". Bubble `"${(v*100).roundToInt()}%"`, caption same as today.
+- **Line spacing** — range 1.0f..2.0f, step 0.1 (steps=9), `majorEvery=0.2f`. Edges: three tight horizontal lines / three loose horizontal lines. Bubble `"${format1(v)}×"`, caption `"$label · ${v}×"` (label logic reused from today's `LineSpacingLabel`).
+- **Margins** — range 0.2f..3.0f, step 0.1 (steps=27), `majorEvery=0.5f`. Edges: page-glyph-with-tall-text / page-glyph-with-narrow-text. Bubble/caption as today.
+
+Replace `WpmSliderRow` in `PacingPanelBits.kt`:
+
+- **Auto-scroll wpm** — range 80f..600f, step 10 (steps=51), `majorEvery=100f`. Edges: turtle-with-down-arrow / hare-with-up-arrow (Material `Icons.Outlined` where possible, else vector drawables). Bubble `"$v"`, caption `"$v wpm"`.
+- **Readaloud cadence** — same range/step/majorEvery/edges/caption; feeds the existing cadence view-model instead of auto-scroll.
+
+Delete `StepperRow` after the migration; audit any lingering callers first.
+
+### Icons
+
+Prefer Material `Icons.Outlined.*` (TextIncrease/TextDecrease, FormatLineSpacing, Speed, etc.) so we don't ship raster assets. Where Material doesn't have a clean fit — margins, and the "reading pace" turtle/hare in particular — add a vector drawable under `app/src/main/res/drawable/`.
+
+## Interaction
+
+- Drag: bubble appears immediately, tracks the thumb, disappears ~150 ms after release.
+- Focus (keyboard/TB): bubble visible while focused; arrow keys nudge by `step` (M3 default).
+- Snapping: value snaps to `step` grid on release (M3 default when `steps > 0`).
+- Haptics: on tick crossing during drag (M3 `SliderColors` / `HapticFeedback.LongPress` at each snap). Guard behind `Build.VERSION.SDK_INT >= 26` — no-op on API 25.
+- No live-preview panel inside the sheet — the sheet is already translucent over the reader, so the reader IS the preview. (The preview block in the prototype was a browser affordance only.)
+
+## Testing
+
+Two JVM tests in `app/src/test/kotlin/com/riffle/app/feature/reader/UnifiedSliderTest.kt`:
+
+1. `formatsBubbleAtEveryStep` — for each of the five call-site configurations, assert `bubbleLabel(v)` at min / mid / max produces the expected string (guards the `100%`/`1.4×`/`250` wpm shape from regressing).
+2. `majorTickPredicateIsCorrect` — extract the "is this value a major tick?" predicate to a top-level `internal fun isMajorTick(value, min, majorEvery, epsilon)`; verify no false positives for step-neighbours (0.1 float-arithmetic edge case).
+
+Instrumentation coverage is unchanged — the existing `ReaderSettingsSheet` harness tests already drive font-size / line-spacing / margins by their semantics; those tests need to be updated to match the new semantic labels (Slider vs stepper Button roles), but the behavioural assertions carry over.
+
+## Rollout
+
+Single PR. No feature flag — this is a visual-only change to persisted values that already worked, and the current stepper and slider both produce identical wire values.
+
+## Open questions
+
+None; edge-icon designs are locked to the prototype (small-A/big-A, tight/loose lines, narrow/wide page, turtle/hare).


### PR DESCRIPTION
## Summary

Replaces the −/+ stepper pills for **font size / line spacing / margins** with sliders, and rebuilds the auto-scroll and cadence **WPM** sliders on the same primitive. Everything routes through a new `UnifiedSliderRow` composable:

- Tick-notched track (minor at every step, major at `majorEvery`; endpoints always drawn).
- Value bubble anchored above the thumb (visible during drag).
- Edge-icon slots that frame the row without extra labels: small-A / big-A, tight / loose lines, narrow / wide page, ‹ / » chevrons for slow / fast.
- Compact 20-dp circular thumb via `SliderDefaults.Thumb(thumbSize = …)`, so M3's own layout keeps the thumb pinned to the correct value fraction.

Preserves every persisted range, step, default, and snap contract — the change is visual + interaction, not schema.

## Notes on iteration

The first cut used a raw `Box` thumb, which broke M3's layout math (thumb landed at position 0). Fixed by routing through `SliderDefaults.Thumb(thumbSize = 20.dp)`, which honours the same `SliderState` contract the M3 default track expects. Empty `track = { }` also collapsed the Slider's internal width to zero — kept the default M3 track and zeroed its colours instead.

## Design & plan

- Spec: `docs/superpowers/specs/2026-07-17-formatting-unified-slider-design.md`
- Plan: `docs/superpowers/plans/2026-07-17-formatting-unified-slider.md`

## Test plan

- [x] `UnifiedSliderLabelsTest` — 7 JVM tests for label formatters + `isMajorTick` (float drift, endpoints, minor vs major).
- [x] `./gradlew :app:testDebugUnitTest` — green.
- [ ] Verified live in the Formatting sheet on your device across all three reader modes (paginated / vertical / continuous).