### PR TITLE
fix(reader): make search work in the elided (Highlights-mode) reader

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1185,6 +1185,12 @@ class EpubReaderViewModel @Inject constructor(
                 title = pub.metadata.title ?: "Annotations",
                 initialLocator = initialLocator,
             )
+            // Bind the search controller to the elided Publication so queries typed into the
+            // reader's search top-bar actually execute. The FullBook path binds inside
+            // [onOpenReady]; the Highlights branch returns before that, and without this call
+            // [SearchController]'s debounce collector never starts and every keystroke is a
+            // no-op ("search does nothing in the elided view").
+            search.bind(pub)
             // Bind the annotation session so the highlight-actions popup works in Highlights mode
             // (a prior gap: this branch used to return before binding at all, leaving
             // highlightRenders permanently empty and recolor/delete/note edits silent no-ops).

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -12,7 +12,9 @@ import org.readium.r2.shared.publication.LocalizedString
 import org.readium.r2.shared.publication.Manifest
 import org.readium.r2.shared.publication.Metadata
 import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.publication.services.PerResourcePositionsService
+import org.readium.r2.shared.publication.services.search.StringSearchService
 import org.readium.r2.shared.util.AbsoluteUrl
 import org.readium.r2.shared.util.Try
 import org.readium.r2.shared.util.Url
@@ -231,6 +233,13 @@ class HighlightsPublicationFactory @Inject constructor() {
         // is silently blank in the elided reader. One position per resource is exactly the rail
         // needs: the elided TOC is flat, so [buildRailSegments] produces one segment per elided
         // chapter with equal weight.
+        // Register [StringSearchService] so the reader's search top-bar returns results when opened
+        // against the elided view. Without a search factory here, [Publication.findService(SearchService)]
+        // returns null and every query silently produces zero results — the elided reader "has a
+        // search icon that does nothing" bug. The default extractor factory handles the XHTML
+        // resources we synthesise (see [DefaultResourceContentExtractorFactory]).
+        @OptIn(ExperimentalReadiumApi::class)
+        val searchFactory = StringSearchService.createDefaultFactory()
         val publication = Publication(
             manifest = manifest,
             container = InMemoryContainer(entries),
@@ -241,6 +250,7 @@ class HighlightsPublicationFactory @Inject constructor() {
                         fallbackMediaType = MediaType.XHTML,
                     )
                 },
+                search = searchFactory,
             ),
         )
         return HighlightsPublicationHandle(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
@@ -8,8 +8,10 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.services.positionsByReadingOrder
+import org.readium.r2.shared.publication.services.search.SearchService
 import org.readium.r2.shared.util.RelativeUrl
 import org.readium.r2.shared.util.Url
 
@@ -515,6 +517,30 @@ class HighlightsPublicationFactoryTest {
         assertTrue(
             "every elided chapter must contribute at least one position so railSegments has non-empty counts, got: ${positions.map { it.size }}",
             positions.all { it.isNotEmpty() },
+        )
+    }
+
+    // Regression: the elided reader's search top-bar was a no-op because
+    // [HighlightsPublicationFactory] never registered a [SearchService] on the synthesised
+    // [Publication]. [Publication.findService(SearchService::class)] returned null and
+    // [SearchController.performSearch] short-circuited to empty results on every keystroke.
+    // Reverting the fix flips this red — the assertion pins that a search factory IS bound.
+    @OptIn(ExperimentalReadiumApi::class)
+    @Test
+    fun elidedPublicationRegistersSearchServiceSoReaderSearchTopBarWorks() {
+        val pub = factory.build(
+            sourceId = "S1",
+            itemId = "B1",
+            bookTitle = "Dune",
+            chapters = listOf(
+                ChapterElision("ch1.xhtml", "Chapter One", listOf(hl("h1", "the spice must flow"))),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val service = pub.findService(SearchService::class)
+        assertTrue(
+            "elided Publication must expose a SearchService for the reader's search top-bar to return results",
+            service != null,
         )
     }
 


### PR DESCRIPTION
## Summary

The reader's search top-bar in Highlights (elided) mode accepted keystrokes but never returned results. Two independent bugs stacked to hide the same symptom:

1. `HighlightsPublicationFactory` built the synthesised `Publication` without a `SearchService` factory, so `SearchController.performSearch` hit `pub.findService(SearchService::class) == null` and short-circuited to empty results on every query.
2. `EpubReaderViewModel.openBook()`'s Highlights branch returns before `onOpenReady` and never called `search.bind(pub)` — `SearchController`'s debounce collector was never started, so query changes weren't observed at all.

### Fix

- Register `StringSearchService.createDefaultFactory()` on the elided `Publication` in `HighlightsPublicationFactory.buildHandle` (default HTML/XHTML extractor handles the synthesised chapter bytes).
- Call `search.bind(pub)` in the Highlights branch of `openBook()`, right after `_state.value = ReaderState.Ready(...)`.

### Regression test

`HighlightsPublicationFactoryTest.elidedPublicationRegistersSearchServiceSoReaderSearchTopBarWorks` — asserts `findService(SearchService::class)` is non-null on the synthesised publication. Reverting the `search = searchFactory` line flips it red.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests HighlightsPublicationFactoryTest` — all green
- [ ] Manual: open a book in Annotations (elided) view, tap search, type a term appearing in a highlight snippet, confirm results + prev/next navigation work