### PR TITLE
fix(network): scope HTTP cache entries per bearer to stop cross-user progress leaks

### DIFF
--- a/core/network/src/main/kotlin/com/riffle/core/network/EndpointCacheHeadersInterceptor.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/EndpointCacheHeadersInterceptor.kt
@@ -15,6 +15,13 @@ import okhttp3.Response
  * Used for API endpoints whose origin sends `Cache-Control: private` or no cache header at all
  * (Audiobookshelf, GitHub Releases). Non-cacheable endpoints on the same client — writes, session
  * calls, binary streams — simply don't match any rule and behave as before.
+ *
+ * Also stamps `Vary: Authorization` so OkHttp keys cache entries by bearer token. Every rule here
+ * is per-user (`/api/me`, `/api/me/listening-stats`, `/api/libraries*` — ABS users can be
+ * library-scoped, and `mediaProgress` on `/api/me` is per-user). Without Vary, OkHttp keys the
+ * cache entry on URL alone; two Sources pointing at the same ABS host (two accounts on one server)
+ * would share cache entries and one user's response would be served to the other — user A's
+ * `mediaProgress` then flows through the sweep into user B's `library_items.readingProgress`.
  */
 class EndpointCacheHeadersInterceptor(
     private val rules: List<Rule>,
@@ -33,6 +40,7 @@ class EndpointCacheHeadersInterceptor(
             .removeHeader("Pragma")
             .removeHeader("Cache-Control")
             .header("Cache-Control", "public, max-age=${rule.maxAgeSeconds}")
+            .header("Vary", "Authorization")
             .build()
     }
 }

--- a/core/network/src/test/kotlin/com/riffle/core/network/EndpointCacheHeadersInterceptorTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/EndpointCacheHeadersInterceptorTest.kt
@@ -1,5 +1,6 @@
 package com.riffle.core.network
 
+import okhttp3.Cache
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -9,9 +10,13 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 
 class EndpointCacheHeadersInterceptorTest {
+
+    @get:Rule val tempFolder = TemporaryFolder()
 
     private lateinit var server: MockWebServer
     private lateinit var client: OkHttpClient
@@ -28,6 +33,13 @@ class EndpointCacheHeadersInterceptorTest {
     private fun get(path: String) = client.newCall(
         Request.Builder().url(server.url(path)).build()
     ).execute()
+
+    private fun get(client: OkHttpClient, path: String, authorization: String? = null) =
+        client.newCall(
+            Request.Builder().url(server.url(path)).apply {
+                if (authorization != null) header("Authorization", authorization)
+            }.build()
+        ).execute()
 
     @Test fun `stamps ABS status with 5-minute TTL`() {
         server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
@@ -92,6 +104,41 @@ class EndpointCacheHeadersInterceptorTest {
         val cc = r.header("Cache-Control"); r.close()
         assertNotEquals("public, max-age=900", cc)
         assertEquals("no-store", cc)
+    }
+
+    // Regression: without `Vary: Authorization` on cached per-user responses, OkHttp keys the
+    // cache entry by URL alone. Two Sources pointing at the same ABS host (two user accounts on
+    // one server) would then share `/api/me` cache entries — one user's `mediaProgress` would be
+    // served to the other, and #589's `UiProgressSink` would mirror the wrong fractions into
+    // `library_items.readingProgress`. Manifested as the details page briefly showing another
+    // user's progress before the single-item pull refreshed it.
+    @Test fun `stamps Vary Authorization on cached per-user responses`() {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        val r = get("/api/me")
+        val vary = r.header("Vary"); r.close()
+        assertEquals("Authorization", vary)
+    }
+
+    @Test fun `bearer swap on api me does not serve cached body from a different user`() {
+        val cachedClient = OkHttpClient.Builder()
+            .cache(Cache(tempFolder.newFolder(), 1L shl 20))
+            .addNetworkInterceptor(EndpointCacheHeadersInterceptor(DEFAULT_HTTP_CACHE_RULES))
+            .build()
+
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"user":"alice"}"""))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"user":"bob"}"""))
+
+        val aliceBody = get(cachedClient, "/api/me", authorization = "Bearer alice-token")
+            .use { it.body.string() }
+        val bobBody = get(cachedClient, "/api/me", authorization = "Bearer bob-token")
+            .use { it.body.string() }
+
+        // Critical: without Vary: Authorization, bob would receive the cached alice body
+        // (OkHttp keys by URL alone → the second request would be a HIT on alice's entry).
+        assertEquals("""{"user":"alice"}""", aliceBody)
+        assertEquals("""{"user":"bob"}""", bobBody)
+        // Both bearers hit the origin — Vary keys their cache entries separately.
+        assertEquals(2, server.requestCount)
     }
 
     @Test fun `does not stamp non-GET even if path matches`() {


### PR DESCRIPTION
## The bug

With two ABS user accounts configured as two Sources on the same server, opening a book's details briefly shows the *other* user's progress before flipping to the real value.

## Root cause

Not #589 (which surfaced the leak) but #583 (`perf(caching): add default HTTP cache`).

`EndpointCacheHeadersInterceptor` stamps `Cache-Control: public, max-age=…` on per-user ABS endpoints — `/api/me`, `/api/me/listening-stats`, `/api/libraries*`. OkHttp keys its cache **by URL only**; the `Authorization` header is not part of the key and the interceptor didn't emit `Vary: Authorization`. So two Sources pointing at the same ABS host shared `/api/me` cache entries — User A's `mediaProgress` payload was served to User B for up to 15 minutes.

#589's new `UiProgressSink` (which mirrors server-pulled progress into `library_items.readingProgress`) is what then wrote A's fractions into B's grid / details. The flash on details ON_RESUME is the single-item `/api/me/progress/{id}` pull (uncached) correcting the value a beat later.

## The fix

`EndpointCacheHeadersInterceptor` now also emits `Vary: Authorization` so OkHttp keys each cached entry per bearer. Perf win preserved (same-bearer replay still hits cache); users are isolated.

## Regression test

`bearer swap on api me does not serve cached body from a different user` — exercises a real `OkHttpClient` with a disk `Cache`, hits `/api/me` twice with different `Authorization: Bearer …` values, and asserts each bearer sees its own body plus two origin round-trips. Without `Vary: Authorization`, the second request would be served the first user's cached body and the assertion flips red.

Also added `stamps Vary Authorization on cached per-user responses` as a plain header pin.