### PR TITLE
fix(reader): allow state loss on reader fragment commits

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2769,7 +2769,7 @@ private fun EpubNavigatorView(
                     isLandscape
                 val existingFrag = fragmentRef.value
                 if (existingFrag != null && fragmentDoublePageHolder[0] != isDoublePage) {
-                    fm.beginTransaction().remove(existingFrag).commitNow()
+                    fm.beginTransaction().remove(existingFrag).commitNowAllowingStateLoss()
                     readiumPresenter?.detach()
                     fragmentRef.value = null
                     fragmentDoublePageHolder[0] = null
@@ -2782,7 +2782,7 @@ private fun EpubNavigatorView(
                 // can recreate it properly with latestLocator() as the initial position.
                 if (fragmentRef.value == null) {
                     fm.findFragmentById(containerId)?.let { stale ->
-                        fm.beginTransaction().remove(stale).commitNow()
+                        fm.beginTransaction().remove(stale).commitNowAllowingStateLoss()
                     }
                 }
 
@@ -2817,7 +2817,7 @@ private fun EpubNavigatorView(
                     fm.fragmentFactory = fragmentFactory
                     fm.beginTransaction()
                         .add(containerId, EpubNavigatorFragment::class.java, null)
-                        .commitNow()
+                        .commitNowAllowingStateLoss()
                     val fragment = fm.findFragmentById(containerId) as? EpubNavigatorFragment
                         ?: return@AndroidView
                     fragmentRef.value = fragment

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderScreen.kt
@@ -467,7 +467,7 @@ private fun PdfNavigatorViewContent(
             // properly with latestLocator() as the initial position.
             if (fragmentRef.value == null) {
                 fm.findFragmentById(containerId)?.let { stale ->
-                    fm.beginTransaction().remove(stale).commitNow()
+                    fm.beginTransaction().remove(stale).commitNowAllowingStateLoss()
                 }
             }
 
@@ -482,7 +482,7 @@ private fun PdfNavigatorViewContent(
                 fm.fragmentFactory = fragmentFactory
                 fm.beginTransaction()
                     .add(containerId, PdfiumNavigatorFragment::class.java, null)
-                    .commitNow()
+                    .commitNowAllowingStateLoss()
                 @Suppress("UNCHECKED_CAST")
                 val fragment = fm.findFragmentById(containerId) as? PdfiumNavigatorFragment
                     ?: return@AndroidView

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderFragmentCommitVariantTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderFragmentCommitVariantTest.kt
@@ -1,0 +1,51 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.io.File
+
+/**
+ * Regression guard for the Android 15 crash where the reader's Compose `AndroidView`
+ * committed a `FragmentTransaction` after the host activity's `onSaveInstanceState`,
+ * producing `IllegalStateException: Can not perform this action after
+ * onSaveInstanceState`. Every fragment commit inside `EpubReaderScreen` /
+ * `PdfReaderScreen` must use `commitNowAllowingStateLoss()`; a plain `commitNow()`
+ * runs `checkStateLoss` and crashes.
+ */
+class ReaderFragmentCommitVariantTest {
+
+    @Test
+    fun `epub reader screen has no plain commitNow calls`() {
+        assertNoPlainCommitNow(
+            "app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt",
+        )
+    }
+
+    @Test
+    fun `pdf reader screen has no plain commitNow calls`() {
+        assertNoPlainCommitNow(
+            "app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderScreen.kt",
+        )
+    }
+
+    private fun assertNoPlainCommitNow(relativePath: String) {
+        val source = locate(relativePath).readText()
+        val plainCommitNow = Regex("""\.commitNow\(\)""").findAll(source).count()
+        assertEquals(
+            "$relativePath must use commitNowAllowingStateLoss() for every fragment " +
+                "transaction; plain commitNow() crashes after onSaveInstanceState.",
+            0,
+            plainCommitNow,
+        )
+    }
+
+    private fun locate(relativePath: String): File {
+        var dir: File? = File(".").absoluteFile
+        while (dir != null) {
+            val candidate = File(dir, relativePath)
+            if (candidate.isFile) return candidate
+            dir = dir.parentFile
+        }
+        error("Could not locate $relativePath from ${File(".").absolutePath}")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes an `IllegalStateException: Can not perform this action after onSaveInstanceState` crash reported from the wild (ASUS AI2302, Android 15, Riffle 2.30.0).

The reader's Compose `AndroidView` in `EpubReaderScreen` and `PdfReaderScreen` commits `FragmentTransaction`s to add / remove `EpubNavigatorFragment` / `PdfiumNavigatorFragment`. Plain `commitNow()` runs `checkStateLoss` and throws when the `AndroidView` attaches (or re-runs its `update` block) after the host activity has already saved state. The stack trace is a textbook match: `View.dispatchAttachedToWindow` → Compose `onAttachedToWindow` invoke → `FragmentTransaction.commit` → `checkStateLoss`.

Switches every `commitNow()` inside the two reader screens to `commitNowAllowingStateLoss()`, matching the sibling call already using this variant. State loss is safe here — Readium restores its own position from the initial locator we thread in via `latestLocator()` / `state.initialLocator`, so there's no user-visible state to lose across the transaction.

## Changes

- `EpubReaderScreen.kt` (3 sites) and `PdfReaderScreen.kt` (2 sites): `commitNow()` → `commitNowAllowingStateLoss()`.
- New `ReaderFragmentCommitVariantTest`: source-level regression guard that fails if either reader screen reintroduces a plain `.commitNow()`. Verified red-on-revert, green with fix.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests "*.ReaderFragmentCommitVariantTest"` — passes
- [x] Verified the guard flips red when the fix is reverted
- [ ] On-device repro on ASUS AI2302 / Android 15 (background reader → resume) — cannot reproduce without the affected hardware; state-loss commit is the documented remedy for this exact stack