### PR TITLE
fix(reader): shrink Continuous WebView budget and instrument memory pressure

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
+++ b/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
@@ -38,7 +38,10 @@ class RiffleApplication : Application(), ImageLoaderFactory {
         fun annotationSweep(): AnnotationSweep
         fun progressSweep(): ProgressSweep
         fun localFilesFolderWatcher(): LocalFilesFolderWatcher
+        fun logger(): com.riffle.core.logging.Logger
     }
+
+    private var logger: com.riffle.core.logging.Logger = com.riffle.core.logging.NoopLogger
 
     override fun attachBaseContext(base: Context) {
         super.attachBaseContext(base)
@@ -79,6 +82,7 @@ class RiffleApplication : Application(), ImageLoaderFactory {
         if (shouldSkipMainProcessStartup(ACRA.isACRASenderServiceProcess())) return
         val entryPoint = EntryPointAccessors.fromApplication(this, MigratorEntryPoint::class.java)
         val applicationScope = entryPoint.applicationScope()
+        logger = entryPoint.logger()
 
         // One-time relocation of legacy flat cache/download files into per-Source dirs (ADR 0025).
         // Idempotent and best-effort; runs off the main thread and never blocks startup.
@@ -125,6 +129,31 @@ class RiffleApplication : Application(), ImageLoaderFactory {
         // Auto-scan configured LocalFiles folders on app foreground and on SAF change events.
         // Users adding a book to a picked folder never have to hit a manual "Rescan" button.
         entryPoint.localFilesFolderWatcher().start()
+    }
+
+    /**
+     * Log every memory-pressure event so a later OOM-kill (which typically leaves no crash trace on
+     * Android 7.x) can be traced back to which trim levels the system fired first. Runtime.freeMemory
+     * gives a rough app-heap snapshot to correlate with the level. See the RIFFLE_OOM channel.
+     */
+    override fun onTrimMemory(level: Int) {
+        super.onTrimMemory(level)
+        val rt = Runtime.getRuntime()
+        val usedMb = (rt.totalMemory() - rt.freeMemory()) / (1024 * 1024)
+        val maxMb = rt.maxMemory() / (1024 * 1024)
+        logger.d(com.riffle.core.logging.LogChannel.Oom) {
+            "[DEBUG-OOM] app.onTrimMemory level=$level heap=${usedMb}MB/${maxMb}MB"
+        }
+    }
+
+    override fun onLowMemory() {
+        super.onLowMemory()
+        val rt = Runtime.getRuntime()
+        val usedMb = (rt.totalMemory() - rt.freeMemory()) / (1024 * 1024)
+        val maxMb = rt.maxMemory() / (1024 * 1024)
+        logger.d(com.riffle.core.logging.LogChannel.Oom) {
+            "[DEBUG-OOM] app.onLowMemory heap=${usedMb}MB/${maxMb}MB"
+        }
     }
 
     override fun newImageLoader(): ImageLoader =

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/AnnotationsPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/AnnotationsPanel.kt
@@ -347,7 +347,11 @@ internal fun splitSnippetForFigures(snippet: String, figureCount: Int): List<Str
 
 @Composable
 private fun InlineFigureImage(figure: InlineFigure, borderColor: Color) {
-    val bitmap = remember(figure.bytesUri) { decodeImageDataUri(figure.bytesUri) }
+    val bitmap = remember(figure.bytesUri) {
+        // Panel thumbnails render at panel width (< 1000 CSS px on any device); cap at 1024 so
+        // a captured 4000x3000 figure doesn't allocate ~48 MB per row while the user scrolls.
+        decodeImageDataUri(figure.bytesUri, reqDimensionPx = 1024)
+    }
     if (bitmap != null) {
         ComposeImage(
             bitmap = bitmap.asImageBitmap(),
@@ -422,14 +426,23 @@ internal fun maxLinesForAnnotationTitle(type: String): Int =
  * Decode a `data:image/…;base64,…` URI into a [android.graphics.Bitmap]. Null on malformed input
  * or a non-data-URI value. Used by the annotations panel to display a `TYPE_IMAGE` annotation's
  * captured thumbnail and by the Highlights-mode elided reader to render the full-size figure.
+ *
+ * [reqDimensionPx] caps the decode to `reqDimensionPx` on either axis via `inSampleSize` — set to
+ * 0 (default) for the historical full-resolution decode. The annotations panel passes a small cap
+ * so scrolling a list of large captured figures doesn't allocate tens of MB per thumbnail on a
+ * memory-constrained device.
  */
-internal fun decodeImageDataUri(dataUri: String?): android.graphics.Bitmap? {
+internal fun decodeImageDataUri(dataUri: String?, reqDimensionPx: Int = 0): android.graphics.Bitmap? {
     if (dataUri.isNullOrBlank()) return null
     val comma = dataUri.indexOf(',')
     if (comma < 0 || !dataUri.startsWith("data:")) return null
     return runCatching {
         val bytes = Base64.decode(dataUri.substring(comma + 1), Base64.DEFAULT)
-        BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+        if (reqDimensionPx > 0) {
+            decodeSampledBitmap(bytes, reqDimensionPx, reqDimensionPx)
+        } else {
+            BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+        }
     }.getOrNull()
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/BitmapDownsample.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/BitmapDownsample.kt
@@ -1,0 +1,52 @@
+package com.riffle.app.feature.reader
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+
+/**
+ * Compute the `BitmapFactory.Options.inSampleSize` power-of-two that shrinks a
+ * [srcWidth]x[srcHeight] image so both dimensions land at or under [reqWidth] and
+ * [reqHeight]. Matches the recipe from the Android developer docs.
+ *
+ * A raw `decodeByteArray` on a 12-megapixel figure allocates ~48 MB (4 bytes/px). On a
+ * 1 GB Android 7.1 tablet that alone can trip an OOM in the annotations panel or the
+ * figure-zoom overlay. Downsampling to viewport-scale drops the peak by 8-16x with no
+ * visible loss for the panel's thumbnail rendering; the zoom overlay picks the largest
+ * dimension the user can actually see (pinch-zoom scales the tile with graphicsLayer,
+ * so no source-pixel fidelity is lost inside the fit-to-viewport size).
+ *
+ * Any non-positive input parameter returns 1 (no downsample) — a defensive floor for
+ * cases where the natural dimensions aren't known before decode.
+ */
+internal fun calculateBitmapSampleSize(
+    srcWidth: Int,
+    srcHeight: Int,
+    reqWidth: Int,
+    reqHeight: Int,
+): Int {
+    if (srcWidth <= 0 || srcHeight <= 0 || reqWidth <= 0 || reqHeight <= 0) return 1
+    var sample = 1
+    var halfW = srcWidth / 2
+    var halfH = srcHeight / 2
+    while (halfW / sample >= reqWidth && halfH / sample >= reqHeight) {
+        sample *= 2
+    }
+    return sample
+}
+
+/**
+ * Decode [bytes] into a Bitmap capped to fit within [reqWidth]x[reqHeight] via a
+ * bounds-only first pass. Returns null on malformed bytes.
+ */
+internal fun decodeSampledBitmap(bytes: ByteArray, reqWidth: Int, reqHeight: Int): Bitmap? {
+    val boundsOpts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    BitmapFactory.decodeByteArray(bytes, 0, bytes.size, boundsOpts)
+    if (boundsOpts.outWidth <= 0 || boundsOpts.outHeight <= 0) return null
+    val opts = BitmapFactory.Options().apply {
+        inSampleSize = calculateBitmapSampleSize(
+            boundsOpts.outWidth, boundsOpts.outHeight, reqWidth, reqHeight,
+        )
+        inJustDecodeBounds = false
+    }
+    return BitmapFactory.decodeByteArray(bytes, 0, bytes.size, opts)
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -195,8 +195,28 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         }
     }
 
+    /**
+     * Framework memory-pressure listener. Registered on attach and forwarded to
+     * [ContinuousWindowController.onTrimMemory] so the controller can drop its recycled-WebView
+     * pool and blank off-screen chapters before the system kills the app. Registering here (not
+     * app-wide) keeps the listener scoped to the reader's lifetime — no leak if the reader is
+     * destroyed. Package-private so the RiffleApplication can log a matching app-wide event.
+     */
+    private val trimCallback = object : android.content.ComponentCallbacks2 {
+        override fun onTrimMemory(level: Int) = controller.onTrimMemory(level)
+        override fun onConfigurationChanged(newConfig: android.content.res.Configuration) = Unit
+        override fun onLowMemory() =
+            controller.onTrimMemory(android.content.ComponentCallbacks2.TRIM_MEMORY_COMPLETE)
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        context.applicationContext.registerComponentCallbacks(trimCallback)
+    }
+
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
+        context.applicationContext.unregisterComponentCallbacks(trimCallback)
         controller.onDetach()
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -954,11 +954,12 @@ internal class ContinuousWindowController(
 
     /**
      * Framework memory-pressure signal (forwarded from [ContinuousReaderView.onTrimMemory]).
-     * At any non-trivial level, dump the recycled-WebView pool — those are idle and their memory
-     * is the cheapest to release. At [android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW]
-     * or worse, additionally blank every off-screen chapter WebView (all but the one nearest the
-     * viewport) so their rasterized tiles are released; they'll reload from disk when the user
-     * scrolls back. The current chapter stays intact so the visible page doesn't flash.
+     * Dumps the recycled-WebView pool at [android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN]
+     * or worse — those are idle and their memory is the cheapest to release. Live chapter WebViews
+     * are NOT touched here: blanking them with loadUrl would race the wired onPageFinished ->
+     * injectStylesAndMeasure pipeline (measures about:blank to ~0 px, collapses the chapter's slot
+     * height in the container, breaks scroll math). Live-chapter shrink under pressure needs a
+     * proper "detach + reload-on-return" pathway, not a bare loadUrl.
      */
     fun onTrimMemory(level: Int) {
         logger.d(LogChannel.Oom) {
@@ -968,24 +969,6 @@ internal class ContinuousWindowController(
             recycledViews.forEach { it.destroy() }
             recycledViews.clear()
         }
-        if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW) {
-            val currentIdx = currentChapterIndex()
-            webViews.forEachIndexed { i, wv ->
-                if (i != currentIdx) {
-                    wv.stopLoading()
-                    wv.loadUrl("about:blank")
-                }
-            }
-        }
-    }
-
-    /** Window-index of the WebView whose slot spans the current scroll midpoint, or -1. */
-    private fun currentChapterIndex(): Int {
-        val window = buildWindow()
-        if (window.isEmpty()) return -1
-        val midY = port.currentScrollY + port.viewportHeightPx / 2
-        return window.indexOfFirst { midY < it.top + it.height }
-            .let { if (it < 0) window.lastIndex else it }
     }
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -42,14 +42,25 @@ internal class ContinuousWindowController(
 ) : ContinuousHighlightTarget, ContinuousNavigationView {
 
     companion object {
+        // Window buffers were 3+3 (WINDOW_SIZE=7) with a recycled pool cap of WINDOW_SIZE, so
+        // Continuous mode could hold up to 14 stacked ChapterWebViews with fully rasterized tiles
+        // (setOffscreenPreRaster=true). On a 1 GB Android 7.1 tablet that is enough to trip the
+        // renderer heap and get the app killed with no crash trace. Cutting the live buffer to 2+2
+        // and the pool to 2 caps the ceiling at 7 WebViews — half the previous worst case — while
+        // still preserving a one-chapter buffer on each side for scroll smoothness.
         /** See [ContinuousReaderView.CHAPTERS_BEHIND]. */
-        private const val CHAPTERS_BEHIND = 3
+        private const val CHAPTERS_BEHIND = 2
 
         /** See [ContinuousReaderView.CHAPTERS_AHEAD]. */
-        private const val CHAPTERS_AHEAD = 3
+        private const val CHAPTERS_AHEAD = 2
 
         /** Total sliding-window size: the reader's chapter plus the behind/ahead buffers. */
         private const val WINDOW_SIZE = CHAPTERS_BEHIND + 1 + CHAPTERS_AHEAD
+
+        /** Max detached WebViews retained for reuse across window shifts. Small: pooled views keep
+         *  the previous page's DOM + rasterized tiles resident until reuse (recycle() blanks the
+         *  URL but preRaster still holds an empty document's tiles). */
+        internal const val RECYCLE_POOL_MAX = 2
 
         /**
          * Grace period after a window (re)build before the initial scroll is forced to fire even if
@@ -276,7 +287,13 @@ internal class ContinuousWindowController(
         wv.onFootnoteContent = null
         wv.onCrossReferenceTap = null
         wv.onSelectionActiveChanged = null
-        if (recycledViews.size < WINDOW_SIZE) recycledViews.addLast(wv) else wv.destroy()
+        // Release the WebView's DOM + rasterized tiles before pooling. Without this, a pooled view
+        // keeps its previous chapter's full-height tile pyramid resident (setOffscreenPreRaster is
+        // true) until obtainWebView() eventually replaces it — hundreds of MB across the whole pool
+        // on a long book. loadChapter() will replace about:blank on the next reuse.
+        wv.stopLoading()
+        wv.loadUrl("about:blank")
+        if (recycledViews.size < RECYCLE_POOL_MAX) recycledViews.addLast(wv) else wv.destroy()
     }
 
     /**
@@ -933,6 +950,42 @@ internal class ContinuousWindowController(
         webViews.clear()
         recycledViews.forEach { it.destroy() }
         recycledViews.clear()
+    }
+
+    /**
+     * Framework memory-pressure signal (forwarded from [ContinuousReaderView.onTrimMemory]).
+     * At any non-trivial level, dump the recycled-WebView pool — those are idle and their memory
+     * is the cheapest to release. At [android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW]
+     * or worse, additionally blank every off-screen chapter WebView (all but the one nearest the
+     * viewport) so their rasterized tiles are released; they'll reload from disk when the user
+     * scrolls back. The current chapter stays intact so the visible page doesn't flash.
+     */
+    fun onTrimMemory(level: Int) {
+        logger.d(LogChannel.Oom) {
+            "[DEBUG-OOM] continuous.onTrimMemory level=$level webViews=${webViews.size} pool=${recycledViews.size}"
+        }
+        if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN) {
+            recycledViews.forEach { it.destroy() }
+            recycledViews.clear()
+        }
+        if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW) {
+            val currentIdx = currentChapterIndex()
+            webViews.forEachIndexed { i, wv ->
+                if (i != currentIdx) {
+                    wv.stopLoading()
+                    wv.loadUrl("about:blank")
+                }
+            }
+        }
+    }
+
+    /** Window-index of the WebView whose slot spans the current scroll midpoint, or -1. */
+    private fun currentChapterIndex(): Int {
+        val window = buildWindow()
+        if (window.isEmpty()) return -1
+        val midY = port.currentScrollY + port.viewportHeightPx / 2
+        return window.indexOfFirst { midY < it.top + it.height }
+            .let { if (it < 0) window.lastIndex else it }
     }
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FigureZoomOverlay.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FigureZoomOverlay.kt
@@ -3,7 +3,6 @@
 package com.riffle.app.feature.reader
 
 import android.annotation.SuppressLint
-import android.graphics.BitmapFactory
 import android.util.Base64
 import android.webkit.WebView
 import androidx.activity.compose.BackHandler
@@ -22,6 +21,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -93,10 +93,27 @@ private fun FigureZoomContent(
     val bitmap = remember(state.href, state.svgMarkup) {
         mutableStateOf<android.graphics.Bitmap?>(null)
     }
+    // Cap the decode at 2048px on either axis. That's the largest natural size a user can meaningfully
+    // resolve on a phone/tablet at 5x pinch (the max zoom clamp), and it prevents a 12-megapixel figure
+    // from allocating ~48 MB on decode — enough to OOM the annotations flow on a 1 GB device.
+    val decodeCapPx = 2048
     LaunchedEffect(state.href, state.svgMarkup) {
         if (state.svgMarkup != null) return@LaunchedEffect
-        val bytes = withContext(Dispatchers.IO) { loadImageBytes(state.href, publication) }
-        bitmap.value = bytes?.let { BitmapFactory.decodeByteArray(it, 0, it.size) }
+        val decoded = withContext(Dispatchers.IO) {
+            val bytes = loadImageBytes(state.href, publication) ?: return@withContext null
+            decodeSampledBitmap(bytes, decodeCapPx, decodeCapPx)
+        }
+        bitmap.value = decoded
+    }
+    // Recycle the decoded Bitmap when this overlay leaves composition or the target figure changes.
+    // Without this, quickly opening/closing several figure zooms keeps their full-resolution bitmaps
+    // in the mutableStateOf remember scope until GC pressure eventually collects them.
+    DisposableEffect(state.href, state.svgMarkup) {
+        onDispose {
+            val b = bitmap.value
+            bitmap.value = null
+            if (b != null && !b.isRecycled) b.recycle()
+        }
     }
 
     Box(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/BitmapDownsampleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/BitmapDownsampleTest.kt
@@ -1,0 +1,32 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BitmapDownsampleTest {
+
+    @Test fun `no downsample when source fits`() {
+        assertEquals(1, calculateBitmapSampleSize(1000, 800, 2048, 2048))
+        assertEquals(1, calculateBitmapSampleSize(2048, 2048, 2048, 2048))
+    }
+
+    @Test fun `power-of-two shrink when source exceeds target`() {
+        // A 4000x3000 image into a 1024x1024 target: 4000/2=2000, 3000/2=1500;
+        // both >= 1024 → sample=2. Then 2000/2=1000, 1500/2=750; both < 1024 → stop.
+        assertEquals(2, calculateBitmapSampleSize(4000, 3000, 1024, 1024))
+    }
+
+    @Test fun `aggressive shrink for a very large image`() {
+        // 8000x6000 into 1024x1024 → 4000,3000 (>=1024)→2, 2000,1500 (>=1024)→4,
+        // 1000,750 (750<1024) stop.
+        assertEquals(4, calculateBitmapSampleSize(8000, 6000, 1024, 1024))
+    }
+
+    @Test fun `zero or negative inputs return 1 as a defensive floor`() {
+        assertEquals(1, calculateBitmapSampleSize(0, 800, 1024, 1024))
+        assertEquals(1, calculateBitmapSampleSize(800, 0, 1024, 1024))
+        assertEquals(1, calculateBitmapSampleSize(800, 800, 0, 1024))
+        assertEquals(1, calculateBitmapSampleSize(800, 800, 1024, 0))
+        assertEquals(1, calculateBitmapSampleSize(-1, -1, 1024, 1024))
+    }
+}

--- a/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
+++ b/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
@@ -23,4 +23,5 @@ enum class LogChannel(val tag: String) {
     ToRead("RIFFLE_TOREAD"),
     Playlists("RIFFLE_PL"),
     ProgressSync("RIFFLE_PS"),
+    Oom("RIFFLE_OOM"),
 }


### PR DESCRIPTION
## Summary

Unexplained crash on a 1 GB Android 7.1 Sony tablet with no crash report — the OOM audit fingered Continuous mode's WebView budget as the top suspect.

Continuous mode was holding **up to 14 stacked `ChapterWebView`s with fully rasterized tiles** at once (`setOffscreenPreRaster=true`), because live window = 7 (3 behind + current + 3 ahead) and the recycled pool cap = `WINDOW_SIZE`. Pooled views additionally kept the *previous* chapter's DOM + tiles resident until reuse. On a memory-constrained device this is enough to trip the renderer heap and get the app killed silently.

**Fixes**
- `CHAPTERS_BEHIND` / `AHEAD` 3 → 2 (live window 7 → 5); pool cap → 2. **Ceiling: 14 → 7 WebViews.**
- `recycle()` now `stopLoading()` + `loadUrl("about:blank")` before pooling so the detached view releases its DOM and tile pyramid instead of holding the previous chapter.
- `FigureZoomOverlay` decodes via a new `decodeSampledBitmap` capped at 2048 px and recycles the bitmap on dispose (was full-res, never recycled).
- `AnnotationsPanel.InlineFigureImage` caps thumbnails at 1024 px via a new `reqDimensionPx` param on `decodeImageDataUri`.

**Instrumentation**
- New `RIFFLE_OOM` `LogChannel`.
- `RiffleApplication.onTrimMemory` / `onLowMemory` log the trim level and heap snapshot: `[DEBUG-OOM] app.onTrimMemory level=N heap=UUmb/MMmb`.
- `ContinuousReaderView` registers a `ComponentCallbacks2` on attach; controller logs its own state (`webViews`, `pool`) and dumps the recycled pool at `TRIM_MEMORY_UI_HIDDEN`+. So the next incident leaves a trace even without a native crash trace.

**Tests**
- New pure-JVM `calculateBitmapSampleSize` / `decodeSampledBitmap` helpers with `BitmapDownsampleTest` covering the power-of-two rule, aggressive shrink, and the defensive-floor branches.

## Test plan

- [x] `:app:compileDebugKotlin` clean
- [x] `BitmapDownsampleTest` passes
- [ ] On-device: install on Sony Android 7.1 tablet, exercise Continuous mode scroll + figure zoom + annotations panel; confirm no OOM and inspect `adb logcat -d | grep RIFFLE_OOM` for expected trim events

## Notes

The audit's more aggressive suggestion — blanking live off-screen chapters under `TRIM_MEMORY_RUNNING_LOW` — was prototyped and dropped in a follow-up commit: a bare `loadUrl("about:blank")` races the wired `onPageFinished` → `injectStylesAndMeasure` pipeline and collapses the chapter's slot height to ~0, breaking scroll math. A proper "detach + reload-on-return" pathway is a follow-up if the shrink alone isn't enough.