### PR TITLE
fix(reader): preserve immersive mode when dismissing annotation popup

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -119,6 +119,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import org.json.JSONObject
 import org.jsoup.nodes.Document
@@ -1505,6 +1506,12 @@ private fun EpubNavigatorView(
     // handler so a tap that only dismisses the text-selection popup does not also toggle
     // immersive mode. Written on the JS background thread; consumed on the main thread.
     val pagedSelectionActiveAtDown = remember { AtomicBoolean(false) }
+    // Timestamp (System.nanoTime()) of the most recent HighlightActionsPopup dismissal. The popup
+    // is non-focusable (see HighlightActionsSheet), so an outside tap that dismisses it also
+    // propagates to the reader and would otherwise flip immersive mode. Recording the dismiss time
+    // lets the paged/continuous tap listeners swallow that immediate follow-up tap only, without
+    // suppressing genuine taps that happen after the dismiss window closes.
+    val highlightPopupDismissedAtNs = remember { AtomicLong(0L) }
     val pagedSelectionRectBridge = remember {
         RiffleSelectionRectBridge(
             store = pagedSelectionRectCss,
@@ -1575,7 +1582,10 @@ private fun EpubNavigatorView(
             coroutineScope = coroutineScope,
             ensureSentenceQuotesReady = { currentEnsureSentenceQuotesReady() },
             navigation = object : ContinuousNavigationSink {
-                override fun onTap() = currentOnTap()
+                override fun onTap() {
+                    if (consumePopupDismissedTap(highlightPopupDismissedAtNs)) return
+                    currentOnTap()
+                }
                 override fun onLocator(locator: Locator) = onPositionChanged(locator)
             },
             links = object : ContinuousLinkSink {
@@ -1778,6 +1788,7 @@ private fun EpubNavigatorView(
         object : InputListener {
             override fun onTap(event: TapEvent): Boolean {
                 if (consumeSelectionSuppressedTap(pagedSelectionActiveAtDown)) return false
+                if (consumePopupDismissedTap(highlightPopupDismissedAtNs)) return false
                 currentOnTap()
                 return false
             }
@@ -2996,7 +3007,13 @@ private fun EpubNavigatorView(
                 onPick = { color -> onRecolorHighlight(editTarget.id, color) },
                 onDelete = { onDeleteHighlight(editTarget.id) },
                 onOpenNoteEditor = { onOpenNoteEditor(editTarget.id, editTarget.anchorRect) },
-                onDismiss = onDismissHighlightActions,
+                onDismiss = {
+                    // Record the dismiss time so the tap that dismissed the popup (Compose fires
+                    // onDismissRequest at ACTION_OUTSIDE but the same touch still reaches the
+                    // reader) doesn't also toggle immersive mode. See [highlightPopupDismissedAtNs].
+                    highlightPopupDismissedAtNs.set(System.nanoTime())
+                    onDismissHighlightActions()
+                },
                 noteOnly = editTarget.noteOnly,
                 showOpenInBook = showOpenInBook,
                 onOpenInBook = { onOpenInBook(editTarget.id) },
@@ -3167,6 +3184,27 @@ internal fun clampReaderSelectionRectBottomYs(
 // Compose closure that can't be exercised without a live Readium fragment.
 internal fun consumeSelectionSuppressedTap(activeAtDown: AtomicBoolean): Boolean =
     activeAtDown.getAndSet(false)
+
+// Window (ms) after a HighlightActionsPopup dismissal during which the very next tap is treated
+// as the dismissing tap and swallowed. Sized generously enough to cover the gap between Compose's
+// ACTION_OUTSIDE-driven onDismissRequest and the follow-up tap fired from the WebView / continuous
+// gesture detector, but small enough that a genuine tap a moment later still toggles immersive.
+internal const val POPUP_DISMISS_TAP_WINDOW_MS: Long = 300L
+
+// Returns true if the tap that just fired should be swallowed because a HighlightActionsPopup
+// dismissed within the recent window. Consumes the timestamp so only the first follow-up tap is
+// suppressed. Extracted for JVM unit-testing — the paged/continuous callsites wrap Compose
+// closures that can't be exercised without a live Readium fragment.
+internal fun consumePopupDismissedTap(
+    dismissedAtNs: AtomicLong,
+    nowNs: Long = System.nanoTime(),
+    windowMs: Long = POPUP_DISMISS_TAP_WINDOW_MS,
+): Boolean {
+    val at = dismissedAtNs.getAndSet(0L)
+    if (at == 0L) return false
+    val elapsedNs = nowNs - at
+    return elapsedNs in 0..(windowMs * 1_000_000L)
+}
 
 // Builds the DirectionalNavigationAdapter Riffle attaches to paged/vertical mode. Extracted so a
 // JVM test can pin the tap-navigation config: tapEdges MUST stay empty so screen taps toggle

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/PopupDismissedTapTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/PopupDismissedTapTest.kt
@@ -1,0 +1,69 @@
+package com.riffle.app.feature.reader
+
+import java.util.concurrent.atomic.AtomicLong
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression coverage for "tap that dismissed the HighlightActionsPopup also toggled immersive
+ * mode". [HighlightActionsPopup] is deliberately non-focusable so the popup Window doesn't steal
+ * input focus (any focus transfer causes the OS to reveal the system bars), but that means the
+ * outside tap that dismisses the popup also propagates to the reader's tap listener. Recording
+ * the dismiss timestamp and consuming the very next tap keeps immersive mode intact.
+ *
+ * These assertions fail if the timestamp is not consumed (so a later tap is also swallowed) or
+ * if the suppression window stops honouring the dismiss time.
+ */
+class PopupDismissedTapTest {
+
+    @Test
+    fun `no dismiss recorded means tap passes through`() {
+        val at = AtomicLong(0L)
+
+        val consumed = consumePopupDismissedTap(at, nowNs = 1_000_000_000L)
+
+        assertFalse("no popup dismissal → tap must toggle immersive normally", consumed)
+    }
+
+    @Test
+    fun `tap within window after dismiss is swallowed and timestamp cleared`() {
+        val at = AtomicLong(500_000_000L)
+
+        val consumed = consumePopupDismissedTap(
+            dismissedAtNs = at,
+            nowNs = 500_000_000L + 10_000_000L, // 10ms after dismiss
+        )
+
+        assertTrue("first tap after popup dismissal must be swallowed", consumed)
+        assertEquals(
+            "timestamp must be cleared so the next tap is not also swallowed",
+            0L,
+            at.get(),
+        )
+    }
+
+    @Test
+    fun `tap outside window is not swallowed`() {
+        val at = AtomicLong(500_000_000L)
+        val windowMs = 300L
+        val nowNs = 500_000_000L + (windowMs + 50) * 1_000_000L
+
+        val consumed = consumePopupDismissedTap(at, nowNs = nowNs, windowMs = windowMs)
+
+        assertFalse("tap after the window closes must toggle immersive normally", consumed)
+    }
+
+    @Test
+    fun `second tap after a suppressed one is not swallowed`() {
+        val at = AtomicLong(500_000_000L)
+
+        val first = consumePopupDismissedTap(at, nowNs = 501_000_000L)
+        val second = consumePopupDismissedTap(at, nowNs = 502_000_000L)
+
+        assertTrue(first)
+        assertFalse("only the tap that dismissed the popup is swallowed", second)
+    }
+
+}


### PR DESCRIPTION
## Summary
Tapping outside the highlight-actions popup dismissed it correctly but also toggled immersive mode off, revealing the system bars. `HighlightActionsPopup` is deliberately non-focusable (any focus transfer causes the OS to reveal the bars), so the outside tap propagates to the reader's tap listener and fires `immersiveState::toggle`.

Fix: stamp `System.nanoTime()` when the popup dismisses, and swallow the very next reader tap if it lands within a 300 ms window. Applied to both the paged/vertical `InputListener.onTap` and the continuous `ContinuousNavigationSink.onTap`. Mirrors the existing `pagedSelectionActiveAtDown` suppression pattern used for the text-selection ActionMode.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests PopupDismissedTapTest --tests SelectionSuppressedTapTest` — green (new regression suite + existing selection-suppression suite)
- [ ] Manual on device: open highlight actions, tap outside → popup dismisses, immersive stays on
- [ ] Verify a genuine reader tap ~500 ms after popup dismiss still toggles immersive
- [ ] Check continuous mode reader (separate tap path)