### PR TITLE
fix(reader): render Annotations View excerpts in the book body font

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -487,18 +487,28 @@ internal val SELECTION_SPAN_TRACKER_JS = """
                 figures.push(entry);
               }
             } catch (e) { figures = []; }
-            // Origin font-family at the selection's start element (issue #484). Read from the
-            // start container walked up to its parent Element (text nodes have no computed
-            // style). Empty string on failure — Kotlin side falls back to the book's body font.
-            var ff = '';
-            try {
-              var startEl = rng.startContainer;
-              if (startEl && startEl.nodeType === 3) startEl = startEl.parentElement;
-              if (startEl && startEl.nodeType === 1) {
-                var cs = window.getComputedStyle(startEl);
-                if (cs) ff = cs.fontFamily || '';
-              }
-            } catch (e) { ff = ''; }
+            // Origin font-family for the elided view (issue #484). Prefer the book's computed
+            // BODY font (already probed and cached on window.__riffleBookBodyFont by the
+            // one-shot probe above) over the selection's start-element style — a highlight
+            // that starts on a heading, code sample, or pull-quote would otherwise stamp the
+            // display face (e.g. `Reg` on a Nimbus/Reg/lucida book) onto the row, and the
+            // elided view then renders that excerpt in the wrong face — visibly different
+            // from every other highlight on the same book. The elided view shows excerpts as
+            // body paragraphs, so the body font is the right choice for every annotation.
+            // Only when the body probe is unavailable (very early install, chapter shell with
+            // no content yet) do we fall through to the start-element style — better than
+            // recording nothing.
+            var ff = window.__riffleBookBodyFont || '';
+            if (!ff) {
+              try {
+                var startEl = rng.startContainer;
+                if (startEl && startEl.nodeType === 3) startEl = startEl.parentElement;
+                if (startEl && startEl.nodeType === 1) {
+                  var cs = window.getComputedStyle(startEl);
+                  if (cs) ff = cs.fontFamily || '';
+                }
+              } catch (e) { ff = ''; }
+            }
             window.__riffleSelData = {
               text: text,
               p: Math.max(0, Math.min(1, br2.top / docH)),

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -532,11 +532,19 @@ private fun appendOriginFontFamilyStyle(
     // Filter the shared [FALLBACK_ORIGIN_FONT_FAMILY] sentinel so a sentinel-stamped annotation
     // doesn't force a bare `font-family: serif !important` inline on its `<p>` — let the fallback
     // chain (bookBodyFontFamily, then ReadiumCSS default) take over.
+    // Prefer the book's body font over the annotation's own captured `originFontFamily`
+    // (elided-view-per-p-wrong-font-regression, 2026-07-19). A highlight that started on a
+    // heading, code sample, or pull-quote captured the display face (e.g. `Reg` on the
+    // Nimbus/Reg/lucida-mixed A Philosophy of Software Design) — rendering the elided-view
+    // excerpt in that face makes it visibly diverge from every other highlight on the same
+    // book. Elided-view excerpts are always body paragraphs, so the book body font is right
+    // for every row. Falls back to the annotation's own captured value only when the caller
+    // has no body-font hint (fresh Highlights VM whose DB rows all lack a real captured value).
+    val body = bookBodyFontFamily
+        ?.takeIf { it.isNotBlank() && it != FALLBACK_ORIGIN_FONT_FAMILY }
     val ownFont = originFontFamily
         ?.takeIf { it.isNotBlank() && it != FALLBACK_ORIGIN_FONT_FAMILY }
-    val fallback = bookBodyFontFamily
-        ?.takeIf { it.isNotBlank() && it != FALLBACK_ORIGIN_FONT_FAMILY }
-    val raw = ownFont ?: fallback
+    val raw = body ?: ownFont
     val safe = sanitizeCssFontFamily(raw) ?: return
     // No `!important` (elided-view-serif-font-regression follow-up): with it, the captured
     // origin font pinned per-excerpt regardless of the reader's Font pref — switching to

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
@@ -438,6 +438,33 @@ class HighlightsPublicationFactoryTest {
         )
     }
 
+    // Regression (elided-view-per-p-wrong-font, 2026-07-19): a highlight that started on a
+    // heading, code sample, or pull-quote captured the display face (e.g. `Reg` on the
+    // Nimbus/Reg/lucida-mixed *A Philosophy of Software Design*) — rendering the elided-view
+    // excerpt in that face makes it visibly diverge from every other highlight on the same book.
+    // The book-body font (derived from plurality across the book's rows) must win over the
+    // annotation's own captured value at render time.
+    @Test
+    fun bookBodyFontFamily_winsOverAnnotationOwnFont_onExcerpt() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "One",
+                    listOf(hl("h1", "heading-styled excerpt", originFontFamily = "Reg")),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+            bookBodyFontFamily = "Nimbusromno9l",
+        )
+        val html = readChapterHtml(pub, index = 0)
+        assertTrue(
+            "excerpt <p> must render in the book body font, not the annotation's captured " +
+                "heading face; html was: $html",
+            html.contains("font-family: Nimbusromno9l;") && !html.contains("font-family: Reg;")
+        )
+    }
+
     // A font-family value whose bytes contain something outside the safe allowlist (e.g. an
     // injected `};color:red;`) must be dropped, not written into the excerpt style attribute —
     // the DB is not a trust boundary and CSS injection must not be possible.


### PR DESCRIPTION
## Summary

Annotations View excerpts were sometimes rendered in a face visibly different from other rows on the same book — e.g. on *A Philosophy of Software Design* (Nimbusromno9l body / Reg headings / lucidasanstypewriter code) a highlight straddling a heading captured `originFontFamily='Reg'` and rendered its `<p>` in the heading face while every neighbour rendered in Nimbus.

Root cause: the selection-tracker JS captured `getComputedStyle(startEl).fontFamily`, so a highlight starting on a heading, code sample, or pull-quote stamped that display face onto the row. The elided-view render then honoured the per-annotation font over the book body font, producing the visible divergence.

Fix, both sides:

1. **Capture (`ReaderWebViewScripts.SELECTION_SPAN_TRACKER_JS`)** — prefer `window.__riffleBookBodyFont` (already probed and cached per chapter install by the one-shot body-font probe higher in the same script) over the start element's computed style. Highlights starting on non-body elements no longer stamp the display face.
2. **Render (`HighlightsPublicationFactory.appendOriginFontFamilyStyle`)** — prefer the caller-supplied `bookBodyFontFamily` over the annotation's own captured value. Fixes pre-existing rows written under the old behaviour without a data migration; new rows will match anyway via (1).

## Test plan

- [x] New JVM regression `bookBodyFontFamily_winsOverAnnotationOwnFont_onExcerpt` in `HighlightsPublicationFactoryTest`: asserts that a row captured with `originFontFamily='Reg'` renders as `font-family: Nimbusromno9l;` (and NOT `Reg`) when the book body font is `Nimbusromno9l`. Flips red if either preference is reverted.
- [x] Existing font-family tests continue to cover the ownFont-only fallback (no body font supplied) and the sentinel-filter cases.
- [x] Manually verified on emulator-5554 against the reported book: every excerpt, including the row previously stamped with `originFontFamily='Reg'` (`23bef279…` — "Eliminate special cases in code / Up until…"), now renders in Nimbusromno9l alongside the other excerpts.