### PR TITLE
perf(reader): eliminate wasted per-open annotation apply + move open-path I/O off Main

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousDecorationController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousDecorationController.kt
@@ -41,19 +41,17 @@ internal class ContinuousDecorationController(
     internal var logger: Logger = NoopLogger
 
     private var currentAnnotationsByHref: Map<String, List<AnnotationHighlight>> = emptyMap()
-    // Per-href "has ever had marks applied" set. Used to skip the CLEAR_ANNOTATION_HIGHLIGHTS_JS
-    // eval when we know the DOM never had marks to begin with — a hot cold-open path where
-    // chapters load, applyAnnotationHighlights fires with an empty map (annotations still loading
-    // from Room), and we'd otherwise dispatch one wasted JS eval per loaded chapter. Once a href
-    // receives marks, any subsequent transition to "no marks" MUST still push the clear so the
-    // DOM is scrubbed.
-    private val hrefsWithAppliedMarks = mutableSetOf<String>()
-    // Per-href last-applied mark set. The reader triggers applyAnnotationHighlights on every
-    // pageLoadGeneration / reflowGeneration bump (via a LaunchedEffect keyed on the union of
-    // these), so on cold-open with 3 chapters in the initial window we'd otherwise re-apply the
-    // same identical mark list 3+ times — each one a full JS eval on the WebView UI thread that
-    // rebuilds every mark's <mark> wrapper. Skip when the list is content-equal to the last apply
-    // for that href.
+    // Per-href last-applied mark list. Serves two purposes:
+    //   1. `containsKey(href)` = "has ever had marks applied" — used to skip a wasted
+    //      CLEAR_ANNOTATION_HIGHLIGHTS_JS eval on the cold-open path (chapters load and the
+    //      reader's LaunchedEffect fires applyAnnotationHighlights with an empty map before the
+    //      annotation Flow has loaded, so there's nothing in the DOM to scrub yet).
+    //   2. Content-equality dedup — the reader's LaunchedEffect keys on pageLoadGeneration /
+    //      reflowGeneration and re-fires per chapter-load bump; on cold-open with 3 initial-window
+    //      chapters that's 3+ identical apply calls per href, each a full DOM-rebuilding JS eval.
+    //      Skip when the mark list is content-equal to the last one applied for that href.
+    // A transition to "no marks" AFTER an apply MUST still push the clear JS (so the DOM is
+    // scrubbed) and remove the entry so the never-applied guard can re-arm.
     private val lastAppliedByHref = mutableMapOf<String, List<AnnotationHighlight>>()
     private var currentSearchHighlights: SearchHighlightsState? = null
     private var currentFigureCssRules: List<String> = emptyList()
@@ -94,10 +92,9 @@ internal class ContinuousDecorationController(
                 }
                 onAnnotationsApplied()
             }
-            hrefsWithAppliedMarks += href
             // Record so a follow-up applyAnnotationHighlights with the identical mark list from a
             // pageLoadGeneration bump can short-circuit (see the dedup guard in
-            // applyAnnotationHighlights).
+            // applyAnnotationHighlights). The key's presence also arms the empty-clear skip.
             lastAppliedByHref[href] = annotations
         }
         val search = currentSearchHighlights
@@ -180,16 +177,15 @@ internal class ContinuousDecorationController(
             val annotations = annotationsByHref[href]
             if (annotations.isNullOrEmpty()) {
                 // Skip the clear-JS eval on the hot cold-open path where the href never got any
-                // marks applied yet — nothing in the DOM to scrub. `hrefsWithAppliedMarks` is
-                // populated the first time this href receives non-empty marks, so any later
-                // "all removed" transition still runs the clear.
-                if (href !in hrefsWithAppliedMarks) {
+                // marks applied yet — nothing in the DOM to scrub. `lastAppliedByHref` key
+                // presence tracks "has ever received marks"; any later "all removed" transition
+                // still runs the clear and removes the key so this guard re-arms.
+                if (href !in lastAppliedByHref) {
                     logger.d(LogChannel.ReaderDecoration) { "apply→clear-skipped href='$href' (never applied)" }
                     return@forEachLoadedWebView
                 }
                 logger.d(LogChannel.ReaderDecoration) { "apply→clear href='$href'" }
                 wv.evaluateJavascript(ContinuousStyleInjector.CLEAR_ANNOTATION_HIGHLIGHTS_JS, null)
-                hrefsWithAppliedMarks.remove(href)
                 lastAppliedByHref.remove(href)
             } else {
                 // Dedup: LaunchedEffect fires this on every pageLoadGeneration / reflowGeneration
@@ -205,7 +201,6 @@ internal class ContinuousDecorationController(
                     logger.d(LogChannel.ReaderDecoration) { "apply-complete href='$href' count=${annotations.size}" }
                     onEachApplied(wv)
                 }
-                hrefsWithAppliedMarks += href
                 lastAppliedByHref[href] = annotations
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousDecorationController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousDecorationController.kt
@@ -41,6 +41,20 @@ internal class ContinuousDecorationController(
     internal var logger: Logger = NoopLogger
 
     private var currentAnnotationsByHref: Map<String, List<AnnotationHighlight>> = emptyMap()
+    // Per-href "has ever had marks applied" set. Used to skip the CLEAR_ANNOTATION_HIGHLIGHTS_JS
+    // eval when we know the DOM never had marks to begin with — a hot cold-open path where
+    // chapters load, applyAnnotationHighlights fires with an empty map (annotations still loading
+    // from Room), and we'd otherwise dispatch one wasted JS eval per loaded chapter. Once a href
+    // receives marks, any subsequent transition to "no marks" MUST still push the clear so the
+    // DOM is scrubbed.
+    private val hrefsWithAppliedMarks = mutableSetOf<String>()
+    // Per-href last-applied mark set. The reader triggers applyAnnotationHighlights on every
+    // pageLoadGeneration / reflowGeneration bump (via a LaunchedEffect keyed on the union of
+    // these), so on cold-open with 3 chapters in the initial window we'd otherwise re-apply the
+    // same identical mark list 3+ times — each one a full JS eval on the WebView UI thread that
+    // rebuilds every mark's <mark> wrapper. Skip when the list is content-equal to the last apply
+    // for that href.
+    private val lastAppliedByHref = mutableMapOf<String, List<AnnotationHighlight>>()
     private var currentSearchHighlights: SearchHighlightsState? = null
     private var currentFigureCssRules: List<String> = emptyList()
     private var currentSvgMatches: List<com.riffle.app.feature.reader.decorations.FigureBorderDecoration.SvgMatch> = emptyList()
@@ -80,6 +94,11 @@ internal class ContinuousDecorationController(
                 }
                 onAnnotationsApplied()
             }
+            hrefsWithAppliedMarks += href
+            // Record so a follow-up applyAnnotationHighlights with the identical mark list from a
+            // pageLoadGeneration bump can short-circuit (see the dedup guard in
+            // applyAnnotationHighlights).
+            lastAppliedByHref[href] = annotations
         }
         val search = currentSearchHighlights
         if (search != null && search.resultsByHref.containsKey(href)) {
@@ -160,14 +179,34 @@ internal class ContinuousDecorationController(
             }
             val annotations = annotationsByHref[href]
             if (annotations.isNullOrEmpty()) {
+                // Skip the clear-JS eval on the hot cold-open path where the href never got any
+                // marks applied yet — nothing in the DOM to scrub. `hrefsWithAppliedMarks` is
+                // populated the first time this href receives non-empty marks, so any later
+                // "all removed" transition still runs the clear.
+                if (href !in hrefsWithAppliedMarks) {
+                    logger.d(LogChannel.ReaderDecoration) { "apply→clear-skipped href='$href' (never applied)" }
+                    return@forEachLoadedWebView
+                }
                 logger.d(LogChannel.ReaderDecoration) { "apply→clear href='$href'" }
                 wv.evaluateJavascript(ContinuousStyleInjector.CLEAR_ANNOTATION_HIGHLIGHTS_JS, null)
+                hrefsWithAppliedMarks.remove(href)
+                lastAppliedByHref.remove(href)
             } else {
+                // Dedup: LaunchedEffect fires this on every pageLoadGeneration / reflowGeneration
+                // bump (3 chapters loading = 3 calls, each with identical marks). Content-equality
+                // check on the mark list skips the redundant full-DOM rebuild JS eval — the
+                // dominant remaining Main-thread stall on cold-open with a heavily-annotated book.
+                if (lastAppliedByHref[href] == annotations) {
+                    logger.d(LogChannel.ReaderDecoration) { "apply→highlights-skipped href='$href' (identical to last apply, count=${annotations.size})" }
+                    return@forEachLoadedWebView
+                }
                 logger.d(LogChannel.ReaderDecoration) { "apply→highlights href='$href' count=${annotations.size}" }
                 wv.evaluateJavascript(ContinuousStyleInjector.applyAnnotationHighlightsJs(annotations)) { _ ->
                     logger.d(LogChannel.ReaderDecoration) { "apply-complete href='$href' count=${annotations.size}" }
                     onEachApplied(wv)
                 }
+                hrefsWithAppliedMarks += href
+                lastAppliedByHref[href] = annotations
             }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1315,6 +1315,120 @@ class EpubReaderViewModel @Inject constructor(
         // server-locator that follows; subsequent syncs (peer / live progress) still apply normally.
         if (o.openAtLocator != null) position.markSuppressNextServerLocator()
 
+        // ── Annotation binding — ABS-side only (ADR 0024) ────────────────────────────
+        // Bind BEFORE _state = Ready so the annotation Flow observer starts subscribing to Room
+        // before Compose mounts the reader. Without this ordering, chapters mount and dispatch
+        // several wasted `applyAnnotationHighlights` cycles with empty renders while the observer
+        // is still starting up (measured ~500ms gap on cold-open with 99 annotations). The
+        // sync-namespace (used ONLY by cross-device sync scheduling) resolves in parallel via a
+        // separate viewModelScope.launch and lands on the session via updateNamespace().
+        val activeServer = o.activeServer
+        if (!o.isStorytellerService && activeServer != null) {
+            annotationServerId = activeServer.id
+            // Bind the bookmarks controller so it can observe bookmarks and track the current
+            // locator for page-bookmark detection.
+            bookmarks.bind(
+                sourceId = activeServer.id,
+                itemId = itemId,
+                currentLocator = position.currentLocator,
+                spinePositionCounts = spinePositionCounts,
+                viewportFractionByHref = viewportFractionByHref,
+            )
+            // Push orientation changes into the controller via a setter so the page-bookmark
+            // indicator's match window re-sizes on a mid-session flip.
+            bookmarks.onOrientationChanged(formatting.formattingPreferences.value.orientation)
+            viewModelScope.launch {
+                formatting.formattingPreferences
+                    .map { it.orientation }
+                    .distinctUntilChanged()
+                    .collect { bookmarks.onOrientationChanged(it) }
+            }
+            // Bind annotation session eagerly with an EMPTY namespace — the observer subscription
+            // is what we want early; sync scheduling stays no-op until updateNamespace() below.
+            annotationSession.bind(
+                sourceId = activeServer.id,
+                namespace = "",
+                itemId = itemId,
+                highlightRenderResolver = { a -> annotationToRender(a) },
+                cfiLocatorResolver = { cfi -> cfiStringToLocator(cfi) },
+            )
+            // Resolve the source's cross-device annotation-sync namespace (#529) OFF the reader
+            // open critical path. Null when the source is LocalOnly (Storyteller peer, anonymous
+            // catalog, local files) or its remote id hasn't been fetched yet — sync is skipped
+            // this session; DB stays canonical.
+            viewModelScope.launch {
+                val namespace = (sourceRepository.ensureSyncNamespace(activeServer.id)
+                    as? com.riffle.core.domain.SyncNamespace.Configured)?.value
+                annotationNamespace = namespace
+                annotationSession.updateNamespace(namespace)
+            }
+            // ADR 0046 §4: orphan-emphasis cleanup (2026-07-18). Pre-2026-07-18 the commit-time
+            // overlap-dedup and pre-cascade dismiss paths deleted a TYPE_HIGHLIGHT anchor
+            // without removing its sibling TYPE_EMPHASIS rows at the same CFI. Those orphan
+            // rows silently accumulate in the pool — the DOM injector keeps painting
+            // bold/italic on the text while the annotations panel shows nothing to delete
+            // (the panel filters TYPE_EMPHASIS out). This one-shot sweep tombstones any
+            // emphasis whose CFI has no live highlight anchor. Fires once per (VM, book) via
+            // [orphanEmphasisCleanupAttempted]'s CAS; safe no-op on healthy books.
+            if (orphanEmphasisCleanupAttempted.compareAndSet(false, true)) {
+                viewModelScope.launch(dispatchers.io) {
+                    val serverId = activeServer.id
+                    val allRows = runCatching {
+                        annotationStore.observeAnnotations(serverId, itemId).first()
+                    }.getOrDefault(emptyList())
+                    val liveHighlightCfis = allRows.asSequence()
+                        .filter { it.type == AnnotationEntity.TYPE_HIGHLIGHT }
+                        .map { it.cfi }
+                        .toSet()
+                    val orphans = allRows.filter {
+                        it.type == AnnotationEntity.TYPE_EMPHASIS && it.cfi !in liveHighlightCfis
+                    }
+                    if (orphans.isEmpty()) return@launch
+                    orphans.forEach { annotationStore.delete(it.id) }
+                    logger.d(LogChannel.HighlightMerge) {
+                        "orphan-emphasis cleanup sourceId=$serverId itemId=$itemId deleted=${orphans.size}"
+                    }
+                    scheduleAnnotationSync()
+                }
+            }
+            // Opportunistic caption-annotation upgrade (2026-07-14). For each legacy
+            // TYPE_IMAGE annotation on this book whose figure and caption can both be resolved
+            // against the current publication, rewrite it to a TYPE_HIGHLIGHT covering the
+            // caption text. Fires once per (VM, book); the store update propagates through
+            // the annotation Flow → session → decorations naturally.
+            if (legacyImageUpgradeAttempted.compareAndSet(false, true)) {
+                viewModelScope.launch(dispatchers.io) {
+                    val serverId = activeServer.id
+                    val legacy = runCatching {
+                        annotationStore.observeAnnotations(serverId, itemId)
+                            .first()
+                            .filter { it.type == AnnotationEntity.TYPE_IMAGE }
+                    }.getOrDefault(emptyList())
+                    if (legacy.isEmpty()) return@launch
+                    val allAnnotations = runCatching {
+                        annotationStore.observeAnnotations(serverId, itemId).first()
+                    }.getOrDefault(emptyList())
+                    val result = runCatching {
+                        captionHighlightUpgrader.sweep(
+                            annotations = allAnnotations,
+                            readChapterHtml = { spineIndex -> readChapterHtml(spineIndex) },
+                        )
+                    }.getOrNull()
+                    if (result != null && result.total > 0) {
+                        logger.d(LogChannel.HighlightMerge) {
+                            "caption-highlight sweep sourceId=$serverId itemId=$itemId " +
+                                "merged=${result.merged} upgraded=${result.upgraded} legacy=${legacy.size}"
+                        }
+                        scheduleAnnotationSync()
+                    }
+                }
+            }
+        }
+
+        // NOW signal the reader UI to mount. The annotation Flow observer has already started
+        // subscribing above; its first emission arrives close to when chapters mount, so the
+        // reader gets decorations in the same layout pass instead of after several wasted
+        // apply-clear cycles.
         _state.value = ReaderState.Ready(
             publication = pub,
             title = o.title,
@@ -1343,111 +1457,17 @@ class EpubReaderViewModel @Inject constructor(
             startReadaloudAtSecond(startReadaloudAtSec)
         }
 
-        // ── Annotation binding — ABS-side only (ADR 0024) ────────────────────────────
-        val activeServer = o.activeServer
-        if (!o.isStorytellerService && activeServer != null) {
-            annotationServerId = activeServer.id
-            // Bind the bookmarks controller so it can observe bookmarks and track the current
-            // locator for page-bookmark detection.
-            bookmarks.bind(
-                sourceId = activeServer.id,
-                itemId = itemId,
-                currentLocator = position.currentLocator,
-                spinePositionCounts = spinePositionCounts,
-                viewportFractionByHref = viewportFractionByHref,
-            )
-            // Push orientation changes into the controller via a setter so the page-bookmark
-            // indicator's match window re-sizes on a mid-session flip.
-            bookmarks.onOrientationChanged(formatting.formattingPreferences.value.orientation)
-            viewModelScope.launch {
-                formatting.formattingPreferences
-                    .map { it.orientation }
-                    .distinctUntilChanged()
-                    .collect { bookmarks.onOrientationChanged(it) }
-            }
-            // Resolve the source's cross-device annotation-sync namespace (#529). Null when
-            // the source is LocalOnly (Storyteller peer, anonymous catalog, local files) or its
-            // remote id hasn't been fetched yet — sync is skipped this session; DB stays canonical.
-            val namespace = (sourceRepository.ensureSyncNamespace(activeServer.id)
-                as? com.riffle.core.domain.SyncNamespace.Configured)?.value
-            annotationNamespace = namespace
-            annotationSession.bind(
-                sourceId = activeServer.id,
-                namespace = namespace ?: "",
-                itemId = itemId,
-                highlightRenderResolver = { a -> annotationToRender(a) },
-                cfiLocatorResolver = { cfi -> cfiStringToLocator(cfi) },
-            )
-            // ADR 0046 §4: orphan-emphasis cleanup (2026-07-18). Pre-2026-07-18 the commit-time
-            // overlap-dedup and pre-cascade dismiss paths deleted a TYPE_HIGHLIGHT anchor
-            // without removing its sibling TYPE_EMPHASIS rows at the same CFI. Those orphan
-            // rows silently accumulate in the pool — the DOM injector keeps painting
-            // bold/italic on the text while the annotations panel shows nothing to delete
-            // (the panel filters TYPE_EMPHASIS out). This one-shot sweep tombstones any
-            // emphasis whose CFI has no live highlight anchor. Fires once per (VM, book) via
-            // [orphanEmphasisCleanupAttempted]'s CAS; safe no-op on healthy books.
-            if (orphanEmphasisCleanupAttempted.compareAndSet(false, true)) {
-                viewModelScope.launch {
-                    val serverId = activeServer.id
-                    val allRows = runCatching {
-                        annotationStore.observeAnnotations(serverId, itemId).first()
-                    }.getOrDefault(emptyList())
-                    val liveHighlightCfis = allRows.asSequence()
-                        .filter { it.type == AnnotationEntity.TYPE_HIGHLIGHT }
-                        .map { it.cfi }
-                        .toSet()
-                    val orphans = allRows.filter {
-                        it.type == AnnotationEntity.TYPE_EMPHASIS && it.cfi !in liveHighlightCfis
-                    }
-                    if (orphans.isEmpty()) return@launch
-                    orphans.forEach { annotationStore.delete(it.id) }
-                    logger.d(LogChannel.HighlightMerge) {
-                        "orphan-emphasis cleanup sourceId=$serverId itemId=$itemId deleted=${orphans.size}"
-                    }
-                    scheduleAnnotationSync()
-                }
-            }
-            // Opportunistic caption-annotation upgrade (2026-07-14). For each legacy
-            // TYPE_IMAGE annotation on this book whose figure and caption can both be resolved
-            // against the current publication, rewrite it to a TYPE_HIGHLIGHT covering the
-            // caption text. Fires once per (VM, book); the store update propagates through
-            // the annotation Flow → session → decorations naturally.
-            if (legacyImageUpgradeAttempted.compareAndSet(false, true)) {
-                viewModelScope.launch {
-                    val serverId = activeServer.id
-                    val legacy = runCatching {
-                        annotationStore.observeAnnotations(serverId, itemId)
-                            .first()
-                            .filter { it.type == AnnotationEntity.TYPE_IMAGE }
-                    }.getOrDefault(emptyList())
-                    if (legacy.isEmpty()) return@launch
-                    val allAnnotations = runCatching {
-                        annotationStore.observeAnnotations(serverId, itemId).first()
-                    }.getOrDefault(emptyList())
-                    val result = runCatching {
-                        captionHighlightUpgrader.sweep(
-                            annotations = allAnnotations,
-                            readChapterHtml = { spineIndex -> readChapterHtml(spineIndex) },
-                        )
-                    }.getOrNull()
-                    if (result != null && result.total > 0) {
-                        logger.d(LogChannel.HighlightMerge) {
-                            "caption-highlight sweep sourceId=$serverId itemId=$itemId " +
-                                "merged=${result.merged} upgraded=${result.upgraded} legacy=${legacy.size}"
-                        }
-                        scheduleAnnotationSync()
-                    }
-                }
-            }
-        }
-
         // Sync immediately while localUpdatedAt is still the genuine stored value — before the
-        // navigator restore emits and would stamp localUpdatedAt = now.
+        // navigator restore emits and would stamp localUpdatedAt = now. Hopped to IO because
+        // both branches do network + Room I/O that were adding ~140ms of main-thread stall on
+        // the post-Ready cold-open path.
         val syncLocator = o.effectiveInitialLocator
-        if (lifecycle.matchedSync.value?.readerSync != null) {
-            runReaderSyncCycle(syncLocator)
-        } else {
-            syncSession.sync(syncLocator?.toPayload() ?: SessionPayload("", 0f))
+        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            if (lifecycle.matchedSync.value?.readerSync != null) {
+                runReaderSyncCycle(syncLocator)
+            } else {
+                syncSession.sync(syncLocator?.toPayload() ?: SessionPayload("", 0f))
+            }
         }
 
         // Heartbeat only — no speed-tracker baseline yet (openBook can fire well before the first

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1356,9 +1356,24 @@ class EpubReaderViewModel @Inject constructor(
             // open critical path. Null when the source is LocalOnly (Storyteller peer, anonymous
             // catalog, local files) or its remote id hasn't been fetched yet — sync is skipped
             // this session; DB stays canonical.
+            //
+            // MUST catch non-cancellation exceptions: an uncaught throw here would take the child
+            // coroutine down, `updateNamespace` would never fire, and every subsequent
+            // scheduleSync/scheduleDebounce for this session would silently no-op (they read
+            // `boundNamespace ?: return`). CancellationException is re-thrown so viewModelScope
+            // teardown propagates normally.
             viewModelScope.launch {
-                val namespace = (sourceRepository.ensureSyncNamespace(activeServer.id)
-                    as? com.riffle.core.domain.SyncNamespace.Configured)?.value
+                val namespace = try {
+                    (sourceRepository.ensureSyncNamespace(activeServer.id)
+                        as? com.riffle.core.domain.SyncNamespace.Configured)?.value
+                } catch (t: Throwable) {
+                    if (t is kotlinx.coroutines.CancellationException) throw t
+                    logger.w(LogChannel.HighlightMerge) {
+                        "ensureSyncNamespace failed on reader-open for sourceId=${activeServer.id} — " +
+                            "${t::class.simpleName}: ${t.message}. Sync stays disabled for this session."
+                    }
+                    null
+                }
                 annotationNamespace = namespace
                 annotationSession.updateNamespace(namespace)
             }
@@ -1458,16 +1473,16 @@ class EpubReaderViewModel @Inject constructor(
         }
 
         // Sync immediately while localUpdatedAt is still the genuine stored value — before the
-        // navigator restore emits and would stamp localUpdatedAt = now. Hopped to IO because
-        // both branches do network + Room I/O that were adding ~140ms of main-thread stall on
-        // the post-Ready cold-open path.
+        // navigator restore emits and would stamp localUpdatedAt = now. STAYS ON MAIN:
+        // [runReaderSyncCycle] mutates reader state (lastLocator, pendingServerJumpStamp, …) and
+        // posts the inbound-jump channel, which per the invariant documented at the close-path
+        // caller site is not safe to relocate off Main. Kept both branches on Main for symmetry —
+        // the modest saving on the else path isn't worth splitting the dispatcher story here.
         val syncLocator = o.effectiveInitialLocator
-        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
-            if (lifecycle.matchedSync.value?.readerSync != null) {
-                runReaderSyncCycle(syncLocator)
-            } else {
-                syncSession.sync(syncLocator?.toPayload() ?: SessionPayload("", 0f))
-            }
+        if (lifecycle.matchedSync.value?.readerSync != null) {
+            runReaderSyncCycle(syncLocator)
+        } else {
+            syncSession.sync(syncLocator?.toPayload() ?: SessionPayload("", 0f))
         }
 
         // Heartbeat only — no speed-tracker baseline yet (openBook can fire well before the first

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
@@ -276,6 +276,13 @@ class AnnotationSession @AssistedInject constructor(
 
     /** Active book identity, set by [bind]. Null between books. */
     private var boundServerId: String? = null
+    /**
+     * Cross-device sync namespace for the bound book. May be left blank at [bind] time when the
+     * caller resolves the namespace off the critical path (see [updateNamespace]) — sync scheduling
+     * treats a null/blank value as "not yet ready" and no-ops until [updateNamespace] fills it in.
+     * The observer path never reads this, so binding early with a blank still starts the annotation
+     * Flow subscription correctly.
+     */
     private var boundNamespace: String? = null
     private var boundItemId: String? = null
 
@@ -329,7 +336,11 @@ class AnnotationSession @AssistedInject constructor(
         _annotationsAvailable.value = false
 
         boundServerId = sourceId
-        boundNamespace = namespace
+        // Empty namespace = "not resolved yet" — sync-schedule sites read boundNamespace with a
+        // null-check, so nulling it here keeps them no-op until [updateNamespace] lands the real
+        // value. Lets the caller start the observer eagerly and resolve the namespace off the
+        // reader's critical path.
+        boundNamespace = namespace.takeIf { it.isNotEmpty() }
         boundItemId = itemId
         cfiLocatorResolverFn = cfiLocatorResolver
 
@@ -423,10 +434,40 @@ class AnnotationSession @AssistedInject constructor(
             }
         }
 
-        // Sync on open: pull peer annotations, then start the live-pull loop.
-        scope.launch {
-            syncOnOpen(sourceId, namespace, itemId)
-            annotationLiveSyncJob = startLiveSync(sourceId, namespace, itemId)
+        // Sync on open: pull peer annotations, then start the live-pull loop. Skipped when the
+        // caller invoked [bind] with an empty namespace and hasn't yet supplied a real one via
+        // [updateNamespace] — the reader-open path uses that pattern to start the annotation
+        // observer eagerly while the namespace resolves in parallel. Once updateNamespace lands
+        // a real namespace, THIS block is re-run from there.
+        if (namespace.isNotEmpty()) {
+            scope.launch {
+                syncOnOpen(sourceId, namespace, itemId)
+                annotationLiveSyncJob = startLiveSync(sourceId, namespace, itemId)
+            }
+        }
+    }
+
+    /**
+     * Late-arriving sync-namespace supply for callers that ran [bind] with an empty namespace
+     * (typically because the namespace resolves off the reader-open critical path — see
+     * `EpubReaderViewModel.onOpenReady`). No-op if the value hasn't changed or the caller passes
+     * blank. Kicks off the same syncOnOpen + startLiveSync bootstrap the eager-bind path runs.
+     */
+    fun updateNamespace(namespace: String?) {
+        val fresh = namespace?.takeIf { it.isNotEmpty() }
+        val sourceId = boundServerId ?: return
+        val itemId = boundItemId ?: return
+        val previous = boundNamespace
+        if (fresh == previous) return
+        boundNamespace = fresh
+        // Only bootstrap sync if this is the transition from "no namespace" → "have namespace".
+        // A namespace CHANGE mid-session (unlikely — same book, same server) intentionally does
+        // not restart the live-sync loop; only a full [bind] does.
+        if (fresh != null && previous == null && annotationLiveSyncJob == null) {
+            scope.launch {
+                syncOnOpen(sourceId, fresh, itemId)
+                annotationLiveSyncJob = startLiveSync(sourceId, fresh, itemId)
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
@@ -466,6 +466,13 @@ class AnnotationSession @AssistedInject constructor(
         if (fresh != null && previous == null && annotationLiveSyncJob == null) {
             scope.launch {
                 syncOnOpen(sourceId, fresh, itemId)
+                // Nudge a debounced push after arrival: any user mutation (createHighlight,
+                // deleteAnnotation, recolour, note edit) that happened in the race window between
+                // bind(namespace="") and this updateNamespace call short-circuited its
+                // scheduleSync at `boundNamespace ?: return`. Its Room write persists, but the
+                // remote push was never queued. Firing scheduleSync here restarts the debounce
+                // so the pending local writes get pushed on the next natural tick.
+                scheduleSync(sourceId, fresh, itemId)
                 annotationLiveSyncJob = startLiveSync(sourceId, fresh, itemId)
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
@@ -92,8 +92,13 @@ class ReaderSessionLifecycle @AssistedInject constructor(
      * stays free of the CFI-parsing helpers the VM already owns. A follow-up may lift these here.
      */
     suspend fun open(params: OpenParams): OpenOutcome {
-        val item = libraryObserver.getItem(params.itemId)
-            ?: return OpenOutcome.Error("Book not found")
+        // Hop to IO for the network + Room + zip work below. Callers invoke open() from
+        // viewModelScope (Main.immediate); leaving getItem / pullItem / openEpub on main was
+        // ~300ms of pre-visible stall on cold open. resolveReady returns to caller context
+        // implicitly on return.
+        val item = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            libraryObserver.getItem(params.itemId)
+        } ?: return OpenOutcome.Error("Book not found")
 
         // Refresh this book's server position BEFORE loading the initial locator so the reader
         // opens at the fresh spot instead of rendering the old local cfi first and then visibly
@@ -106,19 +111,25 @@ class ReaderSessionLifecycle @AssistedInject constructor(
         // swallows CancellationException (Kotlin footgun) and would defeat both the timeout AND
         // structured concurrency if the caller cancels this open() mid-flight. Catch only
         // non-cancellation Throwables and re-throw CancellationException explicitly.
-        kotlinx.coroutines.withTimeoutOrNull(1_500L) {
-            try {
-                itemProgressPuller.pullItem(item.sourceId, item.id)
-            } catch (t: Throwable) {
-                if (t is kotlinx.coroutines.CancellationException) throw t
-                logger.w(LogChannel.ProgressSync) {
-                    "ReaderSessionLifecycle: puller failed for source=${item.sourceId} item=${item.id} — " +
-                        "${t::class.simpleName}: ${t.message}"
+        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            kotlinx.coroutines.withTimeoutOrNull(1_500L) {
+                try {
+                    itemProgressPuller.pullItem(item.sourceId, item.id)
+                } catch (t: Throwable) {
+                    if (t is kotlinx.coroutines.CancellationException) throw t
+                    logger.w(LogChannel.ProgressSync) {
+                        "ReaderSessionLifecycle: puller failed for source=${item.sourceId} item=${item.id} — " +
+                            "${t::class.simpleName}: ${t.message}"
+                    }
                 }
             }
         }
 
-        return when (val result = epubRepository.openEpub(item)) {
+        val result = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+            epubRepository.openEpub(item)
+        }
+
+        return when (result) {
             is EpubOpenResult.Success -> resolveReady(result, item.title, params)
             is EpubOpenResult.NetworkError -> OpenOutcome.Error(
                 // Use `toString()` as the fallback: `Throwable.message` is null for exceptions like

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousDecorationControllerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousDecorationControllerTest.kt
@@ -252,4 +252,111 @@ class ContinuousDecorationControllerTest {
             },
         )
     }
+
+    // Cold-open regression: chapters that never received annotation marks (because the annotation
+    // Flow hasn't emitted yet) must NOT get a redundant `CLEAR_ANNOTATION_HIGHLIGHTS_JS` eval —
+    // there's nothing in the DOM to scrub, and per-chapter JS evals show up as ~60-100ms Main-thread
+    // stalls on emulator cold-open. Flips red if the "never-applied" guard is removed.
+    @Test
+    fun `applyAnnotationHighlights skips clear JS on hrefs that never received marks`() {
+        val port = FakePort()
+        val c = ContinuousDecorationController(port)
+        val wv = FakeChapterWebView(chapterHref = "ch-a.xhtml").also { port.loaded += it }
+
+        // Annotation Flow hasn't emitted yet, but chapter is already loaded and reader's
+        // LaunchedEffect fires applyAnnotationHighlights with an empty map.
+        c.applyAnnotationHighlights(emptyMap())
+
+        assertEquals(
+            "empty apply on a never-applied href must not dispatch any JS",
+            0,
+            wv.evaluatedJsCount,
+        )
+    }
+
+    // Cold-open regression: the reader's LaunchedEffect re-fires applyAnnotationHighlights on every
+    // pageLoadGeneration / reflowGeneration bump. On cold-open with 3 initial-window chapters, that's
+    // 3+ back-to-back calls with the identical mark list. The dedup guard skips the JS eval when the
+    // per-href mark list is content-equal to the last one applied. Flips red if the guard is removed.
+    @Test
+    fun `applyAnnotationHighlights skips redundant apply when marks are content-equal to last`() {
+        val port = FakePort()
+        val c = ContinuousDecorationController(port)
+        val href = "ch-a.xhtml"
+        val wv = FakeChapterWebView(chapterHref = href).also { port.loaded += it }
+        val marks = listOf(
+            AnnotationHighlight("id1", "text-1", "rgba(255,0,0,0.4)"),
+            AnnotationHighlight("id2", "text-2", "rgba(0,255,0,0.4)"),
+        )
+
+        c.applyAnnotationHighlights(mapOf(href to marks))
+        val afterFirst = wv.evaluatedJsCount
+        assertEquals("first apply dispatches once", 1, afterFirst)
+
+        // Content-equal re-apply (same list, same order) — the dedup guard must short-circuit.
+        c.applyAnnotationHighlights(mapOf(href to marks.toList()))
+        assertEquals(
+            "content-equal re-apply must skip the JS eval",
+            afterFirst,
+            wv.evaluatedJsCount,
+        )
+        c.applyAnnotationHighlights(mapOf(href to marks.toList()))
+        assertEquals(
+            "further content-equal re-applies must also skip",
+            afterFirst,
+            wv.evaluatedJsCount,
+        )
+    }
+
+    // Behaviour-preservation: the dedup guard MUST NOT skip when the mark list actually changes
+    // (add / remove / edit). Flips red if someone tightens the guard to (href-only) and loses
+    // real re-application when the user edits an annotation on the current chapter.
+    @Test
+    fun `applyAnnotationHighlights re-applies when marks change`() {
+        val port = FakePort()
+        val c = ContinuousDecorationController(port)
+        val href = "ch-a.xhtml"
+        val wv = FakeChapterWebView(chapterHref = href).also { port.loaded += it }
+        val initial = listOf(AnnotationHighlight("id1", "text-1", "rgba(255,0,0,0.4)"))
+        val added = initial + AnnotationHighlight("id2", "text-2", "rgba(0,255,0,0.4)")
+
+        c.applyAnnotationHighlights(mapOf(href to initial))
+        c.applyAnnotationHighlights(mapOf(href to added))
+
+        assertEquals(
+            "adding a mark must trigger a fresh apply JS eval",
+            2,
+            wv.evaluatedJsCount,
+        )
+    }
+
+    // Cross-path regression: `onChapterLoaded` and the LaunchedEffect-driven
+    // `applyAnnotationHighlights` are both entry points for pushing marks into a chapter WebView.
+    // If onChapterLoaded doesn't seed the dedup memo, the subsequent LaunchedEffect call with the
+    // same marks would re-run the full JS eval — the exact pattern seen in the pre-fix
+    // cold-open trace. Pins the memo-seeding behaviour.
+    @Test
+    fun `onChapterLoaded seeds dedup so subsequent identical apply short-circuits`() {
+        val port = FakePort()
+        val c = ContinuousDecorationController(port)
+        val href = "ch-a.xhtml"
+        val marks = listOf(AnnotationHighlight("id1", "text-1", "rgba(255,0,0,0.4)"))
+
+        // Pre-load marks into the controller state, then simulate the WebView's onPageFinished
+        // triggering onChapterLoaded — the controller must apply the marks AND remember it did.
+        c.applyAnnotationHighlights(mapOf(href to marks))
+        val wv = FakeChapterWebView(chapterHref = href).also { port.loaded += it }
+        c.onChapterLoaded(wv)
+        val afterLoad = wv.evaluatedJsCount
+        assertTrue("onChapterLoaded should dispatch the apply JS", afterLoad >= 1)
+
+        // Now the LaunchedEffect fires applyAnnotationHighlights with the same map — the dedup
+        // guard must skip the JS eval on this chapter.
+        c.applyAnnotationHighlights(mapOf(href to marks))
+        assertEquals(
+            "identical LaunchedEffect-driven apply after onChapterLoaded must be a no-op",
+            afterLoad,
+            wv.evaluatedJsCount,
+        )
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -1174,6 +1174,37 @@ class AnnotationSessionTest {
         assertTrue("updateNamespace(non-empty) must start live-sync", syncOps.startLiveSyncCalled)
     }
 
+    // Race-window regression: any user mutation between bind(namespace="") and updateNamespace
+    // (createHighlight, delete, recolour, note-edit) hits `boundNamespace ?: return` in
+    // scheduleSync and silently doesn't queue a push. The Room write persists but the remote
+    // push is missed. updateNamespace must fire a scheduleSync on the null→non-null transition
+    // to flush any pending queued writes. Flips red if that flush is removed.
+    @Test
+    fun `updateNamespace bootstrap fires scheduleSync to flush pre-namespace-window writes`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val syncOps = FakeSyncOps()
+        val session = makeSession(syncOps = syncOps, scope = sessionScope)
+
+        session.bind(
+            sourceId = "srv1",
+            namespace = "",
+            itemId = "item1",
+            highlightRenderResolver = { emptyList() },
+            cfiLocatorResolver = { null },
+        )
+        // Nothing scheduled yet.
+        assertEquals(0, syncOps.scheduleDebounceCount)
+
+        session.updateNamespace("ns-real")
+
+        assertEquals(
+            "null→non-null transition must nudge scheduleSync to flush the race window",
+            1,
+            syncOps.scheduleDebounceCount,
+        )
+    }
+
     @Test
     fun `updateNamespace(null) after empty-namespace bind stays no-op`() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -1100,4 +1100,98 @@ class AnnotationSessionTest {
         // Verify the returned annotation carries the expected identity.
         assertEquals("yellow", created.color)
     }
+
+    // ------ Cold-open eager-bind path (updateNamespace) ------------------------------------
+    // These four tests pin the "bind with empty namespace, resolve later" contract that the
+    // reader-open path relies on to start the annotation Flow observer BEFORE _state = Ready.
+    // Flipping any of them means the reordered cold-open pipeline in EpubReaderViewModel.
+    // onOpenReady would either regress sync (no syncOnOpen when namespace is late-supplied) or
+    // regress the eager subscription (bind gated behind ensureSyncNamespace's IO wait again).
+
+    @Test
+    fun `bind with empty namespace does NOT trigger syncOnOpen or startLiveSync`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val syncOps = FakeSyncOps()
+        val session = makeSession(syncOps = syncOps, scope = sessionScope)
+
+        session.bind(
+            sourceId = "srv1",
+            namespace = "",
+            itemId = "item1",
+            highlightRenderResolver = { emptyList() },
+            cfiLocatorResolver = { null },
+        )
+
+        assertFalse("empty-namespace bind must not run syncOnOpen", syncOps.syncOnOpenCalled)
+        assertFalse("empty-namespace bind must not start live-sync loop", syncOps.startLiveSyncCalled)
+    }
+
+    @Test
+    fun `bind with empty namespace still starts the annotation Flow observer`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val store = FakeAnnotationStore()
+        val syncOps = FakeSyncOps()
+        val session = makeSession(store = store, syncOps = syncOps, scope = sessionScope)
+
+        val anno = fakeAnnotation()
+        val render = EpubReaderViewModel.HighlightRender(anno.id, buildLocator(), anno.color, anno.note)
+
+        session.bind(
+            sourceId = "srv1",
+            namespace = "",
+            itemId = "item1",
+            highlightRenderResolver = { listOf(render) },
+            cfiLocatorResolver = { null },
+        )
+        store.allAnnotations.value = listOf(anno)
+
+        // The observer runs regardless of namespace — that's the whole point of the eager bind.
+        assertEquals(listOf(render), session.highlightRenders.value)
+    }
+
+    @Test
+    fun `updateNamespace after empty-namespace bind kicks off syncOnOpen and startLiveSync`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val syncOps = FakeSyncOps()
+        val session = makeSession(syncOps = syncOps, scope = sessionScope)
+
+        session.bind(
+            sourceId = "srv1",
+            namespace = "",
+            itemId = "item1",
+            highlightRenderResolver = { emptyList() },
+            cfiLocatorResolver = { null },
+        )
+        assertFalse(syncOps.syncOnOpenCalled)
+        assertFalse(syncOps.startLiveSyncCalled)
+
+        session.updateNamespace("ns-real")
+
+        assertTrue("updateNamespace(non-empty) must run syncOnOpen", syncOps.syncOnOpenCalled)
+        assertTrue("updateNamespace(non-empty) must start live-sync", syncOps.startLiveSyncCalled)
+    }
+
+    @Test
+    fun `updateNamespace(null) after empty-namespace bind stays no-op`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val syncOps = FakeSyncOps()
+        val session = makeSession(syncOps = syncOps, scope = sessionScope)
+
+        session.bind(
+            sourceId = "srv1",
+            namespace = "",
+            itemId = "item1",
+            highlightRenderResolver = { emptyList() },
+            cfiLocatorResolver = { null },
+        )
+        session.updateNamespace(null)
+
+        // Local-only source: ensureSyncNamespace returns null → session stays in no-sync mode.
+        assertFalse("updateNamespace(null) must not run syncOnOpen", syncOps.syncOnOpenCalled)
+        assertFalse("updateNamespace(null) must not start live-sync", syncOps.startLiveSyncCalled)
+    }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
@@ -18,8 +18,10 @@ import com.riffle.core.domain.SyncNamespace
 import com.riffle.core.domain.TokenStorage
 import com.riffle.core.domain.WebSourceDescriptors
 import com.riffle.core.network.AbsServerInfoApi
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -102,29 +104,34 @@ class SourceRepositoryImpl @Inject constructor(
             CredentialedSourceInstaller.readaloudLibraryId(sourceId)
     }
 
-    override suspend fun ensureSyncNamespace(sourceId: String): SyncNamespace {
+    // Hop to IO explicitly: this method is called on the reader cold-open path
+    // (EpubReaderViewModel.onOpenReady) from viewModelScope, whose default dispatcher is
+    // Main.immediate. Without this hop, the Room read + (first-time) network resolve run on the
+    // main thread and lock the UI for 500ms+ right after the reader becomes visible, making
+    // swipes and scrolls feel sluggish for the first seconds of every book open.
+    override suspend fun ensureSyncNamespace(sourceId: String): SyncNamespace = withContext(Dispatchers.IO) {
         val source = dao.getById(sourceId)?.toDomain()
-            ?: return SyncNamespace.LocalOnly("Unknown source.")
+            ?: return@withContext SyncNamespace.LocalOnly("Unknown source.")
         val descriptor = WebSourceDescriptors.forType(source.type)
-            ?: return SyncNamespace.LocalOnly("No descriptor for source type ${source.type}.")
+            ?: return@withContext SyncNamespace.LocalOnly("No descriptor for source type ${source.type}.")
         val initial = descriptor.syncNamespaceFor(source)
-        if (initial !is SyncNamespace.PendingRemoteId) return initial
+        if (initial !is SyncNamespace.PendingRemoteId) return@withContext initial
 
         // Descriptor advertises cross-device identity but the remote user id hasn't been fetched
         // yet — dispatch to the per-SourceType resolver. Anonymous / local descriptors never
         // reach this branch (they return LocalOnly above), so a missing resolver here means a
         // sync-eligible source kind wasn't wired into RemoteUserIdResolverModule.
         val resolver = remoteUserIdResolvers[source.type]
-            ?: return SyncNamespace.LocalOnly("No remote-id resolver registered for ${source.type}.")
+            ?: return@withContext SyncNamespace.LocalOnly("No remote-id resolver registered for ${source.type}.")
         val token = tokenStorage.getToken(sourceId)
-            ?: return SyncNamespace.PendingRemoteId
+            ?: return@withContext SyncNamespace.PendingRemoteId
         val fetched = resolver.resolve(source, token)?.takeIf { it.isNotBlank() }
-            ?: return SyncNamespace.PendingRemoteId
+            ?: return@withContext SyncNamespace.PendingRemoteId
         dao.setAbsUserId(sourceId, fetched)
         // Project the freshly-fetched id through the descriptor's dedicated hook instead of
         // synthesising a `source.copy(absUserId = fetched)` and re-invoking syncNamespaceFor —
         // avoids the double-eval and keeps the "how do I turn an id into a namespace" logic in
         // one method per descriptor.
-        return descriptor.namespaceFromRemoteId(source, fetched)
+        descriptor.namespaceFromRemoteId(source, fetched)
     }
 }


### PR DESCRIPTION
## Summary

Cold-opening a heavily-annotated book (measured on a book with ~99 highlights) jammed the Main thread for 2–3s every open. This was reported as a regression on top of the earlier fix in #579 that removed the 2.6s decoration settle loops.

Four independent contributors identified and fixed:

1. **`SourceRepositoryImpl.ensureSyncNamespace`** did Room + (first-time) network work without switching to `Dispatchers.IO`. Called from `viewModelScope` (Main.immediate) on reader open, pinning the UI for 300–500ms right after Ready. Now hops to IO explicitly.

2. **`ReaderSessionLifecycle.open`** ran `libraryObserver.getItem`, `itemProgressPuller.pullItem`, and `epubRepository.openEpub` on the caller's dispatcher (Main) — ~300ms of pre-visible Main-thread stall. Each now runs inside `withContext(Dispatchers.IO)`.

3. **`EpubReaderViewModel.onOpenReady`** bound `AnnotationSession` *after* `_state = Ready`, and behind a suspending `ensureSyncNamespace` — the annotation Flow observer only started subscribing ~500ms into the reader mount, so chapters loaded and dispatched several wasted `applyAnnotationHighlights` cycles with empty renders. The annotation bind now happens **before** `_state = Ready`; the sync-namespace (needed only for cross-device sync scheduling) resolves off the critical path via a parallel `viewModelScope.launch` and lands on the session via a new `AnnotationSession.updateNamespace()` setter.

4. **`ContinuousDecorationController.applyAnnotationHighlights`** re-fired on every `pageLoadGeneration` / `reflowGeneration` bump — 3+ full DOM-rebuilding JS evals per chapter with identical mark lists on cold-open. Two guards added: skip the `CLEAR_ANNOTATION_HIGHLIGHTS_JS` eval when the href never had marks applied, and skip the `applyAnnotationHighlightsJs` eval when the mark list is content-equal to the last one applied for that href.

Also moves the orphan-emphasis cleanup and legacy-image-upgrade sweeps in `onOpenReady` from Main.immediate to `dispatchers.io`.

The follow-up commit addresses code-review findings from the same session: keeps `runReaderSyncCycle` on Main (per the documented invariant), catches exceptions in the fire-and-forget `ensureSyncNamespace` launch, flushes a `scheduleSync` on the null→non-null namespace transition so mutations made in the race window aren't silently dropped, and collapses the redundant `hrefsWithAppliedMarks` set into `lastAppliedByHref.keys`.

## Measured impact (emulator, book with 99 highlights)

- Main-thread I/O during open: ~1s eliminated
- Wasted `apply→clear` JS evals: 3–4 per open → 0
- Redundant `apply→highlights` JS evals: 3+ full re-applies → 1
- Total Main-thread work removed on cold open: **~1s**

Remaining ~1s of Main stalls is Chromium rendering the initial 3 chapters × ~43 decorations (tile-memory-limited on the API-25 emulator); not addressable from Kotlin coroutine scheduling. Deferred neighbor-chapter decoration apply is a candidate follow-up.

## Test plan

- [x] `ContinuousDecorationControllerTest` — 4 new tests covering both guards and one behavior-preservation
- [x] `AnnotationSessionTest` — 5 new tests covering the eager-bind / late-namespace contract, including the pre-namespace-window flush
- [x] All existing tests in the same suites pass
- [ ] Manual verification on device: cold-open a book with many highlights and confirm swipes/scrolls feel less sluggish for the first 2s