### PR TITLE
fix(reader): render Annotations View in the book's real publisher font

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1611,6 +1611,21 @@ class EpubReaderViewModel @Inject constructor(
         if (source == ReaderSource.Highlights) return
         val trimmed = fontFamily.trim()
         if (trimmed.isBlank()) return
+        // Refuse the sentinel value verbatim (review finding, elided-view-serif-font-regression
+        // follow-up). Latching it into `bookBodyFontFamilyReported` via `compareAndSet` would
+        // block every subsequent real report for the whole VM session (the atomic is set-once)
+        // AND `backfillNullOriginFontFamily` would rewrite every legacy null row on this book
+        // to the sentinel string — which every render/plurality site downstream then filters as
+        // "no captured value" and drops back to browser-default serif. So on a book whose
+        // publisher CSS legitimately sets `p { font-family: serif }`, the effect is the exact
+        // regression this whole change is fixing.
+        //
+        // Skipping the sentinel here is safe: the render path treats "no probed font" and
+        // "probed font equals sentinel" identically anyway (both fall through to ReadiumCSS
+        // default), and skipping leaves the atomic empty so a later chapter whose computed
+        // font is a REAL face (e.g. `Nimbusromno9l, serif` on a chapter that mounts a font
+        // stack, not the generic keyword) can still fill it in.
+        if (trimmed == FALLBACK_ORIGIN_FONT_FAMILY) return
         // Set-once per (VM lifecycle, book). AtomicReference.compareAndSet returns false when
         // we've already stored a non-blank font — cheap no-op on the many repeat reports the
         // JS tracker fires as chapters install across a reading session.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -111,28 +111,40 @@ import javax.inject.Inject
 // single write rather than one per intermediate 0.05× value.
 private const val SPEED_SAVE_DEBOUNCE_MS = 400L
 
-/**
- * Placeholder `font-family` value written on the entity when a live WebView probe returned
- * nothing at annotation-create time (rare selection-teardown race, or bookmarks toggled without
- * a prior selection). Deliberately plain "serif" so the elided view still declares a
- * font-family — [HighlightsPublicationFactory]'s sanitizer will let this pass through while
- * anything the DB coughs up beyond the safe allowlist is dropped. Issue #484.
- */
-private const val FALLBACK_ORIGIN_FONT_FAMILY = "serif"
+// Placeholder `font-family` sentinel written on the entity when no live WebView probe value was
+// available at annotation-create time (rare selection-teardown race, bookmarks toggled without a
+// prior selection, TYPE_IMAGE caption highlights). The store contract requires a non-blank
+// string, so we keep the sentinel; render-time callers (plurality + per-<p> emitter) treat this
+// exact value as "no captured font" and fall back to the book-body probe / ReadiumCSS default.
+// Aliased to [com.riffle.app.feature.reader.highlights.FALLBACK_ORIGIN_FONT_FAMILY] so tests and
+// factory logic reference a single source of truth. Issue #484.
+private const val FALLBACK_ORIGIN_FONT_FAMILY =
+    com.riffle.app.feature.reader.highlights.FALLBACK_ORIGIN_FONT_FAMILY
 
 /** Convenience for the merge-inherit path: returns [Annotation.originFontFamily] on the
  *  domain projection, or null when the annotation predates issue #484 and hasn't been touched
- *  by lazy backfill yet. Callers fall back to [FALLBACK_ORIGIN_FONT_FAMILY]. */
+ *  by lazy backfill yet, OR when the stored value is the [FALLBACK_ORIGIN_FONT_FAMILY] sentinel
+ *  (which is not a real captured font and must not propagate through merges). */
 private fun entityFontFamily(annotation: Annotation): String? =
-    annotation.originFontFamily?.takeIf { it.isNotBlank() }
+    annotation.originFontFamily
+        ?.takeIf { it.isNotBlank() && it != FALLBACK_ORIGIN_FONT_FAMILY }
 
-/** Plurality (mode) `originFontFamily` across every annotation in [chapters], skipping blanks.
- *  Returns null when nothing has a value yet — callers use that to mean "emit no `font-family`
- *  at all" (falls through to ReadiumCSS default). Ties broken by first-seen order. Issue #484. */
-private fun pluralityOriginFont(chapters: List<ChapterElision>): String? =
+/** Plurality (mode) `originFontFamily` across every annotation in [chapters], skipping blanks
+ *  AND the [FALLBACK_ORIGIN_FONT_FAMILY] sentinel — a book whose annotations were all created
+ *  before the WebView probe fired would otherwise plurality-vote the sentinel and force the
+ *  elided view's chapter titles + body to render as bare `serif`, defeating the "inherit the
+ *  origin's face" contract of issue #484.
+ *  Returns null when nothing has a real captured value yet — callers layer the in-memory
+ *  body-font probe on top, then emit no `font-family` at all if that too is unknown. Ties
+ *  broken by first-seen order. */
+internal fun pluralityOriginFont(chapters: List<ChapterElision>): String? =
     chapters.asSequence()
         .flatMap { it.highlights.asSequence() }
-        .mapNotNull { it.originFontFamily?.takeIf { f -> f.isNotBlank() } }
+        .mapNotNull {
+            it.originFontFamily?.takeIf { f ->
+                f.isNotBlank() && f != FALLBACK_ORIGIN_FONT_FAMILY
+            }
+        }
         .groupingBy { it }
         .eachCount()
         .maxByOrNull { it.value }
@@ -250,6 +262,21 @@ class EpubReaderViewModel @Inject constructor(
     private val captionHighlightCleanupAttempted = java.util.concurrent.atomic.AtomicBoolean(false)
     private val legacyImageUpgradeAttempted = java.util.concurrent.atomic.AtomicBoolean(false)
     private val captionHighlightUpgrader by lazy { CaptionHighlightUpgrader(annotationStore) }
+
+    // Set by the WebView-side body-font probe injected in [SELECTION_SPAN_TRACKER_JS] (issue
+    // #484). Set-once — the first non-blank value the reader reports for the current book,
+    // triggers a DB backfill of every legacy null-font row for the same book, and is cached so
+    // subsequent chapter loads (which re-fire the tracker install) don't re-write the DB.
+    //
+    // Also consulted from [loadHighlightsPublication] as the fallback for `elidedBodyFontFamily`
+    // when annotation-plurality yields no real captured font (issue: elided view forced to
+    // serif when every existing annotation was stamped with the [FALLBACK_ORIGIN_FONT_FAMILY]
+    // sentinel). Hoisted next to the other pre-init AtomicRefs so the `viewModelScope.launch {
+    // openBook() }` in `init` doesn't touch a null field when Main.immediate reaches the
+    // Highlights branch before this property has been initialised — same crash class as the
+    // `legacyImageUpgradeAttempted` regression this comment block also documents at its
+    // original site.
+    private val bookBodyFontFamilyReported = java.util.concurrent.atomic.AtomicReference<String>("")
 
     // Formatting/typography/auto-scroll orchestrator — constructed with viewModelScope so
     // teardown is deterministic (the orchestrator's coroutines cancel when the VM is cleared).
@@ -1019,10 +1046,15 @@ class EpubReaderViewModel @Inject constructor(
             // Fallback body-font for excerpts whose annotation has null `originFontFamily`
             // (legacy rows, W3C sync ingest). Pick the plurality font across the captured set —
             // it converges to the book's dominant face as the user creates new annotations.
-            // Null (no captured fonts anywhere) → factory emits no `font-family`, falls all the
-            // way back to ReadiumCSS default (pre-issue-484 behaviour). See issue #484 and
-            // [HighlightsPublicationFactory.buildHandle].
+            // When plurality is null (every captured value is blank or the sentinel), fall back
+            // to whatever the full-book WebView reported this VM session; this heals books whose
+            // annotation set is dominated by sentinel-stamped rows (bookmarks / caption
+            // highlights created without a prior selection). Only null (both plurality AND
+            // in-memory probe unknown) means "emit no `font-family`, ReadiumCSS default wins" —
+            // pre-issue-484 behaviour and the pre-regression rendering for chapter titles.
             elidedBodyFontFamily = pluralityOriginFont(chapters)
+                ?: bookBodyFontFamilyReported.get()
+                    .takeIf { it.isNotBlank() && it != FALLBACK_ORIGIN_FONT_FAMILY }
             // Serve figure bytes from the source EPUB (if it's been downloaded) so annotated
             // figures render as their real image in the elided view instead of the "[figure
             // image not captured]" placeholder. Highlights mode never runs the normal
@@ -1564,17 +1596,9 @@ class EpubReaderViewModel @Inject constructor(
 
     // ---- Annotations -------------------------------------------------------------------------
 
-    // Set by the WebView-side body-font probe injected in [SELECTION_SPAN_TRACKER_JS] (issue
-    // #484). Set-once — the first non-blank value the reader reports for the current book,
-    // triggers a DB backfill of every legacy null-font row for the same book, and is cached so
-    // subsequent chapter loads (which re-fire the tracker install) don't re-write the DB.
-    private val bookBodyFontFamilyReported = java.util.concurrent.atomic.AtomicReference<String>("")
-
-    // (Moved out of this block to above the init launch — see the fields near the constructor
-    // parameters. Kotlin property initializers run in declaration order, and this declaration
-    // used to sit below the init { viewModelScope.launch { openBook() } } block; when the
-    // launched coroutine ran on Main.immediate it hit openBook's Highlights branch before this
-    // field had been assigned, NPE-ing at `legacyImageUpgradeAttempted.compareAndSet(...)`.)
+    // (`bookBodyFontFamilyReported` lives up near the constructor-adjacent fields — same
+    // pre-init-hoist reason as `legacyImageUpgradeAttempted`; the openBook() launch in `init`
+    // touches it via the Highlights branch's `elidedBodyFontFamily` fallback.)
 
     /**
      * Called by [RiffleSelectionRectBridge.onBookBodyFont] on chapter install. Caches the value
@@ -1593,12 +1617,29 @@ class EpubReaderViewModel @Inject constructor(
         if (!bookBodyFontFamilyReported.compareAndSet("", trimmed)) return
         val sourceId = annotationServerId ?: return
         viewModelScope.launch {
-            val updated = runCatching {
+            val backfilled = runCatching {
                 annotationStore.backfillNullOriginFontFamily(sourceId, itemId, trimmed)
             }.getOrElse { 0 }
+            // Also heal rows stamped with the [FALLBACK_ORIGIN_FONT_FAMILY] sentinel — the
+            // "no captured value" marker written by legacy create paths whose live selection
+            // reported nothing (bookmarks, caption highlights, or a selectionchange race).
+            // Without this, a book whose annotations are all sentinel-stamped stays serif in
+            // the elided view even after the user opens the source book. The store no-ops
+            // when [trimmed] equals the sentinel, so a book whose CSS legitimately sets
+            // `body { font-family: serif }` doesn't churn sync.
+            val healed = runCatching {
+                annotationStore.healSentinelOriginFontFamily(
+                    sourceId = sourceId,
+                    itemId = itemId,
+                    sentinel = FALLBACK_ORIGIN_FONT_FAMILY,
+                    fontFamily = trimmed,
+                )
+            }.getOrElse { 0 }
+            val updated = backfilled + healed
             if (updated > 0) {
                 logger.d(LogChannel.HighlightMerge) {
-                    "originFontFamily backfill sourceId=$sourceId itemId=$itemId font='$trimmed' updated=$updated"
+                    "originFontFamily backfill sourceId=$sourceId itemId=$itemId font='$trimmed'" +
+                        " nullBackfilled=$backfilled sentinelHealed=$healed"
                 }
                 scheduleAnnotationSync()
             }
@@ -1730,10 +1771,15 @@ class EpubReaderViewModel @Inject constructor(
                     .forEach { annotationStore.delete(it.id) }
             }
             // Origin font-family at the selection start (issue #484). Non-blank contract on the
-            // store — fall back to the store's plain-serif default when the WebView side happened
-            // to return empty (rare selection-teardown race). The lazy backfill on chapter-load
-            // rewrites approximated values as they get corrected against the real DOM.
-            val originFont = SelectionFontStash.consume().takeIf { it.isNotBlank() } ?: FALLBACK_ORIGIN_FONT_FAMILY
+            // store — fall back through two layers when the WebView side happened to return empty
+            // (rare selection-teardown race, or a paginated selectionchange that raced the Highlight
+            // tap): (a) the book's computed body font this VM session already probed, (b) the
+            // [FALLBACK_ORIGIN_FONT_FAMILY] sentinel. Preferring (a) means the elided view's
+            // per-excerpt `<p>` still renders in the publisher's face for annotations created in
+            // rare-race sessions, avoiding the pre-fix "elided body forced to browser serif" bug.
+            val originFont = SelectionFontStash.consume().takeIf { it.isNotBlank() }
+                ?: bookBodyFontFamilyReported.get().takeIf { it.isNotBlank() }
+                ?: FALLBACK_ORIGIN_FONT_FAMILY
             val created = annotationStore.createHighlight(
                 sourceId = sourceId,
                 itemId = itemId,
@@ -2070,10 +2116,14 @@ class EpubReaderViewModel @Inject constructor(
                 }
                 val cfi = locator.toPayload().ebookLocation
                 val snippet = locator.text.before?.take(200).orEmpty()
-                // Bookmarks have no live text selection to read a range font from — fall back to
-                // the last captured selection font when one is pending, else the plain-serif
-                // placeholder (issue #484). Backfill will refine legacy rows on chapter-load.
+                // Bookmarks have no live text selection to read a range font from — fall back
+                // through the last captured selection font, then the book's computed body font
+                // this VM session already probed (issue: elided view forced browser serif when
+                // the entire book was bookmark-only). Only if both are unknown do we stamp the
+                // [FALLBACK_ORIGIN_FONT_FAMILY] sentinel; the sentinel is filtered at render time
+                // and healed by the next full-book open. Issue #484.
                 val bookmarkFont = SelectionFontStash.consume().takeIf { it.isNotBlank() }
+                    ?: bookBodyFontFamilyReported.get().takeIf { it.isNotBlank() }
                     ?: FALLBACK_ORIGIN_FONT_FAMILY
                 annotationStore.createBookmark(
                     sourceId = sourceId,
@@ -2242,7 +2292,11 @@ class EpubReaderViewModel @Inject constructor(
                     spineIndex = spineIndex,
                     progression = progression,
                     embeddedFigures = listOf(figure),
-                    originFontFamily = FALLBACK_ORIGIN_FONT_FAMILY,
+                    // Caption highlight originates from a long-press on the figure, never a live
+                    // text selection — the range font is inferred from the book's computed body
+                    // font this VM session already probed; sentinel only if that's still empty.
+                    originFontFamily = bookBodyFontFamilyReported.get().takeIf { it.isNotBlank() }
+                        ?: FALLBACK_ORIGIN_FONT_FAMILY,
                 )
                 openHighlightActions(created.id, anchorRect)
                 scheduleAnnotationSync()
@@ -2416,6 +2470,8 @@ class EpubReaderViewModel @Inject constructor(
                             chapter = chapter,
                             bookBodyFontFamily = elidedBodyFontFamily,
                             dataUriByHref = highlightsPublicationHandle?.figureBytesByHref.orEmpty(),
+                            publisherFontFaceCss = highlightsPublicationHandle
+                                ?.publisherFontFaceCss.orEmpty(),
                         )
                         handle.setChapterBytes(chapterHref, freshHtml)
                     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -274,16 +274,32 @@ internal val SELECTION_SPAN_TRACKER_JS = """
     (function () {
       if (window.__riffleSelTrackerInstalled) return;
       window.__riffleSelTrackerInstalled = true;
-      // One-shot body-font probe (issue #484). Fires once per chapter install: reads the source
-      // book's computed body `font-family` and (a) stashes it in `window.__riffleBookBodyFont`
-      // so continuous mode can pull it via evaluateJavascript from onPageFinished, and (b)
-      // bridges it out to Kotlin directly for paginated mode via RiffleSelBridge — the elided
-      // view uses this as the fallback for legacy null-font rows AND to backfill them in the DB.
+      // One-shot body-font probe (issue #484 + elided-view-serif-font-regression). Fires
+      // once per chapter install: reads the source book's computed font on a REAL content
+      // element and stashes it on `window.__riffleBookBodyFont` (continuous mode pulls from
+      // there via evaluateJavascript on onPageFinished) AND bridges it out to Kotlin directly
+      // for paginated mode via `RiffleSelBridge.onBookBodyFont`. Elided-view backfill/heal
+      // uses this to render annotations in the publisher's face.
+      //
+      // We probe a content element (`<p>`/`<li>`/`<span>`) BEFORE falling back to `<body>`
+      // because publisher CSS typically styles paragraphs, not the body. On books like
+      // "A Philosophy of Software Design" the body reports Chromium's default
+      // `"Times New Roman", serif` while `<p>` computes to the publisher's actual face — a
+      // body-only probe stamped every annotation as browser-default serif and defeated the
+      // whole "elided view inherits the origin's font" contract (elided-view-serif-font-
+      // regression). `<body>` remains the final fallback for chapter shells that don't yet
+      // have inner content (the tracker re-fires on the next install once content mounts).
       try {
-        var bodyEl = document.body || document.documentElement;
+        var probeEl = null;
+        var candidates = document.querySelectorAll('p, li, div, span');
+        for (var i = 0; i < candidates.length && i < 20; i++) {
+          var c = candidates[i];
+          if (c && (c.textContent || '').trim().length > 0) { probeEl = c; break; }
+        }
+        if (!probeEl) probeEl = document.body || document.documentElement;
         var bodyFont = '';
-        if (bodyEl) {
-          var bcs = window.getComputedStyle(bodyEl);
+        if (probeEl) {
+          var bcs = window.getComputedStyle(probeEl);
           if (bcs) bodyFont = bcs.fontFamily || '';
         }
         window.__riffleBookBodyFont = bodyFont;

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -291,10 +291,37 @@ internal val SELECTION_SPAN_TRACKER_JS = """
       // have inner content (the tracker re-fires on the next install once content mounts).
       try {
         var probeEl = null;
-        var candidates = document.querySelectorAll('p, li, div, span');
-        for (var i = 0; i < candidates.length && i < 20; i++) {
-          var c = candidates[i];
-          if (c && (c.textContent || '').trim().length > 0) { probeEl = c; break; }
+        // Prefer real body-text elements over chapter-header wrappers. `<p>` and `<li>` are the
+        // canonical body-text carriers publisher CSS styles; the earlier version fell straight
+        // through to `<div>`/`<span>` and picked up leading `<div class="chapternum">7</div>`
+        // (or drop-caps, running heads, etc.) whose computed font is a display face, not the
+        // body face — that value then got backfilled/healed onto every annotation on the book.
+        //
+        // Length gate: candidates with `textContent.trim().length < 40` are almost always
+        // ornamentation (chapter numbers, single-letter drop caps, "Chapter N" labels) rather
+        // than body prose. Skip them and keep looking; if nothing meets the threshold we fall
+        // through to the generic pass, then to `<body>` — never worse than the pre-fix probe.
+        var primary = document.querySelectorAll('p, li');
+        for (var i = 0; i < primary.length && i < 30; i++) {
+          var c = primary[i];
+          if (c && (c.textContent || '').trim().length >= 40) { probeEl = c; break; }
+        }
+        if (!probeEl) {
+          // Second pass: same selectors, no length gate — for chapters whose only body carrier
+          // is a very short paragraph (frontmatter dedications, epigraphs).
+          for (var j = 0; j < primary.length && j < 10; j++) {
+            var c2 = primary[j];
+            if (c2 && (c2.textContent || '').trim().length > 0) { probeEl = c2; break; }
+          }
+        }
+        if (!probeEl) {
+          // Third pass: fall back to any non-empty container. Kept ordered so a real
+          // paragraph elsewhere still wins over a wrapper.
+          var fallback = document.querySelectorAll('div, span, article, section');
+          for (var k = 0; k < fallback.length && k < 20; k++) {
+            var c3 = fallback[k];
+            if (c3 && (c3.textContent || '').trim().length >= 40) { probeEl = c3; break; }
+          }
         }
         if (!probeEl) probeEl = document.body || document.documentElement;
         var bodyFont = '';

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -21,6 +21,18 @@ import org.readium.r2.shared.util.mediatype.MediaType
 import org.readium.r2.shared.util.resource.Resource
 
 /**
+ * Sentinel `originFontFamily` value written on annotation entities when the WebView had no live
+ * `getComputedStyle().fontFamily` to report at annotation-create time (rare selection-teardown
+ * race, bookmarks toggled without a prior selection, TYPE_IMAGE caption highlights). The store
+ * contract requires a non-blank string, so we can't just store null; instead, this exact literal
+ * is the shared "no captured font" marker that [pluralityOriginFont] (in EpubReaderViewModel)
+ * and [appendOriginFontFamilyStyle] both treat as "no value" and fall back through. Kept as
+ * plain `serif` for backwards compatibility with rows already written before the regression fix.
+ * Issue #484 + elided-view-serif-font-regression follow-up.
+ */
+internal const val FALLBACK_ORIGIN_FONT_FAMILY = "serif"
+
+/**
  * One chapter's worth of highlights to be rendered into the elided reader (ADR 0041).
  *
  * [highlights] must already be sorted by (spineIndex, progression, createdAt) — the factory
@@ -51,6 +63,13 @@ class HighlightsPublicationHandle internal constructor(
      *  the initial figure-bearing HTML with a byte-less version and the elided view would
      *  regress to "[figure image not captured]" after the first edit. */
     val figureBytesByHref: Map<String, String>,
+    /** Concatenated publisher `@font-face` rules (with base64-inlined font bytes) extracted from
+     *  the source EPUB's stylesheets — see [PublisherFontFaceExtractor]. Same reasoning as
+     *  [figureBytesByHref]: live-patch re-renders must carry this forward or a colour/note edit
+     *  would strip the embedded font and the elided view would revert to a generic-serif fallback
+     *  (elided-view-serif-font-regression). Empty when no fetcher was supplied, no CSS was
+     *  found, or every referenced font failed to resolve. */
+    val publisherFontFaceCss: String,
 ) {
     /** Overwrite the bytes for [chapterHref] with [freshHtml]'s UTF-8 encoding. No-op if the
      *  chapter isn't in the current spine (i.e. this handle predates a structural change). */
@@ -155,10 +174,32 @@ class HighlightsPublicationFactory @Inject constructor() {
             entries[url] = bytes
         }
 
+        // Publisher `@font-face` inlining (elided-view-serif-font-regression follow-up): pull the
+        // source EPUB's stylesheets + font files and rewrite each `@font-face` `src: url(...)` to
+        // a `data:` URI so the synthesised elided document can actually render the captured
+        // `originFontFamily` face in Original / Publisher mode. Without this, the WebView sees
+        // e.g. `font-family: Nimbusromno9l;`, can't resolve it (the synthesised container
+        // doesn't serve the source book's font files), and falls back to a generic serif that
+        // visibly diverges from what the source reader shows.
+        //
+        // Extraction is opt-in via [resourceFetcher] exposing [ZipEpubResourceFetcher.listEntries]
+        // — for JVM tests and the Noop fetcher this yields an empty list and no `@font-face`
+        // block is emitted (matches the pre-fix rendering exactly for tests that don't need it).
+        val publisherFontFaceCss = when (val fetcher = resourceFetcher) {
+            is ZipEpubResourceFetcher -> {
+                val cssFiles = fetcher.listEntries(listOf(".css"))
+                val fontResolver: (String) -> ByteArray? = { path -> fetcher.fetch(path) }
+                PublisherFontFaceExtractor.extract(cssFiles, fontResolver)
+            }
+            else -> ""
+        }
+
         nonEmptyChapters.forEachIndexed { index, chapter ->
             val href = "highlights/ch$index.xhtml"
             val url = requireNotNull(urlFactory(href)) { "Failed to build synthetic Url for $href" }
-            entries[url] = renderChapterHtml(chapter, bookBodyFontFamily, dataUriByHref).toByteArray(Charsets.UTF_8)
+            entries[url] = renderChapterHtml(
+                chapter, bookBodyFontFamily, dataUriByHref, publisherFontFaceCss,
+            ).toByteArray(Charsets.UTF_8)
             chapterUrls[chapter.href] = url
             readingOrder += Link(
                 href = url,
@@ -185,7 +226,9 @@ class HighlightsPublicationFactory @Inject constructor() {
             manifest = manifest,
             container = InMemoryContainer(entries),
         )
-        return HighlightsPublicationHandle(publication, chapterUrls, entries, dataUriByHref)
+        return HighlightsPublicationHandle(
+            publication, chapterUrls, entries, dataUriByHref, publisherFontFaceCss,
+        )
     }
 
     /**
@@ -198,6 +241,7 @@ class HighlightsPublicationFactory @Inject constructor() {
         chapter: ChapterElision,
         bookBodyFontFamily: String? = null,
         dataUriByHref: Map<String, String> = emptyMap(),
+        publisherFontFaceCss: String = "",
     ): String {
         val body = buildString {
             for (annotation in chapter.highlights) {
@@ -225,14 +269,33 @@ class HighlightsPublicationFactory @Inject constructor() {
         // inline `<body>` style loses on `<h1>`. Per-excerpt `<p>` inline styles from
         // [appendOriginFontFamilyStyle] still override this — inline `!important` beats
         // stylesheet `!important` at equal specificity. Issue #484.
-        val safeBodyFont = sanitizeCssFontFamily(bookBodyFontFamily)
+        // Skip the sentinel — see [FALLBACK_ORIGIN_FONT_FAMILY]. Emitting `font-family: serif`
+        // on `<body>, h1, ...` would force the elided view's chapter titles and excerpts into
+        // browser-default serif for books whose annotation set is dominated by sentinel-stamped
+        // rows.
+        //
+        // No `!important` (elided-view-serif-font-regression follow-up): with `!important` the
+        // captured origin face was pinned regardless of the reader's Font pref, so switching
+        // Original → Serif / Sans / Merriweather only affected `<h1>` (a competing ReadiumCSS
+        // heading rule tied on specificity + importance and won the cascade on some webviews).
+        // Without `!important` our rule serves as the "Original" default, and ReadiumCSS's
+        // font-pref rule (which uses `!important` in Serif/Sans/publisher-typography modes)
+        // now cleanly wins over ours for the whole document — body AND heading — so the toggle
+        // finally does what the user expects.
+        val realBodyFont = bookBodyFontFamily?.takeIf { it != FALLBACK_ORIGIN_FONT_FAMILY }
+        val safeBodyFont = sanitizeCssFontFamily(realBodyFont)
         val bodyFontStyleBlock = if (safeBodyFont != null) {
             val escaped = safeBodyFont.xmlEscape()
-            "body, h1, h2, h3, h4, h5, h6, aside, figcaption, .riffle-fig { font-family: $escaped !important; }"
+            "body, h1, h2, h3, h4, h5, h6, aside, figcaption, .riffle-fig { font-family: $escaped; }"
         } else ""
+        // Emit the publisher `@font-face` rules BEFORE our body-font declaration so the WebView
+        // sees the font source (with inlined base64 bytes) before the first `font-family: X;`
+        // that references its name. Empty when [publisherFontFaceCss] is blank — no `<style>`
+        // noise for tests or books without embedded fonts.
         return """
             |<?xml version="1.0" encoding="UTF-8"?>
-            |<html xmlns="http://www.w3.org/1999/xhtml"><head><title>$title</title>$READIUM_DEFAULT_CSS_LINK<style>$ACCENT_BAR_TAP_CSS
+            |<html xmlns="http://www.w3.org/1999/xhtml"><head><title>$title</title>$READIUM_DEFAULT_CSS_LINK<style>$publisherFontFaceCss
+            |$ACCENT_BAR_TAP_CSS
             |$FIGURE_CENTERING_CSS
             |$bodyFontStyleBlock</style></head>
             |<body>
@@ -466,14 +529,25 @@ private fun appendOriginFontFamilyStyle(
     originFontFamily: String?,
     bookBodyFontFamily: String?,
 ) {
-    val raw = originFontFamily?.takeIf { it.isNotBlank() } ?: bookBodyFontFamily?.takeIf { it.isNotBlank() }
+    // Filter the shared [FALLBACK_ORIGIN_FONT_FAMILY] sentinel so a sentinel-stamped annotation
+    // doesn't force a bare `font-family: serif !important` inline on its `<p>` — let the fallback
+    // chain (bookBodyFontFamily, then ReadiumCSS default) take over.
+    val ownFont = originFontFamily
+        ?.takeIf { it.isNotBlank() && it != FALLBACK_ORIGIN_FONT_FAMILY }
+    val fallback = bookBodyFontFamily
+        ?.takeIf { it.isNotBlank() && it != FALLBACK_ORIGIN_FONT_FAMILY }
+    val raw = ownFont ?: fallback
     val safe = sanitizeCssFontFamily(raw) ?: return
-    // `!important` needed to win against the equally-important body/heading override rule
-    // emitted by [renderChapterHtml] — inline `!important` beats stylesheet `!important`
-    // at equal specificity, so the per-excerpt annotation font wins.
+    // No `!important` (elided-view-serif-font-regression follow-up): with it, the captured
+    // origin font pinned per-excerpt regardless of the reader's Font pref — switching to
+    // Serif/Sans/Merriweather left the body stuck. Non-important lets ReadiumCSS's
+    // font-pref rule (which uses `!important`) win when the user picks a specific face,
+    // while our inline still wins over ReadiumCSS's Publisher-mode default (which uses no
+    // `!important`), so the elided excerpt still renders in the captured origin face by
+    // default. Same reasoning as the body/heading style block in [renderChapterHtml].
     sb.append(" font-family: ")
     sb.append(safe.xmlEscape())
-    sb.append(" !important;")
+    sb.append(";")
 }
 
 /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/PublisherFontFaceExtractor.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/PublisherFontFaceExtractor.kt
@@ -1,0 +1,162 @@
+package com.riffle.app.feature.reader.highlights
+
+import java.util.Base64
+
+/**
+ * Extracts `@font-face` rules from a source EPUB's stylesheets and rewrites each `src: url(...)`
+ * to an inline `data:` URI so the elided-view synthesised HTML can render the publisher's actual
+ * face (elided-view-serif-font-regression follow-up).
+ *
+ * The synthesised elided document is a Publication distinct from the source book — the source
+ * book's Readium asset server does not answer requests routed against the synthesised container,
+ * so plain `src: url(font_rsrc2H2.ttf)` in a captured `@font-face` rule can't resolve. Inlining
+ * every referenced font as base64 gives the WebView a self-contained document that renders the
+ * captured `originFontFamily` value ("Nimbusromno9l" et al) in the correct face when the reader
+ * is in Original / Publisher font mode.
+ *
+ * Size trade-off: font TTFs in a typical EPUB are 15-40 KB each; a book like *A Philosophy of
+ * Software Design* embeds ~8 faces (~250 KB total). Inlining them once per synthesised chapter
+ * HTML is acceptable — the elided document is small compared to the source book and the WebView
+ * caches parsed `@font-face` blocks per document.
+ */
+internal object PublisherFontFaceExtractor {
+
+    /**
+     * Given the raw bytes of every CSS file discovered inside the source EPUB and a resolver
+     * from a font-file path (relative to the CSS file's own directory) to the font's bytes,
+     * returns a single CSS string containing every `@font-face` rule with its `src` rewritten
+     * to `url("data:font/...;base64,...")`.
+     *
+     * Empty when no `@font-face` was found or every referenced font failed to resolve — the
+     * caller then omits the `<style>` block entirely rather than emit a hollow declaration.
+     */
+    fun extract(
+        cssFiles: List<Pair<String, ByteArray>>,
+        fontResolver: (path: String) -> ByteArray?,
+    ): String {
+        val out = StringBuilder()
+        for ((cssPath, bytes) in cssFiles) {
+            val css = runCatching { String(bytes, Charsets.UTF_8) }.getOrNull() ?: continue
+            val cssDir = cssPath.substringBeforeLast('/', "")
+                .let { if (it.isEmpty()) "" else "$it/" }
+            for (rule in fontFaceRules(css)) {
+                val rewritten = rewriteRule(rule, cssDir, fontResolver) ?: continue
+                out.append(rewritten)
+                out.append('\n')
+            }
+        }
+        return out.toString()
+    }
+
+    /**
+     * Splits [css] into raw `@font-face { ... }` rule bodies (INCLUDING the outer `@font-face`
+     * keyword and brace pair). Skips balanced braces inside the rule body so a nested `{}` (very
+     * rare in `@font-face` but permitted) doesn't split the rule mid-way. Whitespace/comments
+     * outside `@font-face` are ignored.
+     */
+    private fun fontFaceRules(css: String): List<String> {
+        val stripped = stripComments(css)
+        val results = mutableListOf<String>()
+        var i = 0
+        val marker = "@font-face"
+        while (true) {
+            val start = stripped.indexOf(marker, i, ignoreCase = true)
+            if (start < 0) break
+            val openBrace = stripped.indexOf('{', start + marker.length)
+            if (openBrace < 0) break
+            // Skip past whitespace between marker and brace; anything else means a false match.
+            val between = stripped.substring(start + marker.length, openBrace)
+            if (between.any { !it.isWhitespace() }) { i = start + marker.length; continue }
+            var depth = 1
+            var j = openBrace + 1
+            while (j < stripped.length && depth > 0) {
+                when (stripped[j]) {
+                    '{' -> depth++
+                    '}' -> depth--
+                }
+                j++
+            }
+            if (depth != 0) break
+            results += stripped.substring(start, j)
+            i = j
+        }
+        return results
+    }
+
+    /** Removes `/* … */` block comments so `@font-face` inside a comment isn't matched. */
+    private fun stripComments(css: String): String {
+        val sb = StringBuilder(css.length)
+        var i = 0
+        while (i < css.length) {
+            if (i + 1 < css.length && css[i] == '/' && css[i + 1] == '*') {
+                val end = css.indexOf("*/", i + 2)
+                i = if (end < 0) css.length else end + 2
+            } else {
+                sb.append(css[i])
+                i++
+            }
+        }
+        return sb.toString()
+    }
+
+    /**
+     * Rewrites every `src: url(<path>)` inside [rule] to `src: url("data:<mime>;base64,<b64>")`
+     * by resolving `<path>` (relative to [cssDir]) through [fontResolver]. Preserves the
+     * comma-separated `local()`/`format()`/etc entries around each `url()`. Returns null when
+     * no `url()` in the rule could be resolved to bytes — the caller then drops the rule
+     * entirely (better than emitting a `@font-face` with an unresolvable `src`, which some
+     * WebViews treat as "font unusable" and refuse to fall back).
+     */
+    private fun rewriteRule(
+        rule: String,
+        cssDir: String,
+        fontResolver: (path: String) -> ByteArray?,
+    ): String? {
+        var anyResolved = false
+        val rewritten = URL_REGEX.replace(rule) { match ->
+            val rawPath = match.groupValues[1].trim().trim('\'', '"')
+            // Already inline — count as resolved so the whole rule survives, but pass the
+            // declaration through untouched (the WebView handles the base64 payload directly).
+            if (rawPath.startsWith("data:", ignoreCase = true)) {
+                anyResolved = true
+                return@replace match.value
+            }
+            val resolved = fontResolver(resolveAgainst(cssDir, rawPath))
+                ?: fontResolver(rawPath)
+                ?: return@replace match.value
+            anyResolved = true
+            val mime = mimeForFontPath(rawPath)
+            val b64 = Base64.getEncoder().encodeToString(resolved)
+            "url(\"data:$mime;base64,$b64\")"
+        }
+        return if (anyResolved) rewritten else null
+    }
+
+    private val URL_REGEX = Regex("""url\(\s*([^)]+?)\s*\)""", RegexOption.IGNORE_CASE)
+
+    private fun resolveAgainst(cssDir: String, rel: String): String {
+        if (rel.startsWith('/')) return rel.trimStart('/')
+        // Naive `..` collapse: enough for the flat font/ subfolder layout every EPUB in the wild
+        // uses. Absolute-path rewriting (drive letters, protocols) is handled by the early
+        // `data:` bail-out above and the `startsWith('/')` branch here.
+        val parts = (cssDir.split('/') + rel.split('/')).filter { it.isNotEmpty() }
+        val stack = ArrayDeque<String>()
+        for (p in parts) when (p) {
+            "." -> {}
+            ".." -> if (stack.isNotEmpty()) stack.removeLast()
+            else -> stack.addLast(p)
+        }
+        return stack.joinToString("/")
+    }
+
+    private fun mimeForFontPath(path: String): String {
+        val lower = path.lowercase()
+        return when {
+            lower.endsWith(".woff2") -> "font/woff2"
+            lower.endsWith(".woff") -> "font/woff"
+            lower.endsWith(".otf") -> "font/otf"
+            lower.endsWith(".ttf") -> "font/ttf"
+            else -> "application/octet-stream"
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/PublisherFontFaceExtractor.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/PublisherFontFaceExtractor.kt
@@ -121,8 +121,21 @@ internal object PublisherFontFaceExtractor {
                 anyResolved = true
                 return@replace match.value
             }
+            // Try the CSS-dir-relative resolution first (the normal EPUB case), then the raw
+            // path as given (in case the caller already handed us a package-absolute path).
+            // Finally, if the raw path starts with '/', ALSO try common EPUB-root prefixes:
+            // most EPUBs stash content under `OEBPS/` (`EPUB/` in newer builds), and a
+            // package-absolute `url('/fonts/x.ttf')` means "relative to the EPUB package root"
+            // — which is the ZIP's OEBPS directory, not the ZIP root. Without this fallback,
+            // the extractor dropped `@font-face` rules on hand-authored EPUBs that use
+            // package-absolute URLs and the elided view fell through to browser-default serif
+            // (review finding).
             val resolved = fontResolver(resolveAgainst(cssDir, rawPath))
                 ?: fontResolver(rawPath)
+                ?: if (rawPath.startsWith('/')) {
+                    val bare = rawPath.trimStart('/')
+                    EPUB_ROOT_PREFIXES.firstNotNullOfOrNull { fontResolver("$it$bare") }
+                } else null
                 ?: return@replace match.value
             anyResolved = true
             val mime = mimeForFontPath(rawPath)
@@ -133,6 +146,11 @@ internal object PublisherFontFaceExtractor {
     }
 
     private val URL_REGEX = Regex("""url\(\s*([^)]+?)\s*\)""", RegexOption.IGNORE_CASE)
+
+    /** Common EPUB "package root" directory prefixes probed when a CSS `url()` starts with `/` —
+     *  see [rewriteRule]. Ordered by prevalence (older EPUBs use `OEBPS/`, EPUB3 tooling tends
+     *  toward `EPUB/`, `content/` shows up on hand-authored books). */
+    private val EPUB_ROOT_PREFIXES = listOf("OEBPS/", "EPUB/", "content/")
 
     private fun resolveAgainst(cssDir: String, rel: String): String {
         if (rel.startsWith('/')) return rel.trimStart('/')

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/ZipEpubResourceFetcher.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/ZipEpubResourceFetcher.kt
@@ -37,6 +37,27 @@ internal class ZipEpubResourceFetcher private constructor(
         return runCatching { zip.getInputStream(entry).use { it.readBytes() } }.getOrNull()
     }
 
+    /**
+     * Returns every ZIP entry whose name ends in one of [suffixes] (case-insensitive), paired with
+     * its raw bytes. Used by [HighlightsPublicationFactory] to discover the source EPUB's CSS
+     * files (`.css`) and font files (`.ttf` / `.otf` / `.woff` / `.woff2`) so the elided view can
+     * inline the publisher's `@font-face` rules — without this the synthesised HTML falls back to
+     * whatever generic serif the WebView happens to pick when it can't resolve the captured
+     * `originFontFamily` name (elided-view-serif-font-regression).
+     */
+    fun listEntries(suffixes: Collection<String>): List<Pair<String, ByteArray>> {
+        val lowered = suffixes.map { it.lowercase() }
+        return zip.entries().asSequence()
+            .filter { !it.isDirectory }
+            .filter { entry -> lowered.any { entry.name.lowercase().endsWith(it) } }
+            .mapNotNull { entry ->
+                runCatching { zip.getInputStream(entry).use { it.readBytes() } }
+                    .getOrNull()
+                    ?.let { entry.name to it }
+            }
+            .toList()
+    }
+
     override fun close() {
         runCatching { zip.close() }
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModelTest.kt
@@ -91,6 +91,7 @@ class AnnotationSearchViewModelTest {
             sourceId: String, itemId: String, chapterHref: String, imageHref: String?, imageSvg: String?,
         ): Annotation? = null
         override suspend fun backfillNullOriginFontFamily(sourceId: String, itemId: String, fontFamily: String) = error("unused")
+        override suspend fun healSentinelOriginFontFamily(sourceId: String, itemId: String, sentinel: String, fontFamily: String) = error("unused")
     }
 
     private fun fakeAudiobookBookmarkStore(): com.riffle.core.domain.AudiobookBookmarkStore =

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
@@ -99,6 +99,7 @@ class LibraryFilterEngineTest {
             sourceId: String, itemId: String, chapterHref: String, imageHref: String?, imageSvg: String?,
         ): com.riffle.core.domain.Annotation? = null
         override suspend fun backfillNullOriginFontFamily(sourceId: String, itemId: String, fontFamily: String) = error("unused")
+        override suspend fun healSentinelOriginFontFamily(sourceId: String, itemId: String, sentinel: String, fontFamily: String) = error("unused")
     }
 
     private fun fakeBookmarkStore(): AudiobookBookmarkStore = object : AudiobookBookmarkStore {

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -103,6 +103,7 @@ class LibraryItemsViewModelTest {
                 sourceId: String, itemId: String, chapterHref: String, imageHref: String?, imageSvg: String?,
             ): com.riffle.core.domain.Annotation? = null
             override suspend fun backfillNullOriginFontFamily(sourceId: String, itemId: String, fontFamily: String) = error("unused")
+            override suspend fun healSentinelOriginFontFamily(sourceId: String, itemId: String, sentinel: String, fontFamily: String) = error("unused")
         }
 
     private fun fakeAudiobookBookmarkStore(): com.riffle.core.domain.AudiobookBookmarkStore =

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/CaptionHighlightUpgraderTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/CaptionHighlightUpgraderTest.kt
@@ -476,6 +476,15 @@ private class InMemoryDao(val rows: MutableStateFlow<List<AnnotationEntity>>) : 
         deviceId: String,
     ) = 0
 
+    override suspend fun healSentinelOriginFontFamily(
+        sourceId: String,
+        itemId: String,
+        sentinel: String,
+        fontFamily: String,
+        updatedAt: Long,
+        deviceId: String,
+    ) = 0
+
     override fun observeBooksWithHighlights(sourceId: String) = flowOf(emptyList<BookHighlightSummary>())
 }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelEmbeddedFiguresTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelEmbeddedFiguresTest.kt
@@ -137,6 +137,16 @@ class EpubReaderViewModelEmbeddedFiguresTest {
             return changed
         }
 
+        override suspend fun healSentinelOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            sentinel: String,
+            fontFamily: String,
+            updatedAt: Long,
+            deviceId: String,
+        ): Int = 0
+
+
         override fun observeBooksWithHighlights(sourceId: String): Flow<List<BookHighlightSummary>> =
             flowOf(emptyList())
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelImageAnnotationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelImageAnnotationTest.kt
@@ -137,6 +137,16 @@ class EpubReaderViewModelImageAnnotationTest {
             return changed
         }
 
+        override suspend fun healSentinelOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            sentinel: String,
+            fontFamily: String,
+            updatedAt: Long,
+            deviceId: String,
+        ): Int = 0
+
+
         override fun observeBooksWithHighlights(sourceId: String): Flow<List<com.riffle.core.database.BookHighlightSummary>> =
             flowOf(emptyList())
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/PluralityOriginFontTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/PluralityOriginFontTest.kt
@@ -1,0 +1,108 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.app.feature.reader.highlights.ChapterElision
+import com.riffle.app.feature.reader.highlights.FALLBACK_ORIGIN_FONT_FAMILY
+import com.riffle.core.database.AnnotationEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the plurality vote used to derive the elided view's fallback `bookBodyFontFamily`
+ * ([EpubReaderViewModel.loadHighlightsPublication] → [HighlightsPublicationFactory]).
+ *
+ * Regression: `elided-view-serif-font-regression`. When every annotation on a book was stamped
+ * with the [FALLBACK_ORIGIN_FONT_FAMILY] sentinel (bookmarks toggled without a live selection,
+ * caption highlights, or the SelectionFontStash race), the plurality used to return "serif",
+ * which the factory then forced onto `<body>, h1, ..., aside, figcaption` via a
+ * `font-family: serif !important` rule — the chapter title and every excerpt rendered in browser
+ * default serif regardless of the book's real face or the user's formatting preferences. The
+ * sentinel is a "no captured value" marker, not a rendering directive; plurality must skip it.
+ */
+class PluralityOriginFontTest {
+
+    @Test
+    fun pluralityReturnsRealFontWhenPresent() {
+        val chapters = listOf(
+            chapter(
+                "ch0",
+                hl("h1", originFontFamily = "Georgia, serif"),
+                hl("h2", originFontFamily = "Georgia, serif"),
+                hl("h3", originFontFamily = "\"Fira Sans\", sans-serif"),
+            ),
+        )
+        assertEquals("Georgia, serif", pluralityOriginFont(chapters))
+    }
+
+    @Test
+    fun pluralityIgnoresSentinelWhenARealFontIsPresent() {
+        val chapters = listOf(
+            chapter(
+                "ch0",
+                hl("h1", originFontFamily = FALLBACK_ORIGIN_FONT_FAMILY),
+                hl("h2", originFontFamily = FALLBACK_ORIGIN_FONT_FAMILY),
+                hl("h3", originFontFamily = FALLBACK_ORIGIN_FONT_FAMILY),
+                hl("h4", originFontFamily = "Merriweather, serif"),
+            ),
+        )
+        assertEquals(
+            "sentinel-stamped rows outnumber the real one, but plurality must still pick the real font",
+            "Merriweather, serif",
+            pluralityOriginFont(chapters),
+        )
+    }
+
+    @Test
+    fun pluralityReturnsNullWhenOnlySentinelStampedRowsExist() {
+        val chapters = listOf(
+            chapter(
+                "ch0",
+                hl("h1", originFontFamily = FALLBACK_ORIGIN_FONT_FAMILY),
+                hl("h2", originFontFamily = FALLBACK_ORIGIN_FONT_FAMILY),
+            ),
+        )
+        assertNull(
+            "all-sentinel input must yield null so the caller falls through to the WebView probe / ReadiumCSS default",
+            pluralityOriginFont(chapters),
+        )
+    }
+
+    @Test
+    fun pluralityReturnsNullWhenAllFontsAreBlankOrNull() {
+        val chapters = listOf(
+            chapter(
+                "ch0",
+                hl("h1", originFontFamily = null),
+                hl("h2", originFontFamily = ""),
+                hl("h3", originFontFamily = "   "),
+            ),
+        )
+        assertNull(pluralityOriginFont(chapters))
+    }
+
+    private fun chapter(href: String, vararg highlights: AnnotationEntity) =
+        ChapterElision(href = href, title = "T", highlights = highlights.toList())
+
+    private fun hl(id: String, originFontFamily: String?): AnnotationEntity = AnnotationEntity(
+        id = id,
+        sourceId = "S1",
+        itemId = "B1",
+        type = AnnotationEntity.TYPE_HIGHLIGHT,
+        cfi = "cfi",
+        color = "yellow",
+        note = null,
+        textSnippet = "snippet",
+        textBefore = "",
+        textAfter = "",
+        chapterHref = "ch0.xhtml",
+        spineIndex = 0,
+        progression = 0.0,
+        bookmarkTitle = "",
+        createdAt = 0L,
+        updatedAt = 0L,
+        originDeviceId = "d",
+        lastModifiedByDeviceId = "d",
+        deleted = false,
+        originFontFamily = originFontFamily,
+    )
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
@@ -126,6 +126,14 @@ class BookmarksControllerTest {
             itemId: String,
             fontFamily: String,
         ): Int = 0
+
+        override suspend fun healSentinelOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            sentinel: String,
+            fontFamily: String,
+        ): Int = 0
+
     }
 
     private fun makeAnnotation(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
@@ -320,7 +320,7 @@ class HighlightsPublicationFactoryTest {
         val html = readChapterHtml(pub, index = 0)
         assertTrue(
             "excerpt <p> carries an inline font-family with the captured value; html was: $html",
-            html.contains("font-family: &quot;Fira Sans&quot;, sans-serif !important;")
+            html.contains("font-family: &quot;Fira Sans&quot;, sans-serif;")
         )
     }
 
@@ -343,15 +343,15 @@ class HighlightsPublicationFactoryTest {
         val html = readChapterHtml(pub, index = 0)
         assertTrue(
             "excerpt <p> falls back to book body font; html was: $html",
-            html.contains("font-family: Georgia, serif !important;")
+            html.contains("font-family: Georgia, serif;")
         )
     }
 
     // The `bookBodyFontFamily` is applied via a `<style>` block that targets `<body>` + every
     // heading tag so the chapter title, notes, and figcaptions inherit the origin's face —
     // matches "the elided view must inherit the origin's font" for the whole document, not just
-    // excerpts. `!important` is load-bearing because ReadiumCSS-default.css sets its own
-    // font-family on headings via `--RS__*Font*` CSS variables.
+    // excerpts. No `!important`: our rule acts as the Original-mode default; ReadiumCSS's
+    // font-pref rule (which uses `!important`) wins when the user picks a specific face.
     @Test
     fun bookBodyFontFamily_isAppliedToHeadingsAndAsideViaStyleBlock() {
         val pub = factory.build(
@@ -370,7 +370,7 @@ class HighlightsPublicationFactoryTest {
             "<style> block must set the book body font on body + headings + aside; html was: $html",
             html.contains(
                 "body, h1, h2, h3, h4, h5, h6, aside, figcaption, .riffle-fig " +
-                    "{ font-family: Georgia, serif !important; }"
+                    "{ font-family: Georgia, serif; }"
             )
         )
     }
@@ -388,6 +388,54 @@ class HighlightsPublicationFactoryTest {
         )
         val html = readChapterHtml(pub, index = 0)
         assertTrue("no inline font-family emitted", !html.contains("font-family:"))
+    }
+
+    // Regression (elided-view-serif-font-regression): a set of annotations dominated by rows
+    // stamped with the [FALLBACK_ORIGIN_FONT_FAMILY] sentinel must NOT force the elided view's
+    // chapter title (`<h1>`), body, and excerpt paragraphs into `font-family: serif`. The
+    // sentinel is a "no captured value" marker, not a rendering directive; falling through to
+    // ReadiumCSS + the user's formatting preferences is what preserves the origin's face.
+    @Test
+    fun sentinelBookBodyFontFamily_doesNotForceSerifOnBodyOrHeadings() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "Chapter Title Here",
+                    listOf(hl("h1", "excerpt", originFontFamily = FALLBACK_ORIGIN_FONT_FAMILY)),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+            bookBodyFontFamily = FALLBACK_ORIGIN_FONT_FAMILY,
+        )
+        val html = readChapterHtml(pub, index = 0)
+        assertTrue(
+            "sentinel must NOT emit any font-family declaration; html was: $html",
+            !html.contains("font-family:")
+        )
+    }
+
+    // Same regression, per-excerpt path: an annotation whose stored [originFontFamily] is the
+    // sentinel must render its `<p>` without a `font-family` override, deferring to whatever
+    // real fallback the caller passes (or ReadiumCSS default when both are absent).
+    @Test
+    fun sentinelOriginFontFamily_onExcerpt_defersToRealFallback() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "One",
+                    listOf(hl("h1", "excerpt", originFontFamily = FALLBACK_ORIGIN_FONT_FAMILY)),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+            bookBodyFontFamily = "Georgia, serif",
+        )
+        val html = readChapterHtml(pub, index = 0)
+        assertTrue(
+            "excerpt <p> must use the real book font, not the sentinel; html was: $html",
+            html.contains("font-family: Georgia, serif;")
+        )
     }
 
     // A font-family value whose bytes contain something outside the safe allowlist (e.g. an

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/PublisherFontFaceExtractorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/PublisherFontFaceExtractorTest.kt
@@ -1,0 +1,142 @@
+package com.riffle.app.feature.reader.highlights
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the `@font-face` extraction + rewrite pipeline used to embed the source EPUB's fonts into
+ * the synthesised elided-view HTML (elided-view-serif-font-regression follow-up).
+ *
+ * Regression this file prevents: without the extractor, the elided view emits
+ * `font-family: Nimbusromno9l;` on `<body>` but no `@font-face` for that face — the WebView can't
+ * resolve it and falls back to a generic system serif that visibly diverges from the source
+ * reader. The tests cover the two subtle failure modes: (a) an unresolved `url(...)` in the CSS
+ * silently drops the whole rule (better than emitting a broken `@font-face` some WebViews treat
+ * as "font unusable" and refuse to fall back), and (b) `url()` paths are resolved against the
+ * CSS file's own directory before hitting the resolver (so an EPUB whose CSS lives in `OEBPS/`
+ * and references `font_rsrc2H2.ttf` correctly asks for `OEBPS/font_rsrc2H2.ttf`).
+ */
+class PublisherFontFaceExtractorTest {
+
+    @Test
+    fun rewritesRelativeUrlToBase64DataUri() {
+        val css = """
+            @font-face {
+              font-family: 'Nimbusromno9l';
+              src: url('font_rsrc2H2.ttf') format('truetype');
+              font-weight: normal;
+            }
+        """.trimIndent()
+        val fontBytes = byteArrayOf(1, 2, 3, 4, 5)
+        val result = PublisherFontFaceExtractor.extract(
+            cssFiles = listOf("OEBPS/stylesheet.css" to css.toByteArray()),
+            fontResolver = { path ->
+                if (path == "OEBPS/font_rsrc2H2.ttf") fontBytes else null
+            },
+        )
+        assertTrue(
+            "expected inlined data URI in output, got: $result",
+            result.contains("data:font/ttf;base64,AQIDBAU="),
+        )
+        assertTrue("expected font-family preserved, got: $result", result.contains("Nimbusromno9l"))
+    }
+
+    @Test
+    fun dropsRuleWhenReferencedFontCannotBeResolved() {
+        val css = """
+            @font-face {
+              font-family: 'GhostFont';
+              src: url('missing.ttf');
+            }
+        """.trimIndent()
+        val result = PublisherFontFaceExtractor.extract(
+            cssFiles = listOf("stylesheet.css" to css.toByteArray()),
+            fontResolver = { null },
+        )
+        // Rule with only unresolvable url()s must be dropped — an emitted `@font-face` with a
+        // broken `src` makes some WebViews mark the family as "unusable" and skip the
+        // system-serif fallback we'd otherwise get.
+        assertEquals("", result.trim())
+    }
+
+    @Test
+    fun ignoresNonFontFaceCssRulesAndBlockComments() {
+        val css = """
+            /* @font-face { src: url(fake.ttf); }  ← must be ignored */
+            body { color: red; }
+            @font-face {
+              font-family: 'Real';
+              src: url(font.ttf);
+            }
+            .other { font-family: 'Real'; }
+        """.trimIndent()
+        val result = PublisherFontFaceExtractor.extract(
+            cssFiles = listOf("s.css" to css.toByteArray()),
+            fontResolver = { if (it == "font.ttf") byteArrayOf(9, 9) else null },
+        )
+        assertTrue(result.contains("'Real'"))
+        // Commented-out rule must not leak into the output.
+        assertFalse(
+            "commented-out @font-face must not be emitted; got: $result",
+            result.contains("fake.ttf"),
+        )
+        // Non-@font-face rules must not be echoed back.
+        assertFalse(
+            "non-@font-face declarations must not be echoed; got: $result",
+            result.contains("color: red") || result.contains(".other"),
+        )
+    }
+
+    @Test
+    fun resolvesUrlAgainstCssDirectoryBeforeFallingBackToRawPath() {
+        val css = """
+            @font-face { font-family: 'A'; src: url('fonts/a.ttf'); }
+        """.trimIndent()
+        val calls = mutableListOf<String>()
+        PublisherFontFaceExtractor.extract(
+            cssFiles = listOf("OEBPS/css/stylesheet.css" to css.toByteArray()),
+            fontResolver = { path ->
+                calls += path
+                if (path == "OEBPS/css/fonts/a.ttf") byteArrayOf(0) else null
+            },
+        )
+        assertTrue(
+            "expected CSS-dir-resolved path (OEBPS/css/fonts/a.ttf) to be asked first; calls=$calls",
+            calls.firstOrNull() == "OEBPS/css/fonts/a.ttf",
+        )
+    }
+
+    @Test
+    fun preservesExistingDataUriUrlsUnchanged() {
+        val css = """
+            @font-face {
+              font-family: 'AlreadyInline';
+              src: url('data:font/ttf;base64,AAAA');
+            }
+        """.trimIndent()
+        val result = PublisherFontFaceExtractor.extract(
+            cssFiles = listOf("s.css" to css.toByteArray()),
+            fontResolver = { error("resolver must NOT be consulted for existing data: URIs") },
+        )
+        // A CSS already carrying its fonts inline is a legitimate publisher pattern
+        // (uncommon but permitted); the extractor must pass such rules through untouched
+        // rather than mark them as unresolved and drop them.
+        assertTrue(result.contains("data:font/ttf;base64,AAAA"))
+    }
+
+    @Test
+    fun emitsEmptyStringWhenNoFontFaceRulesInAnyCssFile() {
+        val css = "body { color: black; } p { margin: 0; }"
+        val result = PublisherFontFaceExtractor.extract(
+            cssFiles = listOf("s.css" to css.toByteArray()),
+            fontResolver = { null },
+        )
+        assertEquals(
+            "no @font-face → empty output → factory omits the <style> block entirely",
+            "",
+            result,
+        )
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/PublisherFontFaceExtractorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/PublisherFontFaceExtractorTest.kt
@@ -126,6 +126,29 @@ class PublisherFontFaceExtractorTest {
         assertTrue(result.contains("data:font/ttf;base64,AAAA"))
     }
 
+    // Regression (review finding): a CSS `@font-face` with `src: url('/fonts/x.ttf')` (leading
+    // slash means "relative to the EPUB package root") must find the font under the EPUB's
+    // package directory (typically `OEBPS/`), not the ZIP root. Without the package-root
+    // fallback the extractor drops the rule and the elided view falls through to a generic
+    // serif — the exact class of miss the whole change is guarding against.
+    @Test
+    fun resolvesLeadingSlashUrlAgainstEpubPackageRootPrefixes() {
+        val css = """
+            @font-face { font-family: 'A'; src: url('/fonts/a.ttf'); }
+        """.trimIndent()
+        val result = PublisherFontFaceExtractor.extract(
+            cssFiles = listOf("OEBPS/css/stylesheet.css" to css.toByteArray()),
+            fontResolver = { path ->
+                // Only the OEBPS/-prefixed path resolves — mirroring the real ZIP layout.
+                if (path == "OEBPS/fonts/a.ttf") byteArrayOf(7, 7, 7) else null
+            },
+        )
+        assertTrue(
+            "expected @font-face rule to survive via OEBPS/-prefix fallback; got: $result",
+            result.contains("data:font/ttf;base64,BwcH"),
+        )
+    }
+
     @Test
     fun emitsEmptyStringWhenNoFontFaceRulesInAnyCssFile() {
         val css = "body { color: black; } p { margin: 0; }"

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -106,6 +106,14 @@ class AnnotationSessionTest {
             itemId: String,
             fontFamily: String,
         ): Int = 0
+
+        override suspend fun healSentinelOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            sentinel: String,
+            fontFamily: String,
+        ): Int = 0
+
     }
 
     /**

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -187,6 +187,14 @@ class ReaderSessionLifecycleTest {
             itemId: String,
             fontFamily: String,
         ): Int = 0
+
+        override suspend fun healSentinelOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            sentinel: String,
+            fontFamily: String,
+        ): Int = 0
+
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────────────────

--- a/app/src/test/kotlin/com/riffle/app/feature/server/AddSourceViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/server/AddSourceViewModelTest.kt
@@ -234,6 +234,16 @@ class AddSourceViewModelTest {
             updatedAt: Long,
             deviceId: String,
         ): Int = 0
+
+        override suspend fun healSentinelOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            sentinel: String,
+            fontFamily: String,
+            updatedAt: Long,
+            deviceId: String,
+        ): Int = 0
+
         override fun observeBooksWithHighlights(sourceId: String) =
             flowOf(emptyList<com.riffle.core.database.BookHighlightSummary>())
     }
@@ -581,6 +591,14 @@ class AddSourceViewModelTest {
             override suspend fun backfillNullOriginFontFamily(
                 sourceId: String,
                 itemId: String,
+                fontFamily: String,
+                updatedAt: Long,
+                deviceId: String,
+            ): Int = 0
+            override suspend fun healSentinelOriginFontFamily(
+                sourceId: String,
+                itemId: String,
+                sentinel: String,
                 fontFamily: String,
                 updatedAt: Long,
                 deviceId: String,

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/SettingsViewModelTest.kt
@@ -298,6 +298,16 @@ class SettingsViewModelTest {
             updatedAt: Long,
             deviceId: String,
         ): Int = 0
+
+        override suspend fun healSentinelOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            sentinel: String,
+            fontFamily: String,
+            updatedAt: Long,
+            deviceId: String,
+        ): Int = 0
+
         override fun observeBooksWithHighlights(sourceId: String) =
             flowOf(emptyList<com.riffle.core.database.BookHighlightSummary>())
     }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
@@ -188,6 +188,23 @@ class AnnotationStoreImpl(
         )
     }
 
+    override suspend fun healSentinelOriginFontFamily(
+        sourceId: String,
+        itemId: String,
+        sentinel: String,
+        fontFamily: String,
+    ): Int {
+        if (fontFamily.isBlank() || sentinel.isBlank() || fontFamily == sentinel) return 0
+        return dao.healSentinelOriginFontFamily(
+            sourceId = sourceId,
+            itemId = itemId,
+            sentinel = sentinel,
+            fontFamily = fontFamily,
+            updatedAt = clock(),
+            deviceId = deviceIdStore.getOrCreate(),
+        )
+    }
+
     override suspend fun upgradeImageToCaptionHighlight(
         id: String,
         cfi: String,

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
@@ -89,6 +89,16 @@ class AnnotationStoreImplTest {
             return updated
         }
 
+        override suspend fun healSentinelOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            sentinel: String,
+            fontFamily: String,
+            updatedAt: Long,
+            deviceId: String,
+        ): Int = 0
+
+
         override suspend fun updateNote(id: String, note: String?, updatedAt: Long, deviceId: String) {
             rows.value = rows.value.map {
                 if (it.id == id) it.copy(note = note, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreTest.kt
@@ -83,6 +83,16 @@ class AnnotationStoreTest {
             }
             return updated
         }
+
+        override suspend fun healSentinelOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            sentinel: String,
+            fontFamily: String,
+            updatedAt: Long,
+            deviceId: String,
+        ): Int = 0
+
         override suspend fun updateNote(id: String, note: String?, updatedAt: Long, deviceId: String) {
             rows.value = rows.value.map {
                 if (it.id == id) it.copy(note = note, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSweepTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSweepTest.kt
@@ -351,5 +351,15 @@ abstract class StubAnnotationDao : AnnotationDao {
         updatedAt: Long,
         deviceId: String,
     ): Int = 0
+
+    override suspend fun healSentinelOriginFontFamily(
+        sourceId: String,
+        itemId: String,
+        sentinel: String,
+        fontFamily: String,
+        updatedAt: Long,
+        deviceId: String,
+    ): Int = 0
+
     override fun observeBooksWithHighlights(sourceId: String) = kotlinx.coroutines.flow.flowOf(emptyList<com.riffle.core.database.BookHighlightSummary>())
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
@@ -1046,6 +1046,16 @@ private class LifecycleInMemoryAnnotationDao : AnnotationDao {
         return changed
     }
 
+    override suspend fun healSentinelOriginFontFamily(
+        sourceId: String,
+        itemId: String,
+        sentinel: String,
+        fontFamily: String,
+        updatedAt: Long,
+        deviceId: String,
+    ): Int = 0
+
+
     override fun observeBooksWithHighlights(sourceId: String) =
         kotlinx.coroutines.flow.flowOf(emptyList<com.riffle.core.database.BookHighlightSummary>())
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerReactiveTargetTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerReactiveTargetTest.kt
@@ -105,5 +105,15 @@ private class NoOpAnnotationDao : AnnotationDao {
         updatedAt: Long,
         deviceId: String,
     ): Int = 0
+
+    override suspend fun healSentinelOriginFontFamily(
+        sourceId: String,
+        itemId: String,
+        sentinel: String,
+        fontFamily: String,
+        updatedAt: Long,
+        deviceId: String,
+    ): Int = 0
+
     override fun observeBooksWithHighlights(sourceId: String): Flow<List<com.riffle.core.database.BookHighlightSummary>> = flowOf(emptyList())
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/FakeAnnotationDao.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FakeAnnotationDao.kt
@@ -85,4 +85,14 @@ internal class FakeAnnotationDao : AnnotationDao {
         updatedAt: Long,
         deviceId: String,
     ): Int = error("not used by this fake")
+
+    override suspend fun healSentinelOriginFontFamily(
+        sourceId: String,
+        itemId: String,
+        sentinel: String,
+        fontFamily: String,
+        updatedAt: Long,
+        deviceId: String,
+    ): Int = 0
+
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
@@ -128,6 +128,33 @@ interface AnnotationDao {
         deviceId: String,
     ): Int
 
+    /**
+     * Heal every row whose `originFontFamily` equals the [sentinel] value (`"serif"`, written by
+     * legacy annotation-create paths when the live WebView probe returned nothing — see
+     * `EpubReaderViewModel.FALLBACK_ORIGIN_FONT_FAMILY`) to the freshly reported publisher font
+     * for this book. Guarded on `fontFamily != sentinel` at the call site — a book whose CSS
+     * legitimately sets `body { font-family: serif }` reports back the sentinel value verbatim
+     * and must not trigger an updatedAt bump on every open (would churn sync).
+     *
+     * Runs alongside [backfillNullOriginFontFamily] on the first non-blank body-font report per
+     * book per session; both queries then no-op on subsequent chapter loads. Same provenance +
+     * timestamp rules apply so peers see one consolidated update.
+     */
+    @Query(
+        "UPDATE annotations SET originFontFamily = :fontFamily, updatedAt = :updatedAt, " +
+            "lastModifiedByDeviceId = :deviceId " +
+            "WHERE sourceId = :sourceId AND itemId = :itemId AND deleted = 0 " +
+            "AND originFontFamily = :sentinel"
+    )
+    suspend fun healSentinelOriginFontFamily(
+        sourceId: String,
+        itemId: String,
+        sentinel: String,
+        fontFamily: String,
+        updatedAt: Long,
+        deviceId: String,
+    ): Int
+
     /** Pending-row count for one book — live Flow for reader-chrome and per-book status. */
     @Query("SELECT COUNT(*) FROM annotations WHERE sourceId = :sourceId AND itemId = :itemId AND updatedAt > lastSyncedAt")
     fun observePendingCountForBook(sourceId: String, itemId: String): Flow<Int>

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationStore.kt
@@ -83,6 +83,22 @@ interface AnnotationStore {
     ): Int
 
     /**
+     * Heal every row whose `originFontFamily` is the [sentinel] "no captured value" marker
+     * (`"serif"` — see `EpubReaderViewModel.FALLBACK_ORIGIN_FONT_FAMILY`) to the freshly
+     * reported publisher font [fontFamily]. Runs alongside [backfillNullOriginFontFamily] on
+     * every first-per-session body-font report so books whose annotations were all created
+     * before a live selection could feed the font stash (bookmarks, caption highlights, or a
+     * selectionchange race) get corrected without the user having to create a new annotation.
+     * No-op — and returns 0 — when [fontFamily] equals the sentinel value.
+     */
+    suspend fun healSentinelOriginFontFamily(
+        sourceId: String,
+        itemId: String,
+        sentinel: String,
+        fontFamily: String,
+    ): Int
+
+    /**
      * Legacy-annotation cleanup: rewrite an existing `TYPE_IMAGE` annotation into a
      * `TYPE_HIGHLIGHT` covering [textSnippet] with [figure] as its sole embeddedFigure. The
      * annotation's id is preserved so sync sees the change as an update (bumped updatedAt +


### PR DESCRIPTION
## Summary

The elided (Annotations) view was rendering every excerpt and chapter title in browser-default serif regardless of what the source book showed, and switching Original/Serif/Sans/Merriweather in Aa only affected the `<h1>`. Three compounding bugs:

1. **Sentinel poisoning.** Every write path stamped `originFontFamily = "serif"` (literal sentinel) whenever the WebView side had no live selection to probe (bookmarks, caption highlights on figures, any highlight whose selectionchange raced the tap). Once that value was in the DB, both the plurality vote (fallback for the body/heading) AND the per‑`<p>` inline style forced `font-family: serif !important` on the elided document, overriding both ReadiumCSS and the user's font pref.
2. **Wrong probe element.** The body‑font probe read `getComputedStyle(document.body).fontFamily` — but on most EPUBs (including *A Philosophy of Software Design*) publisher CSS only styles `<p>` and leaves `<body>` at Chromium's default `"Times New Roman", serif`. So the reported "book body font" was actually the browser default, and every backfilled row got that.
3. **No `@font-face` in the elided doc.** Even once the real publisher face was captured (e.g. `Nimbusromno9l`), the synthesised elided HTML declared `font-family: Nimbusromno9l;` but never included the source EPUB's `@font-face` rules — the WebView couldn't resolve the name and fell back to a generic serif that visibly diverged from the source reader.

## Fix

- **Filter the sentinel at render + create time** (`EpubReaderViewModel`, `HighlightsPublicationFactory`) — plurality/entityFontFamily/appendOriginFontFamilyStyle treat `"serif"` as absent; write sites prefer the in‑memory `bookBodyFontFamilyReported` before falling to the sentinel.
- **Drop `!important` from the body/heading + per‑`<p>` inline** so ReadiumCSS's font‑pref rule wins the toggle — Original renders the captured origin face; Serif/Sans/Merriweather now correctly override for body AND heading.
- **Probe a real content element** — three‑pass: prefer `<p>`/`<li>` with ≥40 chars of body text, fall back to any non‑empty `<p>`/`<li>`, only then to `<div>`/`<span>`/`<article>`/`<section>` (`ReaderWebViewScripts`).
- **New `healSentinelOriginFontFamily` DAO/store method + wire into `noteBookBodyFontFamily`** — the next full‑book open on a book whose annotations were sentinel‑stamped rewrites them to the publisher face; nullBackfill + sentinelHeal both run on the first non‑blank body‑font report.
- **Inject the publisher's `@font-face` into every synthesised elided chapter** (`PublisherFontFaceExtractor`, `ZipEpubResourceFetcher.listEntries`) — walks the source EPUB's stylesheets, rewrites each `src: url(...)` to `data:font/ttf;base64,…` with the actual font bytes inlined, threaded through `HighlightsPublicationHandle` so per‑annotation live‑patch re‑renders don't strip it.
- **Guard the noteBookBodyFontFamily cascade against the sentinel** (post‑review) — refusing `trimmed == FALLBACK_ORIGIN_FONT_FAMILY` at the VM entry point prevents `backfillNullOriginFontFamily` from poisoning legacy NULL rows on books whose publisher CSS legitimately says `font-family: serif`.
- **`PublisherFontFaceExtractor` package‑root fallback** (post‑review) — hand‑authored EPUBs with `src: url('/fonts/x.ttf')` in `OEBPS/styles/…` now find the font via a `OEBPS/`/`EPUB/`/`content/` prefix probe before the rule is dropped.

## Store contract change

`AnnotationStore` gains `healSentinelOriginFontFamily` (nullable‑safe, no‑ops when the reported font equals the sentinel). Every fake `AnnotationStore` / `AnnotationDao` implementation in tests grows the corresponding stub.

## Tests

- 4 new `PluralityOriginFontTest` cases pin sentinel‑filtering behaviour end‑to‑end.
- 2 new `HighlightsPublicationFactoryTest` cases pin that a sentinel value must NOT force serif on `<body>`/`<h1>` or on excerpt `<p>`s.
- 7 new `PublisherFontFaceExtractorTest` cases pin the `@font-face` extract/rewrite pipeline (base64 rewrite, unresolved drop, comment ignore, CSS‑dir‑relative path resolution, inline‑`data:` passthrough, no‑`@font-face` empty output, EPUB package‑root fallback).
- Existing factory tests updated to reflect the no‑`!important` output.

## Deferred follow‑ups (review findings)

- Sentinel design → nullable column. Would collapse the 5+ filter sites into one `IS NULL` backfill and eliminate the `heal…` method entirely. Migration change larger than the regression fix; captured for follow‑up.
- `publisherFontFaceCss` deduplication. Currently inlined into every synthesised chapter's `<style>` block (~7.5 MB on a 30‑chapter, 8‑font book). Emitting a shared synthetic `publisher-fonts.css` and `<link>`‑ing each chapter would dedupe both memory and per‑document parse cost.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest :core:data:testDebugUnitTest` — all green
- [x] Fresh Android 13 AVD, book pushed via Local Files → source reader + elided view render identical `Nimbusromno9l` glyphs
- [x] Toggle Aa in elided view — Original / Serif / Sans serif / Merriweather all flip both heading + body