### PR TITLE
fix(reader): unwedge elided-view continuous scroll

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWindowManager.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWindowManager.kt
@@ -12,7 +12,18 @@ package com.riffle.app.feature.reader
  * Stateful: tracks the [justShiftedForward] guard internally so callers do not have to thread it.
  * Create one instance per [ContinuousReaderView]; call [reset] when the window is rebuilt.
  */
-internal class ChapterWindowManager(private val chaptersBehind: Int) {
+internal class ChapterWindowManager(chaptersBehind: Int) {
+
+    /**
+     * Number of chapters kept behind the viewport midpoint before a forward shift fires. Also the
+     * threshold `viewportChapterIndex − topIndex > chaptersBehind` uses. Mutable so the elided
+     * (Highlights-mode) reader can raise it (short synthetic chapters make the "gap≥2 → oscillate"
+     * pattern common — see [ContinuousPositionTrackerTest] "backward→forward oscillation"), while
+     * full-book continuous mode keeps the lower value that fits its per-chapter memory budget.
+     * Callers must set this BEFORE `openWindowAt` — changing it mid-window doesn't resize the
+     * loaded slots.
+     */
+    var chaptersBehind: Int = chaptersBehind
 
     sealed class Decision {
         data object Hold : Decision()
@@ -54,6 +65,7 @@ internal class ChapterWindowManager(private val chaptersBehind: Int) {
         window: List<ContinuousPositionTracker.ChapterSlot>,
         topIndex: Int,
         totalChapters: Int,
+        viewportHeight: Int = 0,
     ): Decision {
         if (window.isEmpty()) return Decision.Hold
 
@@ -67,12 +79,29 @@ internal class ChapterWindowManager(private val chaptersBehind: Int) {
             && scrollY < firstChapterHeight / 2
             && topIndex > 0
 
+        // Bottom-of-window signal: scroll is clamped at the end of the loaded content. Callers
+        // that don't pass `viewportHeight` (default 0) get `false` here — the midpoint trigger
+        // then governs alone, preserving prior behavior for tests and any legacy call sites.
+        //
+        // Guard: the loaded window must EXCEED the viewport for "bottom" to mean the user
+        // scrolled to reach it. When all loaded chapters fit in one viewport (`loadedContentBottom
+        // <= viewportHeight`), scrollY is pinned at 0 and the bottom is visible without any scroll
+        // — firing here would auto-cascade forward shifts on the very first `decide` after open,
+        // dragging the user past the chapter they opened at and blocking backward nav. This
+        // regressed the initial fix (2026-07-21 log: window jumped [ch5,ch6,ch7]→[ch8,ch9,ch10]
+        // in ~1 s with no user scroll input).
+        val loadedContentBottom = window.last().let { it.top + it.height }
+        val atBottomOfLoadedWindow = viewportHeight > 0 &&
+            loadedContentBottom > viewportHeight &&
+            scrollY + viewportHeight >= loadedContentBottom
+
         val shouldShiftForward = ContinuousPositionTracker.forwardShiftNeeded(
             viewportChapterIndex = viewportChapterIndex,
             topIndex = topIndex,
             loadedChapterCount = window.size,
             readingOrderSize = totalChapters,
             chaptersBehind = chaptersBehind,
+            atBottomOfLoadedWindow = atBottomOfLoadedWindow,
         )
 
         return when {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
@@ -186,10 +186,19 @@ internal object ContinuousPositionTracker {
         loadedChapterCount: Int,
         readingOrderSize: Int,
         chaptersBehind: Int,
+        atBottomOfLoadedWindow: Boolean = false,
     ): Boolean {
         val moreChaptersExist = topIndex + loadedChapterCount < readingOrderSize
         val pastBehindBudget = viewportChapterIndex - topIndex > chaptersBehind
-        return moreChaptersExist && pastBehindBudget
+        // Bottom-of-window trigger: when the trailing chapter(s) in the window are shorter than
+        // half a viewport, the midpoint can never enter their slot no matter how far the user
+        // scrolls — `pastBehindBudget` stays false forever and the reader walls off. This shows up
+        // in elided (Highlights-mode) continuous reading where single-annotation chapters
+        // synthesise to ~500 px pages. Fire when the scroll is clamped at the end of the loaded
+        // content and chapters remain to append. Complements the midpoint trigger — does not
+        // replace it — so the divider-page blank-flash guard the midpoint trigger was introduced
+        // for is preserved.
+        return moreChaptersExist && (pastBehindBudget || atBottomOfLoadedWindow)
     }
 
     data class InitialWindow(val topIndex: Int, val totalChapters: Int, val targetWindowIndex: Int) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -91,6 +91,19 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         onViewportFractionMeasured = { href, fraction -> onViewportFractionMeasured?.invoke(href, fraction) },
     )
 
+    /**
+     * Chapters kept behind the viewport before the sliding window shifts forward. Full-book
+     * continuous mode uses the controller's memory-capped default (1); the elided (Highlights-
+     * mode) reader raises it to 3 so tiny synthetic chapters — often just one highlight tall —
+     * don't oscillate between backward and forward shifts (short middle chapter overshoots the
+     * midpoint into a chapter 2+ slots away, which under `chaptersBehind=1` immediately re-fires
+     * forward after any backward shift). MUST be set before `initialize()` — later changes
+     * don't reshape the already-built window.
+     */
+    var chaptersBehind: Int
+        get() = controller.chaptersBehind
+        set(value) { controller.chaptersBehind = value }
+
     /** Whether the text-selection menu should offer "Highlight" (books with annotations UI). */
     var annotationsAvailable: Boolean
         get() = controller.annotationsAvailable

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -50,14 +50,16 @@ internal class ContinuousWindowController(
         // buffer chapter directly extends the cold-open spinner time (5 chapters at 1+1 → 3);
         // one behind / one ahead is enough to hide the next chapter boundary from a scroll fling
         // without paying for chapters two removed from the viewport.
-        /** See [ContinuousReaderView.CHAPTERS_BEHIND]. */
-        private const val CHAPTERS_BEHIND = 1
+        /** Default number of chapters kept behind the viewport midpoint. Full-book continuous
+         *  mode uses this; the elided (Highlights-mode) reader raises it — see
+         *  [chaptersBehind]. Capped at 1 by memory constraints on Android 7.1 tablets: bigger
+         *  buffers OOM the WebView renderer with real EPUB chapters loaded with offscreen
+         *  pre-raster. Elided-view chapters are synthesised excerpts, small enough to lift the
+         *  cap safely. */
+        private const val DEFAULT_CHAPTERS_BEHIND = 1
 
         /** See [ContinuousReaderView.CHAPTERS_AHEAD]. */
         private const val CHAPTERS_AHEAD = 1
-
-        /** Total sliding-window size: the reader's chapter plus the behind/ahead buffers. */
-        private const val WINDOW_SIZE = CHAPTERS_BEHIND + 1 + CHAPTERS_AHEAD
 
         /** Max detached WebViews retained for reuse across window shifts. Small: pooled views keep
          *  the previous page's DOM + rasterized tiles resident until reuse (recycle() blanks the
@@ -219,7 +221,19 @@ internal class ContinuousWindowController(
     private var shiftPending = false
 
     /** Owns the shift-direction algorithm and the justShiftedForward oscillation guard. */
-    private val windowManager = ChapterWindowManager(CHAPTERS_BEHIND)
+    private val windowManager = ChapterWindowManager(DEFAULT_CHAPTERS_BEHIND)
+
+    /**
+     * Chapters kept behind the viewport before a forward shift fires. Elided-view opens set this
+     * to 2+ (see [DEFAULT_CHAPTERS_BEHIND]) so tiny synthetic chapters don't oscillate. MUST be
+     * set before [openWindowAt] — the initial window size derives from it and can't be resized
+     * mid-window.
+     */
+    internal var chaptersBehind: Int
+        get() = windowManager.chaptersBehind
+        set(value) { windowManager.chaptersBehind = value }
+
+    private val windowSize: Int get() = chaptersBehind + 1 + CHAPTERS_AHEAD
 
     /** True while rebuilding the window after a WebView renderer-process death. */
     private var rendererRecovering = false
@@ -391,8 +405,8 @@ internal class ContinuousWindowController(
         val initial = ContinuousPositionTracker.initialWindow(
             targetIndex = targetIndex,
             allChaptersSize = allChapters.size,
-            chaptersBehind = CHAPTERS_BEHIND,
-            windowSize = WINDOW_SIZE,
+            chaptersBehind = chaptersBehind,
+            windowSize = windowSize,
         )
         topIndex = initial.topIndex
         val targetWindowIndex = initial.targetWindowIndex
@@ -929,7 +943,9 @@ internal class ContinuousWindowController(
         val (href, _) = ContinuousPositionTracker.locatorAt(sY, port.viewportHeightPx, window)
         val viewportMidIndex = allChapters.indexOfFirst { it.link.href.toString() == href }
 
-        val decision = windowManager.decide(sY, viewportMidIndex, window, topIndex, allChapters.size)
+        val decision = windowManager.decide(
+            sY, viewportMidIndex, window, topIndex, allChapters.size, port.viewportHeightPx,
+        )
         when (decision) {
             ChapterWindowManager.Decision.ShiftBackward -> {
                 shiftInProgress = true

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -61,10 +61,13 @@ internal class ContinuousWindowController(
         /** See [ContinuousReaderView.CHAPTERS_AHEAD]. */
         private const val CHAPTERS_AHEAD = 1
 
-        /** Max detached WebViews retained for reuse across window shifts. Small: pooled views keep
-         *  the previous page's DOM + rasterized tiles resident until reuse (recycle() blanks the
-         *  URL but preRaster still holds an empty document's tiles). */
-        internal const val RECYCLE_POOL_MAX = 2
+        /** Baseline max detached WebViews retained for reuse across window shifts (full-book
+         *  continuous mode: `windowSize == 3`). Pooled views keep the previous page's DOM +
+         *  rasterized tiles resident until reuse (recycle() blanks the URL but preRaster still
+         *  holds an empty document's tiles), so the cap has to stay tight on the Android 7.1
+         *  memory budget. Elided-view mode gets a pool matching its larger `windowSize` via
+         *  [recyclePoolMax] — synthetic chapters are small enough to lift the cap safely. */
+        internal const val DEFAULT_RECYCLE_POOL_MAX = 2
 
         /**
          * Grace period after a window (re)build before the initial scroll is forced to fire even if
@@ -235,6 +238,14 @@ internal class ContinuousWindowController(
 
     private val windowSize: Int get() = chaptersBehind + 1 + CHAPTERS_AHEAD
 
+    /**
+     * Recycled-WebView pool cap, sized to the current window. The class-comment invariant is that
+     * the pool cap should equal `windowSize`; when the elided reader raises `chaptersBehind` to 3
+     * (windowSize 5), a hard-coded cap of 2 would destroy 2 WebViews on every shift instead of
+     * recycling them.
+     */
+    private val recyclePoolMax: Int get() = maxOf(DEFAULT_RECYCLE_POOL_MAX, windowSize)
+
     /** True while rebuilding the window after a WebView renderer-process death. */
     private var rendererRecovering = false
 
@@ -334,7 +345,7 @@ internal class ContinuousWindowController(
         // on a long book. loadChapter() will replace about:blank on the next reuse.
         wv.stopLoading()
         wv.loadUrl("about:blank")
-        if (recycledViews.size < RECYCLE_POOL_MAX) recycledViews.addLast(wv) else wv.destroy()
+        if (recycledViews.size < recyclePoolMax) recycledViews.addLast(wv) else wv.destroy()
     }
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -513,7 +513,7 @@ fun EpubReaderScreen(
                         onPageTopResolved = viewModel::onPageTopResolved,
                         onPlayFromHere = viewModel::playFromHere,
                         onEnsureSentenceQuotesReady = viewModel::ensureSentenceQuotesReady,
-                        isElidedContinuous = viewModel.readerSource == ReaderSource.Highlights,
+                        isElidedContinuous = isElidedContinuousReader(viewModel.readerSource),
                         readaloudAvailable = readaloudAvailable,
                         readaloudReservePx = totalReserveCssPx,
                         readaloudHighlightColor = effectiveHighlightColor,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -513,6 +513,7 @@ fun EpubReaderScreen(
                         onPageTopResolved = viewModel::onPageTopResolved,
                         onPlayFromHere = viewModel::playFromHere,
                         onEnsureSentenceQuotesReady = viewModel::ensureSentenceQuotesReady,
+                        isElidedContinuous = viewModel.readerSource == ReaderSource.Highlights,
                         readaloudAvailable = readaloudAvailable,
                         readaloudReservePx = totalReserveCssPx,
                         readaloudHighlightColor = effectiveHighlightColor,
@@ -1398,6 +1399,11 @@ private fun EpubNavigatorView(
     // pair (issue #403 spec: "start from the sentence currently visible — same as Readaloud").
     cadencePageTopProbeRequests: Flow<String> = kotlinx.coroutines.flow.emptyFlow(),
     onCadencePageTopResolved: (href: String, fragmentId: String?) -> Unit = { _, _ -> },
+    /** True when the reader is showing the elided (Highlights-mode) synthesised publication. Used
+     *  to raise the continuous-mode sliding-window `chaptersBehind` so tiny synthetic chapters
+     *  don't trigger backward↔forward oscillation. Defaults to false so the full-book path keeps
+     *  its memory-capped configuration. */
+    isElidedContinuous: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -2913,6 +2919,17 @@ private fun EpubNavigatorView(
                         // Route continuous decoration + WebView console diagnostics to
                         // LogChannel.ReaderDecoration (RIFFLE_DECO) for the in-app debug screen.
                         view.logger = logger
+                        // Elided-view chapters are synthesised excerpts (often < viewport/2). With
+                        // chaptersBehind=1 (the memory-capped default full-book continuous mode
+                        // needs on Android 7.1 tablets), a backward shift into a tall chapter
+                        // sitting behind a short one makes the viewport midpoint overshoot the
+                        // short chapter → gap=2 > chaptersBehind → forward shift immediately
+                        // undoes the backward one. Raising to 3 absorbs one or two consecutive
+                        // short chapters between the target and the new top slot without triggering
+                        // this oscillation. Safe because elided chapter WebViews are small — no
+                        // renderer-OOM risk that motivates the full-book cap. MUST be set before
+                        // `initialize()` — the initial window size derives from it.
+                        if (isElidedContinuous) view.chaptersBehind = 3
                         // Wire the presenter BEFORE attach so the coordinator's onRawPosition
                         // handler routes raw-position events through it on the very first scroll.
                         coordinator.presenter = continuousPresenter

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -180,6 +180,17 @@ private const val OVERLAP_CONTEXT_LEN = 60
 internal fun shouldRunReadingSideEffects(source: ReaderSource): Boolean =
     source != ReaderSource.Highlights
 
+/**
+ * Whether the continuous reader for [source] renders the elided (Highlights-mode) publication.
+ * Wired into [EpubReaderScreen]'s `EpubNavigatorView` call so [ContinuousReaderView.chaptersBehind]
+ * is raised for the elided path only (fix: prevent the short-middle-chapter backward↔forward
+ * oscillation). `internal` + top-level so this exact mapping is unit-testable without a Composable
+ * host — a regression that silently flipped this predicate would re-open the oscillation bug on
+ * every elided open with no other visible symptom.
+ */
+internal fun isElidedContinuousReader(source: ReaderSource): Boolean =
+    source == ReaderSource.Highlights
+
 sealed class ReaderState {
     data object Loading : ReaderState()
     data class Ready(
@@ -3538,10 +3549,16 @@ internal fun highlightsResumeHrefUpdates(hrefs: Flow<String>): Flow<String> =
  * diff-check contains new adds vs the previously-rendered snapshot → structural change →
  * [EpubReaderViewModel.reloadHighlightsView]. Without a debounce, the reader open-close-reopens
  * once per emission (observed: ~8 cycles in ~2.5 s on the elided view of a book with 11 chapters
- * / 74 highlights when the sync ran during initial open). The wait window is a compromise: long
- * enough to coalesce the burst into a single rebuild, short enough that a direct user edit
- * (colour change, note) still feels instant — sub-frame at 60 Hz. `internal` so the flow-op
- * wiring is unit-testable with `runTest` virtual time.
+ * / 74 highlights when the sync ran during initial open).
+ *
+ * Tradeoff: `Flow.debounce` also delays the FIRST emission by the window (~15 frames at 60 Hz),
+ * so a direct user edit (colour change, note add) applies its DOM patch ~250 ms after the DB
+ * write, not immediately. That's above the ~100 ms "feels instant" threshold but below the
+ * ~500 ms threshold where users start second-guessing their tap; acceptable in exchange for
+ * killing the storm. If the delay ever becomes user-visible enough to matter, the fix is to
+ * bypass the debounce for direct-edit-shaped emissions (single-row diff) while keeping it for
+ * multi-row bursts. `internal` so the flow-op wiring is unit-testable with `runTest` virtual
+ * time.
  */
 internal const val HIGHLIGHTS_OBSERVER_DEBOUNCE_MS = 250L
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -80,6 +80,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterNotNull
@@ -2783,7 +2784,14 @@ class EpubReaderViewModel @Inject constructor(
     private fun ensureHighlightsObserver(sourceId: String, itemId: String) {
         if (highlightsObserverJob?.isActive == true) return
         highlightsObserverJob = viewModelScope.launch {
-            annotationDao.observeAnnotationsByPosition(sourceId, itemId).collect { annotations ->
+            // Debounce to coalesce sync-driven emission bursts. Without this, the Room-backed
+            // flow re-emits per row-insert during a sync burst (observed: 8 openBook cycles in
+            // ~2.5 s on the elided view of a book with 11 chapters and 74 highlights, each cycle
+            // firing a `reloadHighlightsView` because the diff saw new adds every time). The
+            // window is short enough (<300 ms) that direct user edits still feel instant.
+            debouncedHighlightsFlow(
+                annotationDao.observeAnnotationsByPosition(sourceId, itemId),
+            ).collect { annotations ->
                 // Filter to highlights only — the elided reader's spine, chapter HTML, and every
                 // downstream patch/rewrite is highlights-only. If we left bookmarks in this stream:
                 //  (1) a chapter's byte rewrite would render bookmarks as fake highlight paragraphs
@@ -3522,6 +3530,26 @@ internal fun decodeReaderSource(raw: String?): ReaderSource =
  */
 internal fun highlightsResumeHrefUpdates(hrefs: Flow<String>): Flow<String> =
     hrefs.distinctUntilChanged().drop(1)
+
+/**
+ * Elided-view observer flow with a debounce window applied. Room's `observeAnnotationsByPosition`
+ * flow re-emits on every row-write in the observed set: during an annotation sync burst (up to a
+ * few dozen inserts landing in one HTTP round), every emission that reaches the observer's
+ * diff-check contains new adds vs the previously-rendered snapshot → structural change →
+ * [EpubReaderViewModel.reloadHighlightsView]. Without a debounce, the reader open-close-reopens
+ * once per emission (observed: ~8 cycles in ~2.5 s on the elided view of a book with 11 chapters
+ * / 74 highlights when the sync ran during initial open). The wait window is a compromise: long
+ * enough to coalesce the burst into a single rebuild, short enough that a direct user edit
+ * (colour change, note) still feels instant — sub-frame at 60 Hz. `internal` so the flow-op
+ * wiring is unit-testable with `runTest` virtual time.
+ */
+internal const val HIGHLIGHTS_OBSERVER_DEBOUNCE_MS = 250L
+
+@OptIn(kotlinx.coroutines.FlowPreview::class)
+internal fun <T> debouncedHighlightsFlow(
+    source: Flow<T>,
+    windowMs: Long = HIGHLIGHTS_OBSERVER_DEBOUNCE_MS,
+): Flow<T> = source.debounce(windowMs)
 
 /**
  * Highlights-mode counterpart to [EpubReaderViewModel.annotationToRender] (Critical #1 fix, ADR

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWindowManagerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWindowManagerTest.kt
@@ -159,6 +159,83 @@ class ChapterWindowManagerTest {
         assertEquals("backward should fire once guard has cleared", ChapterWindowManager.Decision.ShiftBackward, d3)
     }
 
+    // ── elided-view backward↔forward oscillation (chaptersBehind ≥ 2 required) ─────
+    //
+    // Field-observed 2026-07-21 (RIFFLE_DECO logs): elided view with heights `[499, 2809, 3631]`
+    // and `chaptersBehind=1`. User scrolls backward, backward-shift fires (removeBottom + prepend
+    // ch6). The prepend adds a placeholder ~viewport tall + scroll compensation → new scrollY
+    // inside the tall prepended chapter, but viewport midpoint OVERSHOOTS the short middle
+    // chapter (499 px) straight into ch8: viewportChapterIndex still 8, topIndex now 6, gap=2.
+    // With `chaptersBehind=1`, `2 > 1` → forward shift fires → undoes the backward. Perpetual
+    // oscillation, user cannot progress backward. Raising `chaptersBehind` to 2 absorbs a
+    // single short middle chapter (gap=2 no longer > 2); raising to 3 absorbs two consecutive
+    // short chapters (gap=3 no longer > 3). The elided reader uses 3.
+
+    @Test
+    fun `chaptersBehind 1 — backward shift into a short-middle-chapter window oscillates back to forward`() {
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        // Post-backward window: tall ch6 prepended over short ch7 over tall ch8. Scroll
+        // compensation lands the user inside ch6 near ch7 → midY overshoots into ch8.
+        val postBackwardWindow = listOf(
+            slot("ch6", top = 0,     height = 2_337),
+            slot("ch7", top = 2_337, height = 499),    // ← short middle
+            slot("ch8", top = 2_836, height = 2_809),
+        )
+        val d = mgr.decide(
+            scrollY = 2_448,
+            viewportChapterIndex = 8,        // midY = 2448+1200 = 3648 → in ch8 slot [2836..5645)
+            window = postBackwardWindow,
+            topIndex = 6,
+            totalChapters = 11,
+            viewportHeight = 2_400,
+        )
+        assertEquals(
+            "chaptersBehind=1: gap 2 > 1 → forward re-fires → oscillation",
+            ChapterWindowManager.Decision.ShiftForward, d,
+        )
+    }
+
+    @Test
+    fun `chaptersBehind 3 — backward shift into a short-middle-chapter window sticks`() {
+        val mgr = ChapterWindowManager(chaptersBehind = 3)   // elided view's value
+        val postBackwardWindow = listOf(
+            slot("ch6", top = 0,     height = 2_337),
+            slot("ch7", top = 2_337, height = 499),
+            slot("ch8", top = 2_836, height = 2_809),
+        )
+        val d = mgr.decide(
+            scrollY = 2_448,
+            viewportChapterIndex = 8,
+            window = postBackwardWindow,
+            topIndex = 6,
+            totalChapters = 11,
+            viewportHeight = 2_400,
+        )
+        assertEquals(
+            "chaptersBehind=3: gap 2 > 3 is false → backward shift sticks, user can scroll back",
+            ChapterWindowManager.Decision.Hold, d,
+        )
+    }
+
+    @Test
+    fun `chaptersBehind is mutable so the elided reader can raise it before openWindowAt`() {
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        // Verify the public setter propagates to the shift-decision path.
+        mgr.chaptersBehind = 3
+        val d = mgr.decide(
+            scrollY = 0,
+            viewportChapterIndex = 3,     // gap = 3-0 = 3, not > 3 with the raised threshold
+            window = uniformWindow(5),
+            topIndex = 0,
+            totalChapters = 20,
+            viewportHeight = 2_400,
+        )
+        assertEquals(
+            "raised chaptersBehind must gate the forward trigger",
+            ChapterWindowManager.Decision.Hold, d,
+        )
+    }
+
     @Test
     fun `reset clears the guard immediately`() {
         val mgr = ChapterWindowManager(chaptersBehind = 3)
@@ -207,6 +284,114 @@ class ChapterWindowManagerTest {
             window = uniformWindow(7),
             topIndex = 0,
             totalChapters = 20,
+        )
+        assertEquals(ChapterWindowManager.Decision.Hold, d)
+    }
+
+    // ── bottom-of-window trigger (short trailing chapter wall-off) ───────────
+    //
+    // Regression: elided-view continuous mode with a short trailing chapter walls off. Observed
+    // fixture: 11-chapter book, window [ch5,ch6,ch7] heights=[3250,1263,499], viewport 2400.
+    // Max scroll clamps at 2612 with midpoint at 3812 (inside ch6). Midpoint-only trigger gives
+    // `gap = 6-5 = 1 ≤ chaptersBehind(1)` → Hold forever, even though ch8..ch10 are unloaded.
+    // The `viewportHeight` overload propagates a bottom-of-window signal so decide() can fire a
+    // forward shift when scroll is clamped and more chapters remain.
+
+    @Test
+    fun `short trailing chapter at bottom of window fires ShiftForward via viewport-height overload`() {
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = listOf(
+            slot("ch5", top = 0,    height = 3_250),
+            slot("ch6", top = 3_250, height = 1_263),
+            slot("ch7", top = 4_513, height = 499),   // ← short trailing; midY can't enter it
+        )
+        val d = mgr.decide(
+            scrollY = 2_612,             // maxScroll = 5012 - 2400
+            viewportChapterIndex = 6,     // midY falls in ch6
+            window = window,
+            topIndex = 5,
+            totalChapters = 11,
+            viewportHeight = 2_400,
+        )
+        assertEquals(
+            "bottom-of-window trigger must unwedge the wall-off",
+            ChapterWindowManager.Decision.ShiftForward, d,
+        )
+    }
+
+    @Test
+    fun `bottom-of-window trigger does not fire when loaded window fits inside the viewport`() {
+        // Regression pin (2026-07-21 field repro after the initial wall-off fix): elided view
+        // opened with 3 short chapters loaded whose total height (1500 px) is less than the
+        // viewport (2400 px). Without the loadedContentBottom > viewportHeight guard,
+        // atBottomOfLoadedWindow is true even at scrollY=0 → ShiftForward fires immediately →
+        // topIndex advances → next decide() also fires → the window jumps [ch0..ch2] to
+        // [ch3..ch5] with no user input. And once the pattern is established, any backward shift
+        // is immediately re-undone by a fresh forward shift on the next decide, so the user
+        // can't scroll back. Field-observed as "cannot scroll to the chapters BEFORE ch12".
+        //
+        // topIndex=0 pins out the backward-shift path (topIndex>0 is a required condition), so
+        // the ONLY trigger this test exercises is the bottom-of-window one. Midpoint trigger is
+        // false too (midY at 1200 in ch0 → viewportChapterIndex=0 → 0-0=0 not > 1). Decision
+        // must be Hold; without the guard it was ShiftForward.
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = listOf(
+            slot("ch0", top = 0,    height = 500),
+            slot("ch1", top = 500,  height = 500),
+            slot("ch2", top = 1_000, height = 500),   // total = 1500 < viewport (2400)
+        )
+        val d = mgr.decide(
+            scrollY = 0,
+            viewportChapterIndex = 0,
+            window = window,
+            topIndex = 0,
+            totalChapters = 11,
+            viewportHeight = 2_400,
+        )
+        assertEquals(
+            "loaded window fits in viewport — must not auto-cascade forward",
+            ChapterWindowManager.Decision.Hold, d,
+        )
+    }
+
+    @Test
+    fun `bottom-of-window trigger holds when no more chapters exist ahead`() {
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = listOf(
+            slot("ch8", top = 0,    height = 3_250),
+            slot("ch9", top = 3_250, height = 1_263),
+            slot("ch10", top = 4_513, height = 499),
+        )
+        // scroll at bottom, but this IS the last chunk (topIndex+loaded=11=totalChapters).
+        val d = mgr.decide(
+            scrollY = 2_612,
+            viewportChapterIndex = 9,
+            window = window,
+            topIndex = 8,
+            totalChapters = 11,
+            viewportHeight = 2_400,
+        )
+        assertEquals(ChapterWindowManager.Decision.Hold, d)
+    }
+
+    @Test
+    fun `bottom-of-window trigger inactive when not at maxScroll — midpoint trigger governs`() {
+        // scrollY inside the window (not clamped at max) AND above the backward-shift threshold
+        // (firstChapterHeight/2 = 1625). The bottom-of-window trigger must NOT fire and neither
+        // the backward nor the forward trigger applies → Hold.
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = listOf(
+            slot("ch5", top = 0,    height = 3_250),
+            slot("ch6", top = 3_250, height = 1_263),
+            slot("ch7", top = 4_513, height = 499),
+        )
+        val d = mgr.decide(
+            scrollY = 1_700,             // > firstChapterHeight/2 (no backward) and < maxScroll (2612)
+            viewportChapterIndex = 5,     // midY sits inside ch5
+            window = window,
+            topIndex = 5,
+            totalChapters = 11,
+            viewportHeight = 2_400,       // scrollY+vH=4100 < loadedContentBottom=5012 → NOT at bottom
         )
         assertEquals(ChapterWindowManager.Decision.Hold, d)
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -153,6 +153,59 @@ class ContinuousPositionTrackerTest {
         ))
     }
 
+    // ── bottom-of-window trigger: unwedge the short-trailing-chapter wall-off ──
+    //
+    // Regression: elided-view continuous mode walled off at ch7 in an 11-chapter book. Window
+    // [ch5,ch6,ch7] measured heights=[3250,1263,499]; viewport 2400. Max scroll = 5012-2400 =
+    // 2612. At maxScroll, viewport midpoint (3812) falls in ch6 — ch7 is too short (< viewport/2)
+    // for midY to ever enter its slot. So the midpoint-only trigger held forever, even though
+    // ch8..ch10 were unloaded. The user couldn't scroll past ch7.
+    //
+    // Fix: also fire forward shift when the loaded window's bottom is reached (scroll clamped)
+    // AND more chapters exist. This complements the midpoint trigger without regressing the
+    // divider-page blank-flash guard the midpoint trigger was introduced for.
+
+    @Test
+    fun `forwardShiftNeeded — short trailing chapter at bottom of window still fires shift`() {
+        // Exact fixture from the observed AVD wall-off: topIndex=5, window of 3, 11 chapters.
+        // Midpoint sits at ch6 (topIndex+1) so pastBehindBudget is false. Without the bottom-of-
+        // window trigger this returns false forever — reader walls off at ch7.
+        assertTrue(
+            "short trailing chapter must not wall off scroll — bottom-of-window trigger fires",
+            ContinuousPositionTracker.forwardShiftNeeded(
+                viewportChapterIndex = 6, topIndex = 5, loadedChapterCount = 3,
+                readingOrderSize = 11, chaptersBehind = 1,
+                atBottomOfLoadedWindow = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `forwardShiftNeeded — bottom of window with no more chapters still holds`() {
+        // At the last window: reaching the bottom must NOT trigger a shift because there are
+        // no chapters left to append.
+        assertFalse(
+            ContinuousPositionTracker.forwardShiftNeeded(
+                viewportChapterIndex = 10, topIndex = 8, loadedChapterCount = 3,
+                readingOrderSize = 11, chaptersBehind = 1,
+                atBottomOfLoadedWindow = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `forwardShiftNeeded — bottom-of-window default false preserves midpoint-only trigger`() {
+        // Default arg (no bottom-of-window signal) MUST preserve existing behavior — midpoint
+        // trigger is authoritative when the flag isn't passed.
+        assertFalse(
+            "no bottom-of-window info → midpoint trigger is the only path",
+            ContinuousPositionTracker.forwardShiftNeeded(
+                viewportChapterIndex = 6, topIndex = 5, loadedChapterCount = 3,
+                readingOrderSize = 11, chaptersBehind = 1,
+            ),
+        )
+    }
+
     // ── forward→backward oscillation — the "Children of Dune / Introduction" bug ──────────
     //
     // A short chapter (height < viewport) as the new first slot after a forward shift causes the

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelHighlightsSourceTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelHighlightsSourceTest.kt
@@ -6,9 +6,19 @@ import com.riffle.app.feature.reader.highlights.ReaderSource
 import com.riffle.core.database.AnnotationEntity
 import com.riffle.core.models.Annotation
 import com.riffle.core.models.TocEntry
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -406,5 +416,80 @@ class EpubReaderViewModelHighlightsSourceTest {
         val hrefs = flowOf("highlights/ch0.xhtml")
         val result = highlightsResumeHrefUpdates(hrefs).toList()
         assertEquals(emptyList<String>(), result)
+    }
+
+    // ── debouncedHighlightsFlow — regression for the reload storm ─────────────
+    //
+    // Field repro (2026-07-21 AVD, 11-chapter elided view, 74 highlights, sync-in-progress on
+    // open): `annotationDao.observeAnnotationsByPosition` re-emitted per row-insert during the
+    // sync burst — 8 openBook cycles fired in ~2.5 s, each triggering a `reloadHighlightsView`
+    // because the diff saw new adds every time. Debouncing the observer flow before the collect
+    // block coalesces the burst into a single settled emission.
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `debouncedHighlightsFlow coalesces a rapid burst into the last emission`() = runTest {
+        val received = mutableListOf<List<String>>()
+        val source = flow {
+            emit(listOf("a"))
+            delay(50)
+            emit(listOf("a", "b"))
+            delay(50)
+            emit(listOf("a", "b", "c"))
+            // no more emissions — the debounce window closes and the flow settles
+        }
+        val job = launch {
+            debouncedHighlightsFlow(source, windowMs = 250L).collect { received += it }
+        }
+        advanceUntilIdle()
+        job.cancel()
+        assertEquals(
+            "burst of 3 rapid emissions must coalesce to one settled emission",
+            listOf(listOf("a", "b", "c")),
+            received,
+        )
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `debouncedHighlightsFlow lets an emission through after the window elapses`() = runTest {
+        val received = mutableListOf<List<String>>()
+        val source = flow {
+            emit(listOf("a"))
+            delay(500L)              // past the 250 ms debounce window → first emission goes through
+            emit(listOf("a", "b"))
+            delay(500L)              // past the debounce window → second emission goes through
+        }
+        val job = launch {
+            debouncedHighlightsFlow(source, windowMs = 250L).collect { received += it }
+        }
+        advanceUntilIdle()
+        job.cancel()
+        assertEquals(
+            "well-separated emissions must NOT be dropped by the debounce",
+            listOf(listOf("a"), listOf("a", "b")),
+            received,
+        )
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `debouncedHighlightsFlow default window matches the exported constant`() = runTest {
+        // Regression: keep the default window value from silently drifting out of sync with the
+        // documented constant; a shrinking default would let the sync-burst storm regress; a
+        // ballooning one would make direct user edits feel laggy.
+        val received = mutableListOf<Int>()
+        val source = flow {
+            emit(1)
+            delay(HIGHLIGHTS_OBSERVER_DEBOUNCE_MS - 50L)
+            emit(2)
+            // no more emissions → debounce fires with the last value once window elapses
+        }
+        val job = launch {
+            debouncedHighlightsFlow(source).onEach { received += it }.launchIn(this)
+        }
+        advanceUntilIdle()
+        job.cancel()
+        assertEquals(listOf(2), received)
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelHighlightsSourceTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelHighlightsSourceTest.kt
@@ -418,6 +418,25 @@ class EpubReaderViewModelHighlightsSourceTest {
         assertEquals(emptyList<String>(), result)
     }
 
+    // ── isElidedContinuousReader — mapping ReaderSource → elided-mode branch ──
+    //
+    // The single call site in EpubReaderScreen threads this predicate into EpubNavigatorView's
+    // `isElidedContinuous` param, which raises `ContinuousReaderView.chaptersBehind` to 3.
+    // Without that raise, the short-middle-chapter backward↔forward oscillation returns
+    // (documented in ChapterWindowManagerTest, and originally observed 2026-07-21 on the
+    // Riffle elided view). A trivially-shaped predicate — but flipping it silently disables the
+    // oscillation fix on every elided open, so pin the mapping explicitly here.
+
+    @Test
+    fun `isElidedContinuousReader is true for Highlights source`() {
+        assertTrue(isElidedContinuousReader(ReaderSource.Highlights))
+    }
+
+    @Test
+    fun `isElidedContinuousReader is false for FullBook source`() {
+        assertFalse(isElidedContinuousReader(ReaderSource.FullBook))
+    }
+
     // ── debouncedHighlightsFlow — regression for the reload storm ─────────────
     //
     // Field repro (2026-07-21 AVD, 11-chapter elided view, 74 highlights, sync-in-progress on


### PR DESCRIPTION
## Summary

Four fixes for scroll-blocking bugs in the elided (Highlights-mode) continuous reader, surfaced 2026-07-21 while reading a book with 11 elided chapters mixing tall multi-highlight chapters and short single-highlight ones.

**1. Wall-off at short trailing chapter (the original report).** The midpoint-only forward-shift trigger cannot fire when the trailing chapter is shorter than half a viewport — midY never enters its slot regardless of scroll. Added `atBottomOfLoadedWindow` to `ContinuousPositionTracker.forwardShiftNeeded` and threaded a `viewportHeight` overload through `ChapterWindowManager.decide` + `ContinuousWindowController.maybeShift` so the shift fires when scroll is clamped at the end of the loaded content and chapters remain unloaded.

**2. Small-window cascade.** If all loaded chapters fit inside one viewport, the bottom-of-window trigger is `true` at scrollY=0 and would auto-cascade forward shifts, dragging the user past their target and blocking backward nav. Guarded with `loadedContentBottom > viewportHeight`.

**3. Backward↔forward oscillation with short middle chapters.** After a backward shift into `[tall, short, tall]`, midY sits in the third slot, producing `gap=2 > chaptersBehind=1` → forward shift immediately undoes the backward one. Fix: raise `chaptersBehind` for elided view specifically (safe — synthesised excerpt chapters are small; no renderer OOM risk that motivates the full-book cap). Refactored `CHAPTERS_BEHIND` from a `const val` to a per-instance var, exposed via `ContinuousReaderView.chaptersBehind`, wired from `EpubReaderScreen` when `isElidedContinuousReader(source)`. Also resized the recycled-WebView pool to match — `max(2, windowSize)` — so elided shifts recycle instead of destroying WebViews.

**4. Reload storm on elided open.** Room's `observeAnnotationsByPosition` re-emits per row-insert during an annotation sync burst; every emission that arrives before the first has settled is diffed as a structural change and triggers a full `reloadHighlightsView`, producing 8 open→close→reopen cycles in ~2.5 s. Debounced the observer flow (`debouncedHighlightsFlow`, 250 ms window) so a burst coalesces into one settled emission. `Flow.debounce` also delays the first emission by the window (~15 frames at 60 Hz), so direct user edits apply their DOM patch ~250 ms after the DB write — acceptable tradeoff, documented in the KDoc.

## Regression coverage

- `ContinuousPositionTrackerTest`: bottom-of-window trigger fires on short trailing chapter; holds when no chapters remain; default arg preserves midpoint-only behavior.
- `ChapterWindowManagerTest`: end-to-end decisions at maxScroll vs mid-scroll vs last-window; small-window cascade guarded; short-middle-chapter oscillation demonstrated at `chaptersBehind=1` and fixed at `chaptersBehind=3`; mutable-var contract pinned.
- `EpubReaderViewModelHighlightsSourceTest`: rapid burst coalesces to one emission; well-separated emissions both pass through; default window matches the exported constant; `isElidedContinuousReader` pinned true/false for both ReaderSource values.

## Test plan

- [ ] Elided view: open a book with a short trailing chapter — verify scroll reaches the last chapter (previously walled off).
- [ ] Elided view: open a book with a mix of tall and short chapters — verify backward scrolling stays put, no oscillation.
- [ ] Elided view: open a book with a small-window state (all-short window) — verify no auto-cascade forward.
- [ ] Elided view during active sync: verify no visible open→close→reopen loop; one settled render.
- [ ] Full-book continuous mode: verify no regression (chaptersBehind stays at 1, WebView pool cap stays at 2).
- [ ] Direct annotation edit (color change) in elided view: verify ~250 ms delay is imperceptible in normal use.