### PR TITLE
fix(reader): eliminate continuous-mode open-time content reshuffle

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
@@ -192,7 +192,17 @@ internal object ContinuousPositionTracker {
         return moreChaptersExist && pastBehindBudget
     }
 
-    data class InitialWindow(val topIndex: Int, val totalChapters: Int, val targetWindowIndex: Int)
+    data class InitialWindow(val topIndex: Int, val totalChapters: Int, val targetWindowIndex: Int) {
+        /**
+         * Window indices whose real height must be measured before the initial scroll is allowed
+         * to fire. Must cover EVERY chapter in the initial window, not just the target and the
+         * chapters above it: chapters below the target start at a full-screen placeholder height
+         * and collapse when they measure, which — if it happens after container reveal — shifts
+         * on-screen siblings under the user's eye (LinearLayout reflow inside a visible viewport
+         * with no scroll compensation for indices past 0). See ContinuousWindowController.openWindowAt.
+         */
+        fun pendingMeasureIndices(): Set<Int> = (0 until totalChapters).toSet()
+    }
 
     /**
      * Compute the initial sliding-window layout for opening at [targetIndex] in a book of size

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -161,6 +161,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
 
     init {
         controller.onFirstLoadComplete = { isFirstLoadComplete.value = true }
+        controller.onFirstLoadRestart = { isFirstLoadComplete.value = false }
     }
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -151,6 +151,19 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     val isInitialized = mutableStateOf(false)
 
     /**
+     * False from [initialize] until the container is first revealed with content landed at the
+     * initial position — i.e. every chapter in the initial window has measured (or the safety-net
+     * fallback fired). Observed by [EpubReaderScreen] to overlay a loading spinner during the
+     * still-INVISIBLE gap so the user doesn't see a blank reader while WebViews spin up on cold
+     * open. Not re-armed on cross-chapter jumps.
+     */
+    val isFirstLoadComplete = mutableStateOf(false)
+
+    init {
+        controller.onFirstLoadComplete = { isFirstLoadComplete.value = true }
+    }
+
+    /**
      * Wire this view to the coordinator's sinks. Must be called once, from
      * [ContinuousReaderCoordinator.attach], before any chapter is appended/prepended.
      */

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -45,14 +45,16 @@ internal class ContinuousWindowController(
         // Window buffers were 3+3 (WINDOW_SIZE=7) with a recycled pool cap of WINDOW_SIZE, so
         // Continuous mode could hold up to 14 stacked ChapterWebViews with fully rasterized tiles
         // (setOffscreenPreRaster=true). On a 1 GB Android 7.1 tablet that is enough to trip the
-        // renderer heap and get the app killed with no crash trace. Cutting the live buffer to 2+2
-        // and the pool to 2 caps the ceiling at 7 WebViews — half the previous worst case — while
-        // still preserving a one-chapter buffer on each side for scroll smoothness.
+        // renderer heap and get the app killed with no crash trace. Cut first to 2+2, then to 1+1
+        // — the initial-land gate now waits for EVERY window chapter to measure, so each extra
+        // buffer chapter directly extends the cold-open spinner time (5 chapters at 1+1 → 3);
+        // one behind / one ahead is enough to hide the next chapter boundary from a scroll fling
+        // without paying for chapters two removed from the viewport.
         /** See [ContinuousReaderView.CHAPTERS_BEHIND]. */
-        private const val CHAPTERS_BEHIND = 2
+        private const val CHAPTERS_BEHIND = 1
 
         /** See [ContinuousReaderView.CHAPTERS_AHEAD]. */
-        private const val CHAPTERS_AHEAD = 2
+        private const val CHAPTERS_AHEAD = 1
 
         /** Total sliding-window size: the reader's chapter plus the behind/ahead buffers. */
         private const val WINDOW_SIZE = CHAPTERS_BEHIND + 1 + CHAPTERS_AHEAD
@@ -65,9 +67,14 @@ internal class ContinuousWindowController(
         /**
          * Grace period after a window (re)build before the initial scroll is forced to fire even if
          * not every required chapter has measured — so a slow/failed measurement can't strand the
-         * reader on a blank position.
+         * reader on a blank position. Sized to cover cold-open of the whole 3-chapter window on a
+         * low-memory Android 7.1 tablet, where 700 ms routinely elapsed before even the target
+         * chapter reported its real height. When the fallback wins, the initial land happens on
+         * placeholder-sum coordinates and later target-remeasures hard-scroll again — visible as
+         * content "reshuffling" during the load — so keeping it long enough that measurements win
+         * in the common case is worth the extra spinner time on very slow devices.
          */
-        private const val INITIAL_SCROLL_FALLBACK_MS = 700L
+        private const val INITIAL_SCROLL_FALLBACK_MS = 2500L
 
         /** How long after the initial land to override framework smooth-scroll restoration of a
          *  stale scrollY. */
@@ -136,6 +143,22 @@ internal class ContinuousWindowController(
 
     /** Parallel list to the loaded WebViews; index i matches container.getChildAt(i). */
     private val webViews = mutableListOf<ChapterWebView>()
+
+    /**
+     * Invoked exactly once, on the first reveal of the container after [initialize]. Wired from
+     * [ContinuousReaderView] to flip a Compose state used by [EpubReaderScreen] to overlay a
+     * loading spinner over the still-INVISIBLE container during the initial land. Not re-armed
+     * on subsequent [openWindowAt] rebuilds (cross-chapter jumps): those already run under
+     * `smoothTail = true` with a visible tween and would look worse under a full-screen spinner.
+     */
+    internal var onFirstLoadComplete: () -> Unit = {}
+    private var firstLoadComplete: Boolean = false
+
+    private fun notifyFirstLoadCompleteOnce() {
+        if (firstLoadComplete) return
+        firstLoadComplete = true
+        onFirstLoadComplete()
+    }
 
     /** Wired by [ContinuousReaderView.logger] from the reader ViewModel so decoration-path
      *  diagnostics land in the in-app debug screen (channel [LogChannel.ReaderDecoration]).
@@ -375,7 +398,14 @@ internal class ContinuousWindowController(
         pendingFocusAnnotationId = focusAnnotationId
         val totalChapters = initial.totalChapters
         pendingInitialMeasureIndices.clear()
-        pendingInitialMeasureIndices.addAll(0..targetWindowIndex)
+        // Wait for EVERY chapter in the initial window to report its real height, not just the
+        // target and the chapters above it. Chapters below the target start at a full-screen
+        // placeholder height and collapse when they measure; if the container is revealed before
+        // that happens, the LinearLayout re-lays out inside a visible viewport and on-screen
+        // siblings shift under the user's eye (there's no scroll compensation for i > 0 in
+        // `appendChapter.onHeightMeasured`). Gating the reveal on every window chapter's
+        // measurement pays that cost behind the still-INVISIBLE container instead.
+        pendingInitialMeasureIndices.addAll(0 until totalChapters)
         val targetHref = initialHref
         // Only the FIRST invocation of the pending-initial-scroll closure runs the smooth-tail
         // dance. Subsequent invocations from [reapplyLandingAfterFallback] on target-chapter
@@ -389,6 +419,7 @@ internal class ContinuousWindowController(
                     val slot = i?.let { buildWindow().getOrNull(it) }
                     if (i == null || slot == null) {
                         container.visibility = android.view.View.VISIBLE
+                        notifyFirstLoadCompleteOnce()
                         return@post
                     }
                     val y = when {
@@ -416,13 +447,17 @@ internal class ContinuousWindowController(
                         // partial animation from wherever the scroll had already advanced.
                         port.postOnAnimation {
                             container.visibility = android.view.View.VISIBLE
+                            notifyFirstLoadCompleteOnce()
                             port.smoothScrollTo(y)
                         }
                     } else {
                         port.scrollTo(y)
                         landingHoldTargetY = y
                         landingHoldUntilUptimeMs = android.os.SystemClock.uptimeMillis() + LANDING_HOLD_MS
-                        port.postOnAnimation { container.visibility = android.view.View.VISIBLE }
+                        port.postOnAnimation {
+                            container.visibility = android.view.View.VISIBLE
+                            notifyFirstLoadCompleteOnce()
+                        }
                     }
                 }
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -398,14 +398,7 @@ internal class ContinuousWindowController(
         pendingFocusAnnotationId = focusAnnotationId
         val totalChapters = initial.totalChapters
         pendingInitialMeasureIndices.clear()
-        // Wait for EVERY chapter in the initial window to report its real height, not just the
-        // target and the chapters above it. Chapters below the target start at a full-screen
-        // placeholder height and collapse when they measure; if the container is revealed before
-        // that happens, the LinearLayout re-lays out inside a visible viewport and on-screen
-        // siblings shift under the user's eye (there's no scroll compensation for i > 0 in
-        // `appendChapter.onHeightMeasured`). Gating the reveal on every window chapter's
-        // measurement pays that cost behind the still-INVISIBLE container instead.
-        pendingInitialMeasureIndices.addAll(0 until totalChapters)
+        pendingInitialMeasureIndices.addAll(initial.pendingMeasureIndices())
         val targetHref = initialHref
         // Only the FIRST invocation of the pending-initial-scroll closure runs the smooth-tail
         // dance. Subsequent invocations from [reapplyLandingAfterFallback] on target-chapter

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -145,13 +145,17 @@ internal class ContinuousWindowController(
     private val webViews = mutableListOf<ChapterWebView>()
 
     /**
-     * Invoked exactly once, on the first reveal of the container after [initialize]. Wired from
-     * [ContinuousReaderView] to flip a Compose state used by [EpubReaderScreen] to overlay a
-     * loading spinner over the still-INVISIBLE container during the initial land. Not re-armed
-     * on subsequent [openWindowAt] rebuilds (cross-chapter jumps): those already run under
-     * `smoothTail = true` with a visible tween and would look worse under a full-screen spinner.
+     * Invoked when the container is first revealed after [initialize] and again after each
+     * [recoverFromRendererGone] cycle. Wired from [ContinuousReaderView] to flip a Compose state
+     * used by [EpubReaderScreen] to overlay a loading spinner over the still-INVISIBLE container
+     * during the measurement gate. Not re-armed on cross-chapter jumps (`smoothTail = true`):
+     * those already animate visibly and would look worse under a full-screen spinner.
      */
     internal var onFirstLoadComplete: () -> Unit = {}
+
+    /** Paired with [onFirstLoadComplete]; fired when [recoverFromRendererGone] resets the flag so
+     *  the spinner reappears during the rebuild. */
+    internal var onFirstLoadRestart: () -> Unit = {}
     private var firstLoadComplete: Boolean = false
 
     private fun notifyFirstLoadCompleteOnce() {
@@ -512,6 +516,13 @@ internal class ContinuousWindowController(
         container.removeAllViews()
         recycledViews.forEach { it.destroy() }
         recycledViews.clear()
+        // Re-arm the first-load spinner: recovery re-hides the container via openWindowAt and
+        // won't reveal until every chapter has measured (up to INITIAL_SCROLL_FALLBACK_MS ms).
+        // Without this reset the user sees a blank reader for that gap on a mid-session renderer
+        // kill (common on low-memory Android 7.1 tablets — exactly the device the fallback was
+        // widened for).
+        firstLoadComplete = false
+        onFirstLoadRestart()
         if (href.isNotEmpty()) openWindowAt(href, progression)
         port.post { rendererRecovering = false }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2929,6 +2929,19 @@ private fun EpubNavigatorView(
                 },
                 modifier = readerModifier,
             )
+            // Cover the still-INVISIBLE container with a spinner during initial land. Continuous
+            // mode holds `container.visibility = INVISIBLE` from openWindowAt until every chapter
+            // in the initial window has measured (or the safety-net fallback fires), so without
+            // this overlay a cold open shows a blank reader for up to a few seconds on low-memory
+            // Android 7.1 devices where five cold WebViews are spinning up in parallel.
+            val continuousReaderForSpinner = continuousViewRef.value
+            if (continuousReaderForSpinner != null && !continuousReaderForSpinner.isFirstLoadComplete.value) {
+                CircularProgressIndicator(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .testTag("reader_loading"),
+                )
+            }
             // Key on the view ref: AndroidView.factory (which sets continuousViewRef) runs as a
             // layout-phase effect, while LaunchedEffect runs as a composition-phase effect — there
             // is no guaranteed order between the two on first composition. Keying on the ref means

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2933,7 +2933,8 @@ private fun EpubNavigatorView(
             // mode holds `container.visibility = INVISIBLE` from openWindowAt until every chapter
             // in the initial window has measured (or the safety-net fallback fires), so without
             // this overlay a cold open shows a blank reader for up to a few seconds on low-memory
-            // Android 7.1 devices where five cold WebViews are spinning up in parallel.
+            // Android 7.1 devices where the initial-window WebViews spin up in parallel. Also
+            // re-shows during renderer-gone recovery (see recoverFromRendererGone).
             val continuousReaderForSpinner = continuousViewRef.value
             if (continuousReaderForSpinner != null && !continuousReaderForSpinner.isFirstLoadComplete.value) {
                 CircularProgressIndicator(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -724,4 +724,43 @@ class ContinuousPositionTrackerTest {
     fun `preLandY — clamps at zero when target is within half a viewport of the top`() {
         assertEquals(0, ContinuousPositionTracker.preLandY(targetY = 200, viewportHeight = 1200))
     }
+
+    // ── pendingMeasureIndices ─────────────────────────────────────────────────
+    //
+    // Regression gate for the continuous-open reshuffle: the initial scroll must wait for every
+    // chapter in the window to measure, not just the target and above. If someone flips this back
+    // to `0..targetWindowIndex`, chapters below the target reveal at their full-screen placeholder
+    // height and then collapse inside a visible viewport, shifting on-screen siblings.
+
+    @Test
+    fun `pendingMeasureIndices — covers every window chapter, not just target and above`() {
+        // Mid-book open at index 10 with a 3-chapter window (1 behind + target + 1 ahead).
+        val initial = ContinuousPositionTracker.initialWindow(
+            targetIndex = 10, allChaptersSize = 100, chaptersBehind = 1, windowSize = 3,
+        )
+        // Sanity: 1 behind + target + 1 ahead — target sits at window index 1, below-target at 2.
+        assertEquals(1, initial.targetWindowIndex)
+        assertEquals(3, initial.totalChapters)
+        // Below-target index (2) MUST be in the pending set — that's the whole point of the fix.
+        assertEquals(setOf(0, 1, 2), initial.pendingMeasureIndices())
+    }
+
+    @Test
+    fun `pendingMeasureIndices — includes below-target chapters on cold open near start`() {
+        // Open at index 0: no behind buffer, all ahead. Below-target reflow still applies.
+        val initial = ContinuousPositionTracker.initialWindow(
+            targetIndex = 0, allChaptersSize = 100, chaptersBehind = 1, windowSize = 3,
+        )
+        assertEquals(setOf(0, 1, 2), initial.pendingMeasureIndices())
+    }
+
+    @Test
+    fun `pendingMeasureIndices — clamps to available chapters near end of book`() {
+        // Only 2 chapters left from topIndex — window truncates to totalChapters=2.
+        val initial = ContinuousPositionTracker.initialWindow(
+            targetIndex = 8, allChaptersSize = 9, chaptersBehind = 1, windowSize = 3,
+        )
+        assertEquals(2, initial.totalChapters)
+        assertEquals(setOf(0, 1), initial.pendingMeasureIndices())
+    }
 }


### PR DESCRIPTION
## Symptom

Opening a book in continuous mode visibly reshuffled content while the reader was unresponsive — long on a low-memory Android 7.1 tablet, briefly on a modern phone.

## Root cause

Two races in `ContinuousWindowController.openWindowAt`:

1. **Reveal races measurement.** `pendingInitialMeasureIndices` only waited for chapters at and above the target. Chapters below the target started at a full-screen placeholder height and collapsed to real height *after* the container was revealed — LinearLayout re-laid out inside a visible viewport with no scroll compensation for indices past 0, shifting on-screen siblings.
2. **700 ms fallback fired too eagerly on slow devices.** On the 7.1 tablet the fallback routinely elapsed before even the target chapter measured. When the fallback wins the initial land runs on placeholder-sum coordinates and each late target-remeasure hard-scrolls again.

## Fix

- Gate the reveal on measurement of every chapter in the initial window, not just target and above. Extracted the seeding decision to a pure `InitialWindow.pendingMeasureIndices()` so it's testable without Android APIs.
- Raise `INITIAL_SCROLL_FALLBACK_MS` 700 → 2500 so measurements win in the common case on slow devices.
- Shrink the initial window `2+1+2 → 1+1+1` (5 → 3 WebViews). Each extra buffer chapter directly extends the invisible-container time now that the reveal waits for all of them; one behind + one ahead is still enough to hide the next chapter boundary from a scroll fling.
- Expose `isFirstLoadComplete` on `ContinuousReaderView`, driven by a paired `onFirstLoadComplete` / `onFirstLoadRestart` callback pair on the controller. `EpubReaderScreen` overlays a `CircularProgressIndicator` while it's false so the user sees a spinner instead of a blank reader during the (now longer) measurement gate.
- Reset the flag inside `recoverFromRendererGone` so the spinner reappears during mid-session renderer-kill recovery — same slow-device environment the fallback was widened for.

## Test plan

- [x] JVM regression: `ContinuousPositionTrackerTest` pins `pendingMeasureIndices()` covers every chapter in the window (not just target and above). Test flips red if someone reverts to `0..targetWindowIndex`.
- [x] Verified on device by @pkmetski — reshuffle gone; spinner shows during cold open.
- [ ] Watch for regressions with very short chapters and fast fling (1-ahead buffer edge).