### PR TITLE
feat(library): toast on add/remove to To Read

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -421,6 +421,10 @@ class LibraryItemDetailViewModel @Inject constructor(
                 _snackbarEvents.emit(
                     if (wasInToRead) "Couldn't remove from To Read" else "Couldn't add to To Read"
                 )
+            } else {
+                _snackbarEvents.emit(
+                    if (wasInToRead) "Removed from To Read" else "Added to To Read"
+                )
             }
         }
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -561,6 +561,28 @@ class LibraryItemDetailViewModelTest {
     }
 
     @Test
+    fun `toggleToRead emits success snackbar on add and remove`() = runTest(testDispatcher) {
+        val toRead = FakeToReadRepository()
+        val vm = makeVm(repo = fakeRepo(knownItem), toReadRepo = toRead)
+        val snackbarMessages = mutableListOf<String>()
+        val collectorJob = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.snackbarEvents.collect { snackbarMessages += it }
+        }
+        backgroundScope.launch { vm.uiState.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.toggleToRead()
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(listOf("Added to To Read"), snackbarMessages)
+
+        vm.toggleToRead()
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(listOf("Added to To Read", "Removed from To Read"), snackbarMessages)
+
+        collectorJob.cancel()
+    }
+
+    @Test
     fun `toggleToRead removes book when already in To Read`() = runTest {
         val toRead = FakeToReadRepository(initial = setOf(knownItem.id))
         val vm = makeVm(repo = fakeRepo(knownItem), toReadRepo = toRead)


### PR DESCRIPTION
## Summary

Adds a success snackbar confirming the outcome of the To Read toggle on the library item detail screen. Previously only the failure path emitted a snackbar; a successful add or remove flipped state silently.

- `LibraryItemDetailViewModel.toggleToRead` now emits `"Added to To Read"` / `"Removed from To Read"` on the success path.
- The existing `SnackbarHost` in `LibraryItemDetailScreen` already collects `snackbarEvents`, so no UI wiring changes are needed.
- Failure snackbars ("Couldn't add/remove to To Read") are unchanged.

## Test plan

- [x] New JVM unit test `toggleToRead emits success snackbar on add and remove` pins both message strings — flips red if the new else-branch is reverted.
- [x] Existing `toggleToRead*` tests (optimistic flip, failure-revert, remove-when-already-in) still pass.