### PR TITLE
fix(reader): preview highlight swatches against the reader theme, not the app theme

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightActionsPopupTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightActionsPopupTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.IntRect
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -31,6 +32,7 @@ class HighlightActionsPopupTest {
                 anchorRect = stubRect,
                 selected = HighlightColor.YELLOW,
                 note = note,
+                readerBackground = Color.White,
                 onPick = {},
                 onDelete = {},
                 onOpenNoteEditor = onOpenNoteEditor,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -3111,6 +3111,7 @@ private fun EpubNavigatorView(
                 anchorRect = editTarget.anchorRect,
                 selected = selectedColor,
                 note = current?.note ?: currentAnnotation?.note,
+                readerBackground = formattingPrefs.swatchBackdropColor,
                 emphasisStyles = currentEmphasisStyles,
                 onPick = { color -> onRecolorHighlight(editTarget.id, color) },
                 onRemoveColor = { onRemoveHighlightColor(editTarget.id) },

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
@@ -57,10 +57,15 @@ import com.riffle.core.models.HighlightColor
  * A row of the four highlight swatches. The selected swatch gets an onSurface ring + a centred
  * checkmark (reads clearly in both themes); the 4dp padding is always reserved so the row doesn't
  * shift on selection. Modelled on the readaloud settings picker for visual consistency.
+ *
+ * [readerBackground] is painted as an opaque backdrop behind each swatch so the semi-transparent
+ * (alpha 0x80) highlight colour composites against the same paper the reader is drawing — otherwise
+ * the swatches look muddy in a dark app while the reader is on light theme (or vice-versa).
  */
 @Composable
 fun HighlightSwatchRow(
     selected: HighlightColor?,
+    readerBackground: Color,
     onPick: (HighlightColor) -> Unit,
     onPickNone: () -> Unit = {},
     modifier: Modifier = Modifier,
@@ -108,6 +113,7 @@ fun HighlightSwatchRow(
                     )
                     .padding(4.dp)
                     .clip(CircleShape)
+                    .background(readerBackground)
                     .background(swatchColor)
                     .semantics {
                         contentDescription = color.token.replaceFirstChar { it.uppercase() } +
@@ -188,6 +194,7 @@ fun HighlightActionsPopup(
     anchorRect: IntRect,
     selected: HighlightColor?,
     note: String?,
+    readerBackground: Color,
     emphasisStyles: Set<EmphasisStyle> = emptySet(),
     onPick: (HighlightColor) -> Unit,
     /** ADR 0046 §4: remove the highlight color while keeping the emphasis rows intact. */
@@ -231,7 +238,12 @@ fun HighlightActionsPopup(
                             .padding(horizontal = 16.dp, vertical = 12.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
-                        HighlightSwatchRow(selected = selected, onPick = onPick, onPickNone = onRemoveColor)
+                        HighlightSwatchRow(
+                            selected = selected,
+                            readerBackground = readerBackground,
+                            onPick = onPick,
+                            onPickNone = onRemoveColor,
+                        )
                     }
                     // Emphasis chip row + destructive trash share a row: chips left-aligned, trash
                     // pushed to the trailing edge with its own padding so it reads as an escape

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderThemePalette.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderThemePalette.kt
@@ -1,6 +1,7 @@
 package com.riffle.app.feature.reader
 
 import androidx.compose.ui.graphics.Color
+import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.ReaderTheme
 
 // Single source of truth for what each reader theme paints. Readium owns the actual page
@@ -48,3 +49,13 @@ val ReaderTheme.palette: ReaderThemePalette
         // two in lock-step if Light's colours ever move.
         ReaderTheme.Auto -> ReaderTheme.Light.palette
     }
+
+/**
+ * The opaque backdrop colour every highlight-colour swatch must composite over so the alpha-0x80
+ * highlight preview matches what actually lands on a book page. Callers (reader popup, Readaloud
+ * settings, Cadence settings) must paint this behind the swatch — otherwise the app-theme
+ * `Surface` colour underlies the swatch and the preview looks nothing like the highlight (e.g. a
+ * dark-app / light-reader combo makes yellow look muddy in the picker, bright yellow in the book).
+ */
+val FormattingPreferences.swatchBackdropColor: Color
+    get() = theme.palette.background

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/panels/CadenceSettingsPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/panels/CadenceSettingsPanel.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.riffle.app.feature.reader.cadence.CadenceHeroIcon
+import com.riffle.app.feature.reader.swatchBackdropColor
 import com.riffle.core.domain.FormattingPreferences
 
 /**
@@ -78,6 +79,7 @@ fun CadenceSettingsPanel(
     )
     HighlightColorRow(
         selected = prefs.cadenceHighlightColor,
+        readerBackground = prefs.swatchBackdropColor,
         onSelectedChange = { onPrefsChange(prefs.copy(cadenceHighlightColor = it)) },
     )
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/panels/CadenceSettingsPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/panels/CadenceSettingsPanel.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.unit.dp
 import com.riffle.app.feature.reader.cadence.CadenceHeroIcon
 import com.riffle.app.feature.reader.swatchBackdropColor
 import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.domain.withResolvedTheme
+import java.time.LocalTime
 
 /**
  * Cadence drill-in — the sentence-highlight hands-free reading feature. See issue #403 / ADR 0040.
@@ -79,7 +81,9 @@ fun CadenceSettingsPanel(
     )
     HighlightColorRow(
         selected = prefs.cadenceHighlightColor,
-        readerBackground = prefs.swatchBackdropColor,
+        // Resolve Auto → concrete so the picker previews against the paper Readium is currently
+        // painting, not the Light fallback the palette accessor uses when Auto slips through.
+        readerBackground = prefs.withResolvedTheme(LocalTime.now()).swatchBackdropColor,
         onSelectedChange = { onPrefsChange(prefs.copy(cadenceHighlightColor = it)) },
     )
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/panels/PacingPanelBits.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/panels/PacingPanelBits.kt
@@ -104,10 +104,15 @@ private fun FastIcon() {
  * Colour-swatch picker for Cadence's highlight — mirrors the Readaloud picker to keep the visual
  * pattern identical (issue #403: "Independent from Readaloud. Same palette."). Selected swatch
  * carries a contrast ring + a check glyph so the pick is unambiguous in screenshots.
+ *
+ * [readerBackground] is painted behind each swatch so the alpha-0x80 highlight colour composites
+ * against the paper the reader will actually draw — otherwise a dark app theme makes the swatches
+ * look nothing like the highlight that lands on a light-theme reader page.
  */
 @Composable
 internal fun HighlightColorRow(
     selected: HighlightColor,
+    readerBackground: Color,
     onSelectedChange: (HighlightColor) -> Unit,
 ) {
     ListItem(
@@ -131,6 +136,7 @@ internal fun HighlightColorRow(
                             )
                             .padding(4.dp)
                             .clip(CircleShape)
+                            .background(readerBackground)
                             .background(swatchColor)
                             .semantics {
                                 contentDescription = color.name.lowercase()

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudSettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudSettingsScreen.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.riffle.app.feature.reader.swatchBackdropColor
 import com.riffle.app.feature.server.AddSourceBackend
+import com.riffle.core.domain.withResolvedTheme
+import java.time.LocalTime
 import com.riffle.app.feature.settings.DrillInChevron
 import com.riffle.app.feature.settings.SettingsSectionHeader
 import com.riffle.app.feature.settings.SettingsViewModel
@@ -73,8 +75,10 @@ fun ReadaloudSettingsScreen(
     val formattingPreferences by viewModel.globalFormattingPreferences.collectAsState()
     // Swatches must preview against the paper the reader draws, not the app's Material surface.
     // A dark-app / light-reader combo (or vice-versa) otherwise makes the swatches look nothing
-    // like the highlight that lands on the page.
-    val readerBackground = formattingPreferences.swatchBackdropColor
+    // like the highlight that lands on the page. The store persists Auto verbatim, so resolve to
+    // the currently-scheduled concrete theme here — otherwise a night-schedule user opening
+    // Settings during the dark arc would still see swatches on the Light fallback.
+    val readerBackground = formattingPreferences.withResolvedTheme(LocalTime.now()).swatchBackdropColor
 
     val storyteller = servers.firstOrNull { it.serverType == ServerType.STORYTELLER_SERVICE }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudSettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudSettingsScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.riffle.app.feature.reader.swatchBackdropColor
 import com.riffle.app.feature.server.AddSourceBackend
 import com.riffle.app.feature.settings.DrillInChevron
 import com.riffle.app.feature.settings.SettingsSectionHeader
@@ -69,6 +70,11 @@ fun ReadaloudSettingsScreen(
     val serverVersions by viewModel.serverVersions.collectAsState()
     val readaloudSummaries by viewModel.readaloudSummaries.collectAsState()
     val readaloudPreferences by viewModel.readaloudPreferences.collectAsState()
+    val formattingPreferences by viewModel.globalFormattingPreferences.collectAsState()
+    // Swatches must preview against the paper the reader draws, not the app's Material surface.
+    // A dark-app / light-reader combo (or vice-versa) otherwise makes the swatches look nothing
+    // like the highlight that lands on the page.
+    val readerBackground = formattingPreferences.swatchBackdropColor
 
     val storyteller = servers.firstOrNull { it.serverType == ServerType.STORYTELLER_SERVICE }
 
@@ -188,6 +194,7 @@ fun ReadaloudSettingsScreen(
                                     )
                                     .padding(4.dp)
                                     .clip(CircleShape)
+                                    .background(readerBackground)
                                     .background(swatchColor)
                                     .semantics {
                                         contentDescription = color.name.lowercase()

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderThemePaletteTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderThemePaletteTest.kt
@@ -1,0 +1,52 @@
+package com.riffle.app.feature.reader
+
+import androidx.compose.ui.graphics.Color
+import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.domain.ReaderTheme
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the highlight-picker swatch backdrop to the exact opaque colour Readium paints for each
+ * reader theme. Every highlight-colour picker (reader popup, Readaloud settings, Cadence settings)
+ * reads [swatchBackdropColor] and paints it under the alpha-0x80 highlight fill so the picker
+ * previews the colour against the same paper the book will draw. If someone shifted the picker
+ * back to `MaterialTheme.colorScheme.surface`, the picker would follow the app theme instead of
+ * the reader theme — the bug this suite exists to prevent.
+ *
+ * The specific colours mirror Readium's `--RS__backgroundColor` declarations documented in
+ * [ReaderThemePalette]. If Readium's palette ever moves, both the palette and Readium's own
+ * rendering must move together; this test flips red first.
+ */
+class ReaderThemePaletteTest {
+
+    @Test
+    fun light_theme_backdrop_matches_readium_white_page() {
+        val prefs = FormattingPreferences(theme = ReaderTheme.Light)
+        assertEquals(Color(0xFFFFFFFF), prefs.swatchBackdropColor)
+    }
+
+    @Test
+    fun dark_theme_backdrop_matches_readium_black_page() {
+        val prefs = FormattingPreferences(theme = ReaderTheme.Dark)
+        assertEquals(Color(0xFF000000), prefs.swatchBackdropColor)
+    }
+
+    @Test
+    fun darkDim_theme_backdrop_reuses_dark_background() {
+        val prefs = FormattingPreferences(theme = ReaderTheme.DarkDim)
+        assertEquals(Color(0xFF000000), prefs.swatchBackdropColor)
+    }
+
+    @Test
+    fun sepia_theme_backdrop_matches_readium_sepia_page() {
+        val prefs = FormattingPreferences(theme = ReaderTheme.Sepia)
+        assertEquals(Color(0xFFFAF4E8), prefs.swatchBackdropColor)
+    }
+
+    @Test
+    fun auto_theme_backdrop_falls_back_to_light_so_previews_never_crash_on_missed_resolution() {
+        val prefs = FormattingPreferences(theme = ReaderTheme.Auto)
+        assertEquals(Color(0xFFFFFFFF), prefs.swatchBackdropColor)
+    }
+}


### PR DESCRIPTION
The annotation colour picker (and the Readaloud / Cadence pickers in Settings) painted its alpha-0x80 swatches directly over `MaterialTheme.colorScheme.surface`. On a dark-app / light-reader combo (or vice-versa) the picker looked nothing like the highlight that lands on the page — the colours read as muddy in the picker and bright in the reader.

## Fix

Every picker now paints an opaque backdrop of the reader theme's paper behind each swatch, so the alpha-0x80 fill composites against the same surface Readium is drawing.

- New `FormattingPreferences.swatchBackdropColor` extension in `ReaderThemePalette.kt` — single source of truth for the picker backdrop.
- `HighlightSwatchRow` / `HighlightActionsPopup` take a `readerBackground: Color`; painted under the swatch fill.
- Reader popup (`EpubReaderScreen.kt`) sources it from `effectiveFormattingPreferences` (already resolves Auto).
- Settings pickers (Readaloud + Cadence) source it from `globalFormattingPreferences.withResolvedTheme(LocalTime.now())` so a night-schedule Auto user during the dark arc previews on black paper, not the Auto→Light fallback.
- `∅` swatch and popup chrome (emphasis chips, note row, delete) unchanged — only the four colour swatches carry the reader-paper backdrop.

## Tests

- `ReaderThemePaletteTest` (new, JVM): pins `swatchBackdropColor` for every concrete theme (Light/Dark/DarkDim/Sepia) plus the Auto fallback to the exact opaque colours Readium paints. Flips red if the palette drifts.
- `HighlightActionsPopupTest`: updated to pass the new `readerBackground` param.

The visual invariant "swatch composites over reader-paper backdrop" is verified manually on device — captureToImage is API-26+ so the harness AVD (API 25) can't pin it in an instrumentation test.