### PR TITLE
fix(sync): live annotation sync — cache bypass, ∅-color round-trip, ABS-only routing

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncTargetHolder.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncTargetHolder.kt
@@ -21,7 +21,11 @@ import kotlinx.coroutines.runBlocking
  * ABS Sources changes.
  *
  * **Composition rules (ADR 0047):**
- * - WebDAV configured → one WebDAV child servicing every namespace.
+ * - WebDAV configured → one WebDAV child, servicing every namespace **except** those already
+ *   covered by an ABS-bookmark child. Once ABS-bookmark sync is live for an account, WebDAV would
+ *   only add cross-transport reconciliation cost without any read that the ABS-bookmark child
+ *   doesn't already serve; skip it. Komga (and any non-allow-listed ABS source) still routes to
+ *   WebDAV as before.
  * - Each ABS Source with an accessible token and `absUserId` → one ABS-bookmark child, namespace-
  *   scoped to `abs_<absUserId>`. Komga-namespaced books are not routed to any ABS-bookmark child.
  * - Zero children → `current() == null` (annotation sync is off).
@@ -84,25 +88,34 @@ class AnnotationSyncTargetHolder(
         webDavConfig: com.riffle.core.domain.AnnotationSyncConfig?,
         sources: List<Source>,
     ): AnnotationSyncTarget? {
+        // Build ABS children together with the namespace each one serves; we need the namespace
+        // set both here (Child.serves predicate) and below (to exclude WebDAV from those
+        // namespaces), so keep the pair to avoid a lossy downcast.
+        val absChildrenWithNamespaces: List<Pair<CompositeAnnotationSyncTarget.Child, String>> =
+            sources
+                .filter { it.type == SourceType.ABS && it.serverType == ServerType.AUDIOBOOKSHELF }
+                .mapNotNull { source ->
+                    val target = absBookmarkFactory.create(source) ?: return@mapNotNull null
+                    val namespace = "${AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX}${source.absUserId!!}"
+                    CompositeAnnotationSyncTarget.Child(
+                        target = target,
+                        serves = { ns -> ns == namespace },
+                        label = "abs:${source.id.take(8)}",
+                    ) to namespace
+                }
+        val absChildren = absChildrenWithNamespaces.map { it.first }
+        val absServedNamespaces: Set<String> = absChildrenWithNamespaces.mapTo(mutableSetOf()) { it.second }
+
+        // WebDAV steps aside for any namespace an ABS-bookmark child already serves — that account
+        // gets ABS bookmarks only, no WebDAV dual-write. Every other namespace (Komga, non-allow-
+        // listed ABS accounts) continues to route to WebDAV as before.
         val webDavChild = webDavConfig
             ?.let { webDavFactory.create(it) }
             ?.let {
                 CompositeAnnotationSyncTarget.Child(
                     target = it,
-                    serves = { _ -> true },
+                    serves = { ns -> ns !in absServedNamespaces },
                     label = "webdav",
-                )
-            }
-
-        val absChildren = sources
-            .filter { it.type == SourceType.ABS && it.serverType == ServerType.AUDIOBOOKSHELF }
-            .mapNotNull { source ->
-                val target = absBookmarkFactory.create(source) ?: return@mapNotNull null
-                val namespace = "${AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX}${source.absUserId!!}"
-                CompositeAnnotationSyncTarget.Child(
-                    target = target,
-                    serves = { ns -> ns == namespace },
-                    label = "abs:${source.id.take(8)}",
                 )
             }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncTargetHolder.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncTargetHolder.kt
@@ -88,23 +88,19 @@ class AnnotationSyncTargetHolder(
         webDavConfig: com.riffle.core.domain.AnnotationSyncConfig?,
         sources: List<Source>,
     ): AnnotationSyncTarget? {
-        // Build ABS children together with the namespace each one serves; we need the namespace
-        // set both here (Child.serves predicate) and below (to exclude WebDAV from those
-        // namespaces), so keep the pair to avoid a lossy downcast.
-        val absChildrenWithNamespaces: List<Pair<CompositeAnnotationSyncTarget.Child, String>> =
-            sources
-                .filter { it.type == SourceType.ABS && it.serverType == ServerType.AUDIOBOOKSHELF }
-                .mapNotNull { source ->
-                    val target = absBookmarkFactory.create(source) ?: return@mapNotNull null
-                    val namespace = "${AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX}${source.absUserId!!}"
-                    CompositeAnnotationSyncTarget.Child(
-                        target = target,
-                        serves = { ns -> ns == namespace },
-                        label = "abs:${source.id.take(8)}",
-                    ) to namespace
-                }
-        val absChildren = absChildrenWithNamespaces.map { it.first }
-        val absServedNamespaces: Set<String> = absChildrenWithNamespaces.mapTo(mutableSetOf()) { it.second }
+        val absChildren = sources
+            .filter { it.type == SourceType.ABS && it.serverType == ServerType.AUDIOBOOKSHELF }
+            .mapNotNull { source ->
+                val target = absBookmarkFactory.create(source) ?: return@mapNotNull null
+                val namespace = "${AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX}${source.absUserId!!}"
+                CompositeAnnotationSyncTarget.Child(
+                    target = target,
+                    serves = { ns -> ns == namespace },
+                    label = "abs:${source.id.take(8)}",
+                    servedNamespace = namespace,
+                )
+            }
+        val absServedNamespaces: Set<String> = absChildren.mapNotNullTo(mutableSetOf()) { it.servedNamespace }
 
         // WebDAV steps aside for any namespace an ABS-bookmark child already serves — that account
         // gets ABS bookmarks only, no WebDAV dual-write. Every other namespace (Komga, non-allow-

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationW3CCodec.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationW3CCodec.kt
@@ -193,8 +193,13 @@ object AnnotationW3CCodec {
             bodies += buildJsonObject {
                 put("type", "TextualBody")
                 put("purpose", motivation)
-                // For highlights, include the color; for bookmarks, use the title
-                if (entity.type == AnnotationEntity.TYPE_HIGHLIGHT && entity.color.isNotEmpty()) {
+                // For highlights, include the color; for bookmarks, use the title. ADR 0046 §4:
+                // emit `value` even when empty (`""` == user picked ∅ — the format-only anchor)
+                // so peers can distinguish "explicitly no color" from "legacy row where value
+                // was never written." Without this, the receiver's merge falls back to yellow
+                // (COLOR_YELLOW) and a format-only-with-emphasis highlight paints yellow on
+                // device B.
+                if (entity.type == AnnotationEntity.TYPE_HIGHLIGHT) {
                     put("value", entity.color)
                 }
                 if (entity.type == AnnotationEntity.TYPE_BOOKMARK && entity.bookmarkTitle.isNotEmpty()) {

--- a/core/data/src/main/kotlin/com/riffle/core/data/absbookmark/CompositeAnnotationSyncTarget.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/absbookmark/CompositeAnnotationSyncTarget.kt
@@ -38,6 +38,14 @@ class CompositeAnnotationSyncTarget(
 
     private fun eligible(namespace: String): List<Child> = children.filter { it.serves(namespace) }
 
+    /**
+     * Diagnostic accessor: which child labels are routed for [namespace]. Used by
+     * `AnnotationSyncTargetHolderTest` to pin the "WebDAV steps aside for ABS-bookmark-served
+     * namespaces" rule without going through a live network round-trip; also handy in ad-hoc
+     * logging. Order matches [children].
+     */
+    fun eligibleLabels(namespace: String): List<String> = eligible(namespace).map { it.label }
+
     override suspend fun list(namespace: String, itemId: String): List<String> {
         val els = eligible(namespace)
         val union = LinkedHashSet<String>()

--- a/core/data/src/main/kotlin/com/riffle/core/data/absbookmark/CompositeAnnotationSyncTarget.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/absbookmark/CompositeAnnotationSyncTarget.kt
@@ -29,11 +29,15 @@ class CompositeAnnotationSyncTarget(
      *     children typically return true for every namespace; ABS-bookmark children return true
      *     only for their own account's namespace.
      * @param label short human-readable name for diagnostics.
+     * @param servedNamespace the single namespace this child owns exclusively, if any (used by the
+     *     holder to make WebDAV step aside for namespaces an ABS-bookmark child already covers).
+     *     Null for WebDAV / wildcard children whose [serves] is namespace-agnostic.
      */
     data class Child(
         val target: AnnotationSyncTarget,
         val serves: (namespace: String) -> Boolean,
         val label: String,
+        val servedNamespace: String? = null,
     )
 
     private fun eligible(namespace: String): List<Child> = children.filter { it.serves(namespace) }
@@ -41,10 +45,10 @@ class CompositeAnnotationSyncTarget(
     /**
      * Diagnostic accessor: which child labels are routed for [namespace]. Used by
      * `AnnotationSyncTargetHolderTest` to pin the "WebDAV steps aside for ABS-bookmark-served
-     * namespaces" rule without going through a live network round-trip; also handy in ad-hoc
-     * logging. Order matches [children].
+     * namespaces" rule without going through a live network round-trip. Internal — not a
+     * production API surface, only exposed to same-module tests.
      */
-    fun eligibleLabels(namespace: String): List<String> = eligible(namespace).map { it.label }
+    internal fun eligibleLabels(namespace: String): List<String> = eligible(namespace).map { it.label }
 
     override suspend fun list(namespace: String, itemId: String): List<String> {
         val els = eligible(namespace)

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncTargetHolderTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncTargetHolderTest.kt
@@ -1,12 +1,17 @@
 package com.riffle.core.data
 
 import com.riffle.core.data.absbookmark.AbsBookmarkAnnotationSyncTargetFactory
+import com.riffle.core.data.absbookmark.CompositeAnnotationSyncTarget
+import com.riffle.core.domain.AbsWebSourceDescriptor
 import com.riffle.core.domain.AnnotationSyncConfig
 import com.riffle.core.domain.AnnotationSyncConfigStore
 import com.riffle.core.domain.CommitSourceResult
 import com.riffle.core.domain.PendingSource
 import com.riffle.core.domain.SourceRepository
+import com.riffle.core.models.ServerType
 import com.riffle.core.models.Source
+import com.riffle.core.models.SourceType
+import com.riffle.core.models.SourceUrl
 import com.riffle.core.domain.TokenStorage
 import com.riffle.core.network.AbsBookmarkApi
 import com.riffle.core.network.NetworkAbsBookmark
@@ -21,8 +26,10 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -98,6 +105,53 @@ class AnnotationSyncTargetHolderTest {
         assertNull(holder.current())
     }
 
+    // Regression: for accounts served by an ABS-bookmark child (currently the allow-listed
+    // `plamen` / `test` usernames), WebDAV steps aside so that account's annotations flow
+    // over ABS bookmarks only — no dual-write to WebDAV. Every other namespace (Komga, non-
+    // allow-listed ABS accounts) continues to route to WebDAV as before. See
+    // AnnotationSyncTargetHolder composition rules.
+    @Test
+    fun `webdav does not serve namespaces already covered by an abs-bookmark child`() = runTest {
+        val absSource = Source(
+            id = "src-plamen",
+            url = SourceUrl.parse("http://abs.local")!!,
+            isActive = true,
+            insecureConnectionAllowed = false,
+            username = "plamen",
+            type = SourceType.ABS,
+            serverType = ServerType.AUDIOBOOKSHELF,
+            absUserId = "abs-user-1",
+        )
+        val sources = SingleSourceRepository(absSource)
+        val tokenStorage = InMemoryTokenStorage().apply { savedTokens[absSource.id] = "tok" }
+        val absFactory = AbsBookmarkAnnotationSyncTargetFactory(
+            absBookmarkApi = HolderTestNoopAbsBookmarkApi(),
+            tokenStorage = tokenStorage,
+        )
+        val holder = AnnotationSyncTargetHolder(
+            configStore = configStore,
+            webDavFactory = factory,
+            absBookmarkFactory = absFactory,
+            sourceRepository = sources,
+            scope = scope,
+        )
+        configStore.emit(AnnotationSyncConfig("https://dav.example.org/anno", "u", "p"))
+
+        val composite = holder.current() as? CompositeAnnotationSyncTarget
+            ?: error("expected a Composite target when both WebDAV and an ABS child are configured")
+
+        val absNamespace = "${AbsWebSourceDescriptor.ABS_NAMESPACE_PREFIX}${absSource.absUserId}"
+        assertEquals(
+            "ABS-served namespace must route to the ABS child only",
+            listOf("abs:${absSource.id.take(8)}"),
+            composite.eligibleLabels(absNamespace),
+        )
+        assertTrue(
+            "an unrelated namespace (e.g. Komga) must still route to WebDAV",
+            composite.eligibleLabels("komga_other").contains("webdav"),
+        )
+    }
+
     @Test
     fun `a subsequent config change replaces the previous target`() = runTest {
         val holder = holder()
@@ -137,6 +191,24 @@ private class NoopTokenStorage : TokenStorage {
     override suspend fun saveToken(sourceId: String, token: String) {}
     override suspend fun getToken(sourceId: String): String? = null
     override suspend fun deleteToken(sourceId: String) {}
+}
+
+private class InMemoryTokenStorage : TokenStorage {
+    val savedTokens: MutableMap<String, String> = mutableMapOf()
+    override suspend fun saveToken(sourceId: String, token: String) { savedTokens[sourceId] = token }
+    override suspend fun getToken(sourceId: String): String? = savedTokens[sourceId]
+    override suspend fun deleteToken(sourceId: String) { savedTokens.remove(sourceId) }
+}
+
+private class SingleSourceRepository(private val source: Source) : SourceRepository {
+    private val state = MutableStateFlow(listOf(source))
+    override fun observeAll(): Flow<List<Source>> = state
+    override suspend fun getActive(): Source? = source
+    override suspend fun commit(pending: PendingSource, hiddenLibraryIds: Set<String>): CommitSourceResult =
+        CommitSourceResult.Failure(UnsupportedOperationException())
+    override suspend fun setActive(sourceId: String) {}
+    override suspend fun remove(sourceId: String) {}
+    override suspend fun getSourceVersion(sourceId: String): String? = null
 }
 
 private class HolderTestNoopAbsBookmarkApi : AbsBookmarkApi {

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationW3CCodecTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationW3CCodecTest.kt
@@ -1154,6 +1154,43 @@ class AnnotationW3CCodecTest {
         assertEquals("bold,italic,underline,strike", roundTripped.emphasisStyles)
     }
 
+    // Regression: format-only highlights (color = "" — the `∅` swatch pick, sibling of a
+    // TYPE_EMPHASIS row) round-trip through sync with color still empty. Old encoder omitted the
+    // `value` field on empty color; the decoder then produced W3CAnnotation.color = null, and
+    // AnnotationMergeOrchestrator's `color = w3cAnnotation.color ?: COLOR_YELLOW` fallback painted
+    // the peer's format-only anchor as YELLOW on device B. Reproduced as "device A sets formatting
+    // without color, device B syncs the formatting, but sets the color to yellow" (2026-07-21).
+    @Test
+    fun `format-only highlight round-trips with empty color, not yellow`() {
+        val entity = AnnotationEntity(
+            id = "uuid-format-only",
+            sourceId = "abs1",
+            itemId = "item1",
+            type = AnnotationEntity.TYPE_HIGHLIGHT,
+            cfi = "epubcfi(/6/4!/4/2,/1:0,/1:10)",
+            color = "",
+            note = null,
+            textSnippet = "just bold this",
+            textBefore = "",
+            textAfter = "",
+            chapterHref = "chap01.xhtml",
+            createdAt = 1_000_000L,
+            updatedAt = 1_000_000L,
+            originDeviceId = "device-A",
+            lastModifiedByDeviceId = "device-A",
+        )
+
+        val json = codec.annotationEntityToW3C(entity)
+        assertTrue(
+            "empty color must be emitted as `\"value\":\"\"` so peers know it's ∅ not unspecified",
+            json.contains("\"value\":\"\""),
+        )
+
+        val parsed = codec.w3cToAnnotationEntity(json)
+        assertEquals(AnnotationEntity.TYPE_HIGHLIGHT, parsed.type)
+        assertEquals("", parsed.color)
+    }
+
     @Test
     fun `riffle_image body with neither href nor svg is skipped`() {
         val json = """

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
@@ -32,6 +32,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import okhttp3.CacheControl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -694,7 +695,10 @@ class AbsApiClient(
         token: String,
         insecureAllowed: Boolean,
     ): NetworkResult<List<NetworkAbsBookmark>> = OkHttpClassifier.classify(dispatchers.io) {
-        val response = get(baseUrl, "/api/me", token, insecureAllowed).requireSuccessful()
+        // Bypass the shared OkHttp cache for `/api/me` (15-min TTL from EndpointCacheHeadersInterceptor).
+        // Annotation sync piggybacks on user bookmarks; a stale cached body would hide a peer device's
+        // freshly-written bookmark until reopen. Mirrors WebDAV, whose PROPFIND was never cached.
+        val response = get(baseUrl, "/api/me", token, insecureAllowed, bypassCache = true).requireSuccessful()
         val raw = response.requireBody()
         // `/api/me` carries many fields; `json` is configured with ignoreUnknownKeys so the
         // wrapper need only declare `bookmarks` (absent → empty via the default).
@@ -704,13 +708,19 @@ class AbsApiClient(
     private fun client(insecureAllowed: Boolean): OkHttpClient =
         if (insecureAllowed) httpClient.withInsecureTls() else httpClient
 
-    private fun get(baseUrl: String, path: String, token: String, insecureAllowed: Boolean): Response {
-        val request = Request.Builder()
+    private fun get(
+        baseUrl: String,
+        path: String,
+        token: String,
+        insecureAllowed: Boolean,
+        bypassCache: Boolean = false,
+    ): Response {
+        val builder = Request.Builder()
             .url("$baseUrl$path")
             .addHeader("Authorization", "Bearer $token")
             .get()
-            .build()
-        return client(insecureAllowed).newCall(request).execute()
+        if (bypassCache) builder.cacheControl(CacheControl.FORCE_NETWORK)
+        return client(insecureAllowed).newCall(builder.build()).execute()
     }
 }
 

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsBookmarkApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsBookmarkApiTest.kt
@@ -3,6 +3,7 @@ package com.riffle.core.network
 import com.riffle.core.domain.DefaultDispatcherProvider
 
 import kotlinx.coroutines.test.runTest
+import okhttp3.Cache
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -10,9 +11,13 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 
 class AbsBookmarkApiTest {
+
+    @get:Rule val tempFolder = TemporaryFolder()
 
     private lateinit var server: MockWebServer
     private lateinit var client: AbsApiClient
@@ -145,6 +150,45 @@ class AbsBookmarkApiTest {
 
         assertTrue(result is NetworkResult.Success)
         assertTrue((result as NetworkResult.Success).value.isEmpty())
+    }
+
+    // Regression: EndpointCacheHeadersInterceptor stamps `/api/me` with `Cache-Control: max-age=900`
+    // for the details-page perf win, but ABS-bookmark annotation sync (#581) piggybacks on the same
+    // endpoint. Without a cache bypass here, device B's live-sync poll gets served the stale body
+    // for up to 15 minutes and never sees a peer device's freshly-written annotation until reopen.
+    // Mirrors WebDAV, whose PROPFIND was never cached.
+    @Test
+    fun `listBookmarks bypasses the OkHttp cache so peer writes are visible immediately`() = runTest {
+        val cachedHttp = OkHttpClient.Builder()
+            .cache(Cache(tempFolder.newFolder(), 1L shl 20))
+            .addNetworkInterceptor(EndpointCacheHeadersInterceptor(DEFAULT_HTTP_CACHE_RULES))
+            .build()
+        val cachedClient = AbsApiClient(cachedHttp, DefaultDispatcherProvider)
+
+        server.enqueue(
+            MockResponse().setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody("""{"bookmarks":[{"libraryItemId":"ITEM","time":-1,"title":"a","createdAt":1}]}""")
+        )
+        server.enqueue(
+            MockResponse().setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                    """{"bookmarks":[{"libraryItemId":"ITEM","time":-1,"title":"a","createdAt":1},""" +
+                        """{"libraryItemId":"ITEM","time":-2,"title":"peer","createdAt":2}]}"""
+                )
+        )
+
+        val first = cachedClient.listBookmarks(baseUrl(), "tok", false)
+        val second = cachedClient.listBookmarks(baseUrl(), "tok", false)
+
+        assertTrue(first is NetworkResult.Success)
+        assertTrue(second is NetworkResult.Success)
+        // If the cache were consulted, the second call would replay the first body and never see
+        // the peer bookmark — proving both calls went to the origin.
+        assertEquals(1, (first as NetworkResult.Success).value.size)
+        assertEquals(2, (second as NetworkResult.Success).value.size)
+        assertEquals(2, server.requestCount)
     }
 
     @Test


### PR DESCRIPTION
Three annotation-sync fixes uncovered while investigating "highlights don't sync live between devices anymore." All three ship together because they overlap in code paths and testing setup.

## Summary

1. **Highlights weren't syncing live** — `AbsBookmarkApi.listBookmarks` reads all bookmarks off `/api/me`, which `EndpointCacheHeadersInterceptor` stamps with `Cache-Control: max-age=900` (15 min) for the details-page perf win. Device B's live-sync poll kept getting served the stale body for up to 15 minutes and never saw a peer's fresh annotation until the book was reopened. `listBookmarks` now sends the request with `CacheControl.FORCE_NETWORK`, matching WebDAV's uncached PROPFIND. Other `/api/me` callers still hit the cache.

2. **Format-only highlights (color=∅) painted yellow on peer devices** — `AnnotationMergeOrchestrator`'s `color = w3cAnnotation.color ?: COLOR_YELLOW` fallback was firing because the old encoder dropped the `value` field on empty color, and the decoder produced `color = null`. Encoder now emits `"value":""` explicitly on `TYPE_HIGHLIGHT` so peers can distinguish "explicitly ∅" from "unspecified"; the empty string is non-null and now round-trips as ∅.

3. **Allow-listed users (plamen/test) drop WebDAV for their ABS accounts** — once ABS-bookmark sync is live for an account, dual-writing to WebDAV only adds cross-transport reconciliation cost with no read WebDAV serves that ABS bookmarks don't already. `AnnotationSyncTargetHolder` now tightens the WebDAV child's `serves` predicate so it excludes any namespace already covered by an ABS-bookmark child. Komga and any non-allow-listed ABS account continue to route to WebDAV as before.

## Test plan

- [x] `AbsBookmarkApiTest.listBookmarks bypasses the OkHttp cache so peer writes are visible immediately` — two sequential calls through a real Cache + interceptor both hit the origin.
- [x] `AnnotationW3CCodecTest.format-only highlight round-trips with empty color, not yellow` — encoded JSON contains `"value":""`, parsed W3CAnnotation carries `color == ""`.
- [x] `AnnotationSyncTargetHolderTest.webdav does not serve namespaces already covered by an abs-bookmark child` — composite routes ABS namespace to abs-only, Komga still routes to WebDAV.
- [x] Full `:core:data:testDebugUnitTest` + `:core:network:test` green locally.
- [ ] Verified live device-to-device on paginated reader (user-driven).