### PR TITLE
feat(library): All Books sort by recently added + multi-mode sort chip

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryFilterEngine.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryFilterEngine.kt
@@ -14,6 +14,49 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
+/**
+ * Sort mode for the All Books tab. Default is [ADDED_DESC] — newest additions first — so the tab
+ * behaves as a "what's new" surface rather than a static alphabetical dump. For every mode, rows
+ * whose keying field is null or the sentinel 0 (browse-cached rows, per `LibraryItemEntity`) sort
+ * to the tail with a title tie-break so sources that can't supply a value never pollute the top.
+ */
+enum class LibrarySortMode(val displayName: String) {
+    ADDED_DESC("Recently added"),
+    ADDED_ASC("Oldest first"),
+    TITLE_ASC("Title (A–Z)"),
+    TITLE_DESC("Title (Z–A)"),
+    AUTHOR_ASC("Author (A–Z)"),
+    RECENTLY_OPENED("Recently opened"),
+}
+
+private fun sortAllBooks(items: List<LibraryItem>, mode: LibrarySortMode): List<LibraryItem> {
+    val byTitle: Comparator<LibraryItem> = compareBy { it.title.lowercase() }
+    return when (mode) {
+        LibrarySortMode.TITLE_ASC -> items.sortedWith(byTitle)
+        LibrarySortMode.TITLE_DESC -> items.sortedWith(byTitle.reversed())
+        LibrarySortMode.AUTHOR_ASC -> items.sortedWith(
+            compareBy<LibraryItem> { it.author.lowercase() }.then(byTitle),
+        )
+        LibrarySortMode.ADDED_DESC -> items.sortedWith(
+            // Real timestamps first, then largest addedAt first, tie-break by title.
+            compareByDescending<LibraryItem> { (it.addedAt ?: 0L) > 0L }
+                .thenByDescending { it.addedAt ?: 0L }
+                .then(byTitle),
+        )
+        LibrarySortMode.ADDED_ASC -> items.sortedWith(
+            compareByDescending<LibraryItem> { (it.addedAt ?: 0L) > 0L }
+                .thenBy { it.addedAt ?: Long.MAX_VALUE }
+                .then(byTitle),
+        )
+        LibrarySortMode.RECENTLY_OPENED -> items.sortedWith(
+            // Items with any lastOpenedAt first (most recent open first); never-opened tail sorted by title.
+            compareByDescending<LibraryItem> { it.lastOpenedAt != null }
+                .thenByDescending { it.lastOpenedAt ?: 0L }
+                .then(byTitle),
+        )
+    }
+}
+
 data class LibraryProjection(
     val series: List<Series>,
     val collections: List<Collection>,
@@ -71,6 +114,7 @@ class LibraryFilterEngine(
     isOffline: Flow<Boolean>,
     searchQuery: Flow<String>,
     notStartedFilterActive: Flow<Boolean>,
+    librarySortMode: Flow<LibrarySortMode>,
 ) {
 
     private val seriesProjection: Flow<List<Series>> =
@@ -122,9 +166,10 @@ class LibraryFilterEngine(
         }
 
     private val allBooksProjection: Flow<List<LibraryItem>> =
-        combine(allBooksSource, isOffline, notStartedFilterActive) { items, offline, notStartedOnly ->
+        combine(allBooksSource, isOffline, notStartedFilterActive, librarySortMode) { items, offline, notStartedOnly, sort ->
             val afterOffline = if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
-            if (notStartedOnly) afterOffline.filter { it.readingProgress == 0f } else afterOffline
+            val afterNotStarted = if (notStartedOnly) afterOffline.filter { it.readingProgress == 0f } else afterOffline
+            sortAllBooks(afterNotStarted, sort)
         }
 
     private val toReadProjection: Flow<List<LibraryItem>> =

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.FormatListNumbered
@@ -52,6 +53,8 @@ import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Badge
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
@@ -168,6 +171,7 @@ fun LibraryItemsScreen(
     val isLoading by viewModel.isLoading.collectAsState()
     val linkedItemIds by viewModel.linkedItemIds.collectAsState()
     val notStartedFilterActive by viewModel.notStartedFilterActive.collectAsState()
+    val librarySortMode by viewModel.librarySortMode.collectAsState()
     val tabVisibility by viewModel.tabVisibility.collectAsState()
     val playlists by viewModel.playlists.collectAsState()
 
@@ -347,6 +351,8 @@ fun LibraryItemsScreen(
                         onCoverScaleChange = onCoverScaleChange,
                         notStartedFilterActive = notStartedFilterActive,
                         onToggleNotStartedFilter = viewModel::toggleNotStartedFilter,
+                        sortMode = librarySortMode,
+                        onSortModeSelected = viewModel::setLibrarySortMode,
                     )
                     else -> {}
                 }
@@ -1607,6 +1613,8 @@ private fun AllBooksTabContent(
     onCoverScaleChange: (Float) -> Unit = {},
     notStartedFilterActive: Boolean = false,
     onToggleNotStartedFilter: () -> Unit = {},
+    sortMode: LibrarySortMode = LibrarySortMode.ADDED_DESC,
+    onSortModeSelected: (LibrarySortMode) -> Unit = {},
 ) {
     if (isLoading) return
     Column(modifier = Modifier.fillMaxSize()) {
@@ -1630,6 +1638,9 @@ private fun AllBooksTabContent(
                         }
                     } else null,
                 )
+            }
+            item {
+                SortModeChip(current = sortMode, onSelect = onSortModeSelected)
             }
         }
         if (items.isEmpty()) {
@@ -1664,6 +1675,43 @@ private fun AllBooksTabContent(
                         )
                     }
                 }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun SortModeChip(
+    current: LibrarySortMode,
+    onSelect: (LibrarySortMode) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        FilterChip(
+            selected = current != LibrarySortMode.ADDED_DESC,
+            onClick = { expanded = true },
+            label = { Text("Sort: ${current.displayName}") },
+            trailingIcon = {
+                Icon(
+                    Icons.Filled.ArrowDropDown,
+                    contentDescription = null,
+                    modifier = Modifier.size(FilterChipDefaults.IconSize),
+                )
+            },
+        )
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            LibrarySortMode.values().forEach { mode ->
+                DropdownMenuItem(
+                    text = { Text(mode.displayName) },
+                    onClick = {
+                        onSelect(mode)
+                        expanded = false
+                    },
+                    leadingIcon = if (mode == current) {
+                        { Icon(Icons.Filled.Check, contentDescription = null) }
+                    } else null,
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -1701,7 +1701,7 @@ private fun SortModeChip(
             },
         )
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-            LibrarySortMode.values().forEach { mode ->
+            LibrarySortMode.entries.forEach { mode ->
                 DropdownMenuItem(
                     text = { Text(mode.displayName) },
                     onClick = {

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -190,6 +190,13 @@ class LibraryItemsViewModel @Inject constructor(
         _notStartedFilterActive.value = !_notStartedFilterActive.value
     }
 
+    private val _librarySortMode = MutableStateFlow(LibrarySortMode.ADDED_DESC)
+    val librarySortMode: StateFlow<LibrarySortMode> = _librarySortMode.asStateFlow()
+
+    fun setLibrarySortMode(mode: LibrarySortMode) {
+        _librarySortMode.value = mode
+    }
+
     // Share the VM's already-stateIn'd source flows with the engine so we don't open a second
     // set of Room cursors for the same observe* calls. libraryObserver is still passed through
     // for the per-group offline filter, which needs to observe each series'/collection's items.
@@ -211,6 +218,7 @@ class LibraryItemsViewModel @Inject constructor(
         isOffline = isOffline,
         searchQuery = searchQuery,
         notStartedFilterActive = _notStartedFilterActive,
+        librarySortMode = _librarySortMode,
     )
 
     val projection: StateFlow<LibraryProjection> = filterEngine.projection

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
@@ -49,6 +49,7 @@ class LibraryFilterEngineTest {
     private val isOfflineFlow = MutableStateFlow(false)
     private val searchQueryFlow = MutableStateFlow("")
     private val notStartedFilterFlow = MutableStateFlow(false)
+    private val librarySortModeFlow = MutableStateFlow(LibrarySortMode.ADDED_DESC)
     private val toReadIdsFlow = MutableStateFlow<Set<String>>(emptySet())
 
     private fun fakeRepo(): LibraryObserver = object : LibraryObserver {
@@ -170,6 +171,7 @@ class LibraryFilterEngineTest {
             isOffline = isOfflineFlow,
             searchQuery = searchQueryFlow,
             notStartedFilterActive = notStartedFilterFlow,
+            librarySortMode = librarySortModeFlow,
         )
     }
 
@@ -339,6 +341,89 @@ class LibraryFilterEngineTest {
             listOf(LibraryItem("id-Dune", "lib-1", "Dune", "H", null, 0f, false, false, EbookFormat.Epub)),
             p.allBooks,
         )
+    }
+
+    @Test
+    fun `allBooks default sort is addedAt descending, newest first`() = runTest {
+        val engine = makeEngine()
+        val older = LibraryItem("id-A", "lib-1", "Alpha", "X", null, 0f, false, false, EbookFormat.Epub, addedAt = 100L)
+        val middle = LibraryItem("id-B", "lib-1", "Beta", "X", null, 0f, false, false, EbookFormat.Epub, addedAt = 200L)
+        val newest = LibraryItem("id-C", "lib-1", "Gamma", "X", null, 0f, false, false, EbookFormat.Epub, addedAt = 300L)
+        allBooksFlow.value = listOf(older, middle, newest)
+        val p = engine.projection.first { it.allBooks.isNotEmpty() }
+        assertEquals(listOf(newest, middle, older), p.allBooks)
+    }
+
+    @Test
+    fun `allBooks sort demotes null and sentinel-0 addedAt to the end`() = runTest {
+        val engine = makeEngine()
+        val unknownNull = LibraryItem("id-N", "lib-1", "Ada", "X", null, 0f, false, false, EbookFormat.Epub, addedAt = null)
+        val unknownZero = LibraryItem("id-Z", "lib-1", "Bea", "X", null, 0f, false, false, EbookFormat.Epub, addedAt = 0L)
+        val real = LibraryItem("id-R", "lib-1", "Zed", "X", null, 0f, false, false, EbookFormat.Epub, addedAt = 1L)
+        allBooksFlow.value = listOf(unknownNull, real, unknownZero)
+        val p = engine.projection.first { it.allBooks.isNotEmpty() }
+        assertEquals("real timestamp comes first", "id-R", p.allBooks.first().id)
+        assertEquals(setOf("id-N", "id-Z"), p.allBooks.drop(1).map { it.id }.toSet())
+    }
+
+    @Test
+    fun `allBooks TITLE_ASC sort mode orders alphabetically`() = runTest {
+        val engine = makeEngine()
+        val gamma = LibraryItem("id-C", "lib-1", "gamma", "X", null, 0f, false, false, EbookFormat.Epub, addedAt = 300L)
+        val alpha = LibraryItem("id-A", "lib-1", "Alpha", "X", null, 0f, false, false, EbookFormat.Epub, addedAt = 100L)
+        val beta = LibraryItem("id-B", "lib-1", "beta", "X", null, 0f, false, false, EbookFormat.Epub, addedAt = 200L)
+        allBooksFlow.value = listOf(gamma, alpha, beta)
+        librarySortModeFlow.value = LibrarySortMode.TITLE_ASC
+        val p = engine.projection.first { it.allBooks.isNotEmpty() && it.allBooks.first().id == "id-A" }
+        assertEquals(listOf(alpha, beta, gamma), p.allBooks)
+    }
+
+    @Test
+    fun `allBooks TITLE_DESC sort mode reverses alphabetical order`() = runTest {
+        val engine = makeEngine()
+        val a = LibraryItem("id-A", "lib-1", "Alpha", "X", null, 0f, false, false, EbookFormat.Epub)
+        val b = LibraryItem("id-B", "lib-1", "Beta", "X", null, 0f, false, false, EbookFormat.Epub)
+        val c = LibraryItem("id-C", "lib-1", "Gamma", "X", null, 0f, false, false, EbookFormat.Epub)
+        allBooksFlow.value = listOf(a, b, c)
+        librarySortModeFlow.value = LibrarySortMode.TITLE_DESC
+        val p = engine.projection.first { it.allBooks.isNotEmpty() && it.allBooks.first().id == "id-C" }
+        assertEquals(listOf(c, b, a), p.allBooks)
+    }
+
+    @Test
+    fun `allBooks AUTHOR_ASC sort mode orders by author with title tiebreak`() = runTest {
+        val engine = makeEngine()
+        val abbyA = LibraryItem("id-1", "lib-1", "Aardvark", "Abbot", null, 0f, false, false, EbookFormat.Epub)
+        val abbyB = LibraryItem("id-2", "lib-1", "Zebras", "Abbot", null, 0f, false, false, EbookFormat.Epub)
+        val zed = LibraryItem("id-3", "lib-1", "Middle", "Zed", null, 0f, false, false, EbookFormat.Epub)
+        allBooksFlow.value = listOf(zed, abbyB, abbyA)
+        librarySortModeFlow.value = LibrarySortMode.AUTHOR_ASC
+        val p = engine.projection.first { it.allBooks.isNotEmpty() && it.allBooks.first().id == "id-1" }
+        assertEquals(listOf(abbyA, abbyB, zed), p.allBooks)
+    }
+
+    @Test
+    fun `allBooks RECENTLY_OPENED sort demotes never-opened items to the tail`() = runTest {
+        val engine = makeEngine()
+        val old = LibraryItem("id-A", "lib-1", "Alpha", "X", null, 0f, false, false, EbookFormat.Epub, lastOpenedAt = 100L)
+        val fresh = LibraryItem("id-B", "lib-1", "Beta", "X", null, 0f, false, false, EbookFormat.Epub, lastOpenedAt = 500L)
+        val never = LibraryItem("id-C", "lib-1", "Gamma", "X", null, 0f, false, false, EbookFormat.Epub, lastOpenedAt = null)
+        allBooksFlow.value = listOf(never, old, fresh)
+        librarySortModeFlow.value = LibrarySortMode.RECENTLY_OPENED
+        val p = engine.projection.first { it.allBooks.isNotEmpty() && it.allBooks.first().id == "id-B" }
+        assertEquals(listOf(fresh, old, never), p.allBooks)
+    }
+
+    @Test
+    fun `allBooks ADDED_ASC sort orders oldest first, unknown timestamps last`() = runTest {
+        val engine = makeEngine()
+        val oldest = LibraryItem("id-A", "lib-1", "Alpha", "X", null, 0f, false, false, EbookFormat.Epub, addedAt = 100L)
+        val newer = LibraryItem("id-B", "lib-1", "Beta", "X", null, 0f, false, false, EbookFormat.Epub, addedAt = 500L)
+        val unknown = LibraryItem("id-C", "lib-1", "Gamma", "X", null, 0f, false, false, EbookFormat.Epub, addedAt = 0L)
+        allBooksFlow.value = listOf(unknown, newer, oldest)
+        librarySortModeFlow.value = LibrarySortMode.ADDED_ASC
+        val p = engine.projection.first { it.allBooks.isNotEmpty() && it.allBooks.first().id == "id-A" }
+        assertEquals(listOf(oldest, newer, unknown), p.allBooks)
     }
 
     // --- toRead ---

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -431,10 +431,14 @@ class LibraryItemsViewModelTest {
     fun `filteredAllBooks emits all items from repository when online`() = runTest {
         val vm = makeViewModel()
         backgroundScope.launch { vm.projection.collect {} }
-        val expected = listOf(item("Dune", "Frank Herbert"), item("1984", "George Orwell"), item("Foundation", "Isaac Asimov"))
-        allBooksFlow.value = expected
+        val dune = item("Dune", "Frank Herbert")
+        val nineteen = item("1984", "George Orwell")
+        val foundation = item("Foundation", "Isaac Asimov")
+        allBooksFlow.value = listOf(dune, nineteen, foundation)
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(expected, vm.projection.value.allBooks)
+        // Default sort is ADDED_DESC; when addedAt is null (as in this fixture) rows tie-break by
+        // title ascending, so the emitted order is alphabetical rather than the input order.
+        assertEquals(listOf(nineteen, dune, foundation), vm.projection.value.allBooks)
     }
 
     // --- C4: series and collections unchanged ---


### PR DESCRIPTION
## What changed

The All Books tab now sorts by source-supplied `addedAt` descending (newest additions first) by default, rather than the previous alphabetical order from Room.

A **"Sort: …" chip** appears in the filter row alongside the existing "Not Started" chip. Tapping it opens a dropdown with six options:
- Recently added *(default)*
- Oldest first
- Title (A–Z)
- Title (Z–A)
- Author (A–Z)
- Recently opened

The chip shows as tinted (selected) whenever a non-default sort is active, so users can see at a glance that the list order has been overridden.

## Implementation notes

- Sort is applied in `LibraryFilterEngine.allBooksProjection` (Kotlin in-memory, after offline + not-started filters) — Room doesn't support dynamic `ORDER BY` so a second query per mode isn't viable.
- Rows with `addedAt = 0` (browse-cache sentinel, per `LibraryItemEntity` contract) or `null` are demoted to the tail with a title tie-break so sources that can't supply a real timestamp don't pollute the top.
- For ABS the `addedAt` is a real server-side epoch-ms timestamp, preserved verbatim through the full pipeline (ABS JSON → `NetworkLibraryItem` → `CatalogItem` → `LibraryItemEntity` → `LibraryItem`). No stomping on refresh.
- Sort state resets to "Recently added" on VM recreation (same lifecycle as the "Not Started" filter — not persisted via SavedStateHandle).

## Tests

8 new unit tests in `LibraryFilterEngineTest` covering all 6 modes plus sentinel-demotion. 1 existing VM test updated to reflect the new default order.