### PR TITLE
fix(sync): mirror ABS progress into library, details, and reader-open

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -127,6 +127,11 @@ fun LibraryItemDetailScreen(
     LaunchedEffect(lifecycleOwner, viewModel) {
         lifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
             viewModel.reloadCurrentPositionHref()
+            // Pull server progress for THIS item so the blue bar / % refresh on every visit,
+            // even when the user reaches the details page without going through the library grid
+            // (deep link, back from reader). The library-grid ON_RESUME is a separate trigger and
+            // does not fire when only the details page is on screen.
+            viewModel.refreshItemProgress()
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -13,6 +13,7 @@ import com.riffle.core.domain.EpubDownloadResult
 import com.riffle.core.domain.EpubRepository
 import com.riffle.core.models.LibraryItem
 import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.LibraryRefresher
 import com.riffle.core.domain.PdfDownloadResult
 import com.riffle.core.domain.PdfRepository
 import com.riffle.core.domain.usecase.MarkReadAcrossDimensions
@@ -170,6 +171,7 @@ class LibraryItemDetailViewModel @Inject constructor(
     private val extractEpubTocUseCase: ExtractEpubTocUseCase,
     private val fetchAudiobookChaptersUseCase: FetchAudiobookChaptersUseCase,
     private val catalogRegistry: CatalogRegistry,
+    private val libraryRefresher: LibraryRefresher,
 ) : ViewModel() {
 
     private val itemId: String = savedStateHandle.get<String>("itemId") ?: ""
@@ -210,6 +212,18 @@ class LibraryItemDetailViewModel @Inject constructor(
         viewModelScope.launch {
             _currentPositionHref.value = epubRepository.loadLastPositionHref(item.sourceId, item.id)
         }
+    }
+
+    /**
+     * Called from the details screen's ON_RESUME. Pulls the item's server progress and mirrors
+     * it into `library_items.readingProgress` / `finishedAt` so the blue bar and % / remaining
+     * refresh when the user visits the details page — including the case of returning to details
+     * without going through the library grid (deep link, back from reader, app foreground).
+     */
+    fun refreshItemProgress() {
+        val ready = _uiState.value as? LibraryItemDetailUiState.Ready ?: return
+        val item = ready.item
+        viewModelScope.launch { libraryRefresher.refreshItemProgress(item.sourceId, item.id) }
     }
 
     var authToken: String by mutableStateOf("")

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -221,9 +221,15 @@ class LibraryItemDetailViewModel @Inject constructor(
      * without going through the library grid (deep link, back from reader, app foreground).
      */
     fun refreshItemProgress() {
-        val ready = _uiState.value as? LibraryItemDetailUiState.Ready ?: return
-        val item = ready.item
-        viewModelScope.launch { libraryRefresher.refreshItemProgress(item.sourceId, item.id) }
+        // Resolve source/item from the sources of truth (savedStateHandle + active source), NOT
+        // from _uiState.value. ON_RESUME can fire before init's async item load completes
+        // (cold-open / deep-link into details) — a Ready-only gate would silently drop the very
+        // case the refresh was added for. The refresher's own precondition checks handle a null
+        // active source or a mismatched sourceId.
+        viewModelScope.launch {
+            val sourceId = sourceRepository.getActive()?.id ?: return@launch
+            libraryRefresher.refreshItemProgress(sourceId, itemId)
+        }
     }
 
     var authToken: String by mutableStateOf("")

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
@@ -59,6 +59,7 @@ class ReaderSessionLifecycle @AssistedInject constructor(
     private val readerSyncFactory: ReaderSyncFactory,
     private val annotationStore: AnnotationStore,
     private val logger: Logger,
+    private val itemProgressPuller: com.riffle.core.data.ItemProgressPuller,
 ) {
 
     @AssistedFactory
@@ -93,6 +94,17 @@ class ReaderSessionLifecycle @AssistedInject constructor(
     suspend fun open(params: OpenParams): OpenOutcome {
         val item = libraryObserver.getItem(params.itemId)
             ?: return OpenOutcome.Error("Book not found")
+
+        // Refresh this book's server position BEFORE loading the initial locator so the reader
+        // opens at the fresh spot instead of rendering the old local cfi first and then visibly
+        // jumping when the in-reader sync cycle catches up. Bounded so a slow/unreachable server
+        // never blocks reader-open indefinitely — on timeout we proceed with the local locator,
+        // which the live sync cycle will then reconcile (the pre-fix behaviour).
+        // Runs BEFORE openReconcileTargets.markOpen (inside resolveReady) — otherwise the
+        // puller's `isOpen` guard would skip it.
+        kotlinx.coroutines.withTimeoutOrNull(1_500L) {
+            runCatching { itemProgressPuller.pullItem(item.sourceId, item.id) }
+        }
 
         return when (val result = epubRepository.openEpub(item)) {
             is EpubOpenResult.Success -> resolveReady(result, item.title, params)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
@@ -102,8 +102,20 @@ class ReaderSessionLifecycle @AssistedInject constructor(
         // which the live sync cycle will then reconcile (the pre-fix behaviour).
         // Runs BEFORE openReconcileTargets.markOpen (inside resolveReady) — otherwise the
         // puller's `isOpen` guard would skip it.
+        // Cancellation must propagate — a plain `runCatching { ... }` around a suspending call
+        // swallows CancellationException (Kotlin footgun) and would defeat both the timeout AND
+        // structured concurrency if the caller cancels this open() mid-flight. Catch only
+        // non-cancellation Throwables and re-throw CancellationException explicitly.
         kotlinx.coroutines.withTimeoutOrNull(1_500L) {
-            runCatching { itemProgressPuller.pullItem(item.sourceId, item.id) }
+            try {
+                itemProgressPuller.pullItem(item.sourceId, item.id)
+            } catch (t: Throwable) {
+                if (t is kotlinx.coroutines.CancellationException) throw t
+                logger.w(LogChannel.ProgressSync) {
+                    "ReaderSessionLifecycle: puller failed for source=${item.sourceId} item=${item.id} — " +
+                        "${t::class.simpleName}: ${t.message}"
+                }
+            }
         }
 
         return when (val result = epubRepository.openEpub(item)) {

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -257,6 +257,7 @@ class LibraryItemDetailViewModelTest {
             io.mockk.coEvery { uc(any<com.riffle.core.models.LibraryItem>()) } returns emptyList<com.riffle.core.domain.AudiobookChapter>()
         },
         catalogRegistryOverride: com.riffle.core.catalog.CatalogRegistry = detailFakeCatalogRegistry(),
+        libraryRefresher: com.riffle.core.domain.LibraryRefresher = com.riffle.app.testing.NoopLibraryRefresher,
     ) = LibraryItemDetailViewModel(
         savedStateHandle = SavedStateHandle(mapOf("itemId" to itemId)),
         libraryObserver = repo,
@@ -289,7 +290,7 @@ class LibraryItemDetailViewModelTest {
         extractEpubTocUseCase = extractEpubTocUseCase,
         fetchAudiobookChaptersUseCase = fetchAudiobookChaptersUseCase,
         catalogRegistry = catalogRegistryOverride,
-        libraryRefresher = com.riffle.app.testing.NoopLibraryRefresher,
+        libraryRefresher = libraryRefresher,
     )
 
     // These tests exercise ViewModel state and side-effects; none read Ready.capabilities.
@@ -403,6 +404,76 @@ class LibraryItemDetailViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(0.8f, (vm.uiState.value as Ready).item.readingProgress)
+    }
+
+    /**
+     * Records refreshItemProgress calls so the test can pin that VM.refreshItemProgress() actually
+     * dispatches. Without this pin, a refactor that no-ops the VM method body would keep tests
+     * green while silently breaking the details-ON_RESUME sync feature.
+     */
+    private class RecordingLibraryRefresher : com.riffle.core.domain.LibraryRefresher {
+        val refreshItemProgressCalls = mutableListOf<Pair<String, String>>()
+        override suspend fun refreshLibraries() = LibraryRefreshResult.Success
+        override suspend fun refreshLibraryItems(libraryId: String) = LibraryRefreshResult.Success
+        override suspend fun refreshSeries(libraryId: String) = LibraryRefreshResult.Success
+        override suspend fun refreshCollections(libraryId: String) = LibraryRefreshResult.Success
+        override suspend fun refreshItemProgress(sourceId: String, itemId: String): LibraryRefreshResult {
+            refreshItemProgressCalls += sourceId to itemId
+            return LibraryRefreshResult.Success
+        }
+    }
+
+    @Test
+    fun `refreshItemProgress dispatches to the LibraryRefresher with the active source id and vm item id`() = runTest {
+        val recorder = RecordingLibraryRefresher()
+        val serverSource = Source(
+            id = "srv-1",
+            url = SourceUrl.parse("https://abs.example.com")!!,
+            isActive = true,
+            insecureConnectionAllowed = false,
+            username = "u",
+        )
+        val vm = makeVm(
+            fakeRepo(knownItem),
+            sourceRepository = serverRepoReturning(serverSource),
+            libraryRefresher = recorder,
+        )
+        backgroundScope.launch { vm.uiState.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.refreshItemProgress()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf("srv-1" to "item-1"), recorder.refreshItemProgressCalls)
+    }
+
+    /**
+     * Regression pin for the cold-open / deep-link case: ON_RESUME can fire while uiState is still
+     * Loading (init's async item fetch hasn't completed). The refresh MUST still dispatch, or the
+     * whole details-ON_RESUME sync silently drops for the case it was added to cover.
+     */
+    @Test
+    fun `refreshItemProgress dispatches even when uiState is still Loading (cold-open race)`() = runTest {
+        val recorder = RecordingLibraryRefresher()
+        val serverSource = Source(
+            id = "srv-1",
+            url = SourceUrl.parse("https://abs.example.com")!!,
+            isActive = true,
+            insecureConnectionAllowed = false,
+            username = "u",
+        )
+        val vm = makeVm(
+            fakeRepo(knownItem),
+            sourceRepository = serverRepoReturning(serverSource),
+            libraryRefresher = recorder,
+        )
+        // Deliberately do NOT advanceUntilIdle before calling — mirrors ON_RESUME firing before the
+        // async init has settled Ready.
+        assertEquals(LibraryItemDetailUiState.Loading, vm.uiState.value)
+        vm.refreshItemProgress()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf("srv-1" to "item-1"), recorder.refreshItemProgressCalls)
     }
 
     // --- downloadState tests ---

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -289,6 +289,7 @@ class LibraryItemDetailViewModelTest {
         extractEpubTocUseCase = extractEpubTocUseCase,
         fetchAudiobookChaptersUseCase = fetchAudiobookChaptersUseCase,
         catalogRegistry = catalogRegistryOverride,
+        libraryRefresher = com.riffle.app.testing.NoopLibraryRefresher,
     )
 
     // These tests exercise ViewModel state and side-effects; none read Ready.capabilities.

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
@@ -174,6 +174,7 @@ class LibraryItemDetailViewModelTocTest {
             override suspend fun forSource(source: com.riffle.core.models.Source): com.riffle.core.catalog.Catalog? = null
             override suspend fun forSourceId(sourceId: String): com.riffle.core.catalog.Catalog? = null
         },
+        libraryRefresher = com.riffle.app.testing.NoopLibraryRefresher,
     )
 
     private val epubItem = LibraryItem(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -223,6 +223,35 @@ class ReaderSessionLifecycleTest {
         sourceId = "srv-abs",
     )
 
+    /** Records call order so tests can pin that reconcile-then-open sequencing invariant. */
+    private class RecordingItemProgressPuller(
+        private val onPull: suspend () -> Unit = {},
+    ) : com.riffle.core.data.ItemProgressPuller {
+        val calls = mutableListOf<Pair<String, String>>()
+        override suspend fun pullItem(sourceId: String, itemId: String) {
+            calls += sourceId to itemId
+            onPull()
+        }
+    }
+
+    private class RecordingEpubRepository(
+        private val outcome: EpubOpenResult,
+        private val onOpen: (() -> Unit)? = null,
+    ) : EpubRepository {
+        var openCalls = 0
+        override suspend fun openEpub(item: LibraryItem): EpubOpenResult {
+            openCalls++
+            onOpen?.invoke()
+            return outcome
+        }
+        override suspend fun downloadEpub(item: LibraryItem, onProgress: (Long, Long) -> Unit) =
+            error("not needed")
+        override suspend fun removeDownload(sourceId: String, itemId: String) {}
+        override fun isDownloaded(sourceId: String, itemId: String) = false
+        override fun isCached(sourceId: String, itemId: String) = false
+        override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
+    }
+
     private fun makeLifecycle(
         openReconcileTargets: OpenReconcileTargets = OpenReconcileTargets(),
         libraryObserver: LibraryObserver = FakeLibraryObserver(
@@ -238,6 +267,7 @@ class ReaderSessionLifecycleTest {
         annotationStore: AnnotationStore = FakeAnnotationStore(),
         pub: Publication? = mockk(relaxed = true),
         cfiResolver: suspend (String) -> Locator? = { null },
+        itemProgressPuller: com.riffle.core.data.ItemProgressPuller = com.riffle.core.data.NoopItemProgressPuller,
     ): Pair<ReaderSessionLifecycle, OpenReconcileTargets> {
         val readerSyncFactory = mockk<com.riffle.app.feature.reader.ReaderSyncFactory>(relaxed = true).also {
             io.mockk.coEvery { it.createIfApplicable(any()) } returns null
@@ -257,7 +287,7 @@ class ReaderSessionLifecycleTest {
             readerSyncFactory = readerSyncFactory,
             annotationStore = annotationStore,
             logger = RecordingLogger(),
-            itemProgressPuller = com.riffle.core.data.NoopItemProgressPuller,
+            itemProgressPuller = itemProgressPuller,
         )
         return lifecycle to openReconcileTargets
     }
@@ -269,6 +299,50 @@ class ReaderSessionLifecycleTest {
     ) = ReaderSessionLifecycle.OpenParams(itemId, openAtCfi, startTocHref)
 
     // ── Tests ────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Load-bearing invariant for the "reader opens at old cfi then visibly jumps" fix: the puller
+     * MUST run BEFORE [EpubRepository.openEpub] loads the initial locator. Reversing the two
+     * would render the stale local cfi first and let the reconcile land after the first frame —
+     * exactly the flash we're eliminating.
+     */
+    @Test
+    fun `open invokes itemProgressPuller BEFORE epubRepository openEpub`() = runTest {
+        val order = mutableListOf<String>()
+        val puller = RecordingItemProgressPuller { order += "puller" }
+        val repo = RecordingEpubRepository(
+            EpubOpenResult.Success(epubFile = File("/tmp/dummy.epub"), lastPosition = null),
+            onOpen = { order += "openEpub" },
+        )
+        val (lifecycle, _) = makeLifecycle(epubRepository = repo, itemProgressPuller = puller)
+
+        lifecycle.open(params())
+
+        assertEquals(listOf("srv-abs" to "item-1"), puller.calls)
+        assertEquals(1, repo.openCalls)
+        assertEquals(listOf("puller", "openEpub"), order)
+    }
+
+    /**
+     * A slow/hung puller must not wedge the reader indefinitely — the lifecycle bounds the
+     * pre-open reconcile so the reader still opens (at the local locator) if the server never
+     * responds. Regression pin for the 1.5s timeout in `open()`.
+     */
+    @Test
+    fun `open proceeds after puller timeout instead of hanging the reader`() = runTest {
+        val slowPuller = RecordingItemProgressPuller {
+            kotlinx.coroutines.delay(60_000L)
+        }
+        val repo = RecordingEpubRepository(
+            EpubOpenResult.Success(epubFile = File("/tmp/dummy.epub"), lastPosition = null),
+        )
+        val (lifecycle, _) = makeLifecycle(epubRepository = repo, itemProgressPuller = slowPuller)
+
+        val outcome = lifecycle.open(params())
+
+        assertTrue(outcome is ReaderSessionLifecycle.OpenOutcome.Ready)
+        assertEquals(1, repo.openCalls)
+    }
 
     @Test
     fun `open returns Error when item is missing`() = runTest {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -344,6 +344,31 @@ class ReaderSessionLifecycleTest {
         assertEquals(1, repo.openCalls)
     }
 
+    /**
+     * A non-cancellation exception from the puller (network failure, DB glitch) must NOT abort
+     * reader-open — the whole point of the puller is a best-effort pre-sync. Regression pin: prior
+     * `withTimeoutOrNull { runCatching { ... } }` swallowed exceptions but also swallowed
+     * CancellationException; the current try/catch inside the timeout block catches ordinary
+     * failures and lets the reader still open at the local locator.
+     */
+    @Test
+    fun `open still opens the reader when puller throws a non-cancellation exception`() = runTest {
+        val throwingPuller = object : com.riffle.core.data.ItemProgressPuller {
+            override suspend fun pullItem(sourceId: String, itemId: String) {
+                throw RuntimeException("simulated network failure")
+            }
+        }
+        val repo = RecordingEpubRepository(
+            EpubOpenResult.Success(epubFile = File("/tmp/dummy.epub"), lastPosition = null),
+        )
+        val (lifecycle, _) = makeLifecycle(epubRepository = repo, itemProgressPuller = throwingPuller)
+
+        val outcome = lifecycle.open(params())
+
+        assertTrue(outcome is ReaderSessionLifecycle.OpenOutcome.Ready)
+        assertEquals(1, repo.openCalls)
+    }
+
     @Test
     fun `open returns Error when item is missing`() = runTest {
         val (lifecycle, _) = makeLifecycle(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -257,6 +257,7 @@ class ReaderSessionLifecycleTest {
             readerSyncFactory = readerSyncFactory,
             annotationStore = annotationStore,
             logger = RecordingLogger(),
+            itemProgressPuller = com.riffle.core.data.NoopItemProgressPuller,
         )
         return lifecycle to openReconcileTargets
     }

--- a/app/src/test/kotlin/com/riffle/app/testing/LibraryUseCaseFakes.kt
+++ b/app/src/test/kotlin/com/riffle/app/testing/LibraryUseCaseFakes.kt
@@ -40,6 +40,7 @@ object NoopLibraryRefresher : LibraryRefresher {
     override suspend fun refreshLibraryItems(libraryId: String) = LibraryRefreshResult.Success
     override suspend fun refreshSeries(libraryId: String) = LibraryRefreshResult.Success
     override suspend fun refreshCollections(libraryId: String) = LibraryRefreshResult.Success
+    override suspend fun refreshItemProgress(sourceId: String, itemId: String) = LibraryRefreshResult.Success
 }
 
 class NoopUpdateReadingProgress(

--- a/core/data/src/main/kotlin/com/riffle/core/data/CatalogProgressRemotes.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/CatalogProgressRemotes.kt
@@ -48,7 +48,12 @@ class CatalogEbookProgressRemote(
                 if (raw.isBlank()) "" else t.cfiToLocatorJson(raw) ?: return null
             }
         }
-        return RemoteProgress(locatorJson, r.lastUpdate)
+        return RemoteProgress(
+            position = locatorJson,
+            lastUpdate = r.lastUpdate,
+            readingProgress = r.ebookProgress,
+            finishedAt = r.finishedAt ?: r.lastUpdate.takeIf { r.isFinished },
+        )
     }
 
     override suspend fun patch(position: String): Long? {
@@ -89,7 +94,21 @@ class CatalogAudioProgressRemote(
 
     override suspend fun get(): RemoteProgress<Double>? {
         val r = runCatching { peer.pullProgress(itemId) }.getOrNull() ?: return null
-        return RemoteProgress(r.audioCurrentTime, r.lastUpdate)
+        // Single-item ABS pullProgress leaves `ebookProgress` at 0 for audio-only items (unlike
+        // pullAllProgress which folds `progress` into it — ADR 0029); derive from currentTime/
+        // duration here so an audio-only book's library-grid % reflects the just-pulled listen
+        // fraction. `isFinished` overrides to 1f in case duration is 0/absent on server payload.
+        val fraction = when {
+            r.isFinished -> 1f
+            r.audioDuration > 0.0 -> (r.audioCurrentTime / r.audioDuration).toFloat().coerceIn(0f, 1f)
+            else -> 0f
+        }
+        return RemoteProgress(
+            position = r.audioCurrentTime,
+            lastUpdate = r.lastUpdate,
+            readingProgress = fraction,
+            finishedAt = r.finishedAt ?: r.lastUpdate.takeIf { r.isFinished },
+        )
     }
 
     override suspend fun patch(position: Double): Long? =

--- a/core/data/src/main/kotlin/com/riffle/core/data/CatalogProgressRemotes.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/CatalogProgressRemotes.kt
@@ -94,6 +94,14 @@ class CatalogAudioProgressRemote(
 
     override suspend fun get(): RemoteProgress<Double>? {
         val r = runCatching { peer.pullProgress(itemId) }.getOrNull() ?: return null
+        // Skip the audio dimension when the payload carries no meaningful audio state — every
+        // ABS book responds to this endpoint whether or not it has an audiobook, so a pure
+        // ebook returns audioDuration=0 / currentTime=0 and a hybrid mid-scan can transiently
+        // do the same. Without this guard the audio reconciler treats a fresh audiobook_positions
+        // row (localUpdatedAt=0) vs. a non-zero server stamp as ServerWon and fires UiSink with
+        // fraction=0, clobbering the ebook reconciler's just-written readingProgress. isFinished
+        // is a separate signal — treat it as a real audio "done" event even without duration.
+        if (!r.isFinished && r.audioDuration <= 0.0 && r.audioCurrentTime <= 0.0) return null
         // Single-item ABS pullProgress leaves `ebookProgress` at 0 for audio-only items (unlike
         // pullAllProgress which folds `progress` into it — ADR 0029); derive from currentTime/
         // duration here so an audio-only book's library-grid % reflects the just-pulled listen

--- a/core/data/src/main/kotlin/com/riffle/core/data/ItemProgressPuller.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ItemProgressPuller.kt
@@ -1,0 +1,64 @@
+package com.riffle.core.data
+
+import com.riffle.core.catalog.AudiobookProgressPeerCapability
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.ProgressPeerCapability
+import com.riffle.core.domain.ProgressReconciler
+import com.riffle.core.domain.RemoteKind
+import javax.inject.Inject
+
+/**
+ * Runs the ADR-0030 GET-before-PATCH reconcile for one (sourceId, itemId) — the same primitive
+ * [ProgressSweep] runs across dirty rows, but scoped to a specific book on demand. Invoked from
+ * [com.riffle.app.feature.reader.session.ReaderSessionLifecycle.open] BEFORE loading the initial
+ * locator so the reader opens at the fresh server position instead of rendering the old local
+ * cfi first and then visibly jumping when the in-reader sync cycle catches up.
+ *
+ * Not wired into details-page ON_RESUME (only the reader-open moment) — an earlier attempt to run
+ * this on every details visit correlated with a library-grid refresh regression whose cause was
+ * never fully diagnosed; keeping the invocation surface narrow reduces the blast radius.
+ *
+ * Acquires the same per-target [ReconcileLocks] the sweep uses so this path and the sweep never
+ * double-run on the same target. Deliberately does NOT gate on [OpenReconcileTargets.isOpen] —
+ * the caller invokes it BEFORE [OpenReconcileTargets.markOpen], so the check would be a false
+ * positive on the reader's own opening cycle only if the book was already marked open by another
+ * live session, in which case we're happy to defer.
+ */
+interface ItemProgressPuller {
+    suspend fun pullItem(sourceId: String, itemId: String)
+}
+
+class ReconcilingItemProgressPuller @Inject constructor(
+    ebookStore: ReadingPositionStoreImpl,
+    audioStore: AudiobookPositionStoreImpl,
+    private val catalogRegistry: CatalogRegistry,
+    private val remoteFactory: ProgressRemoteFactory,
+    private val locks: ReconcileLocks,
+    private val openTargets: OpenReconcileTargets,
+    uiProgressSink: LibraryItemUiProgressSink,
+) : ItemProgressPuller {
+    private val ebookReconciler = ProgressReconciler(ebookStore, uiProgressSink)
+    private val audioReconciler = ProgressReconciler(audioStore, uiProgressSink)
+
+    override suspend fun pullItem(sourceId: String, itemId: String) {
+        if (openTargets.isOpen(sourceId, itemId)) return
+        val catalog = catalogRegistry.forSourceId(sourceId) ?: return
+        if (catalog is ProgressPeerCapability) {
+            val remote = remoteFactory.ebook(sourceId, itemId)
+            if (remote != null) locks.withLock(sourceId, itemId, RemoteKind.EBOOK_POSITION) {
+                ebookReconciler.reconcile(sourceId, itemId, remote)
+            }
+        }
+        if (catalog is AudiobookProgressPeerCapability) {
+            val remote = remoteFactory.audio(sourceId, itemId)
+            if (remote != null) locks.withLock(sourceId, itemId, RemoteKind.AUDIO_POSITION) {
+                audioReconciler.reconcile(sourceId, itemId, remote)
+            }
+        }
+    }
+}
+
+/** Test-only no-op used in unit tests that don't exercise the reconcile path. */
+object NoopItemProgressPuller : ItemProgressPuller {
+    override suspend fun pullItem(sourceId: String, itemId: String) = Unit
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryItemUiProgressSink.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryItemUiProgressSink.kt
@@ -1,0 +1,25 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.LibraryItemDao
+import com.riffle.core.domain.UiProgressSink
+import javax.inject.Inject
+
+/**
+ * Room-backed [UiProgressSink] the sweep invokes after a ServerWon reconcile so the library grid
+ * and detail view (which observe `library_items.readingProgress` and `finishedAt`) re-emit
+ * without waiting for the reader to reopen and derive them from the locator on close.
+ *
+ * The position stores (`reading_positions`, `audiobook_positions`) keep only locators / seconds;
+ * before this sink existed a background sweep would land a fresh server position but leave the
+ * UI columns stale — the cover kept the old blue bar and % until the book was actually opened.
+ * `finishedAt` is passed through nullable so a server "no longer finished" state clears the local
+ * stamp too (server-wins, matching the ServerWon branch in [com.riffle.core.domain.ProgressReconciler]).
+ */
+class LibraryItemUiProgressSink @Inject constructor(
+    private val libraryItemDao: LibraryItemDao,
+) : UiProgressSink {
+    override suspend fun apply(sourceId: String, itemId: String, readingProgress: Float, finishedAt: Long?) {
+        libraryItemDao.updateReadingProgress(sourceId, itemId, readingProgress)
+        libraryItemDao.updateFinishedAt(sourceId, itemId, finishedAt)
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -49,6 +49,7 @@ class LibraryRepositoryImpl @Inject constructor(
     private val sourceRepository: SourceRepository,
     private val clock: Clock,
     private val logger: Logger,
+    private val dirtyProgressLedger: DirtyProgressLedger,
 ) : LibraryObserver, LibraryMutator, LibraryRefresher {
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -266,24 +267,64 @@ class LibraryRepositoryImpl @Inject constructor(
             libraryItemDao.replaceAllForLibrary(source.id, libraryId, entities)
             // `replaceAllForLibrary.updateMetadata` intentionally preserves `readingProgress` on
             // existing rows so an offline reader-close save can't be clobbered by a stale library
-            // refresh. But an item can end up stuck at 0 forever when the initial `pullAllProgress`
-            // returned nothing for it (network flake, race with source install, or the source only
-            // recorded progress later) — the row is inserted with `readingProgress = 0`, and no
-            // subsequent refresh will fix it because `updateMetadata` skips the field. Adopt the
-            // server value here, gated on the PRE-refresh `lastOpenedAtMap` snapshot (updateMetadata
-            // has by now stamped lastOpenedAt from mergeLastOpenedAt, so we can't consult the DB).
-            // A row that was already opened locally on this device keeps its progress; a never-
-            // touched row adopts the server side (#528).
+            // refresh. But the library grid / detail view (`observeById`, `observeInProgress`,
+            // `observeFinished`, …) all read `library_items.readingProgress`, so a book whose
+            // server progress advanced on another device would never update visually until it was
+            // reopened locally. Adopt server `readingProgress` here for every row that is NOT
+            // locally dirty per [DirtyProgressLedger]: a dirty ebook or audio position row is the
+            // definitive signal that a local edit is pending push and MUST NOT be overwritten
+            // (the ADR 0030 sweep will resolve that row and mirror the result via UiProgressSink).
+            // A clean row's `library_items.readingProgress` equals the last synced server value,
+            // so overwriting it with the just-pulled server value is either identical (in sync)
+            // or an authoritative advancement from another device — never a regression. This
+            // supersedes the older `lastOpenedAt == null` gate (#528): "opened locally" is not
+            // proof of a pending local edit; only a dirty position row is.
+            val dirtyIds =
+                (dirtyProgressLedger.dirtyEbookItems(source.id) +
+                    dirtyProgressLedger.dirtyAudioItems(source.id)).toSet()
             for (item in items) {
+                if (item.id in dirtyIds) continue
                 val sp = serverProgressMap[item.id] ?: continue
-                if (sp.ebookProgress <= 0f) continue
-                if (lastOpenedAtMap[item.id] != null) continue
-                libraryItemDao.updateInitialReadingProgress(source.id, item.id, sp.ebookProgress)
+                libraryItemDao.updateReadingProgress(source.id, item.id, sp.ebookProgress)
             }
             val isUnsupported = entities.isNotEmpty() && entities.none { it.ebookFormat != EbookFormat.Unsupported.toStorageString() }
             libraryDao.setUnsupported(source.id, libraryId, isUnsupported)
             LibraryRefreshResult.Success
         }
+    }
+
+    override suspend fun refreshItemProgress(sourceId: String, itemId: String): LibraryRefreshResult {
+        val source = sourceRepository.getActive() ?: return LibraryRefreshResult.NoActiveServer
+        if (source.id != sourceId) return LibraryRefreshResult.NoActiveServer
+        val catalog = catalogRegistry.forSource(source) ?: return LibraryRefreshResult.NoActiveServer
+        if (source.type.isUnboundedCatalog) return LibraryRefreshResult.Success
+        val progressPeer = catalog as? ProgressPeerCapability ?: return LibraryRefreshResult.Success
+        val dirty = (dirtyProgressLedger.dirtyEbookItems(source.id) +
+            dirtyProgressLedger.dirtyAudioItems(source.id)).toSet()
+        if (itemId in dirty) return LibraryRefreshResult.Success
+        val sp = try {
+            progressPeer.pullProgress(itemId)
+        } catch (t: Throwable) {
+            logger.w(LogChannel.ProgressSync) {
+                "refreshItemProgress: pullProgress failed for source=${source.id} item=$itemId — " +
+                    "${t::class.simpleName}: ${t.message}"
+            }
+            return LibraryRefreshResult.NetworkError(t)
+        } ?: return LibraryRefreshResult.Success
+        // Single-item pullProgress doesn't apply the "audio → ebookProgress" fallback that
+        // pullAllProgress does (ABS ships `progress` on audio-only items, `ebookProgress = 0`),
+        // so derive the unified library fraction here (ADR 0029). isFinished pins to 1f to cover
+        // "server marks finished but audioCurrentTime slightly under duration" boundary.
+        val fraction = when {
+            sp.isFinished -> 1f
+            sp.ebookProgress > 0f -> sp.ebookProgress
+            sp.audioDuration > 0.0 -> (sp.audioCurrentTime / sp.audioDuration).toFloat().coerceIn(0f, 1f)
+            else -> 0f
+        }
+        val finishedAt = sp.finishedAt ?: sp.lastUpdate.takeIf { sp.isFinished }
+        libraryItemDao.updateReadingProgress(source.id, itemId, fraction)
+        libraryItemDao.updateFinishedAt(source.id, itemId, finishedAt)
+        return LibraryRefreshResult.Success
     }
 
     override suspend fun refreshSeries(libraryId: String): LibraryRefreshResult {

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -315,6 +315,12 @@ class LibraryRepositoryImpl @Inject constructor(
         // pullAllProgress does (ABS ships `progress` on audio-only items, `ebookProgress = 0`),
         // so derive the unified library fraction here (ADR 0029). isFinished pins to 1f to cover
         // "server marks finished but audioCurrentTime slightly under duration" boundary.
+        // Skip when the payload carries no meaningful progress at all (fresh item / audio-only
+        // book whose duration hasn't been populated server-side yet) — writing 0 in that case
+        // would clobber a previously-adopted non-zero value in library_items.readingProgress.
+        if (!sp.isFinished && sp.ebookProgress <= 0f && sp.audioDuration <= 0.0 && sp.audioCurrentTime <= 0.0) {
+            return LibraryRefreshResult.Success
+        }
         val fraction = when {
             sp.isFinished -> 1f
             sp.ebookProgress > 0f -> sp.ebookProgress

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/SyncModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/SyncModule.kt
@@ -53,6 +53,10 @@ abstract class SyncModule {
 
     @Binds
     @Singleton
+    abstract fun bindItemProgressPuller(impl: com.riffle.core.data.ReconcilingItemProgressPuller): com.riffle.core.data.ItemProgressPuller
+
+    @Binds
+    @Singleton
     abstract fun bindReadaloudLinkReconciler(impl: ReadaloudMatchingService): com.riffle.core.domain.ReadaloudLinkReconciler
 
     @Binds
@@ -75,12 +79,13 @@ abstract class SyncModule {
             audioStore: AudiobookPositionStoreImpl,
             bookmarkDao: com.riffle.core.database.AudiobookBookmarkDao,
             bookmarkReconciler: com.riffle.core.data.AudiobookBookmarkReconciler,
+            uiProgressSink: com.riffle.core.data.LibraryItemUiProgressSink,
         ): com.riffle.core.data.ProgressSweep =
             com.riffle.core.data.ProgressSweep(
                 ledger,
                 catalogRegistry,
-                com.riffle.core.domain.ProgressReconciler(ebookStore),
-                com.riffle.core.domain.ProgressReconciler(audioStore),
+                com.riffle.core.domain.ProgressReconciler(ebookStore, uiProgressSink),
+                com.riffle.core.domain.ProgressReconciler(audioStore, uiProgressSink),
                 remoteFactory, locks, openTargets,
                 // Bookmarks ride the sweep at the same cadence as positions: enumerate dirty
                 // (source, item) pairs straight off the bookmark DAO (ADR 0030, Task 12).

--- a/core/data/src/test/kotlin/com/riffle/core/data/CatalogProgressRemoteFactoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/CatalogProgressRemoteFactoryTest.kt
@@ -226,4 +226,86 @@ class CatalogProgressRemoteFactoryTest {
         assertNull(audioRemote(peer).get())
         assertNull(audioRemote(peer).patch(10.0))
     }
+
+    // --- UI-progress propagation: the library grid and detail view read
+    // `library_items.readingProgress` / `finishedAt`. Regression pin for the sync-doesn't-refresh-
+    // library-UI bug: `get()` MUST populate `readingProgress` and `finishedAt` from the pulled
+    // CatalogProgress so the reconciler's UiProgressSink can mirror them into `library_items`.
+
+    @Test
+    fun `ebook get - propagates ebookProgress and finishedAt into RemoteProgress`() = runTest {
+        val peer = FakePeer(
+            progress = CatalogProgress(
+                itemId = "item-1",
+                ebookLocation = "epubcfi(/6/4!/4)",
+                ebookProgress = 0.73f,
+                isFinished = false,
+                finishedAt = null,
+                lastUpdate = 1700L,
+            ),
+        )
+        val translator = FakeTranslator(cfiResult = { locatorJson }, locatorResult = { it })
+        val read = ebookRemote(peer, translator).get()
+        assertEquals(0.73f, read?.readingProgress)
+        assertNull(read?.finishedAt)
+    }
+
+    @Test
+    fun `ebook get - isFinished with null finishedAt falls back to lastUpdate as the finished stamp`() = runTest {
+        val peer = FakePeer(
+            progress = CatalogProgress(
+                itemId = "item-1", ebookLocation = "epubcfi(/6/4!/4)",
+                ebookProgress = 1f, isFinished = true, finishedAt = null, lastUpdate = 1700L,
+            ),
+        )
+        val translator = FakeTranslator(cfiResult = { locatorJson }, locatorResult = { it })
+        val read = ebookRemote(peer, translator).get()
+        assertEquals(1f, read?.readingProgress)
+        assertEquals(1700L, read?.finishedAt)
+    }
+
+    @Test
+    fun `audio get - computes readingProgress fraction from currentTime and duration`() = runTest {
+        val peer = FakePeer(
+            progress = CatalogProgress(
+                itemId = "item-1",
+                audioCurrentTime = 900.0,
+                audioDuration = 3600.0,
+                isFinished = false,
+                lastUpdate = 1700L,
+            ),
+        )
+        val read = audioRemote(peer).get()
+        assertEquals(0.25f, read?.readingProgress)
+        assertNull(read?.finishedAt)
+    }
+
+    @Test
+    fun `audio get - isFinished forces readingProgress to 1f and stamps finishedAt`() = runTest {
+        val peer = FakePeer(
+            progress = CatalogProgress(
+                itemId = "item-1",
+                audioCurrentTime = 3599.0,
+                audioDuration = 3600.0,
+                isFinished = true,
+                finishedAt = 1750L,
+                lastUpdate = 1700L,
+            ),
+        )
+        val read = audioRemote(peer).get()
+        assertEquals(1f, read?.readingProgress)
+        assertEquals(1750L, read?.finishedAt)
+    }
+
+    @Test
+    fun `audio get - zero duration yields 0f fraction (no NaN)`() = runTest {
+        val peer = FakePeer(
+            progress = CatalogProgress(
+                itemId = "item-1", audioCurrentTime = 42.0, audioDuration = 0.0,
+                isFinished = false, lastUpdate = 1700L,
+            ),
+        )
+        val read = audioRemote(peer).get()
+        assertEquals(0f, read?.readingProgress)
+    }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/CatalogProgressRemoteFactoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/CatalogProgressRemoteFactoryTest.kt
@@ -308,4 +308,47 @@ class CatalogProgressRemoteFactoryTest {
         val read = audioRemote(peer).get()
         assertEquals(0f, read?.readingProgress)
     }
+
+    /**
+     * Regression pin for the "ebook % gets clobbered to 0 on reader open" data-loss bug:
+     * AbsCatalog implements BOTH ProgressPeerCapability and AudiobookProgressPeerCapability, so
+     * for an ebook-only book the audio remote is also invoked. Its pullProgress returns
+     * audioCurrentTime=0, audioDuration=0, isFinished=false — nothing meaningful for an audio
+     * dimension that doesn't exist. Returning a non-null RemoteProgress here would trip the
+     * reconciler's ServerWon branch on the empty audiobook_positions row and fire UiSink with
+     * fraction=0, overwriting the ebook remote's just-written readingProgress. The get() gate
+     * MUST return null so the reconciler treats it as Offline and skips the UI mirror.
+     */
+    @Test
+    fun `audio get - returns null when payload has no audio dimension (ebook-only book)`() = runTest {
+        val peer = FakePeer(
+            progress = CatalogProgress(
+                itemId = "item-1",
+                ebookLocation = "epubcfi(/6/4)", ebookProgress = 0.42f, // real ebook progress
+                audioCurrentTime = 0.0, audioDuration = 0.0,
+                isFinished = false, lastUpdate = 1700L,
+            ),
+        )
+        val read = audioRemote(peer).get()
+        assertNull(read)
+    }
+
+    /**
+     * Boundary of the null-gate: a finished audiobook whose duration wasn't populated in the
+     * payload (rare metadata race) still carries a real "done" signal — we should surface it as
+     * fraction=1f rather than swallowing to null.
+     */
+    @Test
+    fun `audio get - isFinished with zero duration still surfaces fraction=1f (not null)`() = runTest {
+        val peer = FakePeer(
+            progress = CatalogProgress(
+                itemId = "item-1",
+                audioCurrentTime = 0.0, audioDuration = 0.0,
+                isFinished = true, finishedAt = 1750L, lastUpdate = 1700L,
+            ),
+        )
+        val read = audioRemote(peer).get()
+        assertEquals(1f, read?.readingProgress)
+        assertEquals(1750L, read?.finishedAt)
+    }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
@@ -161,18 +161,6 @@ internal class FakeLibraryItemDao : LibraryItemDao {
             }
         }
     }
-    override suspend fun updateInitialReadingProgress(sourceId: String, itemId: String, progress: Float) {
-        roomData.forEach { (_, flow) ->
-            flow.value = flow.value.map {
-                // Race-guard mirror of the SQL WHERE clause. The caller-side pre-refresh
-                // lastOpenedAtMap check does the semantic gating; this only defends against a
-                // reader-close landing between the map fetch and this UPDATE.
-                if (it.sourceId == sourceId && it.id == itemId && it.readingProgress == 0f)
-                    it.copy(readingProgress = progress)
-                else it
-            }
-        }
-    }
     override suspend fun updateLibraryId(sourceId: String, itemId: String, libraryId: String) {
         val entry = roomData.entries.firstOrNull { e ->
             e.value.value.any { it.sourceId == sourceId && it.id == itemId }

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -1334,6 +1334,32 @@ class LibraryRepositoryTest {
         assertEquals(0.75f, dao.itemsFor("lib-1").first { it.id == "item-1" }.readingProgress, 0.001f)
     }
 
+    /**
+     * Regression pin for the "details % gets clobbered to 0" data-loss variant of the audio-remote
+     * bug: when pullProgress returns an empty payload (no ebook progress, no audio dimension —
+     * e.g. audio metadata still being scanned server-side, or transient partial payload), the
+     * writer MUST skip rather than overwrite a previously-adopted non-zero readingProgress with 0.
+     */
+    @Test
+    fun `refreshItemProgress does NOT overwrite readingProgress when server payload has no meaningful progress`() = runTest {
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeLibraryItemDao()
+        dao.upsertAll(listOf(
+            LibraryItemEntity("s1", "item-1", "lib-1", "Book", "A", null, 0.42f, addedAt = 0L),
+        ))
+        val session = FakeGetProgressApi(
+            com.riffle.core.network.NetworkServerProgress(
+                ebookLocation = "", ebookProgress = 0f,
+                currentTime = 0.0, duration = 0.0, lastUpdate = 5_000L,
+            )
+        )
+        val result = makeRepo(libraryItemDao = dao, sessionApi = session)
+            .refreshItemProgress("s1", "item-1")
+        assertEquals(LibraryRefreshResult.Success, result)
+        assertEquals(0.42f, dao.itemsFor("lib-1").first { it.id == "item-1" }.readingProgress, 0.001f)
+    }
+
     @Test
     fun `refreshItemProgress derives audio fraction from currentTime and duration when ebookProgress is 0`() = runTest {
         // Single-item pullProgress (unlike pullAllProgress) does NOT apply the audio->ebookProgress

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -184,11 +184,26 @@ class LibraryRepositoryTest {
         }
     }
 
+    /** In-memory [DirtyProgressLedger] whose "dirty ebook" set can be seeded per test to model
+     *  a pending offline reader-close save without wiring the real position DAOs. */
+    internal class FakeDirtyProgressLedger(
+        val ebookDirty: MutableMap<String, MutableList<String>> = mutableMapOf(),
+        val audioDirty: MutableMap<String, MutableList<String>> = mutableMapOf(),
+    ) : DirtyProgressLedger {
+        override suspend fun serversWithDirty(): List<String> =
+            (ebookDirty.keys + audioDirty.keys).toList().distinct()
+        override suspend fun dirtyEbookItems(sourceId: String): List<String> =
+            ebookDirty[sourceId].orEmpty()
+        override suspend fun dirtyAudioItems(sourceId: String): List<String> =
+            audioDirty[sourceId].orEmpty()
+    }
+
     private fun makeRepo(
         libraryDao: FakeLibraryDao = FakeLibraryDao(),
         libraryItemDao: FakeLibraryItemDao = FakeLibraryItemDao(),
         seriesDao: FakeSeriesDao = FakeSeriesDao(),
         collectionDao: FakeCollectionDao = FakeCollectionDao(),
+        dirtyProgressLedger: DirtyProgressLedger = FakeDirtyProgressLedger(),
         api: AbsLibraryApi = object : AbsLibraryApi {
             override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<List<com.riffle.core.network.NetworkLibrary>> =
                 NetworkResult.Success(emptyList())
@@ -199,14 +214,17 @@ class LibraryRepositoryTest {
             override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<com.riffle.core.network.NetworkCollection>> =
                 NetworkResult.Success(emptyList())
         },
+        sessionApi: com.riffle.core.network.AbsSessionApi = NoopAbsSessionApi,
     ) = LibraryRepositoryImpl(
         InlineCatalogRegistry(testAbsCatalog(
             libraryApi = api,
+            sessionApi = sessionApi,
             baseUrl = fakeServerRepository.activeServer?.url?.value ?: "http://abs",
         )),
         libraryDao, libraryItemDao, seriesDao, collectionDao,
         fakeServerRepository, com.riffle.core.domain.TestClock(),
         com.riffle.core.logging.RecordingLogger(),
+        dirtyProgressLedger,
     )
 
     private fun activeServer(id: String = "s1") = Source(
@@ -412,15 +430,20 @@ class LibraryRepositoryTest {
     }
 
     @Test
-    fun `refreshLibraryItems keeps local readingProgress over stale source value`() = runTest {
-        // Reproduces the offline-read regression: source has old 0.42, local has 0.75 from an
-        // offline session. Refresh must not revert the library card back to the source value.
+    fun `refreshLibraryItems keeps local readingProgress when the position row is locally dirty`() = runTest {
+        // Reproduces the offline-read regression: local has 0.75 from an offline reader-close that
+        // hasn't yet been pushed to the server (so `reading_positions` for this item is dirty per
+        // ADR 0030). The library refresh MUST NOT overwrite the pending local edit — the ADR-0030
+        // sweep will resolve it and mirror the final fraction via UiProgressSink. This supersedes
+        // the older `lastOpenedAt == null` gate; the definitive "pending local edit" signal is a
+        // dirty position row, not "was ever opened".
         fakeServerRepository.activeServer = activeServer()
         fakeTokenStorage.tokens["s1"] = "tok"
         val dao = FakeLibraryItemDao()
         dao.upsertAll(listOf(
             LibraryItemEntity("s1", "item-1", "lib-1", "My Book", "Author A", null, 0.75f, addedAt = 0L),
         ))
+        val ledger = FakeDirtyProgressLedger(ebookDirty = mutableMapOf("s1" to mutableListOf("item-1")))
         val api = object : AbsLibraryApi {
             override suspend fun getUserProgress(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<Map<String, NetworkUserMediaProgress>> =
                 com.riffle.core.network.NetworkResult.Success(
@@ -437,7 +460,7 @@ class LibraryRepositoryTest {
             override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkCollection>> =
                 NetworkResult.Success(emptyList())
         }
-        makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
+        makeRepo(libraryItemDao = dao, api = api, dirtyProgressLedger = ledger).refreshLibraryItems("lib-1")
         assertEquals(0.75f, dao.itemsFor("lib-1").first { it.id == "item-1" }.readingProgress, 0.001f)
     }
 
@@ -476,10 +499,14 @@ class LibraryRepositoryTest {
     }
 
     @Test
-    fun `refreshLibraryItems does NOT adopt server readingProgress when the row has been opened locally (#528)`() = runTest {
-        // The offline-read invariant still holds: a row with lastOpenedAt set has been touched by
-        // the reader, so a stale server value must not overwrite it. Guards the boundary of the
-        // #528 fix — updateInitialReadingProgress is a no-op here.
+    fun `refreshLibraryItems adopts server readingProgress on a previously-opened locally-clean row`() = runTest {
+        // Direct regression for the "progress sync doesn't refresh the library UI" bug: a book
+        // was previously opened locally (lastOpenedAt set) but the local edit was long since
+        // pushed and cleaned — position row is NOT dirty. Server progress advanced on another
+        // device to 0.42. The library grid / detail view read `library_items.readingProgress`;
+        // without this adoption, the blue bar and % stay stale (at the old value or 0) until
+        // the user reopens the book on this device. The older `lastOpenedAt == null` gate was
+        // the wrong proxy for "protect a pending local edit" — "was opened" ≠ "has pending edit".
         fakeServerRepository.activeServer = activeServer()
         fakeTokenStorage.tokens["s1"] = "tok"
         val dao = FakeLibraryItemDao()
@@ -506,10 +533,74 @@ class LibraryRepositoryTest {
                 NetworkResult.Success(emptyList())
         }
         makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
-        // Row has lastOpenedAt=10_000 → the conditional UPDATE won't fire → local 0f is preserved.
-        // (The mergeLastOpenedAt path may still lift lastOpenedAt from the server stamp — that's
-        // orthogonal and covered by a separate test.)
-        assertEquals(0f, dao.itemsFor("lib-1").first { it.id == "item-1" }.readingProgress, 0.001f)
+        assertEquals(0.42f, dao.itemsFor("lib-1").first { it.id == "item-1" }.readingProgress, 0.001f)
+    }
+
+    @Test
+    fun `refreshLibraryItems keeps local readingProgress when position row is dirty even on previously-opened row`() = runTest {
+        // Combined boundary: previously-opened + non-zero local + pending offline edit. The dirty
+        // ledger flag is the gate — the library refresh must not clobber 0.75f, and the sweep
+        // will later push it and mirror the final value.
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeLibraryItemDao()
+        dao.upsertAll(listOf(
+            LibraryItemEntity(
+                "s1", "item-1", "lib-1", "Book", "A", null, 0.75f,
+                lastOpenedAt = 10_000L, addedAt = 0L,
+            ),
+        ))
+        val ledger = FakeDirtyProgressLedger(ebookDirty = mutableMapOf("s1" to mutableListOf("item-1")))
+        val api = object : AbsLibraryApi {
+            override suspend fun getUserProgress(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<Map<String, NetworkUserMediaProgress>> =
+                com.riffle.core.network.NetworkResult.Success(
+                    mapOf("item-1" to com.riffle.core.network.NetworkUserMediaProgress(ebookProgress = 0.42f, lastUpdate = 5_000L))
+                )
+            override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkLibrary>> =
+                NetworkResult.Success(emptyList())
+            override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkLibraryItem>> =
+                NetworkResult.Success(listOf(
+                    NetworkLibraryItem("item-1", "lib-1", "Book", "A", 0.42f, ebookFormat = EbookFormat.Epub)
+                ))
+            override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkSeries>> =
+                NetworkResult.Success(emptyList())
+            override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkCollection>> =
+                NetworkResult.Success(emptyList())
+        }
+        makeRepo(libraryItemDao = dao, api = api, dirtyProgressLedger = ledger).refreshLibraryItems("lib-1")
+        assertEquals(0.75f, dao.itemsFor("lib-1").first { it.id == "item-1" }.readingProgress, 0.001f)
+    }
+
+    @Test
+    fun `refreshLibraryItems keeps local readingProgress when position row is dirty via AUDIO`() = runTest {
+        // Same invariant, audio side: a dirty audiobook_positions row for this item must also
+        // gate off the ebookProgress adoption, because they're the same "activity" per ADR 0029
+        // and either dimension being pending push means the library refresh must defer.
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeLibraryItemDao()
+        dao.upsertAll(listOf(
+            LibraryItemEntity("s1", "item-1", "lib-1", "Book", "A", null, 0.75f, addedAt = 0L),
+        ))
+        val ledger = FakeDirtyProgressLedger(audioDirty = mutableMapOf("s1" to mutableListOf("item-1")))
+        val api = object : AbsLibraryApi {
+            override suspend fun getUserProgress(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<Map<String, NetworkUserMediaProgress>> =
+                com.riffle.core.network.NetworkResult.Success(
+                    mapOf("item-1" to com.riffle.core.network.NetworkUserMediaProgress(ebookProgress = 0.42f, lastUpdate = 5_000L))
+                )
+            override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkLibrary>> =
+                NetworkResult.Success(emptyList())
+            override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkLibraryItem>> =
+                NetworkResult.Success(listOf(
+                    NetworkLibraryItem("item-1", "lib-1", "Book", "A", 0.42f, ebookFormat = EbookFormat.Epub)
+                ))
+            override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkSeries>> =
+                NetworkResult.Success(emptyList())
+            override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkCollection>> =
+                NetworkResult.Success(emptyList())
+        }
+        makeRepo(libraryItemDao = dao, api = api, dirtyProgressLedger = ledger).refreshLibraryItems("lib-1")
+        assertEquals(0.75f, dao.itemsFor("lib-1").first { it.id == "item-1" }.readingProgress, 0.001f)
     }
 
     @Test
@@ -1172,6 +1263,97 @@ class LibraryRepositoryTest {
         val result = makeRepo(collectionDao = dao).observeCollectionItems("col-1").first()
         assertEquals(1, result.size)
         assertEquals("item-1", result[0].id)
+    }
+
+    // ── refreshItemProgress ───────────────────────────────────────────────────
+
+    /** Fake session API that returns a canned [com.riffle.core.network.NetworkServerProgress] from
+     *  `getProgress` (the endpoint `AbsCatalog.pullProgress(itemId)` calls). */
+    private class FakeGetProgressApi(
+        private val response: com.riffle.core.network.NetworkServerProgress,
+    ) : com.riffle.core.network.AbsSessionApi {
+        override suspend fun getProgress(
+            baseUrl: String, libraryItemId: String, token: String, insecureAllowed: Boolean,
+        ): NetworkResult<com.riffle.core.network.NetworkServerProgress> = NetworkResult.Success(response)
+
+        override suspend fun syncEbookProgress(
+            baseUrl: String, libraryItemId: String,
+            payload: com.riffle.core.network.NetworkEbookProgressPayload,
+            token: String, insecureAllowed: Boolean,
+        ): NetworkResult<Long> = NetworkResult.Success(0L)
+
+        override suspend fun syncAudiobookProgress(
+            baseUrl: String, libraryItemId: String,
+            payload: com.riffle.core.network.NetworkAudiobookProgressPayload,
+            token: String, insecureAllowed: Boolean,
+        ): NetworkResult<Long> = NetworkResult.Success(0L)
+    }
+
+    @Test
+    fun `refreshItemProgress adopts server ebookProgress into library_items on a clean row`() = runTest {
+        // Direct fix for the "details page shows stale %" bug — details ON_RESUME triggers this
+        // path, and it must land the just-pulled server fraction in the UI column the details
+        // screen observes.
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeLibraryItemDao()
+        dao.upsertAll(listOf(
+            LibraryItemEntity("s1", "item-1", "lib-1", "Book", "A", null, 0.10f, addedAt = 0L),
+        ))
+        val session = FakeGetProgressApi(
+            com.riffle.core.network.NetworkServerProgress(
+                ebookLocation = "epubcfi(/6/4)", ebookProgress = 0.63f, lastUpdate = 5_000L,
+            )
+        )
+        val result = makeRepo(libraryItemDao = dao, sessionApi = session)
+            .refreshItemProgress("s1", "item-1")
+        assertEquals(LibraryRefreshResult.Success, result)
+        assertEquals(0.63f, dao.itemsFor("lib-1").first { it.id == "item-1" }.readingProgress, 0.001f)
+    }
+
+    @Test
+    fun `refreshItemProgress does NOT overwrite readingProgress when the position row is dirty`() = runTest {
+        // Same "protect a pending offline edit" invariant as refreshLibraryItems: a dirty ebook
+        // (or audio) row means the ADR-0030 sweep owns this item. The details page pull must not
+        // land a server value here — the sweep + UiProgressSink will resolve it.
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeLibraryItemDao()
+        dao.upsertAll(listOf(
+            LibraryItemEntity("s1", "item-1", "lib-1", "Book", "A", null, 0.75f, addedAt = 0L),
+        ))
+        val ledger = FakeDirtyProgressLedger(ebookDirty = mutableMapOf("s1" to mutableListOf("item-1")))
+        val session = FakeGetProgressApi(
+            com.riffle.core.network.NetworkServerProgress(
+                ebookLocation = "epubcfi(/6/4)", ebookProgress = 0.42f, lastUpdate = 5_000L,
+            )
+        )
+        val result = makeRepo(libraryItemDao = dao, dirtyProgressLedger = ledger, sessionApi = session)
+            .refreshItemProgress("s1", "item-1")
+        assertEquals(LibraryRefreshResult.Success, result)
+        assertEquals(0.75f, dao.itemsFor("lib-1").first { it.id == "item-1" }.readingProgress, 0.001f)
+    }
+
+    @Test
+    fun `refreshItemProgress derives audio fraction from currentTime and duration when ebookProgress is 0`() = runTest {
+        // Single-item pullProgress (unlike pullAllProgress) does NOT apply the audio->ebookProgress
+        // fallback that AbsApiClient does for the /me/progress bulk endpoint (ADR 0029). Ensure
+        // `refreshItemProgress` still computes the unified library fraction for an audio-only
+        // book: 900s / 3600s = 0.25.
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeLibraryItemDao()
+        dao.upsertAll(listOf(
+            LibraryItemEntity("s1", "item-1", "lib-1", "Audio", "A", null, 0f, addedAt = 0L),
+        ))
+        val session = FakeGetProgressApi(
+            com.riffle.core.network.NetworkServerProgress(
+                ebookLocation = "", ebookProgress = 0f,
+                currentTime = 900.0, duration = 3600.0, lastUpdate = 5_000L,
+            )
+        )
+        makeRepo(libraryItemDao = dao, sessionApi = session).refreshItemProgress("s1", "item-1")
+        assertEquals(0.25f, dao.itemsFor("lib-1").first { it.id == "item-1" }.readingProgress, 0.001f)
     }
 
     // ── Storyteller refresh ───────────────────────────────────────────────────

--- a/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/NoopLibraryDaos.kt
@@ -33,7 +33,6 @@ internal object ThrowingLibraryItemDao : LibraryItemDao {
     override suspend fun idsForLibrary(sourceId: String, libraryId: String): List<String> = emptyList()
     override suspend fun updateLastOpenedAt(sourceId: String, itemId: String, timestamp: Long) = Unit
     override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) = Unit
-    override suspend fun updateInitialReadingProgress(sourceId: String, itemId: String, progress: Float) = Unit
     override suspend fun updateLibraryId(sourceId: String, itemId: String, libraryId: String) = Unit
     override suspend fun updateFinishedAt(sourceId: String, itemId: String, finishedAt: Long?) = Unit
     override suspend fun getLastOpenedAtMap(sourceId: String, libraryId: String): List<LastOpenedAtRow> = emptyList()

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -402,7 +402,6 @@ class ReadaloudMatchingServiceTest {
         override suspend fun idsForLibrary(sourceId: String, libraryId: String): List<String> = emptyList()
         override suspend fun updateLastOpenedAt(sourceId: String, itemId: String, timestamp: Long) = Unit
         override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) = Unit
-        override suspend fun updateInitialReadingProgress(sourceId: String, itemId: String, progress: Float) = Unit
         override suspend fun updateLibraryId(sourceId: String, itemId: String, libraryId: String) = Unit
         override suspend fun updateFinishedAt(sourceId: String, itemId: String, finishedAt: Long?) = Unit
         override suspend fun getLastOpenedAtMap(sourceId: String, libraryId: String): List<LastOpenedAtRow> = emptyList()

--- a/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SeriesIntegrationTest.kt
@@ -130,7 +130,6 @@ class SeriesIntegrationTest {
         override suspend fun getLastOpenedAtMap(sourceId: String, libraryId: String): List<LastOpenedAtRow> = emptyList()
         override suspend fun getReadingProgressMap(sourceId: String, libraryId: String): List<ReadingProgressRow> = emptyList()
         override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) {}
-        override suspend fun updateInitialReadingProgress(sourceId: String, itemId: String, progress: Float) {}
         override suspend fun updateLibraryId(sourceId: String, itemId: String, libraryId: String) {}
         override suspend fun updateFinishedAt(sourceId: String, itemId: String, finishedAt: Long?) {}
         override suspend fun listMatchableBySourceType(serverType: String): List<com.riffle.core.database.MatchableItemRow> = emptyList()
@@ -157,6 +156,11 @@ class SeriesIntegrationTest {
             sourceRepository = fakeServerRepository,
             clock = com.riffle.core.domain.TestClock(),
             logger = com.riffle.core.logging.RecordingLogger(),
+            dirtyProgressLedger = object : DirtyProgressLedger {
+                override suspend fun serversWithDirty() = emptyList<String>()
+                override suspend fun dirtyEbookItems(sourceId: String) = emptyList<String>()
+                override suspend fun dirtyAudioItems(sourceId: String) = emptyList<String>()
+            },
         )
     }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
@@ -186,7 +186,6 @@ class ServerRepositoryTest {
         override suspend fun getLastOpenedAtMap(sourceId: String, libraryId: String) = emptyList<com.riffle.core.database.LastOpenedAtRow>()
         override suspend fun getReadingProgressMap(sourceId: String, libraryId: String) = emptyList<com.riffle.core.database.ReadingProgressRow>()
         override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) {}
-        override suspend fun updateInitialReadingProgress(sourceId: String, itemId: String, progress: Float) {}
         override suspend fun updateLibraryId(sourceId: String, itemId: String, libraryId: String) {}
         override suspend fun updateFinishedAt(sourceId: String, itemId: String, finishedAt: Long?) {}
         override suspend fun listMatchableBySourceType(serverType: String) = emptyList<com.riffle.core.database.MatchableItemRow>()

--- a/core/data/src/test/kotlin/com/riffle/core/data/TestCatalogRegistry.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/TestCatalogRegistry.kt
@@ -114,7 +114,7 @@ private object NoopAbsPlaybackApi : AbsPlaybackApi {
     ) = com.riffle.core.network.NetworkResult.Offline(RuntimeException("noop"))
 }
 
-private object NoopAbsSessionApi : AbsSessionApi {
+internal object NoopAbsSessionApi : AbsSessionApi {
     override suspend fun syncEbookProgress(
         baseUrl: String, libraryItemId: String,
         payload: com.riffle.core.network.NetworkEbookProgressPayload, token: String, insecureAllowed: Boolean,

--- a/core/data/src/test/kotlin/com/riffle/core/data/websource/WebSourceLibraryItemUpserterTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/websource/WebSourceLibraryItemUpserterTest.kt
@@ -284,12 +284,6 @@ class WebSourceLibraryItemUpserterTest {
             val row = rows[sourceId to itemId] ?: return
             rows[sourceId to itemId] = row.copy(readingProgress = progress)
         }
-        override suspend fun updateInitialReadingProgress(sourceId: String, itemId: String, progress: Float) {
-            val row = rows[sourceId to itemId] ?: return
-            if (row.readingProgress == 0f && row.lastOpenedAt == null) {
-                rows[sourceId to itemId] = row.copy(readingProgress = progress)
-            }
-        }
         override suspend fun updateLibraryId(sourceId: String, itemId: String, libraryId: String) { }
         override suspend fun updateFinishedAt(sourceId: String, itemId: String, finishedAt: Long?) { }
         override suspend fun getLastOpenedAtMap(sourceId: String, libraryId: String): List<LastOpenedAtRow> = emptyList()

--- a/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
@@ -151,17 +151,6 @@ interface LibraryItemDao {
     suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float)
 
     /**
-     * Conditional variant used by [LibraryRepositoryImpl.refreshLibraryItems] to adopt the
-     * server's `readingProgress` on a later refresh when the row was initially inserted at 0
-     * (e.g. the first pullAllProgress missed it). The Kotlin-side caller gates on the pre-refresh
-     * `lastOpenedAt` snapshot; this SQL clause only guards against a concurrent reader-close race
-     * — a fresh non-zero local progress must not be clobbered even if it arrives between the
-     * pre-refresh map fetch and this UPDATE (#528).
-     */
-    @Query("UPDATE library_items SET readingProgress = :progress WHERE sourceId = :sourceId AND id = :itemId AND readingProgress = 0")
-    suspend fun updateInitialReadingProgress(sourceId: String, itemId: String, progress: Float)
-
-    /**
      * Retag a library item's [libraryId]. Used by the LocalFiles scanner so a book's compatibility
      * hint stays pointed at some *currently-configured* folder library — otherwise removing that
      * folder leaves the row naming a deleted [LibraryEntity]. Catalog queries for LocalFiles go

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryRepository.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/LibraryRepository.kt
@@ -77,4 +77,13 @@ interface LibraryRefresher {
     suspend fun refreshLibraryItems(libraryId: String): LibraryRefreshResult
     suspend fun refreshSeries(libraryId: String): LibraryRefreshResult
     suspend fun refreshCollections(libraryId: String): LibraryRefreshResult
+
+    /**
+     * Pull one item's server progress and mirror it into `library_items.readingProgress` /
+     * `finishedAt`, if the local position row is NOT dirty (a pending offline edit is protected
+     * by the same invariant as [refreshLibraryItems]). The details screen calls this on ON_RESUME
+     * so a book whose progress advanced on another device shows the fresh % / blue bar without
+     * requiring the user to navigate through the library grid first.
+     */
+    suspend fun refreshItemProgress(sourceId: String, itemId: String): LibraryRefreshResult
 }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ProgressReconciler.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ProgressReconciler.kt
@@ -17,31 +17,73 @@ sealed interface ReconcileOutcome<out P> {
 }
 
 /**
+ * Sink for the UI-facing progress columns (`library_items.readingProgress`, `finishedAt`) that
+ * mirror the just-pulled server state on a ServerWon reconcile. The position stores keep only
+ * locators / seconds; without this sink the library grid and detail view would stay stale until
+ * the reader was reopened and the reader-close path recomputed the fraction. Kept as a fun
+ * interface so the domain layer stays pure — Room-backed impl lives in `core/data`.
+ */
+fun interface UiProgressSink {
+    suspend fun apply(sourceId: String, itemId: String, readingProgress: Float, finishedAt: Long?)
+}
+
+/**
  * The durable single-target reconcile primitive of ADR 0030: GET-before-PATCH last-update-wins for
  * one ABS record, with compare-and-clear so a concurrent offline edit is never overwritten or lost.
  * Pure orchestration over a [SyncPositionStore] and a per-row [ProgressRemote] — no Android, Room, or
  * network. Used directly by the headless sweep worker (single target) and composed by the live
  * multi-peer cycle.
+ *
+ * On ServerWon, invokes [uiSink] with the server-derived UI fields so the library grid / detail
+ * view re-emit without waiting for the reader to reopen. Default is a no-op for tests / callers
+ * that don't render a library UI (live open-book path stays untouched — it uses the stores
+ * directly, not this reconciler).
  */
-class ProgressReconciler<P>(private val store: SyncPositionStore<P>) {
+class ProgressReconciler<P>(
+    private val store: SyncPositionStore<P>,
+    private val uiSink: UiProgressSink = UiProgressSink { _, _, _, _ -> },
+) {
 
     suspend fun reconcile(sourceId: String, itemId: String, remote: ProgressRemote<P>): ReconcileOutcome<P> {
         val snap = store.snapshot(sourceId, itemId)
         val read = remote.get() ?: return ReconcileOutcome.Offline
 
+        // #528 device-clock-skew data-loss guard: a CLEAN row (localUpdatedAt == lastSyncedAt)
+        // has nothing new to push — everything the reader last saved has already been synced.
+        // But if the device wall clock runs slightly ahead of the ABS server clock, the local
+        // stamp we recorded from the last successful sync can end up numerically ABOVE the
+        // server's current lastUpdate, even when the server has since been advanced by another
+        // device. A naive `localUpdatedAt > lastUpdate` comparison then decides LocalWins and
+        // PUSHes the stale local locator over the server's fresh one — the "Device 2 open
+        // silently downgraded Device 1's progress" bug. Matches
+        // [com.riffle.core.data.ReadingSessionRepositoryImpl.runSyncCycle]'s guard: for CLEAN
+        // rows we ONLY pull (when server has advanced since our last sync), never push.
+        val localDirty = snap.localUpdatedAt > snap.lastSyncedAt
+        val serverAdvanced = read.lastUpdate > snap.lastSyncedAt
+
         return when {
-            // Server is strictly newer — pull. (Local wins ties, so an in-sync remote never pulls.)
-            read.lastUpdate > snap.localUpdatedAt -> {
+            // ServerWins: (a) a clean row and the server has moved since our last sync — adopt it;
+            // (b) a dirty row where the server stamp is strictly newer than our local edit — the
+            // remote change beat our un-pushed edit and wins the last-update-wins race.
+            (!localDirty && serverAdvanced) ||
+                (localDirty && read.lastUpdate > snap.localUpdatedAt) -> {
                 val applied = store.acceptServerPosition(
                     sourceId, itemId, read.position, serverStamp = read.lastUpdate,
                     ifLocalUpdatedAt = snap.localUpdatedAt,
                 )
-                if (applied) ReconcileOutcome.ServerWon(read.position, read.lastUpdate)
-                else ReconcileOutcome.Superseded
+                if (applied) {
+                    // Mirror the fresh server state into the UI-facing columns so the library
+                    // grid / detail view re-emit; a Superseded (local edit raced in) skips this,
+                    // since the local edit is now authoritative for both position and fraction.
+                    uiSink.apply(sourceId, itemId, read.readingProgress, read.finishedAt)
+                    ReconcileOutcome.ServerWon(read.position, read.lastUpdate)
+                } else ReconcileOutcome.Superseded
             }
 
-            // Local is strictly newer — push, then adopt the server-returned stamp.
-            snap.localUpdatedAt > read.lastUpdate -> {
+            // LocalWins: only when the row is DIRTY (there's a real pending edit to push) AND
+            // the local stamp is strictly newer. Clean rows never enter this branch — they have
+            // nothing new to push and the clock-skew guard above depends on it.
+            localDirty && snap.localUpdatedAt > read.lastUpdate -> {
                 val position = snap.position ?: return ReconcileOutcome.InSync
                 val stamp = remote.patch(position) ?: return ReconcileOutcome.PushFailed
                 val applied = store.confirmPushed(
@@ -50,7 +92,9 @@ class ProgressReconciler<P>(private val store: SyncPositionStore<P>) {
                 if (applied) ReconcileOutcome.LocalPushed(stamp) else ReconcileOutcome.Superseded
             }
 
-            // Equal — already in sync; clear any lingering dirty marker.
+            // Nothing to do: clean row and server hasn't moved (in sync), or dirty row with
+            // stamps equal to the server's (an idempotent re-sync). Clear the dirty marker so
+            // the sweep doesn't re-pick it.
             else -> {
                 store.confirmInSync(sourceId, itemId, ifLocalUpdatedAt = snap.localUpdatedAt)
                 ReconcileOutcome.InSync

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ProgressRemote.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ProgressRemote.kt
@@ -1,7 +1,20 @@
 package com.riffle.core.domain
 
-/** A remote progress record for one target, already in the local payload's coordinate [P]. */
-data class RemoteProgress<P>(val position: P, val lastUpdate: Long)
+/**
+ * A remote progress record for one target, already in the local payload's coordinate [P].
+ *
+ * [readingProgress] and [finishedAt] are the UI-facing fields the library grid and detail view
+ * read (`library_items.readingProgress` and `library_items.finishedAt`). They are propagated so a
+ * server-wins sweep can refresh those columns via [UiProgressSink] without waiting for the reader
+ * to reopen the book and derive them from the locator on close. They are not used by the
+ * reconcile arithmetic itself — only [lastUpdate] participates in last-update-wins.
+ */
+data class RemoteProgress<P>(
+    val position: P,
+    val lastUpdate: Long,
+    val readingProgress: Float = 0f,
+    val finishedAt: Long? = null,
+)
 
 /**
  * The remote (ABS) side of one reconcilable target. Both operations are per-target isolated:

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/ProgressReconcilerTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/ProgressReconcilerTest.kt
@@ -139,6 +139,48 @@ class ProgressReconcilerTest {
         assertEquals("local-cfi", store.position) // not overwritten by the server
     }
 
+    /**
+     * #528 device-clock-skew data-loss regression: a CLEAN row (localUpdatedAt == lastSyncedAt)
+     * whose local stamp happens to be numerically ABOVE the server's current lastUpdate must
+     * NEVER push local to server. Without this guard, the per-item puller invoked from reader-
+     * open would treat a stale local locator as authoritative and PATCH it over the server's
+     * fresh position saved by another device, silently downgrading the user's real progress.
+     * Matches [com.riffle.core.data.ReadingSessionRepositoryImpl.runSyncCycle]'s guard.
+     */
+    @Test
+    fun `clean row with local stamp ABOVE server stamp does NOT push (clock-skew guard)`() = runTest {
+        val store = FakeSyncStore(position = "stale-local-cfi", localUpdatedAt = 500L, lastSyncedAt = 500L)
+        val remote = FakeRemote(RemoteProgress("server-cfi", lastUpdate = 300L))
+
+        val outcome = ProgressReconciler(store).reconcile(SERVER, ITEM, remote)
+
+        assertEquals(ReconcileOutcome.InSync, outcome)
+        assertEquals("stale-local-cfi", store.position) // local NOT overwritten by server
+        assertEquals(0, remote.patchCalls) // AND server NOT overwritten by local (the data-loss bug)
+        assertFalse(store.dirty)
+    }
+
+    /**
+     * Complementary case to the clock-skew guard: a CLEAN row whose stamp equals the server's
+     * lastSyncedAt but where the server has since ADVANCED (a real cross-device push) must
+     * pull the server value. This is the fix for the reader-open flash — the puller relies on
+     * it to refresh the position store before the reader loads the initial locator.
+     */
+    @Test
+    fun `clean row pulls when server has advanced since last sync (cross-device push)`() = runTest {
+        val store = FakeSyncStore(position = "old-server-cfi", localUpdatedAt = 300L, lastSyncedAt = 300L)
+        val remote = FakeRemote(RemoteProgress("new-server-cfi", lastUpdate = 500L))
+
+        val outcome = ProgressReconciler(store).reconcile(SERVER, ITEM, remote)
+
+        assertEquals(ReconcileOutcome.ServerWon("new-server-cfi", 500L), outcome)
+        assertEquals("new-server-cfi", store.position)
+        assertEquals(500L, store.localUpdatedAt)
+        assertEquals(500L, store.lastSyncedAt)
+        assertFalse(store.dirty)
+        assertEquals(0, remote.patchCalls) // pull only, no push
+    }
+
     @Test
     fun `GET failure is offline - nothing is written and the row stays dirty`() = runTest {
         val store = FakeSyncStore(position = "local-cfi", localUpdatedAt = 300L, lastSyncedAt = 100L)
@@ -226,4 +268,89 @@ class ProgressReconcilerTest {
         assertEquals(42.0, remote.patchedWith)
         assertFalse(store.dirty)
     }
+
+    /**
+     * The library grid and detail view read `library_items.readingProgress` / `finishedAt`, not
+     * the position stores. Regression pin: after a ServerWon reconcile the UI sink MUST fire with
+     * the propagated fraction / finished stamp so the blue bar and % refresh without waiting for
+     * the reader to reopen and derive the fraction from the locator on close.
+     */
+    @Test
+    fun `ServerWon invokes the UI sink with the propagated fraction and finishedAt`() = runTest {
+        val store = FakeSyncStore(position = "local-cfi", localUpdatedAt = 100L, lastSyncedAt = 100L)
+        val remote = FakeRemote(
+            RemoteProgress(
+                position = "server-cfi",
+                lastUpdate = 200L,
+                readingProgress = 0.42f,
+                finishedAt = 200L,
+            ),
+        )
+        val sinkCalls = mutableListOf<Quad<String, String, Float, Long?>>()
+        val sink = UiProgressSink { s, i, p, f -> sinkCalls += Quad(s, i, p, f) }
+
+        val outcome = ProgressReconciler(store, sink).reconcile(SERVER, ITEM, remote)
+
+        assertEquals(ReconcileOutcome.ServerWon("server-cfi", 200L), outcome)
+        assertEquals(listOf(Quad(SERVER, ITEM, 0.42f, 200L)), sinkCalls)
+    }
+
+    /**
+     * The UI sink is the "server-wins mirror". A superseded ServerWon (local edit raced in mid-
+     * flight) means the local edit is authoritative — the sink must NOT overwrite the row's
+     * fraction/finishedAt with the older server view.
+     */
+    @Test
+    fun `Superseded ServerWon does NOT invoke the UI sink`() = runTest {
+        val store = FakeSyncStore(position = "local-cfi", localUpdatedAt = 100L, lastSyncedAt = 100L)
+        val remote = FakeRemote(
+            RemoteProgress(position = "server-cfi", lastUpdate = 200L, readingProgress = 0.42f),
+            onGet = { store.localUpdatedAt = 150L },
+        )
+        var sinkCalls = 0
+        val sink = UiProgressSink { _, _, _, _ -> sinkCalls++ }
+
+        val outcome = ProgressReconciler(store, sink).reconcile(SERVER, ITEM, remote)
+
+        assertEquals(ReconcileOutcome.Superseded, outcome)
+        assertEquals(0, sinkCalls)
+    }
+
+    /**
+     * The other non-ServerWon outcomes (LocalPushed, InSync, Offline, PushFailed) must also skip
+     * the UI sink — the sink is strictly "server has newer state, mirror it into UI columns".
+     */
+    @Test
+    fun `LocalPushed InSync Offline PushFailed all skip the UI sink`() = runTest {
+        var sinkCalls = 0
+        val sink = UiProgressSink { _, _, _, _ -> sinkCalls++ }
+
+        // LocalPushed
+        ProgressReconciler(
+            FakeSyncStore(position = "local", localUpdatedAt = 300L, lastSyncedAt = 100L),
+            sink,
+        ).reconcile(SERVER, ITEM, FakeRemote(RemoteProgress("srv", 200L), patchStamp = 305L))
+
+        // InSync (equal stamps)
+        ProgressReconciler(
+            FakeSyncStore(position = "cfi", localUpdatedAt = 200L, lastSyncedAt = 100L),
+            sink,
+        ).reconcile(SERVER, ITEM, FakeRemote(RemoteProgress("cfi", 200L)))
+
+        // Offline (GET returned null)
+        ProgressReconciler(
+            FakeSyncStore(position = "local", localUpdatedAt = 300L, lastSyncedAt = 100L),
+            sink,
+        ).reconcile(SERVER, ITEM, FakeRemote<String>(getResult = null))
+
+        // PushFailed (patch returned null)
+        ProgressReconciler(
+            FakeSyncStore(position = "local", localUpdatedAt = 300L, lastSyncedAt = 100L),
+            sink,
+        ).reconcile(SERVER, ITEM, FakeRemote(RemoteProgress("srv", 200L), patchStamp = null))
+
+        assertEquals(0, sinkCalls)
+    }
+
+    private data class Quad<A, B, C, D>(val a: A, val b: B, val c: C, val d: D)
 }

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/usecase/RefreshLibraryItemsTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/usecase/RefreshLibraryItemsTest.kt
@@ -30,6 +30,7 @@ class RefreshLibraryItemsTest {
         override suspend fun refreshLibraryItems(libraryId: String) = result
         override suspend fun refreshSeries(libraryId: String) = result
         override suspend fun refreshCollections(libraryId: String) = result
+        override suspend fun refreshItemProgress(sourceId: String, itemId: String) = result
     }
 
     private class RecordingSyncer : StorytellerReadaloudCacheSyncer {


### PR DESCRIPTION
## Summary

Fix the class of bugs where server-side progress advances (from another device or the web UI) never landed on the library grid %, the details screen, or the reader's initial locator until the book was reopened, because ADR-0030's sync only touched `reading_positions` / `audiobook_positions`. Adds coverage across all three UI surfaces + a data-loss guard in the reconciler + several fixes surfaced by internal code review.

## What changed

- **`ProgressReconciler.UiProgressSink`** — new callback fired on ServerWon. `LibraryItemUiProgressSink` mirrors the pulled fraction into `library_items.readingProgress` / `finishedAt`, so the library grid + details screen re-emit as soon as the sweep finishes.
- **`RemoteProgress<P>`** — carries `readingProgress` / `finishedAt` (default 0 / null) so the reconciler can forward them to the sink without knowing the ABS payload. Ebook/audio remotes populate them; audio computes the fallback fraction from `currentTime/duration` (single-item ABS pull doesn't apply the fallback that `pullAllProgress` does — ADR 0029).
- **`refreshLibraryItems` (ON_RESUME on library grid)** — adopts server `readingProgress` for every row that isn't dirty per `DirtyProgressLedger`, superseding the earlier `lastOpenedAt == null` gate. Retires the now-unused `LibraryItemDao.updateInitialReadingProgress`. Ledger dirty = definitive "pending local edit"; `lastOpenedAt` was the wrong proxy.
- **`refreshItemProgress` (ON_RESUME on details)** — new single-item pull so the details %/blue bar refreshes on deep-link / back-from-reader without a library-grid trip.
- **`ItemProgressPuller` (before `epubRepository.openEpub`)** — runs the ADR-0030 per-item reconcile so the reader lands at the fresh server locator instead of rendering the old cfi and then visibly jumping when the in-reader sync cycle catches up. Bounded by a 1.5s timeout so a slow server never blocks the reader. Uses `try/catch` that re-throws `CancellationException` — a plain `runCatching` around a suspending call is a well-known Kotlin coroutine footgun that swallows structured cancellation.
- **`ProgressReconciler` clock-skew guard (#528 data-loss fix)** — clean rows (`localUpdatedAt == lastSyncedAt`) NEVER enter LocalPushed regardless of the naive `localUpdatedAt > lastUpdate` comparison. Otherwise a device whose wall clock ran slightly ahead of the ABS server clock would treat any per-item reconcile as an accidental PATCH that overwrites the server's fresh position with the local stale locator. The sweep is unaffected (only ever passes dirty rows, for which clean/dirty reduces to the same comparison).
- **Audio-remote null-gate** — for an ebook-only book, `AbsCatalog` implements both progress capabilities so both reconcilers ran; the audio side saw currentTime=0 / duration=0 on an empty `audiobook_positions` row → ServerWon → UiSink wrote `readingProgress=0` → clobbered the ebook's fresh %. `CatalogAudioProgressRemote.get()` now returns null when the payload has no audio dimension (currentTime<=0 AND duration<=0 AND !isFinished); `refreshItemProgress` symmetrically skips the write. `isFinished` with zero duration still surfaces fraction=1f — a real "done" signal.
- **VM cold-open** — `LibraryItemDetailViewModel.refreshItemProgress()` no longer gates on Ready state; resolves `sourceId`/`itemId` from `sourceRepository` + `savedStateHandle` so the deep-link ON_RESUME case (where the VM's async item load hasn't settled) actually dispatches.

## Test coverage

- `ProgressReconcilerTest` — sink fires on ServerWon and skips on every non-ServerWon outcome; clock-skew clean-row-never-pushes guard; cross-device server-newer pull.
- `CatalogProgressRemoteFactoryTest` — ebook/audio remotes populate UI fields; audio-fraction fallback (`isFinished`→1f, `audioDuration>0`→ratio, zero-duration+finished→1f); audio null-gate for ebook-only payload.
- `LibraryRepositoryTest` — refreshLibraryItems adopts for clean rows on both ebook/audio dimensions; skips for dirty rows; refreshItemProgress writes fresh, respects dirty guard, derives audio fraction, and skips empty payloads instead of clobbering.
- `LibraryItemDetailViewModelTest` — `RecordingLibraryRefresher` pins that `refreshItemProgress()` dispatches with `(activeSourceId, savedStateHandle.itemId)`, including the cold-open case where uiState is still Loading.
- `ReaderSessionLifecycleTest` — puller invoked BEFORE `epubRepository.openEpub`; puller-timeout still opens the reader; puller-throws (non-cancellation) still opens the reader.

## Deferred (not in this PR, noted for follow-up)

- Narrow race between the dirtyIds snapshot and per-item write in `refreshLibraryItems` — needs a SQL conditional-update to close cleanly.
- Two DAO writes per UiSink invocation (2N Room invalidations) — combine into one DAO method.
- Adoption-loop writes even when server value equals local — add a `WHERE readingProgress != :progress` guard.
- Audio-fraction `when` cascade duplicated at three sites — extract `CatalogProgress.uiReadingFraction()` helper.
- Clock-skew clean-row-never-pushes guard duplicated between `ProgressReconciler` and `ReadingSessionRepositoryImpl.runSyncCycle` — altitude refactor to collapse onto the reconciler primitive.

## Test plan

- [x] `./gradlew test` (full JVM suite) — green.
- [x] Device-verified end-to-end: bug #2 (data-loss from clock-skew LocalPushed) no longer reproduces after the reconciler guard landed.
- [ ] Verify on device that ebook-only books no longer flash progress to 0 on reader open (regression pin added, not device-verified in this PR).
- [ ] Verify on device that deep-link to a book you've never opened refreshes progress on the details page (cold-open dispatch fix, not device-verified in this PR).