### PR TITLE
fix(annotations): merge overlapping selections + remember last pick

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/DraftPopupSelection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/DraftPopupSelection.kt
@@ -1,0 +1,54 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.models.EmphasisStyle
+import com.riffle.core.models.HighlightColor
+
+/**
+ * Pure derivation of the highlight-actions popup's pre-selected state (swatch + emphasis chips).
+ *
+ * Extracted from [EpubReaderScreen]'s popup block so the selection rules are JVM-testable without
+ * standing up Compose. The rules — one place, one truth:
+ *
+ * - **Persisted annotation** (`isDraft = false`): `selectedColor` reflects the row's stored color;
+ *   empty color → `null` (∅ shown); `emphasisStyles` reflects the sibling emphasis row at the same
+ *   CFI, empty otherwise.
+ * - **Pending draft** (`isDraft = true`): ADR 0046 §4 — pre-select the per-book last-used state so
+ *   dismissing the sheet with no explicit pick auto-commits the "last color" annotation the user
+ *   is used to (see [com.riffle.app.feature.reader.session.AnnotationSession.dismissHighlightActions]).
+ *   `selectedColor` = last-used color (or `null` when the last pick was ∅);
+ *   `emphasisStyles` = last-used emphasis set.
+ */
+internal fun resolveDraftPopupSelection(
+    isDraft: Boolean,
+    persistedColor: String?,
+    persistedEmphasisStyles: Set<EmphasisStyle>,
+    lastUsedHighlightColor: HighlightColor,
+    lastUsedColorIsNone: Boolean,
+    lastUsedEmphasisStyles: Set<EmphasisStyle>,
+): DraftPopupSelection {
+    if (isDraft) {
+        val color = if (lastUsedColorIsNone) null else lastUsedHighlightColor
+        return DraftPopupSelection(selectedColor = color, emphasisStyles = lastUsedEmphasisStyles)
+    }
+    val color = if (persistedColor.isNullOrEmpty()) null else HighlightColor.fromToken(persistedColor)
+    return DraftPopupSelection(selectedColor = color, emphasisStyles = persistedEmphasisStyles)
+}
+
+internal data class DraftPopupSelection(
+    val selectedColor: HighlightColor?,
+    val emphasisStyles: Set<EmphasisStyle>,
+)
+
+/**
+ * Dismiss behaviour predicate for a pending draft (Bug 2, 2026-07-19).
+ *
+ * Returns `true` when the popup's dismiss should COMMIT the draft using the per-book last-used
+ * preset (colour + emphasis) instead of discarding — the user's explicit spec was "dismissal
+ * must only happen when no colour selected AND no formatting done either." When the last colour
+ * pick was ∅ AND no emphasis preset is remembered, there is no meaningful preset to commit, so
+ * the dismiss discards the draft (pre-fix behaviour).
+ */
+internal fun shouldAutoCommitDraftOnDismiss(
+    lastUsedColorIsNone: Boolean,
+    lastUsedEmphasisStyles: Set<EmphasisStyle>,
+): Boolean = !lastUsedColorIsNone || lastUsedEmphasisStyles.isNotEmpty()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubCfiRange.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubCfiRange.kt
@@ -139,9 +139,61 @@ internal fun locateSnippetInBody(
     }
     // Anchor-less fallback: only trustworthy if the snippet appears exactly once in the chapter.
     val first = body.indexOf(snippet)
-    if (first < 0) return null
-    if (body.indexOf(snippet, first + 1) >= 0) return null
-    return first.toLong()
+    if (first >= 0 && body.indexOf(snippet, first + 1) < 0) return first.toLong()
+    // Whitespace-tolerant fallback (2026-07-19): a multi-paragraph selection has "\n" or spaces
+    // between paragraphs in the Readium-captured snippet, but [readableBodyText] concatenates
+    // adjacent block-element text nodes with NO separator (a blank-only text node between
+    // `<p>` elements is skipped). Verbatim indexOf then fails on cross-paragraph snippets, so
+    // the overlap-merge detector treats overlapping multi-paragraph selections as disjoint and
+    // both rows persist as a doubly-annotated span. Rebuild a regex from the snippet where every
+    // whitespace run becomes `\s*` — matches whether or not the body carries the separator, and
+    // stays unambiguous because the surrounding non-whitespace tokens are still order-sensitive.
+    val tokens = snippet.split(Regex("\\s+")).filter { it.isNotEmpty() }
+    if (tokens.isEmpty()) return null
+    val pattern = tokens.joinToString(separator = "\\s*") { Regex.escape(it) }
+    val regex = try { Regex(pattern) } catch (_: Throwable) { return null }
+    val anchoredMatch = if (anchorTail.isNotEmpty()) {
+        val anchorTokens = anchorTail.split(Regex("\\s+")).filter { it.isNotEmpty() }
+        if (anchorTokens.isEmpty()) null
+        else {
+            val anchorPattern = anchorTokens.joinToString(separator = "\\s*") { Regex.escape(it) }
+            val combined = try { Regex("$anchorPattern\\s*$pattern") } catch (_: Throwable) { null }
+            combined?.find(body)?.let { m ->
+                val snippetStart = Regex(pattern).find(body, m.range.first)?.range?.first
+                snippetStart?.toLong()
+            }
+        }
+    } else null
+    if (anchoredMatch != null) return anchoredMatch
+    val loose = regex.find(body) ?: return null
+    val next = regex.find(body, loose.range.first + 1)
+    if (next != null) return null
+    return loose.range.first.toLong()
+}
+
+/**
+ * Compute the half-open end char of a snippet located at [startChar] in [html]'s readable body,
+ * by walking the body forward and consuming as many non-whitespace chars as the snippet has.
+ * Handles the multi-paragraph case where `snippet.length` overshoots the actual body span: a
+ * cross-paragraph snippet like "para1.\nThe" is 10 chars, but the readable body concatenates
+ * text nodes with no separator ("para1.The"), so the actual span is 9 chars.
+ *
+ * Callers use this instead of `startChar + snippet.length` when the snippet may cross a block
+ * boundary — otherwise the returned range would extend past the user's selection, and highlight
+ * decorations would paint over adjacent text they shouldn't (reported 2026-07-20: "wash extends
+ * to whole paragraph after Annotate").
+ */
+internal fun snippetEndCharInBody(html: String, startChar: Long, snippet: String): Long {
+    val body = readableBodyText(html)
+    val nonWs = snippet.count { !it.isWhitespace() }
+    if (nonWs <= 0) return startChar
+    var idx = startChar.toInt().coerceAtLeast(0).coerceAtMost(body.length)
+    var consumed = 0
+    while (idx < body.length && consumed < nonWs) {
+        if (!body[idx].isWhitespace()) consumed++
+        idx++
+    }
+    return idx.toLong()
 }
 
 /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -285,6 +285,8 @@ fun EpubReaderScreen(
     val annotations by viewModel.annotations.collectAsState()
     val emphasisPool by viewModel.emphasisPool.collectAsState()
     val lastUsedEmphasisStyles by viewModel.lastUsedEmphasisStyles.collectAsState()
+    val lastUsedHighlightColor by viewModel.lastUsedHighlightColor.collectAsState()
+    val lastUsedColorIsNone by viewModel.lastUsedColorIsNone.collectAsState()
     // ADR 0046 §4: draft-time preview needs the pending selection's text + last-used styles so
     // the DOM emphasis injector can wrap the range BEFORE commit — otherwise a chip that's
     // pre-selected (from the per-book preset) shows checked in the sheet but the text isn't
@@ -537,6 +539,8 @@ fun EpubReaderScreen(
                         onToggleEmphasis = viewModel::toggleEmphasisStyle,
                         emphasisPool = emphasisPool,
                         lastUsedEmphasisStyles = lastUsedEmphasisStyles,
+                        lastUsedHighlightColor = lastUsedHighlightColor,
+                        lastUsedColorIsNone = lastUsedColorIsNone,
                         draftAnnotation = draftAnnotation,
                         highlightDomPatches = viewModel.highlightDomPatches,
                         showOpenInBook = shouldShowOpenInBook(viewModel.readerSource),
@@ -1352,6 +1356,10 @@ private fun EpubNavigatorView(
     /** ADR 0046 §4: per-book last-used emphasis set, used to preview chip pre-selection while
      *  the sheet is open on a pending draft. */
     lastUsedEmphasisStyles: Set<com.riffle.core.models.EmphasisStyle> = emptySet(),
+    /** ADR 0046 §4: per-book last-used highlight colour + ∅ flag; used to pre-select the swatch
+     *  in the popup when the sheet is open on a pending draft. */
+    lastUsedHighlightColor: HighlightColor = HighlightColor.DEFAULT,
+    lastUsedColorIsNone: Boolean = false,
     /** ADR 0046 §4: the in-flight draft, if any. Threaded down so the DOM emphasis injector
      *  can preview bold/italic on the pending selection BEFORE commit (chip pre-selected
      *  from the per-book preset must visually match the text). */
@@ -3081,32 +3089,27 @@ private fun EpubNavigatorView(
             // decoration), so `current` above is always null for image annotations. Fall back to
             // the full annotations list so the palette can still show the current colour selected.
             val currentAnnotation = annotations.firstOrNull { it.id == editTarget.id }
-            // ADR 0046 §4: after `∅` the annotation's `color` is empty. `HighlightColor.fromToken`
-            // falls back to DEFAULT for unknown/empty (sync forward-compat), so passing an empty
-            // color through it would show yellow as selected. Detect empty here and pass null so
-            // the swatch row highlights the `∅` circle instead.
-            //
-            // For the DRAFT sentinel target (no persisted annotation yet), no lookup can succeed;
-            // show ∅ as pre-selected — the user hasn't picked a colour yet, and any real tap
-            // commits the draft with that pick.
+            // ADR 0046 §4: swatch + chip pre-selection is derived by [resolveDraftPopupSelection]
+            // (pure helper — see its KDoc for the persisted-vs-draft rules; the draft case pre-
+            // selects the per-book last-used state so a dismiss-without-explicit-pick auto-commits
+            // in the user's remembered colour/emphasis).
             val isDraft = editTarget.id == com.riffle.app.feature.reader.session.AnnotationSession.DRAFT_ANNOTATION_ID
-            val effectiveColor = current?.color ?: currentAnnotation?.color
-            val selectedColor = if (isDraft || effectiveColor.isNullOrEmpty()) null
-                else HighlightColor.fromToken(effectiveColor)
-            // ADR 0046: derive the current emphasis set on this highlight's range so the popup
-            // knows which B/I/U/S chips are active. Same-CFI equality — the "layered emphasis"
-            // gesture is always relative to the visible highlight target.
-            val currentEmphasisStyles: Set<com.riffle.core.models.EmphasisStyle> = run {
-                if (isDraft) {
-                    // ADR 0046 §4: preview the last-used emphasis set as chip pre-selection.
-                    // Any chip tap commits the draft with that style layered on top of the preset.
-                    return@run lastUsedEmphasisStyles
-                }
+            val persistedEmphasisStyles: Set<com.riffle.core.models.EmphasisStyle> = run {
                 val hlCfi = currentAnnotation?.cfi
                 if (hlCfi.isNullOrEmpty()) emptySet()
                 else emphasisPool.firstOrNull { it.cfi == hlCfi }
                     ?.emphasisStyles.orEmpty()
             }
+            val popupSelection = resolveDraftPopupSelection(
+                isDraft = isDraft,
+                persistedColor = current?.color ?: currentAnnotation?.color,
+                persistedEmphasisStyles = persistedEmphasisStyles,
+                lastUsedHighlightColor = lastUsedHighlightColor,
+                lastUsedColorIsNone = lastUsedColorIsNone,
+                lastUsedEmphasisStyles = lastUsedEmphasisStyles,
+            )
+            val selectedColor = popupSelection.selectedColor
+            val currentEmphasisStyles = popupSelection.emphasisStyles
             HighlightActionsPopup(
                 anchorRect = editTarget.anchorRect,
                 selected = selectedColor,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -854,6 +854,16 @@ class EpubReaderViewModel @Inject constructor(
     val lastUsedEmphasisStyles: StateFlow<Set<com.riffle.core.models.EmphasisStyle>> =
         annotationSession.lastUsedEmphasisStyles
 
+    /** ADR 0046 §4: per-book last-used highlight colour, delegated so the screen can preview it
+     *  as the swatch row's pre-selection when the sheet opens on a draft. Pair with
+     *  [lastUsedColorIsNone] — when true the ∅ swatch is pre-selected instead. */
+    val lastUsedHighlightColor: StateFlow<com.riffle.core.models.HighlightColor> =
+        annotationSession.lastUsedHighlightColor
+
+    /** ADR 0046 §4: `true` when the last colour pick was ∅ so the swatch row pre-selects the
+     *  crossed circle instead of the [lastUsedHighlightColor] value. */
+    val lastUsedColorIsNone: StateFlow<Boolean> = annotationSession.lastUsedColorIsNone
+
     /** ADR 0046 §4: the in-flight [AnnotationSession.DraftAnnotation], if any. The screen reads
      *  this so the DOM emphasis injector can preview bold/italic on the pending selection using
      *  the draft's [AnnotationSession.DraftAnnotation.textSnippet] + [AnnotationSession.DraftAnnotation.textBefore]
@@ -907,7 +917,29 @@ class EpubReaderViewModel @Inject constructor(
      */
     private fun annotationIdOf(decorationId: String): String = decorationId.substringBefore('#')
 
-    fun dismissHighlightActions() = annotationSession.dismissHighlightActions()
+    /**
+     * Dismiss the highlight-actions popup.
+     *
+     * ADR 0046 §4 (updated 2026-07-19): for a pending DRAFT, dismissing without an explicit swatch
+     * or chip tap now COMMITS the draft in the per-book last-used state — colour = last-used
+     * colour (or `∅` if the user's last pick was ∅), emphasis = last-used set — instead of
+     * discarding. Only a preset of `∅` + no emphasis discards; otherwise the pre-selected state
+     * shown in the popup would be a lie ("chip checked but annotation vanished on tap-outside").
+     * The trash icon still routes through [deleteHighlight] → [AnnotationSession.discardDraft].
+     */
+    fun dismissHighlightActions() {
+        val target = annotationSession.highlightToEdit.value
+        if (target?.id == com.riffle.app.feature.reader.session.AnnotationSession.DRAFT_ANNOTATION_ID) {
+            val presetColorIsNone = annotationSession.lastUsedColorIsNone.value
+            val presetEmphasis = annotationSession.lastUsedEmphasisStyles.value
+            if (shouldAutoCommitDraftOnDismiss(presetColorIsNone, presetEmphasis)) {
+                val colorToken = if (presetColorIsNone) "" else annotationSession.lastUsedHighlightColor.value.token
+                viewModelScope.launch { commitDraft(initialColor = colorToken, keepSheetOpen = false) }
+                return
+            }
+        }
+        annotationSession.dismissHighlightActions()
+    }
 
     /** Note-editor target — non-null while the note-editor dialog is open. */
     val noteEditorTarget: StateFlow<HighlightEditTarget?> = annotationSession.noteEditorTarget
@@ -1821,8 +1853,15 @@ class EpubReaderViewModel @Inject constructor(
             // time via [mergeAdjacentIntoHighlight] — recolour to match or note-cleared. See
             // docs/superpowers/specs/2026-07-05-highlight-auto-merge-design.md ("On note-clear").
             val cfiRange = if (locatedChar != null) {
+                // End char via non-whitespace walk: a multi-paragraph snippet like "para1.\nThe"
+                // is 10 chars but the readable body has "para1.The" (9 chars) since blank-only
+                // text nodes between block elements are skipped. Using raw `snippet.length` would
+                // overshoot by the newline count and the CFI range would extend past the user's
+                // selection — reported 2026-07-20 as "wash extends to whole paragraph". Walking
+                // the body forward consuming non-whitespace chars gives the true end.
+                val endExclusive = snippetEndCharInBody(html, locatedChar, snippet)
                 buildHighlightCfiRange(
-                    spineStep, html, locatedChar, (locatedChar + snippet.length - 1L).coerceAtLeast(locatedChar),
+                    spineStep, html, locatedChar, (endExclusive - 1L).coerceAtLeast(locatedChar),
                 )
             } else {
                 buildHighlightCfiRangeForSelection(spineStep, html, progression, snippet)
@@ -1923,6 +1962,7 @@ class EpubReaderViewModel @Inject constructor(
     private suspend fun commitDraft(
         initialColor: String,
         addEmphasisStyle: com.riffle.core.models.EmphasisStyle? = null,
+        keepSheetOpen: Boolean = true,
     ) {
         val draft = annotationSession.draftAnnotation.value ?: return
         // Cleanup of a fully-empty annotation (no colour + no emphasis + no note) is deferred
@@ -1932,32 +1972,48 @@ class EpubReaderViewModel @Inject constructor(
         // it — on a cold cache immediately after bind, the preset reads empty even when the
         // store has real styles, and tapping ∅ would then discard a draft whose real preset
         // would have layered emphasis onto the highlight ("annotation is discarded").
-        // Deferred overlap dedup — a larger selection covering an existing highlight replaces it.
-        // ADR 0046 §4: MUST cascade sibling emphasis rows at the deleted highlight's CFI, or
-        // every overlap-dedup leaks a TYPE_EMPHASIS row with no live anchor. Users who iterated
-        // on layered bold/italic annotations accumulated N orphan emphasis rows (observed
-        // 2026-07-18 — 29 orphans on a debug device), which manifested as "annotations don't
-        // show in the panel and the underlying text stays formatted forever" because the DOM
-        // injector kept reading the orphan emphasis rows but the panel filters TYPE_EMPHASIS out.
-        annotationSession.highlightRenders.value
-            .filter { normalizeEpubHref(it.locator.href.toString()) == normalizeEpubHref(draft.chapterHref) }
-            .forEach { render ->
-                val existSnippet = render.locator.text.highlight ?: return@forEach
-                val existAfter = render.locator.text.after ?: ""
-                if (highlightOverlapsAtSamePosition(
-                        draft.textSnippet, draft.textAfter, existSnippet, existAfter,
-                    )) {
-                    val victim = annotationSession.annotations.value.firstOrNull { it.id == render.id }
-                    if (victim != null) {
-                        annotationSession.emphasisPool.value
-                            .filter { it.cfi == victim.cfi }
-                            .forEach { annotationStore.delete(it.id) }
-                    }
-                    annotationStore.delete(render.id)
-                }
+        // Deferred overlap MERGE — a new selection that partially or fully overlaps existing
+        // highlights in the same chapter is unioned with them into ONE highlight covering
+        // `[min(starts), max(ends))`. Pre-fix behaviour (before 2026-07-19) required snippet
+        // substring containment and only DELETED the victim without extending the draft's range,
+        // which left a genuine partial overlap (new begins inside existing, extends past its tail)
+        // untouched — both rows persisted and painted a double-strength wash over the shared span.
+        // The new detector [computeOverlapMerge] uses char-offset ranges resolved via
+        // [locateSnippetInBody], so any true positional overlap merges.
+        //
+        // ADR 0046 §4 cascade: MUST cascade sibling emphasis rows at each victim's CFI, or the
+        // merge leaks a TYPE_EMPHASIS row with no live anchor. Users who iterated on layered
+        // bold/italic annotations accumulated N orphan emphasis rows (observed 2026-07-18 — 29
+        // orphans on a debug device); manifested as "annotations don't show in the panel and the
+        // underlying text stays formatted forever" (panel filters TYPE_EMPHASIS out, DOM injector
+        // does not).
+        val html = readChapterHtml(draft.spineIndex)
+        val candidates = annotationSession.annotations.value
+            .filter { it.type == com.riffle.core.database.AnnotationEntity.TYPE_HIGHLIGHT }
+            .filter { normalizeEpubHref(it.chapterHref) == normalizeEpubHref(draft.chapterHref) }
+        val overlapMerge = html?.let {
+            computeOverlapMerge(it, draft.textSnippet, draft.textBefore, candidates)
+        }
+        overlapMerge?.victimIds?.forEach { victimId ->
+            val victim = candidates.firstOrNull { it.id == victimId }
+            if (victim != null) {
+                annotationSession.emphasisPool.value
+                    .filter { it.cfi == victim.cfi }
+                    .forEach { annotationStore.delete(it.id) }
             }
-        // Standalone TYPE_IMAGE absorption for figures the new highlight now encloses.
-        val absorbedFilenames = draft.embeddedFigures?.mapNotNull { it.href }?.map(::figureHrefFilename)?.toSet().orEmpty()
+            annotationStore.delete(victimId)
+        }
+        // If we merged, rebuild the persisted range fields from the union so the stored highlight
+        // covers the full `[mergedStart, mergedEnd)` span. Fall back to draft fields when no
+        // overlap was detected (the common path) or the DOM rebuild fails (safety net).
+        val mergedFields: MergedDraftFields = if (overlapMerge != null && html != null) {
+            buildMergedDraftFields(html, draft.spineIndex, draft.embeddedFigures, overlapMerge, candidates)
+                ?: draft.toDraftFields()
+        } else {
+            draft.toDraftFields()
+        }
+        // Standalone TYPE_IMAGE absorption for figures the merged highlight now encloses.
+        val absorbedFilenames = mergedFields.embeddedFigures?.mapNotNull { it.href }?.map(::figureHrefFilename)?.toSet().orEmpty()
         if (absorbedFilenames.isNotEmpty()) {
             annotationSession.annotations.value
                 .filter { it.type == com.riffle.core.database.AnnotationEntity.TYPE_IMAGE }
@@ -1968,15 +2024,15 @@ class EpubReaderViewModel @Inject constructor(
         val created = annotationStore.createHighlight(
             sourceId = draft.sourceId,
             itemId = draft.itemId,
-            cfi = draft.cfiRange,
-            textSnippet = draft.textSnippet,
+            cfi = mergedFields.cfiRange,
+            textSnippet = mergedFields.textSnippet,
             chapterHref = draft.chapterHref,
-            textBefore = draft.textBefore,
-            textAfter = draft.textAfter,
+            textBefore = mergedFields.textBefore,
+            textAfter = mergedFields.textAfter,
             color = initialColor,
             spineIndex = draft.spineIndex,
-            progression = draft.progression,
-            embeddedFigures = draft.embeddedFigures,
+            progression = mergedFields.progression,
+            embeddedFigures = mergedFields.embeddedFigures,
             originFontFamily = draft.originFontFamily,
         )
         val presetStyles = annotationSession.lastUsedEmphasisStyles.value
@@ -1985,14 +2041,14 @@ class EpubReaderViewModel @Inject constructor(
             annotationStore.createEmphasis(
                 sourceId = draft.sourceId,
                 itemId = draft.itemId,
-                cfi = draft.cfiRange,
-                textSnippet = draft.textSnippet,
+                cfi = mergedFields.cfiRange,
+                textSnippet = mergedFields.textSnippet,
                 chapterHref = draft.chapterHref,
-                textBefore = draft.textBefore,
-                textAfter = draft.textAfter,
+                textBefore = mergedFields.textBefore,
+                textAfter = mergedFields.textAfter,
                 styles = combinedStyles,
                 spineIndex = draft.spineIndex,
-                progression = draft.progression,
+                progression = mergedFields.progression,
                 originFontFamily = draft.originFontFamily,
             )
         }
@@ -2004,13 +2060,29 @@ class EpubReaderViewModel @Inject constructor(
         // toggleEmphasisStyle, so the very first emphasis a user creates on a book teaches the
         // preset for the next.
         emphasisPreferencesStore.setLastUsedStyles(draft.sourceId, draft.itemId, combinedStyles)
+        // ADR 0046 §4 (2026-07-20 fix): persist the committed COLOUR as the per-book default
+        // too — sibling to the emphasis persistence above. Without this, tapping a swatch on a
+        // draft was committed correctly but the next draft opened on the OLD last-used colour;
+        // the user's most recent pick was forgotten ("the latest selection on the annotation
+        // dialog must be remembered").
+        annotationSession.persistLastUsedColorToken(initialColor)
         // Swap the sheet from the draft sentinel to the real annotation id so the popup rebinds
-        // to the persisted row for subsequent edits. Tag it as just-created so a subsequent
-        // dismiss-with-nothing-picked cleans up the phantom row (see tombstone check in
-        // [AnnotationSession.dismissHighlightActions]).
-        openHighlightActionsJustCreated(created.id, draft.anchorRect)
+        // to the persisted row for subsequent edits — UNLESS the caller is the dismiss-auto-
+        // commit path (2026-07-19 fix), where the user's intent is to close the popup entirely.
+        // Reopening on the persisted row after a first tap-outside required a second tap to
+        // actually close ("first tap doesn't close the modal").
+        if (keepSheetOpen) {
+            // Tag as just-created so a subsequent dismiss-with-nothing-picked cleans up the
+            // phantom row (see tombstone check in [AnnotationSession.dismissHighlightActions]).
+            openHighlightActionsJustCreated(created.id, draft.anchorRect)
+        } else {
+            // Dismiss path — close the sheet outright. The row is persisted with the preset
+            // colour + emphasis; no follow-up edit target is needed.
+            annotationSession.forceCloseHighlightEditTarget()
+        }
         // Clear the draft last — the [beginAnnotationDraft] path set both draft and edit target;
-        // openHighlightActions above already reset the edit target, so we just clean the draft.
+        // openHighlightActions above (or forceClose in the dismiss branch) already reset the
+        // edit target, so we just clean the draft.
         annotationSession.consumeDraft()
         scheduleAnnotationSync()
     }
@@ -2135,7 +2207,10 @@ class EpubReaderViewModel @Inject constructor(
             }
             return
         }
-        val endChar = (rightmostStart + rightmost.textSnippet.length).coerceAtMost(totalChars)
+        // Non-whitespace walk (2026-07-20): rightmost.textSnippet may span a paragraph boundary
+        // whose separator isn't in the readable body stream — raw `.length` would overshoot.
+        val endChar = snippetEndCharInBody(html, rightmostStart, rightmost.textSnippet)
+            .coerceAtMost(totalChars)
         if (endChar <= startChar) {
             logger.d(LogChannel.HighlightMerge) {
                 "edit-merge FAIL id=$id reason=invalid-range startChar=$startChar endChar=$endChar"
@@ -2594,10 +2669,16 @@ class EpubReaderViewModel @Inject constructor(
     private val emphasisToggleMutex = kotlinx.coroutines.sync.Mutex()
 
     fun toggleEmphasisStyle(highlightId: String, style: com.riffle.core.models.EmphasisStyle) {
-        // ADR 0046 §4: draft emphasis tap → commit with color="" + the tapped style. Preserves
-        // any last-used emphasis pre-selection as the base, then adds the tapped chip on top.
+        // ADR 0046 §4: draft emphasis tap → commit with the per-book pre-selected colour
+        // (respecting ∅) + the tapped style. Color and emphasis are INDEPENDENT dimensions —
+        // reported 2026-07-19: hardcoding initialColor="" here wiped the swatch-row pre-selection
+        // when the user toggled a chip on the draft popup ("clearing the font formatting also
+        // cleared the colour"). Preserves any last-used emphasis pre-selection as the base, then
+        // adds the tapped chip on top.
         if (highlightId == com.riffle.app.feature.reader.session.AnnotationSession.DRAFT_ANNOTATION_ID) {
-            viewModelScope.launch { commitDraft(initialColor = "", addEmphasisStyle = style) }
+            val presetColor = if (annotationSession.lastUsedColorIsNone.value) ""
+                else annotationSession.lastUsedHighlightColor.value.token
+            viewModelScope.launch { commitDraft(initialColor = presetColor, addEmphasisStyle = style) }
             return
         }
         val sourceId = annotationServerId ?: return

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRangeOverlap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRangeOverlap.kt
@@ -1,0 +1,179 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.models.Annotation
+import com.riffle.core.models.EmbeddedFigure
+import com.riffle.core.domain.countBodyChars
+import org.jsoup.Jsoup
+
+/** Overlap-merge context length: how much text to snapshot either side of the merged range as
+ *  the persisted textBefore/textAfter. Matches [OVERLAP_CONTEXT_LEN] used by the legacy detector. */
+private const val MERGED_CONTEXT_LEN = 60
+
+/**
+ * True-range overlap detection for the draft-commit merge path (Bug 1 fix, 2026-07-19).
+ *
+ * Prior detector [highlightOverlapsAtSamePosition] used substring containment of one snippet by
+ * the other. That misses partial overlaps where neither snippet contains the other — e.g. a new
+ * selection "was nothing more than a comma…" that begins inside an existing "he was nothing more
+ * than a comma on the page of History." and extends past its tail. Substring failed → no merge
+ * → both highlights coexisted over the shared span (the doubled-orange bug in the video).
+ *
+ * The new detector operates on character-offset ranges resolved via [locateSnippetInBody] and
+ * a strict interval-overlap test. Detection is a pure function so it is JVM-testable independently
+ * of DOM I/O.
+ */
+
+/** Half-open char range `[startChar, endChar)` — endChar exclusive so touching endpoints are
+ *  NOT overlap (adjacent same-colour highlights are handled by the edit-time merge path). */
+internal data class CharRange2(val startChar: Long, val endChar: Long)
+
+/** Strict interval overlap on half-open ranges: `a.start < b.end && b.start < a.end`. */
+internal fun charRangesOverlap(a: CharRange2, b: CharRange2): Boolean =
+    a.startChar < b.endChar && b.startChar < a.endChar
+
+/**
+ * Resolve an annotation's `[startChar, endChar)` in the chapter body via [locateSnippetInBody].
+ * Returns null when the snippet can't be located (legacy row without a matching context, or the
+ * chapter HTML has drifted). Callers skip the pair rather than false-positive merging.
+ *
+ * For multi-paragraph snippets, [locateSnippetInBody]'s whitespace-tolerant fallback may match
+ * a body substring shorter than `textSnippet.length` (because `readableBodyText` drops the
+ * blank-only text nodes between adjacent block elements). Compute `endChar` by scanning forward
+ * through the body's readable text, consuming the snippet's non-whitespace characters — that
+ * gives the correct half-open end even when the raw snippet contains newlines the body doesn't.
+ */
+internal fun annotationCharRange(html: String, textSnippet: String, textBefore: String): CharRange2? {
+    val start = locateSnippetInBody(html, textSnippet, textBefore) ?: return null
+    val end = snippetEndCharInBody(html, start, textSnippet)
+    if (end <= start) return null
+    return CharRange2(start, end)
+}
+
+/**
+ * Detect overlap victims for a new draft against every candidate existing highlight in the same
+ * chapter. Returns the set of victim ids to delete AND the union range `[mergedStart, mergedEnd)`
+ * spanning the draft + all overlapping victims. Null when no overlap or the draft itself can't
+ * be located.
+ *
+ * The caller (commitDraft) uses the union range to rebuild the merged snippet / textBefore /
+ * textAfter / CFI, delete each victim (cascading its sibling emphasis rows), and persist ONE
+ * merged highlight — replacing the pre-fix "delete-only, don't union" logic that shrank the
+ * merged span down to just the new selection.
+ */
+internal data class OverlapMergeResult(
+    val mergedStart: Long,
+    val mergedEnd: Long,
+    val victimIds: List<String>,
+)
+
+/**
+ * Fields of a merged (or plain) draft that get persisted by `commitDraft`. Separated from the
+ * full [com.riffle.app.feature.reader.session.AnnotationSession.DraftAnnotation] so the overlap-
+ * merge path can override just these fields (range/snippet/context/CFI/progression/figures) while
+ * carrying the draft's identity (sourceId, itemId, chapter, spineIndex, originFontFamily, anchor)
+ * through unchanged.
+ */
+internal data class MergedDraftFields(
+    val cfiRange: String,
+    val textSnippet: String,
+    val textBefore: String,
+    val textAfter: String,
+    val progression: Double,
+    val embeddedFigures: List<EmbeddedFigure>?,
+)
+
+/** Trivially lift the draft's own fields into [MergedDraftFields] for the no-overlap path. */
+internal fun com.riffle.app.feature.reader.session.AnnotationSession.DraftAnnotation.toDraftFields(): MergedDraftFields =
+    MergedDraftFields(
+        cfiRange = cfiRange,
+        textSnippet = textSnippet,
+        textBefore = textBefore,
+        textAfter = textAfter,
+        progression = progression,
+        embeddedFigures = embeddedFigures,
+    )
+
+/**
+ * Rebuild the persisted highlight fields for a range-merged draft. Reads the merged snippet from
+ * the DOM via [readableTextBetween], derives textBefore/textAfter from the readable body-text
+ * either side of the union range (bounded by [MERGED_CONTEXT_LEN]), rebuilds the CFI via
+ * [buildHighlightCfiRange], recomputes progression against the chapter's readable-char total,
+ * and re-walks the merged range to collect embedded figures (with bytes/svg re-attached from the
+ * pre-merge draft + victims so re-walking doesn't drop already-captured raster data).
+ *
+ * Returns null when any DOM-derived step fails (missing snippet in text, CFI build fails, empty
+ * body), letting the caller fall back to the un-merged draft fields as a safety net.
+ */
+internal fun buildMergedDraftFields(
+    html: String,
+    draftSpineIndex: Int,
+    draftEmbeddedFigures: List<EmbeddedFigure>?,
+    overlap: OverlapMergeResult,
+    candidates: List<Annotation>,
+): MergedDraftFields? {
+    val mergedStart = overlap.mergedStart
+    val mergedEnd = overlap.mergedEnd
+    val body = readableBodyText(html)
+    val totalChars = countBodyChars(Jsoup.parse(html).body())
+    if (totalChars <= 0L) return null
+    val mergedSnippet = readableTextBetween(html, mergedStart, mergedEnd) ?: return null
+    val spineStep = (draftSpineIndex + 1) * 2
+    val cfiRange = buildHighlightCfiRange(spineStep, html, mergedStart, mergedEnd - 1L) ?: return null
+    val startInt = mergedStart.toInt().coerceIn(0, body.length)
+    val endInt = mergedEnd.toInt().coerceIn(0, body.length)
+    val textBefore = body.substring(0, startInt).takeLast(MERGED_CONTEXT_LEN)
+    val textAfter = body.substring(endInt).take(MERGED_CONTEXT_LEN)
+    val progression = mergedStart.toDouble() / totalChars.toDouble()
+    // Preserve raster bytes / svg the pre-merge rows had captured: index by filename first, then
+    // re-walk the merged range so figure order matches the DOM.
+    val victimFigures = candidates
+        .filter { it.id in overlap.victimIds }
+        .flatMap { it.embeddedFigures.orEmpty() }
+    val walkedFigures = findEnclosedFiguresInHtml(html, mergedStart, mergedEnd - 1L)
+    val figures = if (walkedFigures.isEmpty()) null else {
+        val bytesByFile = mutableMapOf<String, String>()
+        val svgByFile = mutableMapOf<String, String>()
+        (draftEmbeddedFigures.orEmpty() + victimFigures).forEach { fig ->
+            val key = fig.href?.let(::figureHrefFilename) ?: return@forEach
+            fig.imageBytes?.takeIf { it.isNotBlank() }?.let { bytesByFile.putIfAbsent(key, it) }
+            fig.svg?.takeIf { it.isNotBlank() }?.let { svgByFile.putIfAbsent(key, it) }
+        }
+        walkedFigures.mapIndexed { i, fig ->
+            val key = fig.href?.let(::figureHrefFilename)
+            fig.copy(
+                order = i,
+                imageBytes = fig.imageBytes ?: key?.let(bytesByFile::get),
+                svg = fig.svg ?: key?.let(svgByFile::get),
+            )
+        }
+    }
+    return MergedDraftFields(
+        cfiRange = cfiRange,
+        textSnippet = mergedSnippet,
+        textBefore = textBefore,
+        textAfter = textAfter,
+        progression = progression,
+        embeddedFigures = figures,
+    )
+}
+
+internal fun computeOverlapMerge(
+    html: String,
+    draftSnippet: String,
+    draftTextBefore: String,
+    candidates: List<Annotation>,
+): OverlapMergeResult? {
+    val draftRange = annotationCharRange(html, draftSnippet, draftTextBefore) ?: return null
+    var mergedStart = draftRange.startChar
+    var mergedEnd = draftRange.endChar
+    val victims = mutableListOf<String>()
+    for (candidate in candidates) {
+        val range = annotationCharRange(html, candidate.textSnippet, candidate.textBefore) ?: continue
+        if (!charRangesOverlap(draftRange, range)) continue
+        victims += candidate.id
+        if (range.startChar < mergedStart) mergedStart = range.startChar
+        if (range.endChar > mergedEnd) mergedEnd = range.endChar
+    }
+    if (victims.isEmpty()) return null
+    return OverlapMergeResult(mergedStart, mergedEnd, victims)
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
@@ -230,6 +230,14 @@ class AnnotationSession @AssistedInject constructor(
         _draftAnnotation.value = null
     }
 
+    /** Close the highlight-actions sheet without any tombstone / merge side effects. Used by
+     *  the dismiss-auto-commit path in the VM so committing the pre-selected preset closes the
+     *  popup instead of rebinding it to the just-created row (2026-07-19: "first tap doesn't
+     *  close the modal"). */
+    fun forceCloseHighlightEditTarget() {
+        _highlightToEdit.value = null
+    }
+
     companion object {
         /** Sentinel id for [HighlightEditTarget.id] while the sheet is in draft mode. See
          *  [_draftAnnotation]. Chosen to be visually unmistakable in logs / dumps and impossible
@@ -365,16 +373,20 @@ class AnnotationSession @AssistedInject constructor(
                             r.copy(isBeingEdited = r.id == editingId)
                         }
                     }
-                    // ADR 0046 §4: synthesize a render for the pending draft so the temporary
-                    // wash paints on the selection + the last-used emphasis pre-selection is
-                    // previewed. Empty color → the renderer picks the editing wash, not a
-                    // saturated tint. The DOM-wrap side reads emphasisStyles too, so bold/italic
-                    // are visible as preview until the user commits or discards.
+                    // ADR 0046 §4: synthesize a render for the pending draft so the pre-selected
+                    // colour + emphasis (from the per-book last-used preset) paint on the selection
+                    // BEFORE commit. Empty preview color (i.e. last pick was ∅) falls through to
+                    // the neutral editing wash. Without this, the swatch shows a colour as
+                    // pre-selected but the text underneath stays uncoloured until dismiss/commit
+                    // fires — reported 2026-07-19 as "annotation not applied until after panel is
+                    // closed". The DOM-wrap side reads emphasisStyles too, so bold/italic are
+                    // visible as preview until the user commits or discards.
+                    val draftPreviewColor = if (_lastUsedColorIsNone.value) "" else _lastUsedHighlightColor.value.token
                     val draftRender = draft?.let { d ->
                         EpubReaderViewModel.HighlightRender(
                             id = DRAFT_ANNOTATION_ID,
                             locator = d.locator,
-                            color = "",
+                            color = draftPreviewColor,
                             note = null,
                             emphasisStyles = _lastUsedEmphasisStyles.value,
                             isBeingEdited = true,
@@ -581,6 +593,26 @@ class AnnotationSession @AssistedInject constructor(
      * new highlights in the same book are born in it. No-op on the last-used store if the session
      * isn't bound (should not happen from the reader UI).
      */
+    /**
+     * Persist a raw color token as the per-book last-used colour (2026-07-20 fix). Used by the
+     * draft-commit path in [EpubReaderViewModel.commitDraft] so the colour a user picked on a
+     * draft popup is remembered for the NEXT annotation on this book — the pre-fix path only
+     * updated last-used-emphasis, so the first draft picked yellow, the second draft's popup
+     * still opened on yellow (the initial default), but a subsequent switch to blue on that first
+     * draft was silently forgotten. Empty token means the ∅ swatch was picked; sets the sibling
+     * "last was none" flag so the next popup opens with ∅.
+     */
+    suspend fun persistLastUsedColorToken(colorToken: String) {
+        val sid = boundServerId ?: return
+        val iid = boundItemId ?: return
+        if (colorToken.isEmpty()) {
+            highlightColorPreferencesStore.setLastUsedIsNone(sid, iid, true)
+        } else {
+            highlightColorPreferencesStore.setLastUsedColor(sid, iid, HighlightColor.fromToken(colorToken))
+            highlightColorPreferencesStore.setLastUsedIsNone(sid, iid, false)
+        }
+    }
+
     suspend fun recolorHighlight(id: String, color: HighlightColor) {
         annotationStore.recolor(id, color.token)
         val sid = boundServerId ?: return

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/DraftPopupSelectionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/DraftPopupSelectionTest.kt
@@ -1,0 +1,122 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.models.EmphasisStyle
+import com.riffle.core.models.HighlightColor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pins the popup pre-selection rules (Bug 2, 2026-07-19): a pending draft must pre-select the
+ * per-book last-used colour + emphasis so a dismiss-without-explicit-pick auto-commits in the
+ * user's remembered state — not the ∅ crossed-circle that used to show for every fresh selection.
+ *
+ * These assertions would flip red if line 3082 of EpubReaderScreen.kt were reverted to
+ * `if (isDraft || …) null` (the pre-fix behaviour).
+ */
+class DraftPopupSelectionTest {
+
+    @Test
+    fun draft_preSelectsLastUsedColor_whenNotNone() {
+        val result = resolveDraftPopupSelection(
+            isDraft = true,
+            persistedColor = null,
+            persistedEmphasisStyles = emptySet(),
+            lastUsedHighlightColor = HighlightColor.GREEN,
+            lastUsedColorIsNone = false,
+            lastUsedEmphasisStyles = emptySet(),
+        )
+        assertEquals(HighlightColor.GREEN, result.selectedColor)
+        assertEquals(emptySet<EmphasisStyle>(), result.emphasisStyles)
+    }
+
+    @Test
+    fun draft_preSelectsNone_whenLastUsedIsNone() {
+        val result = resolveDraftPopupSelection(
+            isDraft = true,
+            persistedColor = null,
+            persistedEmphasisStyles = emptySet(),
+            lastUsedHighlightColor = HighlightColor.YELLOW,
+            lastUsedColorIsNone = true,
+            lastUsedEmphasisStyles = emptySet(),
+        )
+        assertNull(result.selectedColor)
+    }
+
+    @Test
+    fun draft_preSelectsLastUsedEmphasisStyles() {
+        val preset = setOf(EmphasisStyle.BOLD, EmphasisStyle.ITALIC)
+        val result = resolveDraftPopupSelection(
+            isDraft = true,
+            persistedColor = null,
+            persistedEmphasisStyles = emptySet(),
+            lastUsedHighlightColor = HighlightColor.YELLOW,
+            lastUsedColorIsNone = false,
+            lastUsedEmphasisStyles = preset,
+        )
+        assertEquals(preset, result.emphasisStyles)
+    }
+
+    @Test
+    fun persistedRow_reflectsStoredColor() {
+        val result = resolveDraftPopupSelection(
+            isDraft = false,
+            persistedColor = HighlightColor.BLUE.token,
+            persistedEmphasisStyles = setOf(EmphasisStyle.UNDERLINE),
+            lastUsedHighlightColor = HighlightColor.GREEN,
+            lastUsedColorIsNone = false,
+            lastUsedEmphasisStyles = setOf(EmphasisStyle.BOLD),
+        )
+        assertEquals(HighlightColor.BLUE, result.selectedColor)
+        assertEquals(setOf(EmphasisStyle.UNDERLINE), result.emphasisStyles)
+    }
+
+    @Test
+    fun persistedRow_withEmptyColorShowsNone() {
+        // ADR 0046 §4: after ∅ the row's color is empty; pass null so the swatch row highlights ∅.
+        // (Passing empty through HighlightColor.fromToken would fall back to DEFAULT and show yellow.)
+        val result = resolveDraftPopupSelection(
+            isDraft = false,
+            persistedColor = "",
+            persistedEmphasisStyles = emptySet(),
+            lastUsedHighlightColor = HighlightColor.GREEN,
+            lastUsedColorIsNone = false,
+            lastUsedEmphasisStyles = emptySet(),
+        )
+        assertNull(result.selectedColor)
+    }
+
+    // ---- Auto-commit predicate (dismiss behaviour) ----
+
+    @Test
+    fun autoCommit_whenColorRemembered() {
+        assertEquals(true, shouldAutoCommitDraftOnDismiss(lastUsedColorIsNone = false, lastUsedEmphasisStyles = emptySet()))
+    }
+
+    @Test
+    fun autoCommit_whenEmphasisRemembered_evenIfColorIsNone() {
+        assertEquals(true, shouldAutoCommitDraftOnDismiss(lastUsedColorIsNone = true, lastUsedEmphasisStyles = setOf(EmphasisStyle.BOLD)))
+    }
+
+    @Test
+    fun discard_whenNothingRemembered() {
+        // Only case where dismiss discards the draft entirely — ∅ preset + no emphasis preset.
+        assertEquals(false, shouldAutoCommitDraftOnDismiss(lastUsedColorIsNone = true, lastUsedEmphasisStyles = emptySet()))
+    }
+
+    @Test
+    fun persistedRow_ignoresLastUsedState() {
+        // Regression: persisted-row pre-selection MUST NOT leak the per-book last-used state —
+        // that would show a chip active when no matching emphasis row exists.
+        val result = resolveDraftPopupSelection(
+            isDraft = false,
+            persistedColor = HighlightColor.YELLOW.token,
+            persistedEmphasisStyles = emptySet(),
+            lastUsedHighlightColor = HighlightColor.GREEN,
+            lastUsedColorIsNone = false,
+            lastUsedEmphasisStyles = setOf(EmphasisStyle.BOLD),
+        )
+        assertEquals(HighlightColor.YELLOW, result.selectedColor)
+        assertEquals(emptySet<EmphasisStyle>(), result.emphasisStyles)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightRangeOverlapTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightRangeOverlapTest.kt
@@ -1,0 +1,328 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.database.AnnotationEntity
+import com.riffle.core.models.Annotation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for Bug 1 (2026-07-19): overlapping highlight selections must be MERGED into
+ * a single annotation covering the union range, not double-annotated over the shared span. Pins
+ * the char-offset range-overlap detector introduced to replace [highlightOverlapsAtSamePosition]
+ * (whose substring-only test missed partial overlaps where neither snippet contains the other —
+ * the exact case from the reported video).
+ */
+class HighlightRangeOverlapTest {
+
+    // ---- Pure range-overlap primitive ----
+
+    @Test
+    fun charRangesOverlap_touching_isFalse() {
+        // Half-open range: [0,5) and [5,10) touch at 5 but do not overlap.
+        assertFalse(charRangesOverlap(CharRange2(0, 5), CharRange2(5, 10)))
+    }
+
+    @Test
+    fun charRangesOverlap_disjoint_isFalse() {
+        assertFalse(charRangesOverlap(CharRange2(0, 5), CharRange2(10, 20)))
+    }
+
+    @Test
+    fun charRangesOverlap_partialOverlap_isTrue() {
+        assertTrue(charRangesOverlap(CharRange2(0, 10), CharRange2(5, 15)))
+    }
+
+    @Test
+    fun charRangesOverlap_contains_isTrue() {
+        assertTrue(charRangesOverlap(CharRange2(0, 100), CharRange2(20, 30)))
+        assertTrue(charRangesOverlap(CharRange2(20, 30), CharRange2(0, 100)))
+    }
+
+    // ---- computeOverlapMerge over a fixture chapter ----
+
+    // Fixture: single paragraph, ASCII, no figures. Char offsets are trivially indexOf().
+    private val html = """
+        <html><body><p>There was a man and he had eight sons. Apart from that, he was nothing more than a comma on the page of History. It's sad, but that's all you can say about some people.</p></body></html>
+    """.trimIndent()
+
+    private fun annotation(
+        id: String,
+        textSnippet: String,
+        textBefore: String,
+    ): Annotation = Annotation(
+        id = id,
+        sourceId = "srv",
+        itemId = "item",
+        type = AnnotationEntity.TYPE_HIGHLIGHT,
+        cfi = "epubcfi(/6/2!/4/2,/1:0,/1:5)",
+        color = "yellow",
+        note = null,
+        textSnippet = textSnippet,
+        textBefore = textBefore,
+        textAfter = "",
+        chapterHref = "ch1.xhtml",
+        spineIndex = 0,
+        progression = 0.5,
+        bookmarkTitle = "",
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    @Test
+    fun noExisting_returnsNull() {
+        val result = computeOverlapMerge(
+            html = html,
+            draftSnippet = "man",
+            draftTextBefore = "There was a ",
+            candidates = emptyList(),
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun disjointExisting_returnsNull() {
+        // Draft "man" and existing "History" — clearly disjoint.
+        val existing = annotation("a", textSnippet = "History", textBefore = "on the page of ")
+        val result = computeOverlapMerge(
+            html = html,
+            draftSnippet = "man",
+            draftTextBefore = "There was a ",
+            candidates = listOf(existing),
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun partialOverlap_returnsUnion() {
+        // Video repro: existing yellow "was nothing more than a comma", new selection begins inside
+        // ("nothing more than a comma on the page") and extends past its tail. Neither snippet
+        // contains the other — pre-fix substring detector missed this. Union covers both.
+        val existing = annotation(
+            id = "victim",
+            textSnippet = "was nothing more than a comma",
+            textBefore = "Apart from that, he ",
+        )
+        val result = computeOverlapMerge(
+            html = html,
+            draftSnippet = "nothing more than a comma on the page",
+            draftTextBefore = "he was ",
+            candidates = listOf(existing),
+        )
+        assertNotNull(result)
+        assertEquals(listOf("victim"), result!!.victimIds)
+        // Union start = existing start ("was nothing…"), end = draft end ("…on the page").
+        val bodyText = readableBodyText(html)
+        val expectedStart = bodyText.indexOf("was nothing").toLong()
+        val expectedEnd = bodyText.indexOf("on the page").toLong() + "on the page".length
+        assertEquals(expectedStart, result.mergedStart)
+        assertEquals(expectedEnd, result.mergedEnd)
+    }
+
+    @Test
+    fun draftFullyInsideExisting_returnsExistingRange() {
+        // Existing highlight fully contains the new draft's range; union == existing range.
+        val existing = annotation(
+            id = "victim",
+            textSnippet = "was nothing more than a comma on the page of History",
+            textBefore = "Apart from that, he ",
+        )
+        val result = computeOverlapMerge(
+            html = html,
+            draftSnippet = "more than",
+            draftTextBefore = "was nothing ",
+            candidates = listOf(existing),
+        )
+        assertNotNull(result)
+        assertEquals(listOf("victim"), result!!.victimIds)
+        val bodyText = readableBodyText(html)
+        assertEquals(bodyText.indexOf("was nothing").toLong(), result.mergedStart)
+        assertEquals(
+            bodyText.indexOf("of History").toLong() + "of History".length,
+            result.mergedEnd,
+        )
+    }
+
+    @Test
+    fun draftCoversExisting_returnsDraftRange() {
+        // New selection wraps a smaller existing highlight; union == draft range.
+        val existing = annotation(
+            id = "victim",
+            textSnippet = "comma",
+            textBefore = "more than a ",
+        )
+        val result = computeOverlapMerge(
+            html = html,
+            draftSnippet = "than a comma on the page",
+            draftTextBefore = "was nothing more ",
+            candidates = listOf(existing),
+        )
+        assertNotNull(result)
+        assertEquals(listOf("victim"), result!!.victimIds)
+        val bodyText = readableBodyText(html)
+        assertEquals(bodyText.indexOf("than a comma").toLong(), result.mergedStart)
+        assertEquals(
+            bodyText.indexOf("on the page").toLong() + "on the page".length,
+            result.mergedEnd,
+        )
+    }
+
+    @Test
+    fun multipleExistingUnioned() {
+        // Two adjacent-but-non-touching existing highlights both overlap a big draft; the union
+        // spans the leftmost start through the rightmost end.
+        val a = annotation(
+            id = "left",
+            textSnippet = "was nothing more",
+            textBefore = "Apart from that, he ",
+        )
+        val b = annotation(
+            id = "right",
+            textSnippet = "page of History",
+            textBefore = "comma on the ",
+        )
+        val result = computeOverlapMerge(
+            html = html,
+            draftSnippet = "more than a comma on the page",
+            draftTextBefore = "was nothing ",
+            candidates = listOf(a, b),
+        )
+        assertNotNull(result)
+        assertEquals(setOf("left", "right"), result!!.victimIds.toSet())
+        val bodyText = readableBodyText(html)
+        assertEquals(bodyText.indexOf("was nothing").toLong(), result.mergedStart)
+        assertEquals(
+            bodyText.indexOf("page of History").toLong() + "page of History".length,
+            result.mergedEnd,
+        )
+    }
+
+    @Test
+    fun touchingExisting_notMerged() {
+        // Adjacent (touching) highlights are handled by the edit-time merge path, not the create-
+        // time overlap merger. Ensure we don't merge them here — that would surprise users who
+        // deliberately created two separate same-color neighbours (2026-07-05 design intent).
+        val existing = annotation(
+            id = "neighbor",
+            textSnippet = "eight sons.",
+            textBefore = "he had ",
+        )
+        // Draft immediately after existing: " Apart from" starts exactly where existing ends.
+        val result = computeOverlapMerge(
+            html = html,
+            draftSnippet = "Apart from",
+            draftTextBefore = "eight sons. ",
+            candidates = listOf(existing),
+        )
+        assertNull(result)
+    }
+
+    // ---- buildMergedDraftFields — DOM rebuild after union ----
+
+    // ---- Multi-paragraph snippet locates across block boundaries (Bug B, 2026-07-19) ----
+
+    /**
+     * `readableBodyText` concatenates adjacent block-element text nodes with NO separator (blank-
+     * only text nodes between `<p>` elements are skipped). A user selection spanning a paragraph
+     * boundary has "\n" (or a space) in `textSnippet` that isn't in the body stream — verbatim
+     * `indexOf` fails and the pre-fix overlap detector treated overlapping multi-paragraph
+     * selections as disjoint. Whitespace-tolerant fallback pins this: the snippet still locates.
+     */
+    private val multiParaHtml = """
+        <html><body>
+            <p>The first sentence in paragraph one.</p>
+            <p>The second sentence in paragraph two.</p>
+        </body></html>
+    """.trimIndent()
+
+    /**
+     * The user's video (2026-07-20): a multi-paragraph selection painted a wash spanning the
+     * WHOLE second paragraph instead of just the selected part. Root cause: end-char computed as
+     * `startChar + snippet.length` overshot by the newline count (the `\n` in the snippet has no
+     * counterpart in the readable body stream). Pin the helper that walks non-whitespace chars.
+     */
+    @Test
+    fun snippetEndCharInBody_multiParagraph_doesNotOvershoot() {
+        val body = readableBodyText(multiParaHtml)
+        val snippet = "paragraph one.\nThe second"
+        val start = body.indexOf("paragraph one.").toLong()
+        val end = snippetEndCharInBody(multiParaHtml, start, snippet)
+        // Expected end: position of "second" + length of "second" = just past "second"
+        val expectedEnd = body.indexOf("The second").toLong() + "The second".length
+        assertEquals(expectedEnd, end)
+        // If the pre-fix `start + snippet.length` were used, end would be `start + 25` which
+        // extends 1 char past "second" (into " sentence") because the body drops the newline.
+        val naiveEnd = start + snippet.length
+        assertTrue(
+            "naive .length end (${naiveEnd}) must overshoot the corrected end (${end})",
+            naiveEnd > end,
+        )
+    }
+
+    @Test
+    fun snippetEndCharInBody_singleParagraph_matchesLength() {
+        val html = "<html><body><p>hello world</p></body></html>"
+        val body = readableBodyText(html)
+        val start = body.indexOf("hello").toLong()
+        val end = snippetEndCharInBody(html, start, "hello world")
+        assertEquals(start + "hello world".length, end)
+    }
+
+    @Test
+    fun multiParagraphSnippet_locatesAcrossBlockBoundary() {
+        // Snippet contains "\n" between paragraphs; body has no separator.
+        val snippet = "paragraph one.\nThe second sentence"
+        val start = locateSnippetInBody(multiParaHtml, snippet, "in ")
+        assertNotNull(start)
+        val body = readableBodyText(multiParaHtml)
+        // The match should start at "paragraph one." in the body.
+        assertEquals(body.indexOf("paragraph one.").toLong(), start!!)
+    }
+
+    @Test
+    fun multiParagraphOverlap_detectedAndMerged() {
+        // Existing highlight ends mid-para-2. New selection starts inside para-1 and extends
+        // past existing's tail — pre-fix (substring test on "paragraph one.\nThe second") failed
+        // because the snippet's newline isn't in the body stream.
+        val existing = annotation(
+            id = "cross-para",
+            textSnippet = "sentence in paragraph one.\nThe second",
+            textBefore = "The first ",
+        )
+        val result = computeOverlapMerge(
+            html = multiParaHtml,
+            draftSnippet = "in paragraph one.\nThe second sentence",
+            draftTextBefore = "sentence ",
+            candidates = listOf(existing),
+        )
+        assertNotNull(result)
+        assertEquals(listOf("cross-para"), result!!.victimIds)
+    }
+
+    @Test
+    fun buildMergedDraftFields_producesMergedSnippet() {
+        val draftSnippet = "nothing more than a comma on the page"
+        val draftTextBefore = "he was "
+        val victim = annotation(
+            id = "v",
+            textSnippet = "was nothing more than a comma",
+            textBefore = "Apart from that, he ",
+        )
+        val overlap = computeOverlapMerge(html, draftSnippet, draftTextBefore, listOf(victim))!!
+        val merged = buildMergedDraftFields(
+            html = html,
+            draftSpineIndex = 0,
+            draftEmbeddedFigures = null,
+            overlap = overlap,
+            candidates = listOf(victim),
+        )
+        assertNotNull(merged)
+        assertEquals("was nothing more than a comma on the page", merged!!.textSnippet)
+        assertTrue(merged.cfiRange.startsWith("epubcfi("))
+        assertTrue(merged.textBefore.endsWith("that, he "))
+        assertTrue(merged.textAfter.startsWith(" of History"))
+    }
+}


### PR DESCRIPTION
## Summary

Draft-popup annotation flow overhaul across a series of user-reported regressions during a single session.

- **Overlapping selections** now union into ONE highlight covering the merged range instead of double-painting the shared span. New char-offset range detector (`computeOverlapMerge` in `HighlightRangeOverlap.kt`) replaces the pre-fix substring-only test in `commitDraft`; victims' emphasis rows cascade-delete.
- **Multi-paragraph selections** locate + range correctly: whitespace-tolerant regex fallback in `locateSnippetInBody`, plus new `snippetEndCharInBody` helper. The pre-fix `startChar + snippet.length` overshot by the newline count because `readableBodyText` drops the blank-only text nodes between adjacent block elements — so the CFI range extended past the user's actual selection ("wash covers whole paragraph after Annotate").
- **Draft popup pre-selects** the per-book last-used colour + emphasis (previously the swatch row always showed ∅ for fresh drafts) and paints the pre-selected colour as an immediate preview on the selection (previously a neutral gray wash).
- **Dismiss auto-commits** a draft in the pre-selected state and closes the sheet in one tap; only ∅ + no emphasis discards. Pre-fix the first tap-outside committed but reopened the popup on the just-created row so a second tap was needed to close.
- **Emphasis toggle on a draft** no longer wipes the pre-selected colour — colour and emphasis are independent dimensions ("clearing the font formatting also cleared the colour").
- **commitDraft persists the picked colour** as the per-book default (sibling to the existing `setLastUsedStyles` call), so the next draft opens on the most recent pick.

## Files touched

- `EpubReaderViewModel.kt` — `dismissHighlightActions` intercepts draft branch and routes to auto-commit; new `keepSheetOpen` param on `commitDraft`; `toggleEmphasisStyle` draft path preserves preset colour; endChar via `snippetEndCharInBody` in `createHighlight` + `mergeAfterEdit`; new `lastUsedHighlightColor`/`lastUsedColorIsNone` public state.
- `AnnotationSession.kt` — draft render's preview colour now respects `lastUsedHighlightColor`/`lastUsedColorIsNone`; new `forceCloseHighlightEditTarget()` and `persistLastUsedColorToken()`.
- `EpubReaderScreen.kt` — plumbs new last-used state to `HighlightActionsPopup`, calls extracted `resolveDraftPopupSelection` helper.
- `DraftPopupSelection.kt` (new) — pure helper for popup pre-selection derivation + auto-commit predicate.
- `HighlightRangeOverlap.kt` (new) — char-range overlap detector + DOM rebuild for merged range.
- `EpubCfiRange.kt` — whitespace-tolerant regex fallback in `locateSnippetInBody` + new `snippetEndCharInBody` helper.

## Tests

- `DraftPopupSelectionTest.kt` (new, 9 cases) — swatch / chip pre-selection for draft vs persisted; auto-commit predicate on the dismiss branch.
- `HighlightRangeOverlapTest.kt` (new, 12 cases) — primitive range overlap; partial / contains / union-of-multiple / touching-not-merged; multi-paragraph locate + merge; `buildMergedDraftFields` DOM rebuild.

## Verification

- `./gradlew test` green.
- Device-verified on an ephemeral tablet AVD across four sessions (screenshots retained under `/tmp`): overlap merge collapses to one highlight; colour+emphasis pre-selected on fresh draft; dismiss auto-commits and closes on first tap; toggle-off-B preserves colour; ∅ pick persists so next draft opens on ∅.

## Known follow-up

The user reported a *separate* selection-detection UX issue mid-session (no menu on some selections / jumping / block-forced selection). We investigated and confirmed it's unrelated to this branch — filing separately.

## Test plan

- [ ] Fresh selection → tap Annotate → popup opens with last-used colour + emphasis pre-selected and previewed on the text
- [ ] Tap outside → single-tap dismiss commits in the pre-selected state
- [ ] Overlapping selection → merges into one continuous highlight
- [ ] Multi-paragraph selection → highlight covers only the selected range (no paragraph overshoot)
- [ ] Tap B (bold on) → un-bolds without clearing the swatch colour
- [ ] Next draft popup opens on the most recently picked colour