### PR TITLE
perf(reader): drop 2.6s decoration settle loops to fix cold-open input lag

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1509,7 +1509,6 @@ private fun EpubNavigatorView(
                     presenter.applyDecorations(decorations, group)
                 },
                 fragmentLocator = ::fragmentLocator,
-                currentNavigatorStamp = { presenter.attachmentStamp() },
                 evaluateJavascript = { script -> presenter.evaluateJavascript(script) },
                 emphasisRangeProvider = {
                     // Filtered to only rows needing DOM mutation (bold/italic); underline/strike

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
@@ -3,7 +3,6 @@ package com.riffle.app.feature.reader
 import com.riffle.core.models.EmphasisStyle
 import com.riffle.core.models.HighlightColor
 import com.riffle.core.domain.SentenceQuote
-import kotlinx.coroutines.delay
 import org.readium.r2.navigator.Decoration
 import org.readium.r2.shared.publication.Locator
 
@@ -19,12 +18,6 @@ internal class ReadiumHighlightRenderer(
      * Mirrors the Screen-level [fragmentLocator] function.
      */
     private val fragmentLocator: (ref: String, quote: SentenceQuote?) -> Locator?,
-    /**
-     * Returns a stable identity token for the current navigator instance. Used by the
-     * search settle loop to abort when the fragment has been replaced (page navigation,
-     * rotation). In tests, always returns the same value to let the loop run to completion.
-     */
-    private val currentNavigatorStamp: () -> Any? = { null },
     /**
      * ADR 0046: evaluates arbitrary JS on the current chapter's WebView. Used to wrap emphasis
      * ranges in styled `<span>`s so bold/italic actually reflow the underlying text — overlay
@@ -45,10 +38,6 @@ internal class ReadiumHighlightRenderer(
     private var hasEmphasisDecorations = false
     private var hasNoteGlyphDecorations = false
     private var hasSearchDecorations = false
-    /** Monotonic counter for [applyEmphasisCompanions] calls. The settle-loop breaks when the
-     *  counter moves, so a rapid re-toggle within the 2.6s window doesn't repaint a
-     *  since-cleared decoration. See code-review F6. */
-    private var emphasisApplyGeneration: Long = 0L
 
     override suspend fun applySentenceHighlight(
         fragmentRef: String?,
@@ -126,17 +115,11 @@ internal class ReadiumHighlightRenderer(
         // built-in Style.Underline; strike/bold/italic v1 render as tinted overlays (bold + italic
         // are approximations pending true DOM mutation — captured as follow-up).
         applyEmphasisCompanions(renders)
-        // Readium fixes decoration rects at applyDecorations time. When the first apply runs before
-        // reflow has fully settled (fresh navigator, chapter change, orientation flip), the rects
-        // land against a still-shifting layout and the highlight is either invisible or in the wrong
-        // place. Same settle window as [applySearch] — clear+re-apply on each tick so the diff
-        // forces Readium to re-measure and re-position the boxes.
-        val stamp = currentNavigatorStamp()
-        for (settleDelayMs in longArrayOf(400L, 600L, 700L, 900L)) {
-            delay(settleDelayMs)
-            if (currentNavigatorStamp() !== stamp) break
-            applyDecorationsWithClear(decorations, "annotations")
-        }
+        // Post-apply layout shifts (page-load completion, reflow, orientation) are covered by the
+        // outer LaunchedEffect in EpubReaderScreen re-keying on pageLoadGeneration / reflowGeneration
+        // and re-invoking applyAnnotations. A fixed local settle loop here forced 2.6s of
+        // clear+re-apply JS on cold open and pinned the WebView main thread — the source of the
+        // 2-3s input sluggishness when opening a book with highlights.
     }
 
     override suspend fun applyNoteGlyphs(
@@ -178,15 +161,9 @@ internal class ReadiumHighlightRenderer(
         }
         applyDecorationsBlock(decorations, "search")
         hasSearchDecorations = true
-        // Re-apply across a post-navigation settle window so decoration boxes track the final
-        // layout (Readium fixes rects at applyDecorations time). See the comment at the original
-        // search LaunchedEffect in EpubReaderScreen for full rationale.
-        val stamp = currentNavigatorStamp()
-        for (settleDelayMs in longArrayOf(400L, 600L, 700L, 900L)) {
-            delay(settleDelayMs)
-            if (currentNavigatorStamp() !== stamp) break
-            applyDecorationsWithClear(decorations, "search")
-        }
+        // Post-navigation layout shifts are covered by the outer LaunchedEffect in
+        // EpubReaderScreen re-keying on pageLoadGeneration / reflowGeneration and re-invoking
+        // applySearch. Local settle loop removed for parity with applyAnnotations.
     }
 
     override fun highlightSearchMatch(href: String, text: String) {
@@ -209,7 +186,6 @@ internal class ReadiumHighlightRenderer(
      * overlays and vice versa.
      */
     private suspend fun applyEmphasisCompanions(renders: List<EpubReaderViewModel.HighlightRender>) {
-        val myGeneration = ++emphasisApplyGeneration
         val decorations = renders.flatMap { h ->
             if (h.emphasisStyles.isEmpty()) return@flatMap emptyList()
             buildList {
@@ -260,17 +236,9 @@ internal class ReadiumHighlightRenderer(
                 .filter { it.styles.any { s -> s == EmphasisStyle.BOLD || s == EmphasisStyle.ITALIC } }
             runJs(EmphasisDomInjector.script(ranges))
         }
-        // Same settle window as highlights so decoration rects follow post-reflow layout. Break
-        // as soon as either the navigator instance OR the emphasis generation moves — the latter
-        // means a fresh applyEmphasisCompanions call has landed with a different decoration list,
-        // and continuing to repaint THIS list would fight it.
-        val stamp = currentNavigatorStamp()
-        for (settleDelayMs in longArrayOf(400L, 600L, 700L, 900L)) {
-            delay(settleDelayMs)
-            if (currentNavigatorStamp() !== stamp) break
-            if (myGeneration != emphasisApplyGeneration) break
-            applyDecorationsWithClear(decorations, "emphasis")
-        }
+        // Post-apply layout shifts are covered by the outer LaunchedEffect re-keying on
+        // pageLoadGeneration / reflowGeneration. Local settle loop removed for parity with
+        // applyAnnotations — see the comment there for rationale.
     }
 
     companion object {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.readium.r2.navigator.Decoration
@@ -18,7 +17,6 @@ import org.readium.r2.shared.publication.Locator
 class ReadiumHighlightRendererTest {
 
     private val applied = mutableListOf<Pair<List<Decoration>, String>>()
-    private var navigatorStamp: Any? = Any()
 
     private val renderer = ReadiumHighlightRenderer(
         applyDecorationsBlock = { decorations, group -> applied.add(decorations to group) },
@@ -26,13 +24,11 @@ class ReadiumHighlightRendererTest {
             // Return a minimal locator for any non-blank ref
             if (ref.isNotBlank()) minimalLocator(ref.substringBefore('#')) else null
         },
-        currentNavigatorStamp = { navigatorStamp },
     )
 
     @Before
     fun setUp() {
         applied.clear()
-        navigatorStamp = Any()
     }
 
     private fun minimalLocator(@Suppress("UNUSED_PARAMETER") href: String): Locator {
@@ -101,33 +97,24 @@ class ReadiumHighlightRendererTest {
         )
         renderer.applyAnnotations(renders)
         val annotationCalls = applied.filter { it.second == "annotations" }
-        // Initial apply is clear+apply (2 dispatches); settle window is 4 ticks × (clear + apply) = 8.
-        // We assert on the shape: at least one dispatch carries both decorations, and the very
-        // first dispatch is the pre-apply clear (empty list).
-        assertTrue("expected initial clear+apply plus settle re-applies", annotationCalls.size >= 3)
-        assertEquals(emptyList<Decoration>(), annotationCalls.first().first)
-        val firstNonEmpty = annotationCalls.first { it.first.isNotEmpty() }
-        assertEquals(2, firstNonEmpty.first.size)
-        assertEquals("h1", firstNonEmpty.first[0].id)
-        assertEquals("h2", firstNonEmpty.first[1].id)
+        // A single clear followed by a single apply. No settle loop — that lived until we
+        // discovered it was pinning the WebView main thread for 2.6s on cold open and causing
+        // 2-3s of input sluggishness. Post-apply layout shifts are covered by the outer
+        // LaunchedEffect re-keying on pageLoadGeneration / reflowGeneration.
+        assertEquals("expected exactly clear + apply, no settle re-applies", 2, annotationCalls.size)
+        assertEquals(emptyList<Decoration>(), annotationCalls[0].first)
+        assertEquals(2, annotationCalls[1].first.size)
+        assertEquals("h1", annotationCalls[1].first[0].id)
+        assertEquals("h2", annotationCalls[1].first[1].id)
     }
 
+    // Regression: the settle loop MUST stay out. Its return would re-introduce the cold-open
+    // sluggishness. If someone re-adds a loop here, this test will flip red.
     @Test
-    fun `applyAnnotations settle loop aborts when navigator stamp changes`() = runTest {
-        // Same guard as applySearch: on a fresh navigator stamp between settle ticks, don't keep
-        // shoving decorations into a WebView that isn't ours anymore. Regression pin — without this
-        // abort, an orientation flip mid-settle would spam the old fragment for another second.
-        val recorder = mutableListOf<Pair<List<Decoration>, String>>()
-        val abortingRenderer = ReadiumHighlightRenderer(
-            applyDecorationsBlock = { decorations, group -> recorder.add(decorations to group) },
-            fragmentLocator = { ref, _ -> if (ref.isNotBlank()) minimalLocator(ref.substringBefore('#')) else null },
-            currentNavigatorStamp = { Any() }, // new object every call → stamp always changes
-        )
-        abortingRenderer.applyAnnotations(listOf(makeRender("h1", "c1.xhtml")))
-        val annotationCalls = recorder.filter { it.second == "annotations" }
-        // Initial apply is clear + apply (2 dispatches); the settle loop aborts on the first tick
-        // because the stamp changes, so no settle re-applies fire.
-        assertEquals("only the initial clear+apply fires when the stamp changes", 2, annotationCalls.size)
+    fun `applyAnnotations does not spin a settle loop after the initial apply`() = runTest {
+        renderer.applyAnnotations(listOf(makeRender("h1", "c1.xhtml")))
+        val annotationCalls = applied.filter { it.second == "annotations" }
+        assertEquals(2, annotationCalls.size)
     }
 
     @Test
@@ -181,11 +168,10 @@ class ReadiumHighlightRendererTest {
     fun `applySearch with results applies search group`() = runTest {
         val results = listOf(minimalLocator("c.xhtml"), minimalLocator("c.xhtml"))
         renderer.applySearch(results, activeIndex = 0)
-        // First call is the immediate apply; settle loop adds more (but UnconfinedTestDispatcher
-        // will advance through delays).
         val searchCalls = applied.filter { it.second == "search" }
-        assertTrue(searchCalls.isNotEmpty())
-        assertEquals(2, searchCalls.first().first.size)
+        // A single apply. No settle loop — see `applyAnnotations does not spin a settle loop`.
+        assertEquals(1, searchCalls.size)
+        assertEquals(2, searchCalls[0].first.size)
     }
 
     @Test
@@ -197,21 +183,6 @@ class ReadiumHighlightRendererTest {
         renderer.applySearch(emptyList(), 0)
         val clearCall = applied.firstOrNull { it.second == "search" }
         assertEquals(emptyList<Decoration>(), clearCall?.first)
-    }
-
-    @Test
-    fun `applySearch settle loop aborts when navigator stamp changes`() = runTest {
-        val recorder = mutableListOf<Pair<List<Decoration>, String>>()
-        val abortingRenderer = ReadiumHighlightRenderer(
-            applyDecorationsBlock = { decorations, group -> recorder.add(decorations to group) },
-            fragmentLocator = { ref, _ -> if (ref.isNotBlank()) minimalLocator(ref.substringBefore('#')) else null },
-            currentNavigatorStamp = { Any() }, // new object every call → stamp always changes
-        )
-        abortingRenderer.applySearch(listOf(minimalLocator("c.xhtml")), activeIndex = 0)
-        val searchCalls = recorder.filter { it.second == "search" }
-        // Only the initial apply fires; settle loop aborts on first resume because stamp changed
-        assertEquals(1, searchCalls.size)
-        assertEquals(1, searchCalls[0].first.size)
     }
 
     // ---- highlightSearchMatch ------------------------------------------------

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/regressions/ReadaloudHighlightRotationReflowTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/regressions/ReadaloudHighlightRotationReflowTest.kt
@@ -49,15 +49,11 @@ class ReadaloudHighlightRotationReflowTest {
 
     private val applied = mutableListOf<Pair<List<Decoration>, String>>()
 
-    /** Stable navigator stamp — tests don't care about search-settle abort logic. */
-    private val navigatorStamp = Any()
-
     private val renderer = ReadiumHighlightRenderer(
         applyDecorationsBlock = { decorations, group -> applied.add(decorations to group) },
         fragmentLocator = { ref, _ ->
             if (ref.isNotBlank()) stubLocator() else null
         },
-        currentNavigatorStamp = { navigatorStamp },
     )
 
     /**


### PR DESCRIPTION
## The bug

Opening a book with highlights felt sluggish for 2-3 seconds — swipes in paginated mode and scrolls in vertical/continuous mode all lagged. Reproduced by the user on all three reader modes. Books with no annotations opened smoothly, which pointed at the highlight-decoration pipeline.

## Root cause

`ReadiumHighlightRenderer` had three fixed settle loops (annotations, emphasis companions, search) that scheduled `delay(400) → delay(600) → delay(700) → delay(900)` = 2600ms of forced `clear + re-apply` decoration JS after the initial apply. Two of them (annotations + emphasis) ran concurrently on cold open, each posting `applyDecorations` back onto the WebView Main dispatcher every tick. The WebView main thread was pinned for the exact 2.6s window the user described. Not observable on resume — the driving `LaunchedEffect` keys don't re-fire on resume.

## Fix

Removed the local settle loops. The outer `LaunchedEffect`s in `EpubReaderScreen.kt` already re-key on `pageLoadGeneration` and `reflowGeneration` — the same signals the settle loops were guessing at with fixed delays. Real layout events (page load, rotation, reflow, readaloud reserve flip) still trigger a fresh re-apply of every decoration group.

Also removed the now-dead `currentNavigatorStamp` constructor param and `emphasisApplyGeneration` counter that existed only to abort the removed loops.

## Regression coverage

- New: `applyAnnotations does not spin a settle loop after the initial apply` — asserts exactly 2 dispatches (clear + apply). Flips red if a fixed-timer settle loop is ever re-introduced.
- Tightened: `applyAnnotations with renders...` from `>= 3` to `== 2` dispatches.
- Tightened: `applySearch with results applies search group` from "not empty" to `== 1` dispatch.
- Deleted: two `settle loop aborts when navigator stamp changes` tests — they pinned behavior that no longer exists.

## Verification

- ✅ `./gradlew :app:testDebugUnitTest` — all green.
- ⚠️  **On-device verification pending.** Per `CLAUDE.md`, JVM tests alone are not sufficient for Readium/WebView changes. Please install and open a book with highlights on your device and confirm (a) the 2-3s cold-open sluggishness is gone, and (b) highlight positions look correct on first paint (no misplaced rects before the first swipe). The theoretical risk is that removing the settle loop leaves decorations mispositioned if Readium's layout keeps shifting after `onPageLoaded` — the removed comments cited this as a concrete failure mode. If observed, a minimal single-tick backstop can be added.

## Dismissed review findings

- The `ReadiumPresenter.attachmentStamp()` method and its unit test are now unreferenced outside the test file. Left in place to keep this PR focused; a follow-up can delete them.