### PR TITLE
fix(settings): show newest debug log at top of viewport

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/settings/debug/DebugLogScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/debug/DebugLogScreen.kt
@@ -129,17 +129,18 @@ fun DebugLogScreen(
                 }
             } else {
                 val listState = rememberLazyListState()
-                // Reverse so newest is at the top and remains visible without manual scrolling
-                // when new entries land.
-                LaunchedEffect(filtered.size) {
+                // Buffer is oldest→newest; display newest-first so the most recent entry sits at
+                // the top of the viewport and remains visible without manual scrolling when new
+                // entries land.
+                val newestFirst = remember(filtered) { debugLogDisplayOrder(filtered) }
+                LaunchedEffect(newestFirst.size) {
                     if (listState.firstVisibleItemIndex <= 1) listState.animateScrollToItem(0)
                 }
                 LazyColumn(
                     state = listState,
                     modifier = Modifier.fillMaxSize(),
-                    reverseLayout = true,
                 ) {
-                    items(filtered, key = { it.seq }) { entry ->
+                    items(newestFirst, key = { it.seq }) { entry ->
                         LogRow(entry)
                         HorizontalDivider(color = Color(0x11000000))
                     }
@@ -189,3 +190,12 @@ private fun LogRow(entry: InMemoryLogBuffer.Entry) {
 }
 
 private val TIME_FMT = SimpleDateFormat("HH:mm:ss.SSS", Locale.US)
+
+/**
+ * The buffer stores entries oldest→newest; the debug screen must show newest first so the most
+ * recent entry sits at the top of the viewport. Extracted so the ordering can be pinned by a
+ * pure-JVM test — reverting the flip would otherwise silently regress to an oldest-at-top view.
+ */
+internal fun debugLogDisplayOrder(
+    entries: List<InMemoryLogBuffer.Entry>,
+): List<InMemoryLogBuffer.Entry> = entries.asReversed()

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/debug/DebugLogDisplayOrderTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/debug/DebugLogDisplayOrderTest.kt
@@ -1,0 +1,34 @@
+package com.riffle.app.feature.settings.debug
+
+import com.riffle.core.logging.InMemoryLogBuffer
+import com.riffle.core.logging.LogChannel
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DebugLogDisplayOrderTest {
+
+    @Test
+    fun `newest entry is first`() {
+        val oldest = entry(seq = 1L, timestampMs = 100L, message = "oldest")
+        val mid = entry(seq = 2L, timestampMs = 200L, message = "mid")
+        val newest = entry(seq = 3L, timestampMs = 300L, message = "newest")
+
+        val displayed = debugLogDisplayOrder(listOf(oldest, mid, newest))
+
+        assertEquals(listOf(newest, mid, oldest), displayed)
+    }
+
+    @Test
+    fun `empty input yields empty output`() {
+        assertEquals(emptyList<InMemoryLogBuffer.Entry>(), debugLogDisplayOrder(emptyList()))
+    }
+
+    private fun entry(seq: Long, timestampMs: Long, message: String) = InMemoryLogBuffer.Entry(
+        timestampMs = timestampMs,
+        level = InMemoryLogBuffer.Entry.Level.D,
+        channel = LogChannel.Readaloud,
+        message = message,
+        throwableSummary = null,
+        seq = seq,
+    )
+}


### PR DESCRIPTION
## Summary

`DebugLogScreen` used `reverseLayout = true` on a LazyColumn fed with the
oldest→newest buffer, so index 0 (the oldest entry) landed at the bottom of
the viewport with newer entries stacking upward — the initial view sat on the
oldest logs.

Reverse the list into newest-first order and render without `reverseLayout`,
so the most recent entry lands at the top and new arrivals push in from
above.

## Notes

- Ordering extracted into `debugLogDisplayOrder(...)` so the flip is pinned
  by a pure-JVM regression test (`DebugLogDisplayOrderTest`). Reverting the
  flip would fail `newest entry is first`.