### PR TITLE
fix(reader): show chapter map in Annotations View

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -48,7 +48,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import com.riffle.app.feature.reader.decorations.FigureBorderDecoration
 import com.riffle.app.feature.reader.formatting.RenderCapabilities
-import com.riffle.app.feature.reader.highlights.shouldShowChapterRail
 import com.riffle.app.feature.reader.highlights.shouldShowOpenInBook
 import com.riffle.app.feature.reader.highlights.shouldShowReadaloudUi
 import com.riffle.app.feature.reader.presenter.ContinuousPresenter
@@ -1002,7 +1001,7 @@ private fun EpubChapterRailOverlay(
                     bookTimeRemaining = bookTimeRemaining,
                 )
             }
-            if (showRail && shouldShowChapterRail(viewModel.readerSource)) {
+            if (showRail) {
                 ChapterNavigationRail(
                     segments = railSegments,
                     activeIndex = activeRailSegmentIndex,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -12,6 +12,7 @@ import org.readium.r2.shared.publication.LocalizedString
 import org.readium.r2.shared.publication.Manifest
 import org.readium.r2.shared.publication.Metadata
 import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.publication.services.PerResourcePositionsService
 import org.readium.r2.shared.util.AbsoluteUrl
 import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.Url
@@ -222,9 +223,25 @@ class HighlightsPublicationFactory @Inject constructor() {
             tableOfContents = readingOrder,
         )
 
+        // Register PerResourcePositionsService so [Publication.positionsByReadingOrder] returns
+        // one Locator per elided chapter (elided-view chapter-map follow-up). Without this,
+        // Readium's default services builder leaves no PositionsService bound — the extension
+        // returns emptyList(), [EpubReaderViewModel.spinePositionCounts] emits (spineHrefs, [])
+        // and [EpubReaderViewModel.railSegments] short-circuits to emptyList so the chapter map
+        // is silently blank in the elided reader. One position per resource is exactly the rail
+        // needs: the elided TOC is flat, so [buildRailSegments] produces one segment per elided
+        // chapter with equal weight.
         val publication = Publication(
             manifest = manifest,
             container = InMemoryContainer(entries),
+            servicesBuilder = Publication.ServicesBuilder(
+                positions = { ctx ->
+                    PerResourcePositionsService(
+                        readingOrder = ctx.manifest.readingOrder,
+                        fallbackMediaType = MediaType.XHTML,
+                    )
+                },
+            ),
         )
         return HighlightsPublicationHandle(
             publication, chapterUrls, entries, dataUriByHref, publisherFontFaceCss,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsUiSuppression.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsUiSuppression.kt
@@ -11,10 +11,6 @@ package com.riffle.app.feature.reader.highlights
  *  the real ABS EPUB — the elided Highlights-mode Publication has no matched audiobook. */
 internal fun shouldShowReadaloudUi(source: ReaderSource): Boolean = source == ReaderSource.FullBook
 
-/** The chapter rail needs subchapter resolution against the real book's reading order, which the
- *  synthesised Highlights-mode Publication doesn't have. */
-internal fun shouldShowChapterRail(source: ReaderSource): Boolean = source == ReaderSource.FullBook
-
 /** "Open in book" is the escape hatch out of the elided reader back to the full book; it has no
  *  meaning when already reading the full book. */
 internal fun shouldShowOpenInBook(source: ReaderSource): Boolean = source == ReaderSource.Highlights

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
@@ -9,6 +9,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.publication.services.positionsByReadingOrder
 import org.readium.r2.shared.util.RelativeUrl
 import org.readium.r2.shared.util.Url
 
@@ -457,6 +458,36 @@ class HighlightsPublicationFactoryTest {
         assertTrue(
             "malicious font-family value must be dropped; html was: $html",
             !html.contains("body{color:red") && !html.contains("font-family:")
+        )
+    }
+
+    // Chapter-map / rail regression (elided view "Chapter map toggle didn't do anything"):
+    // enabling the chapter rail in ReaderSource.Highlights only helps if the synthesised
+    // publication actually reports positions per spine item — [EpubReaderViewModel.spinePositionCounts]
+    // reads [Publication.positionsByReadingOrder] and the rail flow guards on non-empty counts.
+    // This pins that the elided [Publication] returns one non-empty position list per elided
+    // chapter, so [EpubReaderViewModel.railSegments] gets a non-empty (spineHrefs, counts) pair
+    // and the rail renders. If Readium's default position service ever stopped returning positions
+    // for our InMemoryContainer-backed publication, this would flip red and the elided chapter
+    // map would silently go blank instead.
+    @Test
+    fun elidedPublicationReportsOnePositionListPerChapterForRailBuilder() {
+        val pub = factory.build(
+            sourceId = "S1",
+            itemId = "B1",
+            bookTitle = "Dune",
+            chapters = listOf(
+                ChapterElision("ch1.xhtml", "Chapter One", listOf(hl("h1", "the spice must flow"))),
+                ChapterElision("ch2.xhtml", "Chapter Two", listOf(hl("h2", "Fear is the mind-killer."))),
+                ChapterElision("ch3.xhtml", "Chapter Three", listOf(hl("h3", "He who controls the spice."))),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val positions = runBlocking { pub.positionsByReadingOrder() }
+        assertEquals("one position list per elided chapter", 3, positions.size)
+        assertTrue(
+            "every elided chapter must contribute at least one position so railSegments has non-empty counts, got: ${positions.map { it.size }}",
+            positions.all { it.isNotEmpty() },
         )
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsUiSuppressionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsUiSuppressionTest.kt
@@ -5,10 +5,16 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Pins the three UI-visibility decision functions ([shouldShowReadaloudUi], [shouldShowChapterRail],
- * [shouldShowOpenInBook]) that [com.riffle.app.feature.reader.EpubReaderScreen] and
- * [com.riffle.app.feature.reader.HighlightActionsPopup] consult to gate Readaloud entry points, the
- * chapter navigation rail, and the "Open in book" row respectively (Task 9, ADR 0041).
+ * Pins the UI-visibility decision functions ([shouldShowReadaloudUi], [shouldShowOpenInBook])
+ * that [com.riffle.app.feature.reader.EpubReaderScreen] and
+ * [com.riffle.app.feature.reader.HighlightActionsPopup] consult to gate Readaloud entry points and
+ * the "Open in book" row respectively (Task 9, ADR 0041).
+ *
+ * The chapter navigation rail is intentionally NOT gated on [ReaderSource] anymore — the elided
+ * (Highlights-mode) publication has a flat one-entry-per-chapter TOC, so the rail's segment
+ * builder produces a meaningful "one segment per elided chapter" layout without needing subchapter
+ * resolution against the real book. If a future change re-introduces a rail suppression, add a
+ * dedicated test for it rather than expanding this one.
  *
  * These are the actual runtime decision points at the call sites, not test-only mirrors — if any of
  * these were flipped (or a call site stopped consulting them), the corresponding assertion here
@@ -20,12 +26,6 @@ class HighlightsUiSuppressionTest {
     fun readaloudHiddenInHighlightsMode() {
         assertFalse(shouldShowReadaloudUi(ReaderSource.Highlights))
         assertTrue(shouldShowReadaloudUi(ReaderSource.FullBook))
-    }
-
-    @Test
-    fun chapterRailHiddenInHighlightsMode() {
-        assertFalse(shouldShowChapterRail(ReaderSource.Highlights))
-        assertTrue(shouldShowChapterRail(ReaderSource.FullBook))
     }
 
     @Test


### PR DESCRIPTION
## Summary

In the elided reader (Annotations View / `ReaderSource.Highlights`) the chapter map didn't render and the on-screen-info toggles appeared to do nothing. Two independent suppressions were stacked:

1. `shouldShowChapterRail(Highlights)` returned `false` — a defensive gate from the ADR 0041 rollout that assumed the elided publication needed subchapter resolution against the real book's spine. It doesn't: the elided TOC is flat (one entry per elided chapter), so `buildRailSegments` naturally produces one segment per chapter.
2. The synthesised `Publication` had no `PositionsService` bound. `positionsByReadingOrder()` returned `emptyList()`, `spinePositionCounts` emitted `(spineHrefs, [])`, and `railSegments`' non-empty-counts guard short-circuited — so **every** derived label (rail, progress %, current chapter name, time-remaining) stayed silent, not just the rail.

## Change

- Remove the `shouldShowChapterRail` gate at `EpubReaderScreen.kt:1005` and drop the helper from `HighlightsUiSuppression.kt`.
- Register `PerResourcePositionsService` on the elided publication so it reports one Locator per elided chapter — matching the flat elided TOC exactly.

## Test plan

- [x] New JVM regression `elidedPublicationReportsOnePositionListPerChapterForRailBuilder` in `HighlightsPublicationFactoryTest` pins that `positionsByReadingOrder()` returns one non-empty list per chapter. Failed before the `ServicesBuilder` change (`expected:<3> but was:<0>`), passes after.
- [x] `HighlightsUiSuppressionTest` updated to reflect that the rail is no longer source-gated.
- [x] `./gradlew :app:testDebugUnitTest --tests 'com.riffle.app.feature.reader.highlights.*'` green after rebase on latest main.
- [ ] Live-device verification of the rail painting in Annotations View — deferred (ADB text-input hangs on API-25 blocked the automated ABS sign-in path; the JVM regression covers the exact silent-failure mode).