### PR TITLE
fix(reader): cancel figure long-press on touchcancel so scrolling suppresses the annotations menu

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapScript.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapScript.kt
@@ -234,6 +234,15 @@ internal object FigureTapScript {
                 if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
                 longPressTarget = null;
             }, true);
+            // Scrolling must take precedence over long-press. When the parent NestedScrollView
+            // (continuous mode) or Readium's pager (paginated/vertical) intercepts the touch
+            // stream past its slop threshold, the WebView receives ACTION_CANCEL — which surfaces
+            // in JS as touchcancel, not touchmove or touchend. Without this handler the 500ms
+            // timer keeps running and the annotations menu pops even though the user is scrolling.
+            document.addEventListener('touchcancel', function() {
+                if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
+                longPressTarget = null;
+            }, true);
             // Cancel the native long-press callout on figures — belt to the CSS's braces above,
             // for WebView builds where the CSS property alone is respected too late.
             document.addEventListener('contextmenu', function(e) {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
@@ -56,6 +56,32 @@ class FigureTapScriptTest {
         assertTrue(script.contains("clearTimeout(longPressTimer)"))
     }
 
+    /**
+     * Scrolling must take precedence over long-press: when the parent scroll container
+     * (continuous mode's NestedScrollView, or Readium's pager in paginated/vertical) claims the
+     * touch stream, the WebView receives ACTION_CANCEL, which surfaces in JS as touchcancel —
+     * NOT touchmove or touchend. Without a touchcancel handler the 500ms long-press timer keeps
+     * running and the annotations menu pops even though the user is scrolling. This assertion
+     * flips red if that handler is removed.
+     */
+    @Test
+    fun `touchcancel clears the pending long-press timer so scrolling suppresses the annotations menu`() {
+        assertTrue(
+            "touchcancel handler must exist so parent-intercepted scrolls cancel the long-press",
+            script.contains("addEventListener('touchcancel'"),
+        )
+        // Locate the touchcancel handler block and assert it clears longPressTimer inside it —
+        // an outer clearTimeout elsewhere would satisfy `script.contains(...)` without actually
+        // wiring cancellation into the touchcancel path.
+        val cancelIdx = script.indexOf("addEventListener('touchcancel'")
+        assertTrue("touchcancel listener not found", cancelIdx >= 0)
+        val cancelBlock = script.substring(cancelIdx, minOf(cancelIdx + 400, script.length))
+        assertTrue(
+            "touchcancel handler must clearTimeout(longPressTimer)",
+            cancelBlock.contains("clearTimeout(longPressTimer)"),
+        )
+    }
+
     @Test
     fun `script exposes window riffleFiguresInsideRange as a callable entry point`() {
         assertTrue(script.contains("window.riffleFiguresInsideRange"))

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
@@ -70,12 +70,14 @@ class FigureTapScriptTest {
             "touchcancel handler must exist so parent-intercepted scrolls cancel the long-press",
             script.contains("addEventListener('touchcancel'"),
         )
-        // Locate the touchcancel handler block and assert it clears longPressTimer inside it —
-        // an outer clearTimeout elsewhere would satisfy `script.contains(...)` without actually
-        // wiring cancellation into the touchcancel path.
+        // Locate only the touchcancel handler block — from the listener registration up to its
+        // closing `}, true);` — to avoid the assertion passing because a clearTimeout appears in
+        // a later handler (e.g. the contextmenu block that follows immediately in the script).
         val cancelIdx = script.indexOf("addEventListener('touchcancel'")
-        assertTrue("touchcancel listener not found", cancelIdx >= 0)
-        val cancelBlock = script.substring(cancelIdx, minOf(cancelIdx + 400, script.length))
+        check(cancelIdx >= 0) // already asserted by assertTrue above; keeps the compiler happy
+        val handlerEnd = script.indexOf("}, true);", cancelIdx).takeIf { it >= 0 }
+            ?: error("touchcancel handler closing delimiter not found")
+        val cancelBlock = script.substring(cancelIdx, handlerEnd + "}, true);".length)
         assertTrue(
             "touchcancel handler must clearTimeout(longPressTimer)",
             cancelBlock.contains("clearTimeout(longPressTimer)"),


### PR DESCRIPTION
## What

When holding down on a figure and then scrolling, the figure annotations menu was appearing even though the user was clearly scrolling, not annotating.

## Why it happened

The existing long-press cancel logic only handled `touchmove` and `touchend`. When the parent scroll container (continuous mode's `NestedScrollView`, or Readium's `ViewPager` in paginated/vertical) intercepts the touch stream past its slop threshold, it calls `requestDisallowInterceptTouchEvent(false)` or takes ownership, causing the WebView to receive `ACTION_CANCEL` — which surfaces in JS as `touchcancel`, **not** `touchmove` or `touchend`. The 500 ms `setTimeout` was never cleared, so `onFigureLongPress` fired anyway.

## Fix

Add a `touchcancel` listener in `FigureTapScript.kt` that mirrors the existing `touchend` cleanup: `clearTimeout(longPressTimer)` + null both tracking variables.

## Test

`FigureTapScriptTest` — added a regression test that locates only the `touchcancel` handler block (bounded by its own closing `}, true);` delimiter rather than a magic 400-char window) and asserts `clearTimeout(longPressTimer)` appears inside it. Flips red if the handler is removed.