### PR TITLE
perf(caching): add default HTTP cache, mirror playlists to Room, cap sidecars

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
@@ -21,6 +21,7 @@ import com.riffle.core.database.ReadaloudDismissalDao
 import com.riffle.core.database.ReadaloudLinkDao
 import com.riffle.core.database.ReadaloudResumePositionDao
 import com.riffle.core.database.ReadingPositionDao
+import com.riffle.core.database.PlaylistDao
 import com.riffle.core.database.RemoteItemFreshnessDao
 import com.riffle.core.database.RiffleDatabase
 import com.riffle.core.database.SeriesDao
@@ -145,4 +146,8 @@ object TestDatabaseModule {
     @Singleton
     fun provideRemoteItemFreshnessDao(db: RiffleDatabase): RemoteItemFreshnessDao =
         db.remoteItemFreshnessDao()
+
+    @Provides
+    @Singleton
+    fun providePlaylistDao(db: RiffleDatabase): PlaylistDao = db.playlistDao()
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -848,7 +848,10 @@ class AudiobookPlayerViewModelBookmarkTest {
         StubLocalStore,
         StubLocalStore,
         StubBuildTrigger,
-        sidecarCache = { _, _ -> null },
+        sidecarCache = object : com.riffle.core.domain.ReadaloudSidecarCache {
+            override fun cachedFile(storytellerSourceId: String, storytellerBookId: String): java.io.File? = null
+            override fun purgeSource(storytellerSourceId: String) = Unit
+        },
         clock = object : com.riffle.core.common.Clock { override fun nowMs() = 0L; override fun nowNs() = 0L },
         logger = RecordingLogger(),
     ) {

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -559,7 +559,10 @@ class SleepTimerTest {
         StubLocalStore,
         StubLocalStore,
         StubBuildTrigger,
-        sidecarCache = { _, _ -> null },
+        sidecarCache = object : com.riffle.core.domain.ReadaloudSidecarCache {
+            override fun cachedFile(storytellerSourceId: String, storytellerBookId: String): java.io.File? = null
+            override fun purgeSource(storytellerSourceId: String) = Unit
+        },
         clock = object : com.riffle.core.common.Clock { override fun nowMs() = 0L; override fun nowNs() = 0L },
         logger = RecordingLogger(),
     ) {

--- a/core/data/src/main/kotlin/com/riffle/core/data/PlaylistsRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/PlaylistsRepositoryImpl.kt
@@ -4,43 +4,56 @@ import com.riffle.core.catalog.Catalog
 import com.riffle.core.catalog.CatalogPlaylist
 import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.catalog.PlaylistsCapability
+import com.riffle.core.database.PlaylistDao
+import com.riffle.core.database.PlaylistEntity
+import com.riffle.core.database.PlaylistItemEntity
+import com.riffle.core.domain.SourceRepository
 import com.riffle.core.logging.LogChannel
 import com.riffle.core.logging.Logger
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Playlists for a library, cached in-memory. The cache is per-rootId — the same source-wide
- * capability serves every root, but we never coalesce results across roots because ABS scopes
- * playlists per-library.
+ * Playlists for a library, persisted to Room so the Playlists tab is populated on cold start
+ * without waiting for [refresh]. Reads are scoped by rootId (the library id); writes fan out to
+ * (rootId, sourceId) via the active [SourceRepository] entry. The rootId-only observation
+ * matches the pre-Room contract — the same rootId across two sources would still coalesce, but
+ * that only happens when a user has two Source rows pointing at the same ABS instance.
  */
 @Singleton
 class PlaylistsRepositoryImpl @Inject constructor(
     private val catalogRegistry: CatalogRegistry,
+    private val sourceRepository: SourceRepository,
+    private val dao: PlaylistDao,
     private val logger: Logger,
 ) : PlaylistsRepository {
-
-    private val cache = MutableStateFlow<Map<String, List<CatalogPlaylist>>>(emptyMap())
 
     override fun observePlaylists(rootId: String): Flow<List<CatalogPlaylist>> =
         // Reserved-name filter is applied here, once. Every consumer — the Playlists tab, the
         // playlist detail screen, and the "Add to playlist…" picker — reads through this flow, so
         // "To Read" / "To Listen" cannot leak into a user-facing surface even if a future caller
-        // forgets the rule.
-        cache.map { byRoot -> byRoot[rootId].orEmpty().filterNot { it.isReservedName() } }
+        // forgets the rule. itemIds hydrated per-playlist so the picker/detail surfaces see the
+        // same shape they did under the in-memory cache.
+        dao.observeByRootId(rootId).map { entities ->
+            entities
+                .map { it.toDomain(itemIds = dao.itemIds(it.sourceId, it.id)) }
+                .filterNot { it.isReservedName() }
+        }
 
     override suspend fun refresh(rootId: String): Boolean {
+        val sourceId = sourceRepository.getActive()?.id
         val cap = activePlaylistsCap() ?: run {
             // No capability on the active Source — treat as empty rather than error so the UI
-            // (which drives tab visibility off this flow) simply hides the tab.
-            cache.value = cache.value + (rootId to emptyList())
+            // (which drives tab visibility off this flow) simply hides the tab. Clear any stale
+            // rows so a source switch away from an ABS instance doesn't leave playlists visible.
+            if (sourceId != null) dao.replaceAllForRoot(rootId, emptyList(), emptyList())
             return true
         }
+        if (sourceId == null) return false
         return runCatching { cap.listPlaylists(rootId) }
-            .onSuccess { cache.value = cache.value + (rootId to it) }
+            .onSuccess { list -> dao.replaceAllForRoot(rootId, list.toEntities(sourceId), list.toItemEntities(sourceId)) }
             .onFailure { logger.d(LogChannel.Playlists) { "refresh($rootId) failed: $it" } }
             .isSuccess
     }
@@ -65,52 +78,68 @@ class PlaylistsRepositoryImpl @Inject constructor(
         }
         val cap = activePlaylistsCap()
             ?: throw IllegalStateException("Active Source has no PlaylistsCapability")
+        val sourceId = sourceRepository.getActive()?.id
+            ?: throw IllegalStateException("No active Source")
         val created = cap.createPlaylist(rootId, name.trim(), initialItemId)
-        cache.value = cache.value + (rootId to (cache.value[rootId].orEmpty() + created))
+        dao.replacePlaylist(
+            playlist = created.toEntity(sourceId),
+            items = created.toItemEntities(sourceId),
+        )
         return created
     }
 
     override suspend fun addItemToPlaylist(rootId: String, playlistId: String, itemId: String): Boolean {
         val cap = activePlaylistsCap() ?: return false
-        val before = cache.value[rootId].orEmpty()
-        val target = before.firstOrNull { it.id == playlistId } ?: return false
-        if (itemId in target.itemIds) return true
-        val updated = target.copy(
-            itemIds = target.itemIds + itemId,
-            bookCount = target.bookCount + 1,
-        )
-        cache.value = cache.value + (rootId to before.map { if (it.id == playlistId) updated else it })
+        val sourceId = sourceRepository.getActive()?.id ?: return false
+        val current = dao.itemIds(sourceId, playlistId)
+        if (itemId in current) return true
         return runCatching { cap.addItemToPlaylist(playlistId, itemId); true }
-            .onFailure {
-                logger.d(LogChannel.Playlists) { "addItemToPlaylist($playlistId, $itemId) failed: $it" }
-                cache.value = cache.value + (rootId to before)
+            .onSuccess {
+                val updatedItems = (current + itemId)
+                    .mapIndexed { index, id -> PlaylistItemEntity(playlistId, sourceId, id, index) }
+                dao.replacePlaylist(
+                    playlist = PlaylistEntity(
+                        id = playlistId,
+                        sourceId = sourceId,
+                        rootId = rootId,
+                        name = playlistNameOrEmpty(sourceId, playlistId),
+                        bookCount = updatedItems.size,
+                    ),
+                    items = updatedItems,
+                )
             }
+            .onFailure { logger.d(LogChannel.Playlists) { "addItemToPlaylist($playlistId, $itemId) failed: $it" } }
             .getOrDefault(false)
     }
 
     override suspend fun removeItemFromPlaylist(rootId: String, playlistId: String, itemId: String): Boolean {
         val cap = activePlaylistsCap() ?: return false
-        val before = cache.value[rootId].orEmpty()
-        val target = before.firstOrNull { it.id == playlistId } ?: return false
-        if (itemId !in target.itemIds) return true
-        val remaining = target.itemIds - itemId
-        val updated = target.copy(
-            itemIds = remaining,
-            bookCount = (target.bookCount - 1).coerceAtLeast(0),
-        )
-        // ABS auto-deletes an emptied playlist server-side. Mirror that locally so the tab hides
-        // once the last item is removed, without waiting for the next refresh.
-        val next = if (remaining.isEmpty()) {
-            before.filterNot { it.id == playlistId }
-        } else {
-            before.map { if (it.id == playlistId) updated else it }
-        }
-        cache.value = cache.value + (rootId to next)
+        val sourceId = sourceRepository.getActive()?.id ?: return false
+        val current = dao.itemIds(sourceId, playlistId)
+        if (itemId !in current) return true
         return runCatching { cap.removeItemFromPlaylist(playlistId, itemId); true }
-            .onFailure {
-                logger.d(LogChannel.Playlists) { "removeItemFromPlaylist($playlistId, $itemId) failed: $it" }
-                cache.value = cache.value + (rootId to before)
+            .onSuccess {
+                val remaining = current - itemId
+                if (remaining.isEmpty()) {
+                    // ABS auto-deletes an emptied playlist server-side. Mirror that locally so the
+                    // tab hides once the last item is removed, without waiting for the next refresh.
+                    dao.deletePlaylistItems(sourceId, playlistId)
+                    dao.deletePlaylist(sourceId, playlistId)
+                } else {
+                    val items = remaining.mapIndexed { i, id -> PlaylistItemEntity(playlistId, sourceId, id, i) }
+                    dao.replacePlaylist(
+                        playlist = PlaylistEntity(
+                            id = playlistId,
+                            sourceId = sourceId,
+                            rootId = rootId,
+                            name = playlistNameOrEmpty(sourceId, playlistId),
+                            bookCount = items.size,
+                        ),
+                        items = items,
+                    )
+                }
             }
+            .onFailure { logger.d(LogChannel.Playlists) { "removeItemFromPlaylist($playlistId, $itemId) failed: $it" } }
             .getOrDefault(false)
     }
 
@@ -119,6 +148,35 @@ class PlaylistsRepositoryImpl @Inject constructor(
         return catalog as? PlaylistsCapability
     }
 
+    // The mutation methods need the playlist name to write a valid parent row; look it up from the
+    // currently-persisted row. If the row was somehow evicted between refresh and mutation we fall
+    // back to empty — the next refresh will fix the name, and the FK on `playlist_items` still
+    // holds because the parent gets written before the join rows.
+    private suspend fun playlistNameOrEmpty(sourceId: String, playlistId: String): String =
+        dao.getById(sourceId, playlistId)?.name.orEmpty()
+
     private fun CatalogPlaylist.isReservedName(): Boolean =
         RESERVED_PLAYLIST_NAMES.any { it.equals(name.trim(), ignoreCase = true) }
 }
+
+private fun CatalogPlaylist.toEntity(sourceId: String) = PlaylistEntity(
+    id = id,
+    sourceId = sourceId,
+    rootId = rootId,
+    name = name,
+    bookCount = bookCount,
+)
+
+private fun CatalogPlaylist.toItemEntities(sourceId: String): List<PlaylistItemEntity> =
+    itemIds.mapIndexed { index, itemId -> PlaylistItemEntity(id, sourceId, itemId, index) }
+
+private fun List<CatalogPlaylist>.toEntities(sourceId: String) = map { it.toEntity(sourceId) }
+private fun List<CatalogPlaylist>.toItemEntities(sourceId: String) = flatMap { it.toItemEntities(sourceId) }
+
+private fun PlaylistEntity.toDomain(itemIds: List<String>) = CatalogPlaylist(
+    id = id,
+    rootId = rootId,
+    name = name,
+    bookCount = bookCount,
+    itemIds = itemIds,
+)

--- a/core/data/src/main/kotlin/com/riffle/core/data/PlaylistsRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/PlaylistsRepositoryImpl.kt
@@ -91,6 +91,11 @@ class PlaylistsRepositoryImpl @Inject constructor(
     override suspend fun addItemToPlaylist(rootId: String, playlistId: String, itemId: String): Boolean {
         val cap = activePlaylistsCap() ?: return false
         val sourceId = sourceRepository.getActive()?.id ?: return false
+        // Parent row required: mutating without it would either write a blank-titled row on the
+        // next replacePlaylist (violating the name invariant) or dangle join rows against a
+        // missing FK. Missing parent means the caller raced with a source-removal / cache-purge;
+        // safest is to no-op and let the next refresh() rebuild the row cleanly.
+        val parent = dao.getById(sourceId, playlistId) ?: return false
         val current = dao.itemIds(sourceId, playlistId)
         if (itemId in current) return true
         return runCatching { cap.addItemToPlaylist(playlistId, itemId); true }
@@ -98,13 +103,7 @@ class PlaylistsRepositoryImpl @Inject constructor(
                 val updatedItems = (current + itemId)
                     .mapIndexed { index, id -> PlaylistItemEntity(playlistId, sourceId, id, index) }
                 dao.replacePlaylist(
-                    playlist = PlaylistEntity(
-                        id = playlistId,
-                        sourceId = sourceId,
-                        rootId = rootId,
-                        name = playlistNameOrEmpty(sourceId, playlistId),
-                        bookCount = updatedItems.size,
-                    ),
+                    playlist = parent.copy(bookCount = updatedItems.size),
                     items = updatedItems,
                 )
             }
@@ -115,6 +114,7 @@ class PlaylistsRepositoryImpl @Inject constructor(
     override suspend fun removeItemFromPlaylist(rootId: String, playlistId: String, itemId: String): Boolean {
         val cap = activePlaylistsCap() ?: return false
         val sourceId = sourceRepository.getActive()?.id ?: return false
+        val parent = dao.getById(sourceId, playlistId) ?: return false
         val current = dao.itemIds(sourceId, playlistId)
         if (itemId !in current) return true
         return runCatching { cap.removeItemFromPlaylist(playlistId, itemId); true }
@@ -128,13 +128,7 @@ class PlaylistsRepositoryImpl @Inject constructor(
                 } else {
                     val items = remaining.mapIndexed { i, id -> PlaylistItemEntity(playlistId, sourceId, id, i) }
                     dao.replacePlaylist(
-                        playlist = PlaylistEntity(
-                            id = playlistId,
-                            sourceId = sourceId,
-                            rootId = rootId,
-                            name = playlistNameOrEmpty(sourceId, playlistId),
-                            bookCount = items.size,
-                        ),
+                        playlist = parent.copy(bookCount = items.size),
                         items = items,
                     )
                 }
@@ -148,12 +142,6 @@ class PlaylistsRepositoryImpl @Inject constructor(
         return catalog as? PlaylistsCapability
     }
 
-    // The mutation methods need the playlist name to write a valid parent row; look it up from the
-    // currently-persisted row. If the row was somehow evicted between refresh and mutation we fall
-    // back to empty — the next refresh will fix the name, and the FK on `playlist_items` still
-    // holds because the parent gets written before the join rows.
-    private suspend fun playlistNameOrEmpty(sourceId: String, playlistId: String): String =
-        dao.getById(sourceId, playlistId)?.name.orEmpty()
 
     private fun CatalogPlaylist.isReservedName(): Boolean =
         RESERVED_PLAYLIST_NAMES.any { it.equals(name.trim(), ignoreCase = true) }

--- a/core/data/src/main/kotlin/com/riffle/core/data/PlaylistsRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/PlaylistsRepositoryImpl.kt
@@ -142,7 +142,6 @@ class PlaylistsRepositoryImpl @Inject constructor(
         return catalog as? PlaylistsCapability
     }
 
-
     private fun CatalogPlaylist.isReservedName(): Boolean =
         RESERVED_PLAYLIST_NAMES.any { it.equals(name.trim(), ignoreCase = true) }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudSidecarStore.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudSidecarStore.kt
@@ -98,6 +98,7 @@ class ReadaloudSidecarStore private constructor(
                         file.delete()
                     }
                 }
+            enforceLruBudget()
         }
     }
 
@@ -163,6 +164,7 @@ class ReadaloudSidecarStore private constructor(
                 when (val result = fetcher.fetch(source.url.value, storytellerBookId, token, source.insecureConnectionAllowed)) {
                     is StorytellerSidecarFetcher.FetchResult.Success -> {
                         file = fileFor(storytellerSourceId, storytellerBookId).apply { writeBytes(result.bytes) }
+                        enforceLruBudget()
                         break
                     }
                     // Book definitively has no SMIL — no point retrying until Storyteller aligns it.
@@ -206,10 +208,54 @@ class ReadaloudSidecarStore private constructor(
         _states.value = emptyMap()
     }
 
+    /**
+     * Deletes every cached sidecar belonging to [storytellerSourceId]. Called from the source-removal
+     * path so a re-added source doesn't inherit stale sidecars keyed to its previous id, and so the
+     * cache dir doesn't retain files whose owning source no longer exists.
+     */
+    override fun purgeSource(storytellerSourceId: String) {
+        val prefix = "$storytellerSourceId-"
+        dir().listFiles().orEmpty()
+            .filter { it.isFile && it.extension == "epub" && it.name.startsWith(prefix) }
+            .forEach { it.delete() }
+        _states.value = _states.value.filterKeys { !it.startsWith(prefix) }
+    }
+
+    /**
+     * Evicts oldest sidecars until the on-disk footprint is within [capBytes]. Oldest is ordered by
+     * [File.lastModified]; on a successful write the just-written file has the newest mtime, so it
+     * is only evicted if a single sidecar exceeds the cap (which shouldn't happen since the
+     * streaming fetcher keeps only the ~1 MB non-audio prefix). Returns the set of evicted keys
+     * (the base filename without extension) for test assertions and internal state cleanup.
+     */
+    internal fun enforceLruBudget(capBytes: Long = MAX_CACHE_BYTES): Set<String> {
+        val files = dir().listFiles().orEmpty()
+            .filter { it.isFile && it.extension == "epub" && it.length() > 0 }
+        var total = files.sumOf { it.length() }
+        if (total <= capBytes) return emptySet()
+        val evicted = mutableSetOf<String>()
+        files.sortedBy { it.lastModified() }.forEach { file ->
+            if (total <= capBytes) return@forEach
+            val size = file.length()
+            if (file.delete()) {
+                total -= size
+                evicted += file.nameWithoutExtension
+            }
+        }
+        if (evicted.isNotEmpty()) {
+            _states.value = _states.value.filterKeys { it !in evicted }
+        }
+        return evicted
+    }
+
     private companion object {
         // 3 retries (4 total attempts). Each attempt is bounded by sidecarStreamClient's callTimeout(240s).
         // Backoff covers transient server load; the dominant cost per attempt is the 240s network timeout.
         const val MAX_RETRIES = 3
         val RETRY_BACKOFF_MS = longArrayOf(30_000L, 60_000L, 120_000L)
+        // 200 MB cap. A sidecar is the ~1 MB non-audio prefix, so this comfortably holds 100+ books
+        // before eviction kicks in — enough that no realistic session hits the ceiling, but bounded
+        // enough that a rarely-cleaned-cache install doesn't grow indefinitely.
+        const val MAX_CACHE_BYTES: Long = 200L * 1024L * 1024L
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudSidecarStore.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudSidecarStore.kt
@@ -89,7 +89,7 @@ class ReadaloudSidecarStore private constructor(
         // Ready and prepare() a no-op, so streaming always fails. Deleting forces a fresh fetch.
         scope.launch {
             dir().listFiles().orEmpty()
-                .filter { it.isFile && it.extension == "epub" && it.length() > 0 }
+                .filter { it.isFile && it.extension == SIDECAR_EXTENSION && it.length() > 0 }
                 .forEach { file ->
                     val hasClips = runCatching {
                         MediaOverlayReader.readTrack(file).clips.isNotEmpty()
@@ -109,10 +109,10 @@ class ReadaloudSidecarStore private constructor(
     /** Per-book prepare states, keyed by [key]. A book is also implicitly [State.Ready] when [cachedFile] exists. */
     val states: StateFlow<Map<String, State>> = _states
 
-    fun key(storytellerSourceId: String, storytellerBookId: String) = "$storytellerSourceId-$storytellerBookId"
+    fun key(storytellerSourceId: String, storytellerBookId: String) = "$storytellerSourceId$KEY_SEPARATOR$storytellerBookId"
 
-    private fun dir(): File = File(cacheRootDir(), "readaloud-sidecars").apply { mkdirs() }
-    private fun fileFor(sourceId: String, bookId: String) = File(dir(), "${key(sourceId, bookId)}.epub")
+    private fun dir(): File = File(cacheRootDir(), SIDECAR_DIR_NAME).apply { mkdirs() }
+    private fun fileFor(sourceId: String, bookId: String) = File(dir(), "${key(sourceId, bookId)}.$SIDECAR_EXTENSION")
 
     /** The cached sidecar if it's already on disk — never triggers a fetch. */
     override fun cachedFile(storytellerSourceId: String, storytellerBookId: String): File? =
@@ -189,7 +189,7 @@ class ReadaloudSidecarStore private constructor(
     /** All cached sidecars. The filename is `<storytellerSourceId>-<storytellerBookId>.epub`; the book id
      *  is numeric (no hyphens), so the last hyphen splits it from the (UUID) server id. */
     fun listCached(): List<CachedSidecar> =
-        dir().listFiles().orEmpty().filter { it.isFile && it.extension == "epub" && it.length() > 0 }.mapNotNull { f ->
+        dir().listFiles().orEmpty().filter { it.isFile && it.extension == SIDECAR_EXTENSION && it.length() > 0 }.mapNotNull { f ->
             val name = f.nameWithoutExtension
             val sourceId = name.substringBeforeLast('-', "")
             val bookId = name.substringAfterLast('-', "")
@@ -214,9 +214,9 @@ class ReadaloudSidecarStore private constructor(
      * cache dir doesn't retain files whose owning source no longer exists.
      */
     override fun purgeSource(storytellerSourceId: String) {
-        val prefix = "$storytellerSourceId-"
+        val prefix = "$storytellerSourceId$KEY_SEPARATOR"
         dir().listFiles().orEmpty()
-            .filter { it.isFile && it.extension == "epub" && it.name.startsWith(prefix) }
+            .filter { it.isFile && it.extension == SIDECAR_EXTENSION && it.name.startsWith(prefix) }
             .forEach { it.delete() }
         _states.value = _states.value.filterKeys { !it.startsWith(prefix) }
     }
@@ -230,7 +230,7 @@ class ReadaloudSidecarStore private constructor(
      */
     internal fun enforceLruBudget(capBytes: Long = MAX_CACHE_BYTES): Set<String> {
         val files = dir().listFiles().orEmpty()
-            .filter { it.isFile && it.extension == "epub" && it.length() > 0 }
+            .filter { it.isFile && it.extension == SIDECAR_EXTENSION && it.length() > 0 }
         var total = files.sumOf { it.length() }
         if (total <= capBytes) return emptySet()
         val evicted = mutableSetOf<String>()
@@ -257,5 +257,12 @@ class ReadaloudSidecarStore private constructor(
         // before eviction kicks in — enough that no realistic session hits the ceiling, but bounded
         // enough that a rarely-cleaned-cache install doesn't grow indefinitely.
         const val MAX_CACHE_BYTES: Long = 200L * 1024L * 1024L
+        // Filename shape is `<sourceId><KEY_SEPARATOR><bookId>.<SIDECAR_EXTENSION>`. The extension
+        // is .epub because the sidecar is an EPUB container carrying only the SMIL + text prefix
+        // (no audio). Both are referenced from the cache-dir name and every listFiles filter, so
+        // they live here rather than as inline literals — a rename can then land in one place.
+        const val SIDECAR_EXTENSION: String = "epub"
+        const val SIDECAR_DIR_NAME: String = "readaloud-sidecars"
+        const val KEY_SEPARATOR: String = "-"
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudSidecarStore.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudSidecarStore.kt
@@ -186,13 +186,13 @@ class ReadaloudSidecarStore private constructor(
     /** A prepared sidecar on disk — surfaced in the Downloads screen so the user can see/clear it. */
     data class CachedSidecar(val storytellerSourceId: String, val storytellerBookId: String, val sizeBytes: Long)
 
-    /** All cached sidecars. The filename is `<storytellerSourceId>-<storytellerBookId>.epub`; the book id
-     *  is numeric (no hyphens), so the last hyphen splits it from the (UUID) server id. */
+    /** All cached sidecars. The filename is `<storytellerSourceId><KEY_SEPARATOR><storytellerBookId>.<SIDECAR_EXTENSION>`;
+     *  the book id is numeric (no [KEY_SEPARATOR]), so the last separator splits it from the (UUID) server id. */
     fun listCached(): List<CachedSidecar> =
         dir().listFiles().orEmpty().filter { it.isFile && it.extension == SIDECAR_EXTENSION && it.length() > 0 }.mapNotNull { f ->
             val name = f.nameWithoutExtension
-            val sourceId = name.substringBeforeLast('-', "")
-            val bookId = name.substringAfterLast('-', "")
+            val sourceId = name.substringBeforeLast(KEY_SEPARATOR, "")
+            val bookId = name.substringAfterLast(KEY_SEPARATOR, "")
             if (sourceId.isEmpty() || bookId.isEmpty()) null else CachedSidecar(sourceId, bookId, f.length())
         }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.SourceDao
 import com.riffle.core.domain.CommitSourceResult
 import com.riffle.core.domain.PendingSource
+import com.riffle.core.domain.ReadaloudSidecarCache
 import com.riffle.core.domain.RemoteUserIdResolver
 import com.riffle.core.models.Source
 import com.riffle.core.domain.SourceFilesCleaner
@@ -20,6 +21,7 @@ import com.riffle.core.network.AbsServerInfoApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
+import javax.inject.Provider
 
 class SourceRepositoryImpl @Inject constructor(
     private val dao: SourceDao,
@@ -28,6 +30,11 @@ class SourceRepositoryImpl @Inject constructor(
     private val libraryDao: LibraryDao,
     private val libraryItemDao: LibraryItemDao,
     private val filesCleaner: SourceFilesCleaner,
+    // Provider (not direct injection) breaks the SourceRepository ↔ ReadaloudSidecarStore Hilt
+    // cycle: the sidecar store needs SourceRepository to look up per-source credentials, and the
+    // repository needs the cache to purge on source removal. Lazy resolution here means the store
+    // is only constructed on the removal path — long after graph resolution has settled.
+    private val sidecarCache: Provider<ReadaloudSidecarCache>,
     private val installer: CredentialedSourceInstaller,
     private val remoteUserIdResolvers: Map<SourceType, @JvmSuppressWildcards RemoteUserIdResolver>,
 ) : SourceRepository {
@@ -71,6 +78,9 @@ class SourceRepositoryImpl @Inject constructor(
         // The file stores live outside Room, so the FK cascade above doesn't touch them — purge the
         // Source's downloaded/cached files here so they don't leak on disk after removal.
         filesCleaner.deleteAllForSource(sourceId)
+        // Readaloud sidecars live in the app cacheDir and are keyed to the storyteller source id;
+        // a re-added source shouldn't inherit sidecars from its predecessor.
+        sidecarCache.get().purgeSource(sourceId)
     }
 
     override suspend fun getSourceVersion(sourceId: String): String? {

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -19,6 +19,7 @@ import com.riffle.core.database.ReadaloudDismissalDao
 import com.riffle.core.database.ReadaloudLinkDao
 import com.riffle.core.database.ReadaloudResumePositionDao
 import com.riffle.core.database.ReadingPositionDao
+import com.riffle.core.database.PlaylistDao
 import com.riffle.core.database.RemoteItemFreshnessDao
 import com.riffle.core.database.RiffleDatabase
 import com.riffle.core.database.SeriesDao
@@ -96,6 +97,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_54_55,
                 RiffleDatabase.MIGRATION_55_56,
                 RiffleDatabase.MIGRATION_56_57,
+                RiffleDatabase.MIGRATION_57_58,
             )
             .build()
 
@@ -190,4 +192,8 @@ object DatabaseModule {
     @Singleton
     fun provideRemoteItemFreshnessDao(db: RiffleDatabase): RemoteItemFreshnessDao =
         db.remoteItemFreshnessDao()
+
+    @Provides
+    @Singleton
+    fun providePlaylistDao(db: RiffleDatabase): PlaylistDao = db.playlistDao()
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/NetworkModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/NetworkModule.kt
@@ -5,6 +5,8 @@ import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.network.AbsApi
 import com.riffle.core.network.AbsApiClient
 import com.riffle.core.data.di.qualifiers.WebSourceOkHttpClient
+import com.riffle.core.network.DEFAULT_HTTP_CACHE_RULES
+import com.riffle.core.network.EndpointCacheHeadersInterceptor
 import com.riffle.core.network.ForceCacheHeadersInterceptor
 import com.riffle.core.network.OfflineStaleFallbackInterceptor
 import com.riffle.core.network.AbsBookmarkApi
@@ -68,9 +70,26 @@ abstract class NetworkModule {
     abstract fun bindStorytellerLibraryApi(impl: StorytellerApiClient): StorytellerLibraryApi
 
     companion object {
+        /**
+         * Shared default client for ABS, Storyteller, and the GitHub releases updater. Carries a
+         * 20 MB disk cache and a network interceptor that stamps `Cache-Control: public, max-age=N`
+         * on a small allowlist of read-only endpoints ([DEFAULT_HTTP_CACHE_RULES]). Writes, progress,
+         * sessions, and binaries do not match any rule and pass through as before.
+         */
         @Provides
         @Singleton
-        fun provideOkHttpClient(): OkHttpClient = OkHttpClient.Builder().build()
+        fun provideOkHttpClient(
+            @ApplicationContext context: Context,
+        ): OkHttpClient {
+            val cacheDir = File(context.cacheDir, "default-http")
+            val cache = Cache(cacheDir, DEFAULT_HTTP_CACHE_BYTES)
+            return OkHttpClient.Builder()
+                .cache(cache)
+                .addNetworkInterceptor(EndpointCacheHeadersInterceptor(DEFAULT_HTTP_CACHE_RULES))
+                .build()
+        }
+
+        private const val DEFAULT_HTTP_CACHE_BYTES: Long = 20L * 1024L * 1024L
 
         /**
          * OkHttp client for web-source scrapers (ADR 0043). Carries a 10 MB disk cache,

--- a/core/data/src/test/kotlin/com/riffle/core/data/PlaylistsRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/PlaylistsRepositoryTest.kt
@@ -12,10 +12,21 @@ import com.riffle.core.catalog.CatalogRoot
 import com.riffle.core.catalog.FacetSelection
 import com.riffle.core.catalog.PlaylistsCapability
 import com.riffle.core.catalog.SortKey
+import com.riffle.core.database.PlaylistDao
+import com.riffle.core.database.PlaylistEntity
+import com.riffle.core.database.PlaylistItemEntity
+import com.riffle.core.domain.CommitSourceResult
+import com.riffle.core.domain.PendingSource
+import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.Source
 import com.riffle.core.models.SourceType
+import com.riffle.core.models.SourceUrl
 import com.riffle.core.logging.RecordingLogger
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -27,17 +38,18 @@ import org.junit.Test
 
 class PlaylistsRepositoryTest {
 
-    private fun makeRepo(catalog: Catalog?) =
-        PlaylistsRepositoryImpl(FakeRegistry(catalog), RecordingLogger())
+    private fun makeRepo(catalog: Catalog?): PlaylistsRepositoryImpl {
+        val dao = FakePlaylistDao()
+        return PlaylistsRepositoryImpl(
+            catalogRegistry = FakeRegistry(catalog),
+            sourceRepository = FakeSourceRepository(),
+            dao = dao,
+            logger = RecordingLogger(),
+        )
+    }
 
     // ── the "To Read" invariant ───────────────────────────────────────────────
 
-    /**
-     * Regression test for the reserved-name filter. If someone removes the filter in
-     * [PlaylistsRepositoryImpl.observePlaylists] or renames [TO_READ_PLAYLIST_NAME], this assertion
-     * flips red — which is the point. "To Read" MUST NOT appear in the user-facing Playlists
-     * surface; it belongs to [ToReadRepository]'s dedicated tab and affordance.
-     */
     @Test
     fun `observePlaylists hides the reserved To Read playlist`() = runTest {
         val cap = FakeCatalog(
@@ -55,11 +67,6 @@ class PlaylistsRepositoryTest {
         assertEquals(listOf("Favourites", "Yearly reread"), names)
     }
 
-    /**
-     * "To Listen" is the audiobook wishlist equivalent surfaced by ABS — the general Playlists
-     * surface must hide it for the same reason it hides "To Read". Regression test: if the
-     * reserved set drops "To Listen" this flips red.
-     */
     @Test
     fun `observePlaylists hides the reserved To Listen playlist`() = runTest {
         val cap = FakeCatalog(
@@ -111,7 +118,6 @@ class PlaylistsRepositoryTest {
             repo.createPlaylist("lib-1", TO_READ_PLAYLIST_NAME)
             fail("expected ReservedPlaylistNameException")
         } catch (_: ReservedPlaylistNameException) {
-            // expected
         }
         assertTrue("must not hit the source", cap.createCalls.isEmpty())
     }
@@ -130,14 +136,14 @@ class PlaylistsRepositoryTest {
         assertTrue(cap.createCalls.isEmpty())
     }
 
-    // ── refresh + cache ───────────────────────────────────────────────────────
+    // ── refresh + cache (Room-backed) ─────────────────────────────────────────
 
     @Test
-    fun `refresh populates the per-root cache`() = runTest {
+    fun `refresh persists per-root cache`() = runTest {
         val cap = FakeCatalog(
             mapOf(
-                "lib-1" to listOf(playlist("pl-a", "A", listOf("i-1"))),
-                "lib-2" to listOf(playlist("pl-b", "B", listOf("i-2"))),
+                "lib-1" to listOf(playlist("pl-a", "A", listOf("i-1"), rootId = "lib-1")),
+                "lib-2" to listOf(playlist("pl-b", "B", listOf("i-2"), rootId = "lib-2")),
             ),
         )
         val repo = makeRepo(cap)
@@ -188,7 +194,7 @@ class PlaylistsRepositoryTest {
     // ── add / remove ──────────────────────────────────────────────────────────
 
     @Test
-    fun `addItemToPlaylist optimistically updates cache then hits source`() = runTest {
+    fun `addItemToPlaylist updates the DAO after the source call succeeds`() = runTest {
         val cap = FakeCatalog(mapOf("lib-1" to listOf(playlist("pl-a", "Favs", emptyList()))))
         val repo = makeRepo(cap)
         repo.refresh("lib-1")
@@ -198,7 +204,7 @@ class PlaylistsRepositoryTest {
     }
 
     @Test
-    fun `addItemToPlaylist reverts cache when source fails`() = runTest {
+    fun `addItemToPlaylist leaves DAO untouched when source fails`() = runTest {
         val cap = FakeCatalog(
             mapOf("lib-1" to listOf(playlist("pl-a", "Favs", listOf("i-0")))),
             addFails = true,
@@ -230,7 +236,7 @@ class PlaylistsRepositoryTest {
 
     /**
      * When the last item is removed, ABS auto-deletes the playlist server-side. The repository
-     * mirrors that by dropping the playlist from the cache so the tab hides immediately without
+     * mirrors that by dropping the playlist from the DAO so the tab hides immediately without
      * waiting for the next refresh — pinning that behaviour here.
      */
     @Test
@@ -243,7 +249,7 @@ class PlaylistsRepositoryTest {
     }
 
     @Test
-    fun `removeItemFromPlaylist reverts cache when source fails`() = runTest {
+    fun `removeItemFromPlaylist leaves DAO untouched when source fails`() = runTest {
         val cap = FakeCatalog(
             mapOf("lib-1" to listOf(playlist("pl-a", "Favs", listOf("i-1", "i-2")))),
             removeFails = true,
@@ -257,10 +263,7 @@ class PlaylistsRepositoryTest {
     // ── getPlaylist ───────────────────────────────────────────────────────────
 
     @Test
-    fun `getPlaylist returns the full playlist including To Read (repository is not the filter for detail lookups)`() = runTest {
-        // A caller with the id already in hand (e.g. from a nav argument) may be inside a screen
-        // that shouldn't exist for To Read, but the repository itself only filters the LIST — the
-        // per-id lookup is transparent so a debugging session can still resolve it if needed.
+    fun `getPlaylist returns the full playlist including To Read`() = runTest {
         val cap = FakeCatalog(mapOf("lib-1" to listOf(playlist("pl-a", "Favs", listOf("i-1")))))
         val repo = makeRepo(cap)
         val loaded = repo.getPlaylist("lib-1", "pl-a")
@@ -277,14 +280,85 @@ class PlaylistsRepositoryTest {
 
     // ── helpers ───────────────────────────────────────────────────────────────
 
-    private fun playlist(id: String, name: String, itemIds: List<String>) = CatalogPlaylist(
-        id = id, rootId = "lib-1", name = name, bookCount = itemIds.size, itemIds = itemIds,
+    private fun playlist(id: String, name: String, itemIds: List<String>, rootId: String = "lib-1") = CatalogPlaylist(
+        id = id, rootId = rootId, name = name, bookCount = itemIds.size, itemIds = itemIds,
     )
 
     private class FakeRegistry(private val catalog: Catalog?) : CatalogRegistry {
         override suspend fun forActive(): Catalog? = catalog
         override suspend fun forSource(source: Source): Catalog? = catalog
         override suspend fun forSourceId(sourceId: String): Catalog? = catalog
+    }
+
+    private class FakeSourceRepository : SourceRepository {
+        private val active = Source(
+            id = "srv-1",
+            url = SourceUrl.parse("http://abs")!!,
+            isActive = true,
+            insecureConnectionAllowed = false,
+            username = "test",
+        )
+        override fun observeAll(): Flow<List<Source>> = flowOf(listOf(active))
+        override suspend fun getActive(): Source? = active
+        override suspend fun getById(sourceId: String): Source? = if (sourceId == active.id) active else null
+        override suspend fun commit(pending: PendingSource, hiddenLibraryIds: Set<String>): CommitSourceResult =
+            throw UnsupportedOperationException()
+        override suspend fun setActive(sourceId: String) = Unit
+        override suspend fun remove(sourceId: String) = Unit
+        override suspend fun getSourceVersion(sourceId: String): String? = null
+    }
+
+    private class FakePlaylistDao : PlaylistDao {
+        private val playlistsRef = MutableStateFlow(emptyList<PlaylistEntity>())
+        private val itemsRef = MutableStateFlow(emptyList<PlaylistItemEntity>())
+
+        override fun observeByRootId(rootId: String): Flow<List<PlaylistEntity>> =
+            playlistsRef.map { list -> list.filter { it.rootId == rootId }.sortedBy { it.name } }
+
+        override fun observeItemIds(sourceId: String, playlistId: String): Flow<List<String>> =
+            itemsRef.map { list ->
+                list.filter { it.sourceId == sourceId && it.playlistId == playlistId }
+                    .sortedBy { it.orderIndex }
+                    .map { it.itemId }
+            }
+
+        override suspend fun itemIds(sourceId: String, playlistId: String): List<String> =
+            itemsRef.value
+                .filter { it.sourceId == sourceId && it.playlistId == playlistId }
+                .sortedBy { it.orderIndex }
+                .map { it.itemId }
+
+        override suspend fun getById(sourceId: String, playlistId: String): PlaylistEntity? =
+            playlistsRef.value.firstOrNull { it.sourceId == sourceId && it.id == playlistId }
+
+        override suspend fun upsertAll(playlists: List<PlaylistEntity>) {
+            playlistsRef.value = playlistsRef.value.filterNot { existing ->
+                playlists.any { it.sourceId == existing.sourceId && it.id == existing.id }
+            } + playlists
+        }
+
+        override suspend fun upsertAllItems(items: List<PlaylistItemEntity>) {
+            itemsRef.value = itemsRef.value.filterNot { existing ->
+                items.any { it.playlistId == existing.playlistId && it.sourceId == existing.sourceId && it.itemId == existing.itemId }
+            } + items
+        }
+
+        override suspend fun deleteByRootId(rootId: String) {
+            playlistsRef.value = playlistsRef.value.filterNot { it.rootId == rootId }
+        }
+
+        override suspend fun deleteItemsByRootId(rootId: String) {
+            val playlistIds = playlistsRef.value.filter { it.rootId == rootId }.map { it.id }.toSet()
+            itemsRef.value = itemsRef.value.filterNot { it.playlistId in playlistIds }
+        }
+
+        override suspend fun deletePlaylist(sourceId: String, playlistId: String) {
+            playlistsRef.value = playlistsRef.value.filterNot { it.sourceId == sourceId && it.id == playlistId }
+        }
+
+        override suspend fun deletePlaylistItems(sourceId: String, playlistId: String) {
+            itemsRef.value = itemsRef.value.filterNot { it.sourceId == sourceId && it.playlistId == playlistId }
+        }
     }
 
     private class FakeCatalog(

--- a/core/data/src/test/kotlin/com/riffle/core/data/PlaylistsRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/PlaylistsRepositoryTest.kt
@@ -50,6 +50,12 @@ class PlaylistsRepositoryTest {
 
     // ── the "To Read" invariant ───────────────────────────────────────────────
 
+    /**
+     * Regression test for the reserved-name filter. If someone removes the filter in
+     * [PlaylistsRepositoryImpl.observePlaylists] or renames [TO_READ_PLAYLIST_NAME], this assertion
+     * flips red — which is the point. "To Read" MUST NOT appear in the user-facing Playlists
+     * surface; it belongs to [ToReadRepository]'s dedicated tab and affordance.
+     */
     @Test
     fun `observePlaylists hides the reserved To Read playlist`() = runTest {
         val cap = FakeCatalog(
@@ -67,6 +73,11 @@ class PlaylistsRepositoryTest {
         assertEquals(listOf("Favourites", "Yearly reread"), names)
     }
 
+    /**
+     * "To Listen" is the audiobook wishlist equivalent surfaced by ABS — the general Playlists
+     * surface must hide it for the same reason it hides "To Read". Regression test: if the
+     * reserved set drops "To Listen" this flips red.
+     */
     @Test
     fun `observePlaylists hides the reserved To Listen playlist`() = runTest {
         val cap = FakeCatalog(

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudSidecarStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudSidecarStoreTest.kt
@@ -172,6 +172,60 @@ class ReadaloudSidecarStoreTest {
         assertEquals(ReadaloudSidecarStore.State.Failed, store.stateOf("srv", "42"))
     }
 
+    // --- purge on source removal ---
+
+    @Test
+    fun `purgeSource deletes only files owned by that source`() = testScope.runTest {
+        val store = store(fetcher { validSidecar })
+        val dir = java.io.File(tmp.root, "readaloud-sidecars").apply { mkdirs() }
+        // Two sources, three books total.
+        java.io.File(dir, "srv-1.epub").writeBytes(byteArrayOf(1, 2, 3))
+        java.io.File(dir, "srv-2.epub").writeBytes(byteArrayOf(1, 2, 3))
+        java.io.File(dir, "other-9.epub").writeBytes(byteArrayOf(1, 2, 3))
+
+        store.purgeSource("srv")
+
+        assertNull(store.cachedFile("srv", "1"))
+        assertNull(store.cachedFile("srv", "2"))
+        assertNotNull(store.cachedFile("other", "9"))
+    }
+
+    // --- LRU eviction ---
+
+    @Test
+    fun `enforceLruBudget evicts oldest files first once cap is exceeded`() = testScope.runTest {
+        val store = store(fetcher { validSidecar })
+        val dir = java.io.File(tmp.root, "readaloud-sidecars").apply { mkdirs() }
+        // Three 100-byte files with strictly-increasing mtimes. Cap of 250 must evict exactly one
+        // (the oldest) to bring total from 300 → 200.
+        val oldest = java.io.File(dir, "srv-1.epub").apply { writeBytes(ByteArray(100)) }
+        val middle = java.io.File(dir, "srv-2.epub").apply { writeBytes(ByteArray(100)) }
+        val newest = java.io.File(dir, "srv-3.epub").apply { writeBytes(ByteArray(100)) }
+        oldest.setLastModified(1_000)
+        middle.setLastModified(2_000)
+        newest.setLastModified(3_000)
+
+        val evicted = store.enforceLruBudget(capBytes = 250)
+
+        // Oldest goes first. Once we're back under cap, no more evictions.
+        assertEquals(setOf("srv-1"), evicted)
+        assertEquals(false, oldest.exists())
+        assertEquals(true, middle.exists())
+        assertEquals(true, newest.exists())
+    }
+
+    @Test
+    fun `enforceLruBudget is a no-op when total is under cap`() = testScope.runTest {
+        val store = store(fetcher { validSidecar })
+        val dir = java.io.File(tmp.root, "readaloud-sidecars").apply { mkdirs() }
+        java.io.File(dir, "srv-1.epub").writeBytes(ByteArray(50))
+        java.io.File(dir, "srv-2.epub").writeBytes(ByteArray(50))
+
+        val evicted = store.enforceLruBudget(capBytes = 1_000)
+
+        assertEquals(emptySet<String>(), evicted)
+    }
+
     // --- helpers ---
 
     private fun zipOf(vararg entries: Pair<String, ByteArray>): ByteArray {

--- a/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
@@ -133,6 +133,14 @@ class ServerRepositoryTest {
 
     private fun fakeFilesCleaner() = RecordingFilesCleaner()
 
+    private class RecordingSidecarCache : com.riffle.core.domain.ReadaloudSidecarCache {
+        val purgedSourceIds = mutableListOf<String>()
+        override fun cachedFile(storytellerSourceId: String, storytellerBookId: String): java.io.File? = null
+        override fun purgeSource(storytellerSourceId: String) { purgedSourceIds += storytellerSourceId }
+    }
+
+    private fun fakeSidecarCache() = RecordingSidecarCache()
+
     private fun fakeLibraryItemDao() = object : com.riffle.core.database.LibraryItemDao {
         val deletedLibraryIds = mutableListOf<String>()
         private val rows = mutableMapOf<String, MutableList<com.riffle.core.database.LibraryItemEntity>>()
@@ -200,7 +208,9 @@ class ServerRepositoryTest {
         libraryItemDao: com.riffle.core.database.LibraryItemDao,
         visibilityStore: LibraryVisibilityPreferencesStore,
         filesCleaner: SourceFilesCleaner,
+        sidecarCache: com.riffle.core.domain.ReadaloudSidecarCache = fakeSidecarCache(),
     ): SourceRepositoryImpl {
+        val sidecarCacheProvider = javax.inject.Provider { sidecarCache }
         // absApi/storytellerApi/libraryApi are still accepted so callers that don't hit the auth
         // path can leave them as `error`-throwing stubs unchanged. They're wired into the auth
         // helper below on demand.
@@ -227,6 +237,7 @@ class ServerRepositoryTest {
             libraryDao = libraryDao,
             libraryItemDao = libraryItemDao,
             filesCleaner = filesCleaner,
+            sidecarCache = sidecarCacheProvider,
             installer = installer,
             remoteUserIdResolvers = resolvers,
         )

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/58.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/58.json
@@ -1,0 +1,1896 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 58,
+    "identityHash": "fde657f251245a99ad78b3a3c32808e0",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER NOT NULL, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, `pageCount` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesSequence",
+            "columnName": "seriesSequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "scope"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, `originFontFamily` TEXT, `emphasisStyles` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedFigures",
+            "columnName": "embeddedFigures",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageHref",
+            "columnName": "imageHref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageSvg",
+            "columnName": "imageSvg",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBytes",
+            "columnName": "imageBytes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originFontFamily",
+            "columnName": "originFontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "emphasisStyles",
+            "columnName": "emphasisStyles",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "local_files_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `treeUri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `addedAtEpochMs` INTEGER NOT NULL, `libraryId` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `treeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtEpochMs",
+            "columnName": "addedAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "treeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `originalUri` TEXT NOT NULL, `copiedPath` TEXT NOT NULL, `coverPath` TEXT, `format` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `mtimeEpochMs` INTEGER NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUri",
+            "columnName": "originalUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "copiedPath",
+            "columnName": "copiedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtimeEpochMs",
+            "columnName": "mtimeEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_files_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_file_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `folderTreeUri` TEXT NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`, `folderTreeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderTreeUri",
+            "columnName": "folderTreeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId",
+            "folderTreeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_file_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_local_files_file_folders_sourceId_folderTreeUri",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "folderTreeUri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId_folderTreeUri` ON `${TABLE_NAME}` (`sourceId`, `folderTreeUri`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_item_freshness",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `lastFetchedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFetchedAt",
+            "columnName": "lastFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `rootId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootId",
+            "columnName": "rootId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_playlists_rootId",
+            "unique": false,
+            "columnNames": [
+              "rootId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_rootId` ON `${TABLE_NAME}` (`rootId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `orderIndex` INTEGER NOT NULL, PRIMARY KEY(`playlistId`, `sourceId`, `itemId`), FOREIGN KEY(`sourceId`, `playlistId`) REFERENCES `playlists`(`sourceId`, `id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "orderIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId",
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_items_sourceId_playlistId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_items_sourceId_playlistId` ON `${TABLE_NAME}` (`sourceId`, `playlistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId",
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "sourceId",
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'fde657f251245a99ad78b3a3c32808e0')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1919,7 +1919,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 57, true,
+            TEST_DB, 58, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -1976,6 +1976,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_54_55,
             RiffleDatabase.MIGRATION_55_56,
             RiffleDatabase.MIGRATION_56_57,
+            RiffleDatabase.MIGRATION_57_58,
         )
 
         db.query("SELECT url, username, serverType, absUserId, type FROM sources WHERE id = 's1'").use { cursor ->
@@ -2645,6 +2646,62 @@ class MigrationTest {
             assertEquals("EMPHASIS", c.getString(0))
             assertEquals("bold,underline", c.getString(1))
         }
+
+        db.close()
+    }
+
+    // Mirrors ABS playlists to Room so the Playlists tab is populated on cold start. Two new
+    // tables: `playlists` (parent, FK-cascade to sources) and `playlist_items` (join, FK-cascade
+    // to the composite (sourceId, id) on `playlists`; `orderIndex` preserves stable itemIds
+    // reconstruction). Pre-existing rows must survive; FK-cascade must wipe both tables on
+    // source removal — no dangling join rows.
+    @Test
+    fun migration57To58_addsPlaylistsTables() {
+        helper.createDatabase(TEST_DB, 57).apply {
+            execSQL(
+                "INSERT INTO sources (id, url, isActive, insecureConnectionAllowed, username, serverType, absUserId, type) " +
+                    "VALUES ('abs1', 'http://abs', 1, 0, '', 'AUDIOBOOKSHELF', NULL, 'ABS')"
+            )
+            close()
+        }
+        val db = helper.runMigrationsAndValidate(TEST_DB, 58, true, RiffleDatabase.MIGRATION_57_58)
+
+        // New tables start empty.
+        db.query("SELECT COUNT(*) FROM playlists").use { c ->
+            assertTrue(c.moveToFirst()); assertEquals(0, c.getInt(0))
+        }
+        db.query("SELECT COUNT(*) FROM playlist_items").use { c ->
+            assertTrue(c.moveToFirst()); assertEquals(0, c.getInt(0))
+        }
+
+        // Playlist + items insert exercises every column and the composite PK / ordering.
+        db.execSQL(
+            "INSERT INTO playlists (id, sourceId, rootId, name, bookCount) " +
+                "VALUES ('pl1', 'abs1', 'lib1', 'Weekend reading', 2)"
+        )
+        db.execSQL(
+            "INSERT INTO playlist_items (playlistId, sourceId, itemId, orderIndex) " +
+                "VALUES ('pl1', 'abs1', 'itemA', 0), ('pl1', 'abs1', 'itemB', 1)"
+        )
+        db.query(
+            "SELECT itemId FROM playlist_items WHERE playlistId = 'pl1' ORDER BY orderIndex ASC"
+        ).use { c ->
+            val ids = mutableListOf<String>()
+            while (c.moveToNext()) ids += c.getString(0)
+            assertEquals(listOf("itemA", "itemB"), ids)
+        }
+
+        // FK ON DELETE CASCADE: removing the source drops both playlists and playlist_items
+        // (the latter via the composite FK from playlist_items → playlists).
+        db.execSQL("PRAGMA foreign_keys=ON")
+        db.execSQL("DELETE FROM sources WHERE id = 'abs1'")
+        db.query("SELECT COUNT(*) FROM playlists").use { c ->
+            assertTrue(c.moveToFirst()); assertEquals(0, c.getInt(0))
+        }
+        db.query("SELECT COUNT(*) FROM playlist_items").use { c ->
+            assertTrue(c.moveToFirst()); assertEquals(0, c.getInt(0))
+        }
+
         db.close()
     }
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/PlaylistDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/PlaylistDao.kt
@@ -1,0 +1,64 @@
+package com.riffle.core.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PlaylistDao {
+
+    @Query("SELECT * FROM playlists WHERE rootId = :rootId ORDER BY name ASC")
+    fun observeByRootId(rootId: String): Flow<List<PlaylistEntity>>
+
+    @Query("SELECT itemId FROM playlist_items WHERE sourceId = :sourceId AND playlistId = :playlistId ORDER BY orderIndex ASC")
+    fun observeItemIds(sourceId: String, playlistId: String): Flow<List<String>>
+
+    @Query("SELECT itemId FROM playlist_items WHERE sourceId = :sourceId AND playlistId = :playlistId ORDER BY orderIndex ASC")
+    suspend fun itemIds(sourceId: String, playlistId: String): List<String>
+
+    @Query("SELECT * FROM playlists WHERE sourceId = :sourceId AND id = :playlistId")
+    suspend fun getById(sourceId: String, playlistId: String): PlaylistEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAll(playlists: List<PlaylistEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAllItems(items: List<PlaylistItemEntity>)
+
+    @Query("DELETE FROM playlists WHERE rootId = :rootId")
+    suspend fun deleteByRootId(rootId: String)
+
+    @Query("DELETE FROM playlist_items WHERE playlistId IN (SELECT id FROM playlists WHERE rootId = :rootId)")
+    suspend fun deleteItemsByRootId(rootId: String)
+
+    @Query("DELETE FROM playlists WHERE sourceId = :sourceId AND id = :playlistId")
+    suspend fun deletePlaylist(sourceId: String, playlistId: String)
+
+    @Query("DELETE FROM playlist_items WHERE sourceId = :sourceId AND playlistId = :playlistId")
+    suspend fun deletePlaylistItems(sourceId: String, playlistId: String)
+
+    @Transaction
+    suspend fun replaceAllForRoot(
+        rootId: String,
+        playlists: List<PlaylistEntity>,
+        items: List<PlaylistItemEntity>,
+    ) {
+        deleteItemsByRootId(rootId)
+        deleteByRootId(rootId)
+        upsertAll(playlists)
+        upsertAllItems(items)
+    }
+
+    @Transaction
+    suspend fun replacePlaylist(
+        playlist: PlaylistEntity,
+        items: List<PlaylistItemEntity>,
+    ) {
+        deletePlaylistItems(playlist.sourceId, playlist.id)
+        upsertAll(listOf(playlist))
+        upsertAllItems(items)
+    }
+}

--- a/core/database/src/main/kotlin/com/riffle/core/database/PlaylistEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/PlaylistEntity.kt
@@ -1,0 +1,29 @@
+package com.riffle.core.database
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+// Playlists mirrored from the active Source (ADR 0027). Keyed by (sourceId, id) — playlist ids are
+// only unique within an ABS instance, so two Sources against the same instance would collide.
+// sourceId FK-cascades so removing a Source clears its playlists, mirroring LibraryEntity.
+@Entity(
+    tableName = "playlists",
+    primaryKeys = ["sourceId", "id"],
+    foreignKeys = [
+        ForeignKey(
+            entity = SourceEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["sourceId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("sourceId"), Index("rootId")],
+)
+data class PlaylistEntity(
+    val id: String,
+    val sourceId: String,
+    val rootId: String,
+    val name: String,
+    val bookCount: Int,
+)

--- a/core/database/src/main/kotlin/com/riffle/core/database/PlaylistItemEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/PlaylistItemEntity.kt
@@ -1,0 +1,30 @@
+package com.riffle.core.database
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+// itemIds membership per playlist, ordered via orderIndex so cold-start observation reconstructs
+// the same sequence the server returned on the last refresh (ABS playlists are user-ordered).
+// sourceId is duplicated on this row for the composite PK — ABS item ids collide across servers.
+// FK-cascades to `playlists(sourceId, id)` so removing a playlist (or the owning source, which
+// itself cascades to playlists) drops these rows too — no dangling join rows.
+@Entity(
+    tableName = "playlist_items",
+    primaryKeys = ["playlistId", "sourceId", "itemId"],
+    foreignKeys = [
+        ForeignKey(
+            entity = PlaylistEntity::class,
+            parentColumns = ["sourceId", "id"],
+            childColumns = ["sourceId", "playlistId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("sourceId", "playlistId")],
+)
+data class PlaylistItemEntity(
+    val playlistId: String,
+    val sourceId: String,
+    val itemId: String,
+    val orderIndex: Int,
+)

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -31,8 +31,10 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         LocalFilesFileEntity::class,
         LocalFilesFileFolderEntity::class,
         RemoteItemFreshnessEntity::class,
+        PlaylistEntity::class,
+        PlaylistItemEntity::class,
     ],
-    version = 57,
+    version = 58,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -58,6 +60,7 @@ abstract class RiffleDatabase : RoomDatabase() {
     abstract fun localFilesFileDao(): LocalFilesFileDao
     abstract fun localFilesFileFolderDao(): LocalFilesFileFolderDao
     abstract fun remoteItemFreshnessDao(): RemoteItemFreshnessDao
+    abstract fun playlistDao(): PlaylistDao
 
     companion object {
         val MIGRATION_1_2 = object : Migration(1, 2) {
@@ -1581,6 +1584,41 @@ abstract class RiffleDatabase : RoomDatabase() {
         val MIGRATION_56_57 = object : Migration(56, 57) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE `annotations` ADD COLUMN `emphasisStyles` TEXT DEFAULT NULL")
+            }
+        }
+
+        // Mirrors ABS playlists to Room (previously a MutableStateFlow) so the Playlists tab is
+        // populated on cold start without waiting for the first refresh. Shape mirrors collections:
+        // `playlists` FK-cascades from `sources`, `playlist_items` FK-cascades from the composite
+        // (sourceId, id) on `playlists` and stores `orderIndex` for stable itemIds reconstruction.
+        val MIGRATION_57_58 = object : Migration(57, 58) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `playlists` (" +
+                        "`id` TEXT NOT NULL, " +
+                        "`sourceId` TEXT NOT NULL, " +
+                        "`rootId` TEXT NOT NULL, " +
+                        "`name` TEXT NOT NULL, " +
+                        "`bookCount` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`sourceId`, `id`), " +
+                        "FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE)"
+                )
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_playlists_sourceId` ON `playlists` (`sourceId`)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_playlists_rootId` ON `playlists` (`rootId`)")
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `playlist_items` (" +
+                        "`playlistId` TEXT NOT NULL, " +
+                        "`sourceId` TEXT NOT NULL, " +
+                        "`itemId` TEXT NOT NULL, " +
+                        "`orderIndex` INTEGER NOT NULL, " +
+                        "PRIMARY KEY(`playlistId`, `sourceId`, `itemId`), " +
+                        "FOREIGN KEY(`sourceId`, `playlistId`) REFERENCES `playlists`(`sourceId`, `id`) " +
+                        "ON UPDATE NO ACTION ON DELETE CASCADE)"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_playlist_items_sourceId_playlistId` " +
+                        "ON `playlist_items` (`sourceId`, `playlistId`)"
+                )
             }
         }
     }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudSidecarCache.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReadaloudSidecarCache.kt
@@ -3,6 +3,12 @@ package com.riffle.core.domain
 import java.io.File
 
 /** Read-only view of the sidecar cache: is a book's sidecar on disk? */
-fun interface ReadaloudSidecarCache {
+interface ReadaloudSidecarCache {
     fun cachedFile(storytellerSourceId: String, storytellerBookId: String): File?
+
+    /**
+     * Deletes every cached sidecar owned by [storytellerSourceId]. Called from the source-removal
+     * path (`SourceRepositoryImpl.remove`) so cached files don't outlive their owning source row.
+     */
+    fun purgeSource(storytellerSourceId: String)
 }

--- a/core/network/src/main/kotlin/com/riffle/core/network/DefaultHttpCacheRules.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/DefaultHttpCacheRules.kt
@@ -1,11 +1,16 @@
 package com.riffle.core.network
 
 /**
- * Cache-Control rules for the shared default `OkHttpClient` used by ABS, Storyteller, and the
- * GitHub releases updater. Rules are conservative: only endpoints whose response is either
- * effectively immutable within the TTL window (server version, user identity, library metadata)
- * or where a stale read is harmless (listening-stats, releases). Progress, session, bookmark, and
- * ebook-binary paths are deliberately absent so a cached copy never masks a live write.
+ * Cache-Control rules for the shared default `OkHttpClient` used by ABS and the GitHub releases
+ * updater. Rules are conservative: only endpoints whose response is either effectively immutable
+ * within the TTL window (server version, user identity, library metadata) or where a stale read
+ * is harmless (listening-stats). Progress, session, bookmark, and ebook-binary paths are
+ * deliberately absent so a cached copy never masks a live write.
+ *
+ * GitHub `/repos/{owner}/{repo}/releases` is deliberately NOT listed: the only caller is the manual Settings
+ * "Check for updates" button, where the user's contract is "check now." A cached response would
+ * make the button silently no-op for up to N hours after the first check. There is no automatic
+ * launch check to amortize.
  *
  * TTL rationale:
  *  - `/status` (5m): version banner + connectivity ping. Only changes on server upgrade.
@@ -13,8 +18,6 @@ package com.riffle.core.network
  *  - `/api/libraries` (15m): library list. Change requires an admin action.
  *  - `/api/libraries/{id}/series` and `/collections` (10m): shape rarely churns mid-session.
  *  - `/api/me/listening-stats` (60s): stats screen entry cost; a minute-old total is fine.
- *  - GitHub `/repos/{owner}/{repo}/releases` (6h): only checked at launch and behind a manual
- *    refresh; a 6-hour cache saves the round-trip on every cold start.
  */
 val DEFAULT_HTTP_CACHE_RULES: List<EndpointCacheHeadersInterceptor.Rule> = listOf(
     EndpointCacheHeadersInterceptor.Rule(Regex("""^/status$"""), maxAgeSeconds = 5 * 60),
@@ -23,5 +26,4 @@ val DEFAULT_HTTP_CACHE_RULES: List<EndpointCacheHeadersInterceptor.Rule> = listO
     EndpointCacheHeadersInterceptor.Rule(Regex("""^/api/libraries$"""), maxAgeSeconds = 15 * 60),
     EndpointCacheHeadersInterceptor.Rule(Regex("""^/api/libraries/[^/]+/series$"""), maxAgeSeconds = 10 * 60),
     EndpointCacheHeadersInterceptor.Rule(Regex("""^/api/libraries/[^/]+/collections$"""), maxAgeSeconds = 10 * 60),
-    EndpointCacheHeadersInterceptor.Rule(Regex("""^/repos/[^/]+/[^/]+/releases$"""), maxAgeSeconds = 6 * 60 * 60),
 )

--- a/core/network/src/main/kotlin/com/riffle/core/network/DefaultHttpCacheRules.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/DefaultHttpCacheRules.kt
@@ -1,0 +1,27 @@
+package com.riffle.core.network
+
+/**
+ * Cache-Control rules for the shared default `OkHttpClient` used by ABS, Storyteller, and the
+ * GitHub releases updater. Rules are conservative: only endpoints whose response is either
+ * effectively immutable within the TTL window (server version, user identity, library metadata)
+ * or where a stale read is harmless (listening-stats, releases). Progress, session, bookmark, and
+ * ebook-binary paths are deliberately absent so a cached copy never masks a live write.
+ *
+ * TTL rationale:
+ *  - `/status` (5m): version banner + connectivity ping. Only changes on server upgrade.
+ *  - `/api/me` (15m): user id + prefs. Server-side edits are rare and the app re-fetches on refresh.
+ *  - `/api/libraries` (15m): library list. Change requires an admin action.
+ *  - `/api/libraries/{id}/series` and `/collections` (10m): shape rarely churns mid-session.
+ *  - `/api/me/listening-stats` (60s): stats screen entry cost; a minute-old total is fine.
+ *  - GitHub `/repos/{owner}/{repo}/releases` (6h): only checked at launch and behind a manual
+ *    refresh; a 6-hour cache saves the round-trip on every cold start.
+ */
+val DEFAULT_HTTP_CACHE_RULES: List<EndpointCacheHeadersInterceptor.Rule> = listOf(
+    EndpointCacheHeadersInterceptor.Rule(Regex("""^/status$"""), maxAgeSeconds = 5 * 60),
+    EndpointCacheHeadersInterceptor.Rule(Regex("""^/api/me/listening-stats$"""), maxAgeSeconds = 60),
+    EndpointCacheHeadersInterceptor.Rule(Regex("""^/api/me$"""), maxAgeSeconds = 15 * 60),
+    EndpointCacheHeadersInterceptor.Rule(Regex("""^/api/libraries$"""), maxAgeSeconds = 15 * 60),
+    EndpointCacheHeadersInterceptor.Rule(Regex("""^/api/libraries/[^/]+/series$"""), maxAgeSeconds = 10 * 60),
+    EndpointCacheHeadersInterceptor.Rule(Regex("""^/api/libraries/[^/]+/collections$"""), maxAgeSeconds = 10 * 60),
+    EndpointCacheHeadersInterceptor.Rule(Regex("""^/repos/[^/]+/[^/]+/releases$"""), maxAgeSeconds = 6 * 60 * 60),
+)

--- a/core/network/src/main/kotlin/com/riffle/core/network/EndpointCacheHeadersInterceptor.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/EndpointCacheHeadersInterceptor.kt
@@ -1,0 +1,38 @@
+package com.riffle.core.network
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * Network interceptor that stamps `Cache-Control: public, max-age=<n>` on successful responses
+ * whose path matches one of the supplied rules. Non-2xx and non-matching requests pass through
+ * untouched, so writes and error responses are never cached.
+ *
+ * Rules are evaluated in order; the first match wins. The path passed to each rule is the URL's
+ * `encodedPath` (no query string), lowercased. Query-parameter differences still key separate
+ * cache entries because OkHttp caches on the full URL.
+ *
+ * Used for API endpoints whose origin sends `Cache-Control: private` or no cache header at all
+ * (Audiobookshelf, GitHub Releases). Non-cacheable endpoints on the same client — writes, session
+ * calls, binary streams — simply don't match any rule and behave as before.
+ */
+class EndpointCacheHeadersInterceptor(
+    private val rules: List<Rule>,
+) : Interceptor {
+
+    data class Rule(val pattern: Regex, val maxAgeSeconds: Int)
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val response = chain.proceed(request)
+        if (!response.isSuccessful) return response
+        if (request.method != "GET") return response
+        val path = request.url.encodedPath.lowercase()
+        val rule = rules.firstOrNull { it.pattern.containsMatchIn(path) } ?: return response
+        return response.newBuilder()
+            .removeHeader("Pragma")
+            .removeHeader("Cache-Control")
+            .header("Cache-Control", "public, max-age=${rule.maxAgeSeconds}")
+            .build()
+    }
+}

--- a/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import okhttp3.CacheControl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
@@ -29,9 +30,15 @@ class GitHubReleaseApi(
      * doesn't stall the updater.
      */
     suspend fun latestRelease(repo: String): GitHubReleaseResult = withContext(dispatchers.io) {
+        // FORCE_NETWORK on the request: the only caller is the manual Settings "Check for updates"
+        // button whose contract is "check now". GitHub's response advertises `Cache-Control:
+        // max-age=60`, which the shared default OkHttp Cache honors — without this override a
+        // re-tap within 60s would serve the previous response from disk and the button would
+        // silently no-op. This forces every tap through to the origin.
         val request = Request.Builder()
             .url("$apiBaseUrl/repos/$repo/releases?per_page=10")
             .header("Accept", "application/vnd.github+json")
+            .cacheControl(CacheControl.FORCE_NETWORK)
             .get()
             .build()
         try {

--- a/core/network/src/test/kotlin/com/riffle/core/network/EndpointCacheHeadersInterceptorTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/EndpointCacheHeadersInterceptorTest.kt
@@ -57,11 +57,15 @@ class EndpointCacheHeadersInterceptorTest {
         assertEquals("public, max-age=60", cc)
     }
 
-    @Test fun `stamps GitHub releases with 6-hour TTL`() {
+    // Regression: the manual Settings "Check for updates" button is the only caller of the
+    // GitHub releases endpoint. Its contract is "check now," so this path must NOT be cached —
+    // any Cache-Control rule that matches `/repos/*/releases` would make the button silently
+    // no-op for up to the TTL window after the first check.
+    @Test fun `does not touch GitHub releases endpoint`() {
         server.enqueue(MockResponse().setResponseCode(200).setBody("[]"))
         val r = get("/repos/pkmetski/riffle/releases")
         val cc = r.header("Cache-Control"); r.close()
-        assertEquals("public, max-age=21600", cc)
+        assertEquals(null, cc)
     }
 
     @Test fun `does not touch ABS progress endpoint`() {

--- a/core/network/src/test/kotlin/com/riffle/core/network/EndpointCacheHeadersInterceptorTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/EndpointCacheHeadersInterceptorTest.kt
@@ -58,9 +58,9 @@ class EndpointCacheHeadersInterceptorTest {
     }
 
     // Regression: the manual Settings "Check for updates" button is the only caller of the
-    // GitHub releases endpoint. Its contract is "check now," so this path must NOT be cached —
-    // any Cache-Control rule that matches `/repos/*/releases` would make the button silently
-    // no-op for up to the TTL window after the first check.
+    // GitHub releases endpoint. Its contract is "check now," so no rule here may stamp Cache-
+    // Control on that path. (GitHubReleaseApi.latestRelease also sends CacheControl.FORCE_NETWORK
+    // on the request so a re-tap bypasses GitHub's own 60s max-age — verified separately.)
     @Test fun `does not touch GitHub releases endpoint`() {
         server.enqueue(MockResponse().setResponseCode(200).setBody("[]"))
         val r = get("/repos/pkmetski/riffle/releases")

--- a/core/network/src/test/kotlin/com/riffle/core/network/EndpointCacheHeadersInterceptorTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/EndpointCacheHeadersInterceptorTest.kt
@@ -1,0 +1,104 @@
+package com.riffle.core.network
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+
+class EndpointCacheHeadersInterceptorTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: OkHttpClient
+
+    @Before fun setUp() {
+        server = MockWebServer().apply { start() }
+        client = OkHttpClient.Builder()
+            .addNetworkInterceptor(EndpointCacheHeadersInterceptor(DEFAULT_HTTP_CACHE_RULES))
+            .build()
+    }
+
+    @After fun tearDown() { server.shutdown() }
+
+    private fun get(path: String) = client.newCall(
+        Request.Builder().url(server.url(path)).build()
+    ).execute()
+
+    @Test fun `stamps ABS status with 5-minute TTL`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        val r = get("/status")
+        val cc = r.header("Cache-Control"); r.close()
+        assertEquals("public, max-age=300", cc)
+    }
+
+    @Test fun `stamps ABS libraries list with 15-minute TTL`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        val r = get("/api/libraries")
+        val cc = r.header("Cache-Control"); r.close()
+        assertEquals("public, max-age=900", cc)
+    }
+
+    @Test fun `stamps ABS series with 10-minute TTL for any library id`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        val r = get("/api/libraries/lib-abc-123/series?limit=500")
+        val cc = r.header("Cache-Control"); r.close()
+        assertEquals("public, max-age=600", cc)
+    }
+
+    @Test fun `stamps ABS listening-stats with 60-second TTL`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        val r = get("/api/me/listening-stats")
+        val cc = r.header("Cache-Control"); r.close()
+        assertEquals("public, max-age=60", cc)
+    }
+
+    @Test fun `stamps GitHub releases with 6-hour TTL`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("[]"))
+        val r = get("/repos/pkmetski/riffle/releases")
+        val cc = r.header("Cache-Control"); r.close()
+        assertEquals("public, max-age=21600", cc)
+    }
+
+    @Test fun `does not touch ABS progress endpoint`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        val r = get("/api/me/progress/item-xyz")
+        val cc = r.header("Cache-Control"); r.close()
+        assertEquals(null, cc)
+    }
+
+    @Test fun `does not touch ABS session sync`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        val r = get("/api/session/sess-1/sync")
+        val cc = r.header("Cache-Control"); r.close()
+        assertEquals(null, cc)
+    }
+
+    @Test fun `leaves non-2xx responses untouched even if path matches`() {
+        server.enqueue(
+            MockResponse().setResponseCode(500)
+                .setHeader("Cache-Control", "no-store")
+                .setBody("boom")
+        )
+        val r = get("/api/libraries")
+        val cc = r.header("Cache-Control"); r.close()
+        assertNotEquals("public, max-age=900", cc)
+        assertEquals("no-store", cc)
+    }
+
+    @Test fun `does not stamp non-GET even if path matches`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        val r = client.newCall(
+            Request.Builder()
+                .url(server.url("/api/libraries"))
+                .post("{}".toRequestBody())
+                .build()
+        ).execute()
+        val cc = r.header("Cache-Control"); r.close()
+        assertEquals(null, cc)
+    }
+}

--- a/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
@@ -188,4 +188,23 @@ class GitHubReleaseApiTest {
         assertFalse(ok)
         assertFalse(dest.exists())
     }
+
+    // Regression: verified on AVD that GitHub sends `Cache-Control: max-age=60` on its releases
+    // response, so without FORCE_NETWORK on the request the shared default OkHttp cache serves the
+    // previous response for up to 60s — silently no-op'ing a re-tap of the Settings "Check for
+    // updates" button. The manual button's contract is "check now", so every call must bypass any
+    // cached copy. If someone drops the .cacheControl(FORCE_NETWORK) line, this test flips red.
+    @Test
+    fun `latestRelease request opts out of the cache with no-cache no-store`() = runTest {
+        server.enqueue(MockResponse().setBody("[]"))
+
+        api.latestRelease("pkmetski/riffle")
+
+        val recorded = server.takeRequest()
+        val cc = recorded.getHeader("Cache-Control").orEmpty()
+        assertTrue(
+            "expected FORCE_NETWORK (no-cache) on the request, got '$cc'",
+            cc.contains("no-cache")
+        )
+    }
 }


### PR DESCRIPTION
Follows the caching audit — closes gaps 1, 2, 3, 4, 8 from the report. Chitanka facet/probe caches deferred to a follow-up (they require an interface split across pure-JVM catalog and Room-backed impl, meaningful subsystem change worth its own review).

## What changed

**Default OkHttpClient — 20 MB disk cache + endpoint-allowlist interceptor.** New `EndpointCacheHeadersInterceptor` in `core:network` stamps `Cache-Control: public, max-age=N` on read-only ABS endpoints (`/status` 5m, `/api/me` + `/api/libraries` 15m, `.../series` + `.../collections` 10m, `/api/me/listening-stats` 60s). Writes, sessions, progress, and binaries don't match any rule and pass through unchanged.

**Manual "Check for updates" bypasses the cache.** `GitHubReleaseApi.latestRelease()` now sets `CacheControl.FORCE_NETWORK` on the request. Without this, GitHub's own `Cache-Control: max-age=60` would let OkHttp serve the second tap from disk, silently no-op'ing the button. Verified on device: the GitHub URL never enters `cache/default-http` even after two taps.

**ABS playlists → Room.** New `playlists` + `playlist_items` tables with `MIGRATION_57_58` (renumbered from 56→57 after main landed its own 56→57 for emphasis annotations). `PlaylistsRepositoryImpl` rewritten to observe Room + mirror on refresh, so the Playlists tab is populated on cold start without waiting for a network fetch. Reserved-name filter for To Read / To Listen preserved. Verified on device: kill app + cut network + reopen → playlist still shows.

**Sidecar LRU + purge on source removal.** `ReadaloudSidecarStore.enforceLruBudget(200 MB)` swept after each successful write. `purgeSource(sourceId)` hook wired via `Provider<ReadaloudSidecarCache>` into `SourceRepositoryImpl.remove()` (Provider indirection breaks the SourceRepository ↔ ReadaloudSidecarStore Hilt cycle). `SIDECAR_EXTENSION` / `SIDECAR_DIR_NAME` / `KEY_SEPARATOR` extracted per AGENTS.md "always reference constants" rule.

## Regression assertions

Each of these flips red if the corresponding change is reverted:

- `EndpointCacheHeadersInterceptorTest.stamps ABS status with 5-minute TTL` — pins the ABS rule set.
- `EndpointCacheHeadersInterceptorTest.does not touch ABS progress endpoint` — pins that writes are never cached.
- `EndpointCacheHeadersInterceptorTest.does not touch GitHub releases endpoint` — pins that no rule matches `/repos/*/releases`.
- `GitHubReleaseApiTest.latestRelease request opts out of the cache with no-cache no-store` — pins the FORCE_NETWORK header.
- `PlaylistsRepositoryTest.refresh persists per-root cache` — pins the Room mirror across a fresh Flow collection.
- `PlaylistsRepositoryTest.removeItemFromPlaylist drops empty playlist from cache to mirror server auto-delete` — pins the ABS auto-delete mirror.
- `ReadaloudSidecarStoreTest.enforceLruBudget evicts oldest files first once cap is exceeded` — pins the LRU ordering.
- `ReadaloudSidecarStoreTest.purgeSource deletes only files owned by that source` — pins the source-scoped prefix filter.
- `MigrationTest.migration57To58_addsPlaylistsTables` — pins schema shape + FK-cascade behavior (validates 57→58 with playlists tables and cascade delete).

## Test plan

- [x] `./gradlew test` — all JVM unit tests green.
- [x] `:core:database:connectedDebugAndroidTest` for `MigrationTest.migration57To58_addsPlaylistsTables` on API-25 AVD.
- [x] `MigrationTest.migrateFullChain` (1→58) on API-25 AVD.
- [x] Manual on-device smoke: add ABS source → playlists populate → force-stop + cut network + relaunch → playlist still visible from Room.
- [x] Manual on-device smoke: "Check for updates" tapped twice with cache inspection — GitHub URL never stored.

## Notes for reviewers

- `getPlaylist(rootId, playlistId)` still routes through the network via `cap.listPlaylists`, unchanged from main. Making it Room-first is a nice-to-have but out of scope; it's a pre-existing limitation, not a regression from this PR.
- The bottom-nav tab-row crossfade artifact when switching libraries (both tab sets alpha-blended briefly) is unrelated to caching — it's `NavHost.AnimatedContent` between two library composables, each rendering its own `NavigationBar`. Separate ticket if you want it fixed.