### PR TITLE
feat(reader): step sliders via edge-icon taps

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingSection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FormattingSection.kt
@@ -41,18 +41,26 @@ fun FormattingSection(
         }
 
         if (capabilities.supportsTextTypography) {
+            val fontSizeRange = 0.5f..2.5f
+            val fontSizeStep = 0.1f
             UnifiedSliderRow(
                 title = "Font size",
                 caption = "%.0f%%".format(Locale.ROOT, prefs.fontSize * 100),
                 value = prefs.fontSize,
                 onValueChange = { onPrefsChange(prefs.copy(fontSize = it.round1())) },
-                valueRange = 0.5f..2.5f,
+                valueRange = fontSizeRange,
                 steps = 19,
                 majorEvery = 0.5f,
                 edgeLeft = { Text("A", style = MaterialTheme.typography.labelMedium) },
                 edgeRight = { Text("A", style = MaterialTheme.typography.titleLarge) },
                 bubbleLabel = ::fontSizeBubble,
                 contentDescription = "Font size",
+                onDecrement = {
+                    onPrefsChange(prefs.copy(fontSize = steppedTypographyValue(prefs.fontSize, -fontSizeStep, fontSizeRange)))
+                },
+                onIncrement = {
+                    onPrefsChange(prefs.copy(fontSize = steppedTypographyValue(prefs.fontSize, fontSizeStep, fontSizeRange)))
+                },
             )
             Spacer(Modifier.height(16.dp))
         }
@@ -74,18 +82,26 @@ fun FormattingSection(
             }
             Spacer(Modifier.height(16.dp))
 
+            val lineSpacingRange = 1.0f..2.0f
+            val lineSpacingStep = 0.1f
             UnifiedSliderRow(
                 title = "Line spacing",
                 caption = "${lineSpacingWord(prefs.lineSpacing)} · %.1f×".format(Locale.ROOT, prefs.lineSpacing),
                 value = prefs.lineSpacing,
                 onValueChange = { onPrefsChange(prefs.copy(lineSpacing = it.round1())) },
-                valueRange = 1.0f..2.0f,
+                valueRange = lineSpacingRange,
                 steps = 9,
                 majorEvery = 0.2f,
                 edgeLeft = { TightLinesIcon() },
                 edgeRight = { LooseLinesIcon() },
                 bubbleLabel = ::lineSpacingBubble,
                 contentDescription = "Line spacing",
+                onDecrement = {
+                    onPrefsChange(prefs.copy(lineSpacing = steppedTypographyValue(prefs.lineSpacing, -lineSpacingStep, lineSpacingRange)))
+                },
+                onIncrement = {
+                    onPrefsChange(prefs.copy(lineSpacing = steppedTypographyValue(prefs.lineSpacing, lineSpacingStep, lineSpacingRange)))
+                },
             )
             Spacer(Modifier.height(20.dp))
         }
@@ -96,18 +112,26 @@ fun FormattingSection(
             Text("Page", style = MaterialTheme.typography.labelMedium)
             Spacer(Modifier.height(8.dp))
         }
+        val marginsRange = 0.2f..3.0f
+        val marginsStep = 0.2f
         UnifiedSliderRow(
             title = "Margins",
             caption = "${marginsWord(prefs.margins)} · %.1f×".format(Locale.ROOT, prefs.margins),
             value = prefs.margins,
             onValueChange = { onPrefsChange(prefs.copy(margins = it.round1())) },
-            valueRange = 0.2f..3.0f,
+            valueRange = marginsRange,
             steps = 27,
             majorEvery = 0.5f,
             edgeLeft = { NarrowMarginsIcon() },
             edgeRight = { WideMarginsIcon() },
             bubbleLabel = ::marginsBubble,
             contentDescription = "Margins",
+            onDecrement = {
+                onPrefsChange(prefs.copy(margins = steppedTypographyValue(prefs.margins, -marginsStep, marginsRange)))
+            },
+            onIncrement = {
+                onPrefsChange(prefs.copy(margins = steppedTypographyValue(prefs.margins, marginsStep, marginsRange)))
+            },
         )
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
@@ -3,6 +3,7 @@
 package com.riffle.app.feature.reader
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -41,6 +42,20 @@ import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
+/**
+ * Advance [current] by [step] (positive or negative), clamp to [range], and round to 1 decimal.
+ * Used by the edge-icon tap handlers on the typography sliders so keyboard-analogue nudging
+ * lands on the same 0.1× lattice the slider itself snaps to.
+ */
+internal fun steppedTypographyValue(
+    current: Float,
+    step: Float,
+    range: ClosedFloatingPointRange<Float>,
+): Float {
+    val next = (current + step).coerceIn(range)
+    return (next * 10f).roundToInt() / 10f
+}
+
 internal fun fontSizeBubble(v: Float): String = "${(v * 100).roundToInt()}%"
 internal fun lineSpacingBubble(v: Float): String = "%.1f×".format(Locale.ROOT, v)
 internal fun marginsBubble(v: Float): String = "%.1f×".format(Locale.ROOT, v)
@@ -73,6 +88,8 @@ internal fun UnifiedSliderRow(
     bubbleLabel: (Float) -> String,
     modifier: Modifier = Modifier,
     contentDescription: String = title,
+    onDecrement: (() -> Unit)? = null,
+    onIncrement: (() -> Unit)? = null,
 ) {
     Column(modifier = modifier.fillMaxWidth()) {
         Row(
@@ -97,7 +114,18 @@ internal fun UnifiedSliderRow(
                 .fillMaxWidth()
                 .height(56.dp),
         ) {
-            Box(Modifier.size(28.dp), contentAlignment = Alignment.Center) { edgeLeft() }
+            Box(
+                modifier = Modifier
+                    .size(28.dp)
+                    .then(
+                        if (onDecrement != null) {
+                            Modifier
+                                .clickable(onClickLabel = "Decrease $contentDescription") { onDecrement() }
+                                .semantics { this.contentDescription = "Decrease $contentDescription" }
+                        } else Modifier,
+                    ),
+                contentAlignment = Alignment.Center,
+            ) { edgeLeft() }
             Spacer(Modifier.width(8.dp))
             SliderTrack(
                 value = value,
@@ -110,7 +138,18 @@ internal fun UnifiedSliderRow(
                 modifier = Modifier.weight(1f),
             )
             Spacer(Modifier.width(8.dp))
-            Box(Modifier.size(28.dp), contentAlignment = Alignment.Center) { edgeRight() }
+            Box(
+                modifier = Modifier
+                    .size(28.dp)
+                    .then(
+                        if (onIncrement != null) {
+                            Modifier
+                                .clickable(onClickLabel = "Increase $contentDescription") { onIncrement() }
+                                .semantics { this.contentDescription = "Increase $contentDescription" }
+                        } else Modifier,
+                    ),
+                contentAlignment = Alignment.Center,
+            ) { edgeRight() }
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/panels/PacingPanelBits.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/panels/PacingPanelBits.kt
@@ -47,6 +47,9 @@ internal fun WpmSliderRow(
     onWpmChange: (Int) -> Unit,
 ) {
     Column(modifier = Modifier.padding(top = 8.dp, bottom = 8.dp)) {
+        // Icon-tap step is coarser than the slider's own 10-wpm snap: single-snap deltas
+        // are imperceptible for reading pace, and 20 wpm lands on the 100-wpm major ticks.
+        val wpmButtonStep = 20
         UnifiedSliderRow(
             title = label,
             caption = "$wpm wpm",
@@ -59,6 +62,8 @@ internal fun WpmSliderRow(
             edgeRight = { FastIcon() },
             bubbleLabel = ::wpmBubble,
             contentDescription = "$label speed",
+            onDecrement = { onWpmChange(AutoScrollSpeed.of(wpm - wpmButtonStep).wpm) },
+            onIncrement = { onWpmChange(AutoScrollSpeed.of(wpm + wpmButtonStep).wpm) },
         )
         Text(
             text = helper,

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/SteppedTypographyValueTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/SteppedTypographyValueTest.kt
@@ -1,0 +1,52 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.autoscroll.AutoScrollSpeed
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Locks the icon-tap step per slider. If a caller ever passes a bare `+ step` (no clamp / no
+ * round) the assertions here flip red — that is the regression this test exists to prevent.
+ */
+class SteppedTypographyValueTest {
+
+    private val fontSizeRange = 0.5f..2.5f
+    private val lineSpacingRange = 1.0f..2.0f
+    private val marginsRange = 0.2f..3.0f
+
+    @Test fun fontSizeIncrementsByTenPercent() {
+        assertEquals(1.1f, steppedTypographyValue(1.0f, 0.1f, fontSizeRange), 1e-4f)
+        assertEquals(0.9f, steppedTypographyValue(1.0f, -0.1f, fontSizeRange), 1e-4f)
+    }
+
+    @Test fun fontSizeClampsAtRangeEdges() {
+        assertEquals(2.5f, steppedTypographyValue(2.5f, 0.1f, fontSizeRange), 1e-4f)
+        assertEquals(0.5f, steppedTypographyValue(0.5f, -0.1f, fontSizeRange), 1e-4f)
+    }
+
+    @Test fun lineSpacingSnapsToOneDecimalLattice() {
+        // 1.4 + 0.1 in Float is 1.5000001; the helper must round to the tick.
+        assertEquals(1.5f, steppedTypographyValue(1.4f, 0.1f, lineSpacingRange), 1e-4f)
+        assertEquals(1.0f, steppedTypographyValue(1.0f, -0.1f, lineSpacingRange), 1e-4f)
+        assertEquals(2.0f, steppedTypographyValue(2.0f, 0.1f, lineSpacingRange), 1e-4f)
+    }
+
+    @Test fun marginsStepIsTwoTenths() {
+        // Margins run 0.2×–3.0× with a 0.2× icon-tap step (coarser than the 0.1× slider tick
+        // because 28 taps end-to-end reads worse than 14).
+        assertEquals(1.2f, steppedTypographyValue(1.0f, 0.2f, marginsRange), 1e-4f)
+        assertEquals(0.8f, steppedTypographyValue(1.0f, -0.2f, marginsRange), 1e-4f)
+        assertEquals(3.0f, steppedTypographyValue(3.0f, 0.2f, marginsRange), 1e-4f)
+        assertEquals(0.2f, steppedTypographyValue(0.2f, -0.2f, marginsRange), 1e-4f)
+    }
+
+    @Test fun wpmIconStepLandsOnTwentyWpmGrid() {
+        // The pacing sliders route the icon-tap through AutoScrollSpeed.of so a 20-wpm delta
+        // is re-snapped to the underlying 10-wpm lattice; both directions must clamp at the
+        // range edges (80 / 600) rather than wrap or overshoot.
+        assertEquals(270, AutoScrollSpeed.of(250 + 20).wpm)
+        assertEquals(230, AutoScrollSpeed.of(250 - 20).wpm)
+        assertEquals(600, AutoScrollSpeed.of(600 + 20).wpm)
+        assertEquals(80, AutoScrollSpeed.of(80 - 20).wpm)
+    }
+}


### PR DESCRIPTION
## Summary

The formatting and pacing sliders (Font size, Line spacing, Margins, Cadence/Auto-scroll WPM) now respond to taps on their left/right edge icons. Each slider gets a step tuned to its range and perceptibility:

| Slider | Icon-tap step | Range | Taps end-to-end |
|---|---|---|---|
| Font size | 0.1× (10%) | 0.5×–2.5× | 20 |
| Line spacing | 0.1× | 1.0×–2.0× | 10 |
| Margins | 0.2× | 0.2×–3.0× | 14 |
| Cadence / Auto-scroll WPM | 20 wpm | 80–600 | 26 |

Typography steps go through a shared `steppedTypographyValue()` helper that clamps to range and re-snaps to the 0.1× lattice (so `1.4f + 0.1f` lands on exactly `1.5f`, not `1.5000001f`). WPM taps route through `AutoScrollSpeed.of(...)` so a 20-wpm delta is re-snapped to the underlying 10-wpm grid and clamps at 80/600.

Edge icons become clickable only when a step callback is supplied — sliders wired without `onDecrement`/`onIncrement` keep their current non-interactive icons. Click labels are `"Decrease {name}"` / `"Increase {name}"` for accessibility.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests SteppedTypographyValueTest` — new regression test pinning 0.1× / 0.2× / 20-wpm deltas, range clamping at both edges, and float-drift re-snap. Would flip red if any caller reverts to a bare `± step`.
- [ ] Manually verify on device: each edge icon on Formatting sheet (font size / line spacing / margins) and Pacing panel (cadence / auto-scroll) moves the slider by the expected step and stops at range endpoints.