### PR TITLE
fix(sync): stop annotation edits and scroll positions reverting under peer sync

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1417,8 +1417,14 @@ class EpubReaderViewModel @Inject constructor(
         if (!shouldRunReadingSideEffects(source)) return
         val locator = position.snapshotLastLocator() ?: return
         viewModelScope.launch {
-            if (lifecycle.matchedSync.value?.readerSync != null) runReaderSyncCycle(locator)
-            else syncSession.sync(locator.toPayload())
+            // Gate the dirty-check `loadLocalUpdatedAt` on any pending onPositionChanged save.
+            // Without this the tick can read a stale localUpdatedAt while the fresh save is still
+            // queued, decide ServerWins on the just-superseded server locator, and yank the
+            // reader back to the pre-scroll position (the "scroll snaps back" symptom).
+            position.withSaveLock {
+                if (lifecycle.matchedSync.value?.readerSync != null) runReaderSyncCycle(locator)
+                else syncSession.sync(locator.toPayload())
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/PositionOrchestrator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/PositionOrchestrator.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.readium.r2.shared.publication.Locator
 
 /**
@@ -40,6 +42,17 @@ class PositionOrchestrator @AssistedInject constructor(
 
     val serverJump: ServerJumpCoordinator = ServerJumpCoordinator()
     val resumeRestorer: ResumeRestorer = ResumeRestorer(refire = { serverJump.requestJump(it) })
+
+    /**
+     * Serializes local position saves (dispatched from [onPositionChanged] via [scope.launch]) with
+     * any read of `localUpdatedAt` that drives a sync-cycle dirty check ([withSaveLock]). Without
+     * this, the periodic sync tick could read `localUpdatedAt` from the DB *before* an in-flight
+     * save from the just-received scroll had landed, decide `serverLastUpdate > lastSyncedAt`, and
+     * yank the reader back to the pre-scroll locator via [ServerJumpCoordinator] — the "scroll
+     * snaps back" symptom. Kotlinx Mutex is fair (FIFO), so a save queued from `onPositionChanged`
+     * always runs before the sync-tick coroutine that was launched afterwards.
+     */
+    private val saveMutex = Mutex()
 
     // ---- Per-book state (reset by bindBook) ----
 
@@ -157,12 +170,21 @@ class PositionOrchestrator @AssistedInject constructor(
         // navigation leaves no pending stamp and we let PositionSaveCoordinator stamp `now`.
         val serverJumpStamp = serverJump.consumePendingStamp()
         scope.launch {
-            positionSaveCoordinator?.onChanged(locator.toJSON().toString())
-            if (serverJumpStamp != null) {
-                readingPositionStore?.updateLocalTimestamp(sourceId, itemId, serverJumpStamp)
+            saveMutex.withLock {
+                positionSaveCoordinator?.onChanged(locator.toJSON().toString())
+                if (serverJumpStamp != null) {
+                    readingPositionStore?.updateLocalTimestamp(sourceId, itemId, serverJumpStamp)
+                }
             }
         }
     }
+
+    /**
+     * Runs [block] under the same mutex that serializes local saves. Sync-cycle callers must wrap
+     * their `loadLocalUpdatedAt` + follow-up work in this so any pending save from a fresh
+     * `onPositionChanged` completes before the dirty-check read (see [saveMutex] docstring).
+     */
+    suspend fun <T> withSaveLock(block: suspend () -> T): T = saveMutex.withLock { block() }
 
     // ---- Facade delegations preserved so the VM's call sites don't churn ---------------------
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/PositionOrchestratorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/PositionOrchestratorTest.kt
@@ -224,6 +224,53 @@ class PositionOrchestratorTest {
         assertTrue("Stamp should be recorded", fakeStore.savedTimestamps.any { it.first == 999L })
     }
 
+    /**
+     * Regression: the periodic sync tick reads `localUpdatedAt` from the store to decide dirty vs
+     * server-wins. Before the [PositionOrchestrator.withSaveLock] gate existed, that read could
+     * race the in-flight `scope.launch` save from a fresh `onPositionChanged`, see stale disk
+     * state, and yank the reader back to the pre-scroll locator. Assert that a save queued from
+     * `onPositionChanged` completes before a subsequently-called `withSaveLock` block runs.
+     */
+    @Test
+    fun `withSaveLock waits for a queued onPositionChanged save`() = runTest(testDispatcher) {
+        val order = mutableListOf<String>()
+        val gate = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val saveCoordinator = PositionSaveCoordinator<String>(
+            savePosition = { pos ->
+                gate.await() // Hold the save open until we release it
+                order.add("save:$pos")
+            },
+            updateProgress = { },
+        )
+        val fakeStore = FakeReadingPositionStore()
+        val scope = kotlinx.coroutines.CoroutineScope(testDispatcher)
+        val orchestrator = PositionOrchestrator(scope)
+        orchestrator.bindBook(
+            itemId = "item1",
+            sourceId = "server1",
+            positionSaveCoordinator = saveCoordinator,
+            readingPositionStore = fakeStore,
+            spinePositionCounts = MutableStateFlow(emptyList<String>() to emptyList()),
+        )
+        // Consume initialLocatorSeen so the next onPositionChanged actually schedules a save.
+        orchestrator.onPositionChanged(buildLocator("ch1.html", 0.0))
+        // Queue a save that is currently stuck on `gate`.
+        orchestrator.onPositionChanged(buildLocator("ch1.html", 0.5))
+
+        // Launch a withSaveLock that mimics the sync tick. It must NOT run until the save unblocks.
+        val syncJob = launch {
+            orchestrator.withSaveLock { order.add("sync-read") }
+        }
+        // Sanity: sync hasn't taken the lock yet because save is holding it.
+        assertTrue("sync must not run while save is in flight; order=$order", order.isEmpty())
+
+        // Release the save; sync then proceeds.
+        gate.complete(Unit)
+        syncJob.join()
+
+        assertEquals(listOf("save:${buildLocator("ch1.html", 0.5).toJSON()}", "sync-read"), order)
+    }
+
     /** (10) armReturnRestore re-fires server locator on spurious chapter-top clobber */
     @Test
     fun `armReturnRestore re-fires server locator on spurious chapter-top clobber`() = runTest(testDispatcher) {

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationStoreImplTest.kt
@@ -58,13 +58,21 @@ class AnnotationStoreImplTest {
 
         override suspend fun tombstone(id: String, updatedAt: Long, deviceId: String) {
             rows.value = rows.value.map {
-                if (it.id == id) it.copy(deleted = true, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it
+                if (it.id == id) it.copy(
+                    deleted = true,
+                    updatedAt = maxOf(it.updatedAt + 1, updatedAt),
+                    lastModifiedByDeviceId = deviceId,
+                ) else it
             }
         }
 
         override suspend fun recolor(id: String, color: String, updatedAt: Long, deviceId: String) {
             rows.value = rows.value.map {
-                if (it.id == id) it.copy(color = color, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it
+                if (it.id == id) it.copy(
+                    color = color,
+                    updatedAt = maxOf(it.updatedAt + 1, updatedAt),
+                    lastModifiedByDeviceId = deviceId,
+                ) else it
             }
         }
 
@@ -101,7 +109,11 @@ class AnnotationStoreImplTest {
 
         override suspend fun updateNote(id: String, note: String?, updatedAt: Long, deviceId: String) {
             rows.value = rows.value.map {
-                if (it.id == id) it.copy(note = note, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it
+                if (it.id == id) it.copy(
+                    note = note,
+                    updatedAt = maxOf(it.updatedAt + 1, updatedAt),
+                    lastModifiedByDeviceId = deviceId,
+                ) else it
             }
         }
 
@@ -113,7 +125,11 @@ class AnnotationStoreImplTest {
 
         override suspend fun renameBookmark(id: String, title: String, updatedAt: Long, deviceId: String) {
             rows.value = rows.value.map {
-                if (it.id == id) it.copy(bookmarkTitle = title, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId) else it
+                if (it.id == id) it.copy(
+                    bookmarkTitle = title,
+                    updatedAt = maxOf(it.updatedAt + 1, updatedAt),
+                    lastModifiedByDeviceId = deviceId,
+                ) else it
             }
         }
 
@@ -150,7 +166,11 @@ class AnnotationStoreImplTest {
             rows.value = rows.value.map {
                 if (it.id == id && it.type == AnnotationEntity.TYPE_EMPHASIS && !it.deleted) {
                     updated++
-                    it.copy(emphasisStyles = emphasisStyles, updatedAt = updatedAt, lastModifiedByDeviceId = deviceId)
+                    it.copy(
+                        emphasisStyles = emphasisStyles,
+                        updatedAt = maxOf(it.updatedAt + 1, updatedAt),
+                        lastModifiedByDeviceId = deviceId,
+                    )
                 } else it
             }
             return updated
@@ -270,6 +290,93 @@ class AnnotationStoreImplTest {
         assertEquals("blue", row?.color)
         assertEquals(5000L, row?.updatedAt)
         assertEquals("device-X", row?.lastModifiedByDeviceId)
+    }
+
+    // Regression: annotation edits sync via LWW on updatedAt. A peer file (or a prior remote merge
+    // that adopted a peer's future stamp) can leave a row with updatedAt ahead of this device's
+    // wall clock. Without the atomic MAX(updatedAt+1, :updatedAt) guard in AnnotationDao.recolor,
+    // the local edit stamps updatedAt = clock() ≤ peer stamp, and the next AnnotationLiveSync tick
+    // upserts the peer's old color back over the recolor — the "color reverts" bug.
+    @Test
+    fun `recolor stamps strictly newer than an inherited future updatedAt (revert-race guard)`() = runTest {
+        val s = store()
+        val created = s.createHighlight(
+            "abs1", "item1", "epubcfi(/6/4!/4/2,/1:0,/1:10)", "t", "c.xhtml",
+            originFontFamily = TEST_FONT,
+        )
+        // Peer merge landed a future stamp on this row (wall clock skew or adopted-peer stamp).
+        rows.value = rows.value.map {
+            if (it.id == created.id) it.copy(updatedAt = 999_999L) else it
+        }
+        // Local clock is behind the peer stamp.
+        now = 5000L
+
+        s.recolor(created.id, "blue")
+
+        val row = dao.getById(created.id)
+        assertEquals("blue", row?.color)
+        assertTrue(
+            "updatedAt must be strictly greater than the pre-existing stamp; was ${row?.updatedAt}",
+            (row?.updatedAt ?: 0L) > 999_999L,
+        )
+    }
+
+    @Test
+    fun `updateNote stamps strictly newer than an inherited future updatedAt (revert-race guard)`() = runTest {
+        val s = store()
+        val created = s.createHighlight(
+            "abs1", "item1", "epubcfi(/6/4!/4/2,/1:0,/1:10)", "t", "c.xhtml",
+            originFontFamily = TEST_FONT,
+        )
+        rows.value = rows.value.map {
+            if (it.id == created.id) it.copy(updatedAt = 999_999L) else it
+        }
+        now = 5000L
+
+        s.updateNote(created.id, "Fresh note")
+
+        val row = dao.getById(created.id)
+        assertEquals("Fresh note", row?.note)
+        assertTrue((row?.updatedAt ?: 0L) > 999_999L)
+    }
+
+    @Test
+    fun `delete tombstone stamps strictly newer than an inherited future updatedAt (revert-race guard)`() = runTest {
+        val s = store()
+        val created = s.createHighlight(
+            "abs1", "item1", "epubcfi(/6/4!/4/2,/1:0,/1:10)", "t", "c.xhtml",
+            originFontFamily = TEST_FONT,
+        )
+        rows.value = rows.value.map {
+            if (it.id == created.id) it.copy(updatedAt = 999_999L) else it
+        }
+        now = 5000L
+
+        s.delete(created.id)
+
+        val row = dao.getById(created.id)
+        assertEquals(true, row?.deleted)
+        assertTrue((row?.updatedAt ?: 0L) > 999_999L)
+    }
+
+    @Test
+    fun `renameBookmark stamps strictly newer than an inherited future updatedAt (revert-race guard)`() = runTest {
+        val s = store()
+        val created = s.createBookmark(
+            "abs1", "item1", "epubcfi(/6/6!/4/1:0)", "", "ch2.xhtml",
+            spineIndex = 0, progression = 0.0, bookmarkTitle = "old",
+            originFontFamily = TEST_FONT,
+        )
+        rows.value = rows.value.map {
+            if (it.id == created.id) it.copy(updatedAt = 999_999L) else it
+        }
+        now = 5000L
+
+        s.renameBookmark(created.id, "renamed")
+
+        val row = dao.getById(created.id)
+        assertEquals("renamed", row?.bookmarkTitle)
+        assertTrue((row?.updatedAt ?: 0L) > 999_999L)
     }
 
     @Test

--- a/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AnnotationDao.kt
@@ -81,16 +81,33 @@ interface AnnotationDao {
     @Upsert
     suspend fun upsertAll(annotations: List<AnnotationEntity>)
 
+    // Every user-edit update below stamps `updatedAt = MAX(updatedAt + 1, :updatedAt)` rather than
+    // `:updatedAt` verbatim. AnnotationLiveSync's LWW merge (AnnotationMergeService) picks the row
+    // with the highest updatedAt; if a peer file's row (or a prior local upsert that adopted a
+    // peer's future stamp) sits at wall_clock+ε, a raw local `clock()` write can land at or below
+    // that peer stamp and be overwritten by the next merge tick — the "recolor reverts" bug. The
+    // atomic SQL max mirrors the guard in TimestampedPositionStore.save: the local edit is always
+    // strictly newer than any prior state on this row, regardless of cross-device clock skew.
+
     /** Tombstone an annotation so the delete can later propagate to other devices. */
-    @Query("UPDATE annotations SET deleted = 1, updatedAt = :updatedAt, lastModifiedByDeviceId = :deviceId WHERE id = :id")
+    @Query(
+        "UPDATE annotations SET deleted = 1, updatedAt = MAX(updatedAt + 1, :updatedAt), " +
+            "lastModifiedByDeviceId = :deviceId WHERE id = :id"
+    )
     suspend fun tombstone(id: String, updatedAt: Long, deviceId: String)
 
     /** Recolour an annotation in place, bumping updatedAt + provenance so the change can propagate. */
-    @Query("UPDATE annotations SET color = :color, updatedAt = :updatedAt, lastModifiedByDeviceId = :deviceId WHERE id = :id")
+    @Query(
+        "UPDATE annotations SET color = :color, updatedAt = MAX(updatedAt + 1, :updatedAt), " +
+            "lastModifiedByDeviceId = :deviceId WHERE id = :id"
+    )
     suspend fun recolor(id: String, color: String, updatedAt: Long, deviceId: String)
 
     /** Set (or clear) the note on a highlight in place, bumping updatedAt + provenance. */
-    @Query("UPDATE annotations SET note = :note, updatedAt = :updatedAt, lastModifiedByDeviceId = :deviceId WHERE id = :id")
+    @Query(
+        "UPDATE annotations SET note = :note, updatedAt = MAX(updatedAt + 1, :updatedAt), " +
+            "lastModifiedByDeviceId = :deviceId WHERE id = :id"
+    )
     suspend fun updateNote(id: String, note: String?, updatedAt: Long, deviceId: String)
 
     /** Replace the styles set on an emphasis row in place, bumping updatedAt + provenance (ADR 0046).
@@ -98,7 +115,8 @@ interface AnnotationDao {
      *  Returns the row count updated so the store can distinguish a stale-id miss from a real edit
      *  (see code-review F7); zero means the update landed on nothing and no sync push is needed. */
     @Query(
-        "UPDATE annotations SET emphasisStyles = :emphasisStyles, updatedAt = :updatedAt, " +
+        "UPDATE annotations SET emphasisStyles = :emphasisStyles, " +
+            "updatedAt = MAX(updatedAt + 1, :updatedAt), " +
             "lastModifiedByDeviceId = :deviceId WHERE id = :id AND type = 'EMPHASIS' AND deleted = 0"
     )
     suspend fun updateEmphasisStyles(id: String, emphasisStyles: String, updatedAt: Long, deviceId: String): Int
@@ -114,7 +132,10 @@ interface AnnotationDao {
     fun observeAnnotationsByPosition(sourceId: String, itemId: String): Flow<List<AnnotationEntity>>
 
     /** Update the user-editable title of a bookmark, bumping updatedAt + provenance. */
-    @Query("UPDATE annotations SET bookmarkTitle = :title, updatedAt = :updatedAt, lastModifiedByDeviceId = :deviceId WHERE id = :id AND type = 'BOOKMARK'")
+    @Query(
+        "UPDATE annotations SET bookmarkTitle = :title, updatedAt = MAX(updatedAt + 1, :updatedAt), " +
+            "lastModifiedByDeviceId = :deviceId WHERE id = :id AND type = 'BOOKMARK'"
+    )
     suspend fun renameBookmark(id: String, title: String, updatedAt: Long, deviceId: String)
 
     /**


### PR DESCRIPTION
Two independent \"my fresh local edit reverts\" bugs — both were a background pull-side write clobbering an unfinished local edit.

## 1. Annotation edits revert (recolor, note, bookmark title, delete, emphasis)

`AnnotationLiveSync` polls peer files every 30 s and runs pure LWW on `updatedAt`. `AnnotationStoreImpl`'s edit paths stamped `updatedAt = clock()` verbatim, but a peer file (or a prior local upsert that adopted a peer's future stamp) can leave the row at `wall_clock + ε`. A subsequent local edit landed at or below the peer stamp, and the next merge tick upserted the peer's old value back — the reported \"recolor a highlight, it snaps back\" symptom.

Fix in `core/database/AnnotationDao.kt`: five user-edit UPDATE queries (`tombstone`, `recolor`, `updateNote`, `renameBookmark`, `updateEmphasisStyles`) now stamp `updatedAt = MAX(updatedAt + 1, :updatedAt)` atomically in SQL. Mirrors the guard already present in `TimestampedPositionStore.save`.

Regression tests in `AnnotationStoreImplTest`: seed a row with `updatedAt = 999_999` while the local clock is 5000, run each edit, assert the stamp is strictly > 999_999. One test per mutated field.

## 2. Scroll position snaps back to the previous locator

`PositionOrchestrator.onPositionChanged` dispatched its DB save via `scope.launch { positionSaveCoordinator.onChanged(...) }`; the periodic sync tick (`ReadingSessionCoordinator` → `EpubReaderViewModel.syncCurrentPosition`) launched its own coroutine that read `localUpdatedAt` from the same store. With no ordering, the tick could observe pre-scroll disk state, decide \`ServerWins\` on the just-superseded server locator, and pipe it back through `ServerJumpCoordinator` into the open reader.

Fix: `PositionOrchestrator` gains a `Mutex saveMutex`; the save `scope.launch` block runs under `withLock`; a `suspend fun <T> withSaveLock(block: suspend () -> T): T` is exposed. `EpubReaderViewModel.syncCurrentPosition` wraps its sync-cycle work in `position.withSaveLock { ... }` so `loadLocalUpdatedAt` reads after any pending save. Kotlinx `Mutex` is fair (FIFO) — a save queued from `onPositionChanged` always beats the subsequently-launched sync tick to the lock.

Regression test in `PositionOrchestratorTest` uses a `CompletableDeferred` gate to hold a save open, then asserts a concurrent `withSaveLock` block only runs after the save completes.

## Follow-up noted, not fixed here

`syncCurrentPosition` now holds `saveMutex` through the entire sync cycle including the ABS HTTP round-trip. In principle a concurrent `onPositionChanged` save is blocked for the tick duration and, if the VM cancels mid-tick, could drop the queued save. A cleaner fix would snapshot `localUpdatedAt` inside the lock and release before the network call, but that requires plumbing the timestamp through `runReaderSyncCycle` + `ReadingSessionRepositoryImpl.runSyncCycle`. For typical sync intervals and network latencies the added window is <1 s and the correctness win dominates; happy to do the deeper refactor as a follow-up if this shows up in practice.

## Test plan

- [x] `./gradlew :core:data:test` — green
- [x] `./gradlew :app:testDebugUnitTest --tests \"...PositionOrchestratorTest\"` — green
- [ ] Manual repro on device: recolor a highlight, wait for a sync tick, verify no revert
- [ ] Manual repro on device: scroll to a new location during a sync tick, verify no snap-back