### PR TITLE
fix(reader): stop resume-restore watcher from fighting user backward scroll

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -485,6 +485,7 @@ fun EpubReaderScreen(
                             }
                         },
                         onTap = immersiveState::toggle,
+                        onUserInteracted = viewModel::onUserInteracted,
                         onSelectionEnded = {
                             // Belt-and-braces: sticky IMMERSIVE (see immersiveSystemBarsBehavior)
                             // handles the ActionMode-dismiss reveal on its own — the OS auto-hides
@@ -1313,6 +1314,7 @@ private fun EpubNavigatorView(
     currentSearchIndex: Int,
     volumeNavEvents: Flow<VolumeNavEvent>,
     onTap: () -> Unit,
+    onUserInteracted: () -> Unit,
     onSelectionEnded: () -> Unit,
     onSelectionActiveChanged: (Boolean) -> Unit,
     latestLocator: () -> Locator?,
@@ -2753,6 +2755,7 @@ private fun EpubNavigatorView(
                 }
                 container.onPullEnded = { pullActive = false }
                 container.onPullProgress = { p -> pullProgress = p }
+                container.onUserTouch = { onUserInteracted() }
 
                 val fragmentContainer = (container.getChildAt(0) as? android.view.ViewGroup)
                     ?.getChildAt(0) as? FragmentContainerView

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1679,6 +1679,15 @@ class EpubReaderViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Called from the reader surface on the first touch of a gesture (ACTION_DOWN). Disarms the
+     * post-resume position-restore watcher so a genuine user scroll — including a backward scroll
+     * within the same chapter — is never re-fired forward. See [ResumeRestorer.onUserInteracted].
+     */
+    fun onUserInteracted() {
+        position.onUserInteracted()
+    }
+
     fun onReaderClosed() {
         if (shouldRunReadingSideEffects(source)) {
             readingSessionCoordinator.onClosed(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ScrollBoundaryNavigationContainer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ScrollBoundaryNavigationContainer.kt
@@ -34,6 +34,13 @@ class ScrollBoundaryNavigationContainer(context: Context) : FrameLayout(context)
     var onPullEnded: (() -> Unit)? = null
     var onPullProgress: ((progress: Float) -> Unit)? = null
 
+    /**
+     * Fires on ACTION_DOWN for every touch on the reader surface, regardless of reader mode. Used
+     * by the ViewModel to disarm the post-resume position-restore watcher — see
+     * [com.riffle.app.feature.reader.session.ResumeRestorer.onUserInteracted].
+     */
+    var onUserTouch: (() -> Unit)? = null
+
     private var lastNavigationMs = 0L
     private var lastVolumeNavMs = 0L
     private var lastTouchY = 0f
@@ -124,6 +131,9 @@ class ScrollBoundaryNavigationContainer(context: Context) : FrameLayout(context)
     }
 
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        // Unconditional user-touch signal — fires in all reader modes so the resume-restore
+        // watcher can disarm on any user gesture (see [onUserTouch] docstring).
+        if (ev.actionMasked == MotionEvent.ACTION_DOWN) onUserTouch?.invoke()
         if (isScrollMode) {
             when (ev.actionMasked) {
                 MotionEvent.ACTION_DOWN -> {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/PositionOrchestrator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/PositionOrchestrator.kt
@@ -239,6 +239,9 @@ class PositionOrchestrator @AssistedInject constructor(
     /** @see ResumeRestorer.armReturnRestore */
     fun armReturnRestore(origin: Locator) = resumeRestorer.armReturnRestore(origin)
 
+    /** @see ResumeRestorer.onUserInteracted */
+    fun onUserInteracted() = resumeRestorer.onUserInteracted()
+
     /** Resets [initialLocatorSeen] — called when the reader is resumed so the first Readium
      *  emission (the WebView restoration) is not treated as user progress. */
     fun resetInitialLocatorSeen() {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ResumeRestorer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ResumeRestorer.kt
@@ -124,9 +124,16 @@ class ResumeRestorer(
      * [ScrollBoundaryNavigationContainer.dispatchTouchEvent]). Disarms the retry watcher for the
      * rest of this resume cycle so a user's backward scroll — indistinguishable at the
      * position-stream level from a Readium chapter-top clobber — is never re-fired forward.
+     *
+     * Also clears [pendingReturnLocator]: once the user has taken over, the restore is fully done
+     * and the anchor must be freed so the next [ReaderSessionLifecycle]-driven
+     * [setReturnAnchor] (which honours a no-overwrite contract) can capture this session's
+     * fresh position instead of the now-stale arm target.
      */
     fun onUserInteracted() {
         userInteractedSinceArm = true
+        pendingReturnLocator = null
+        returnRestoreAttempts = 0
     }
 
     /** Reset all per-book state. Called from [PositionOrchestrator.bindBook]. */

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ResumeRestorer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ResumeRestorer.kt
@@ -31,6 +31,15 @@ class ResumeRestorer(
     private var returnRestoreAttempts = 0
 
     /**
+     * True once the user has physically touched the screen since the last [armReturnRestore]. Any
+     * position emission after that is user-driven (a scroll, a tap-nav) and must NOT be treated as
+     * a spurious Readium reflow — even if it would satisfy the chapter-top pattern below. The
+     * retry watcher exists to fight Readium's post-resume column-snap, which fires *before* any
+     * touch reaches the WebView; once the user has taken over, the watcher's job is done.
+     */
+    private var userInteractedSinceArm = false
+
+    /**
      * Retry watcher — invoked from the position intake before it updates the position streams.
      *
      * Defensive re-restore: Readium's post-resume column-snap can emit a chapter-top position
@@ -44,6 +53,13 @@ class ResumeRestorer(
     fun onPositionEmitted(locator: Locator) {
         val remaining = returnRestoreAttempts
         if (remaining <= 0) return
+        // Once the user has touched the screen since the arm, any subsequent emission is user
+        // input (a scroll — possibly backward within the same chapter, which looks identical to a
+        // Readium clobber at the position-stream level). Do NOT fight it.
+        if (userInteractedSinceArm) {
+            returnRestoreAttempts = 0
+            return
+        }
         val pending = pendingReturnLocator
         if (pending == null) {
             returnRestoreAttempts = 0
@@ -99,12 +115,24 @@ class ResumeRestorer(
     fun armReturnRestore(origin: Locator) {
         pendingReturnLocator = origin
         returnRestoreAttempts = 5
+        userInteractedSinceArm = false
         refire(origin)
+    }
+
+    /**
+     * Called when the user physically touches the reader surface (see
+     * [ScrollBoundaryNavigationContainer.dispatchTouchEvent]). Disarms the retry watcher for the
+     * rest of this resume cycle so a user's backward scroll — indistinguishable at the
+     * position-stream level from a Readium chapter-top clobber — is never re-fired forward.
+     */
+    fun onUserInteracted() {
+        userInteractedSinceArm = true
     }
 
     /** Reset all per-book state. Called from [PositionOrchestrator.bindBook]. */
     fun reset() {
         pendingReturnLocator = null
         returnRestoreAttempts = 0
+        userInteractedSinceArm = false
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ResumeRestorerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ResumeRestorerTest.kt
@@ -143,6 +143,23 @@ class ResumeRestorerTest {
     }
 
     @Test
+    fun `onUserInteracted clears pending anchor so setReturnAnchor can capture fresh position`() {
+        val f = Fixture()
+        f.restorer.armReturnRestore(buildLocator("a.html", 0.5))
+        f.restorer.onUserInteracted()
+        // Anchor must be cleared: setReturnAnchor is a no-overwrite operation, so a lingering
+        // stale anchor would prevent the next onReaderClosed from recording the current position
+        // and the following resume would snap the user back to where they were two sessions ago.
+        assertNull("anchor cleared after user takes over", f.restorer.peekReturnAnchor())
+        f.restorer.setReturnAnchor(buildLocator("b.html", 0.3))
+        assertEquals(
+            "setReturnAnchor now writes fresh position",
+            "b.html",
+            f.restorer.peekReturnAnchor()?.href?.toString(),
+        )
+    }
+
+    @Test
     fun `armReturnRestore re-arms after prior onUserInteracted`() {
         val f = Fixture()
         f.restorer.armReturnRestore(buildLocator("a.html", 0.5))

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ResumeRestorerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ResumeRestorerTest.kt
@@ -121,6 +121,41 @@ class ResumeRestorerTest {
     }
 
     @Test
+    fun `onUserInteracted disarms retry — subsequent chapter-top does not refire`() {
+        val f = Fixture()
+        f.restorer.armReturnRestore(buildLocator("a.html", 0.5))
+        f.refired.clear()
+        // The user touched the screen — any subsequent emission is user input, not Readium reflow.
+        f.restorer.onUserInteracted()
+        f.restorer.onPositionEmitted(buildLocator("a.html", 0.0))
+        assertEquals("no refire after user touch", 0, f.refired.size)
+    }
+
+    @Test
+    fun `onUserInteracted disarms retry — backward user scroll not fought`() {
+        val f = Fixture()
+        f.restorer.armReturnRestore(buildLocator("a.html", 0.5))
+        f.refired.clear()
+        f.restorer.onUserInteracted()
+        // Genuine backward scroll within the same chapter — must reach the user, not be re-fired.
+        f.restorer.onPositionEmitted(buildLocator("a.html", 0.2))
+        assertEquals("no refire on backward scroll after touch", 0, f.refired.size)
+    }
+
+    @Test
+    fun `armReturnRestore re-arms after prior onUserInteracted`() {
+        val f = Fixture()
+        f.restorer.armReturnRestore(buildLocator("a.html", 0.5))
+        f.restorer.onUserInteracted()
+        f.refired.clear()
+        // Next resume cycle: a fresh arm must re-enable the retry watcher.
+        f.restorer.armReturnRestore(buildLocator("a.html", 0.5))
+        f.refired.clear()
+        f.restorer.onPositionEmitted(buildLocator("a.html", 0.0))
+        assertEquals("re-armed after fresh armReturnRestore", 1, f.refired.size)
+    }
+
+    @Test
     fun `reset clears anchor and budget`() {
         val f = Fixture()
         f.restorer.armReturnRestore(buildLocator("a.html", 0.5))


### PR DESCRIPTION
## Summary

Scrolling occasionally refused to comply for the first ~10 s after opening a book or resuming from sleep: a backward scroll within the current chapter snapped the user forward to their previously viewed position. Distinct from #580's save-vs-sync-tick race (mutex fix untouched).

### Root cause

`ResumeRestorer.onPositionEmitted` refires the pre-close origin on any post-arm emission with `incomingProg < originProg - 0.01` in the same href. It was intended to catch Readium's post-resume column-snap chapter-top clobber (#259). A genuine user backward scroll within the same chapter is indistinguishable from that clobber at the position-stream level, so the watcher snapped the user forward on every backward drag for the full 5-attempt budget after ON_START (reader open with a stored anchor, wake from sleep, app-switcher return).

### Fix

Explicit signal, not a wall-clock guess: `ResumeRestorer.onUserInteracted()`. Once the user physically touches the reader surface (ACTION_DOWN in `ScrollBoundaryNavigationContainer.dispatchTouchEvent`, unconditional across all three reader modes), the watcher disarms for the rest of that resume cycle. Readium's clobber still gets caught because it fires before any touch reaches the WebView.

Wiring: `ScrollBoundaryNavigationContainer.onUserTouch` → `EpubNavigatorView(onUserInteracted=…)` → `EpubReaderViewModel.onUserInteracted()` → `PositionOrchestrator.onUserInteracted()` → `ResumeRestorer.onUserInteracted()`.

### Follow-up commit (self-review)

`onUserInteracted` also clears `pendingReturnLocator` — otherwise the anchor stays set, `setReturnAnchor` (no-overwrite contract) skips the next ON_STOP, and a subsequent resume would arm with the stale anchor and snap the reader back to a two-sessions-old position.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests "...session.ResumeRestorerTest"` green
- [ ] Reproduce on device: open book with stored anchor, wake from sleep, immediately scroll backward within current chapter — snap-back gone
- [ ] Verify Readium post-resume clobber is still caught (chapter-top emission before any touch → refires origin)
- [ ] Verify all three reader modes (paginated / vertical / continuous)
- [ ] Verify next-session anchor is fresh after a user interaction + background cycle