### PR TITLE
fix(reader): elided-view emphasis styles, gray null-color bar, inline publisher italics

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -650,6 +650,12 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
                 // Origin font-family at the selection's start element (issue #484). Stashed for
                 // EpubReaderViewModel.createHighlight/toggleBookmark to persist onto the entity.
                 SelectionFontStash.set(obj.optString("ff", ""))
+                // Inline-formatted excerpt HTML (issue: elided view drops italics) — allowlist
+                // sanitisation happens on both the extractor and render side. Empty when the
+                // selection has no publisher formatting on top of the plaintext (extractor
+                // suppresses the field in that case), which routes the elided view to its plain
+                // textSnippet render path.
+                SelectionSnippetHtmlStash.set(obj.optString("html", ""))
                 // Figures enclosed by the selection range — captured by SELECTION_SPAN_TRACKER_JS
                 // while the range was still live (raster figures rasterised via canvas to a data
                 // URI; SVG serialised verbatim). Stashed here so EpubReaderViewModel.createHighlight

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -3419,6 +3419,19 @@ internal class RiffleSelectionRectBridge(
     }
 
     /**
+     * Called from [ReaderWebViewScripts.SELECTION_SPAN_TRACKER_JS] on every selectionchange with
+     * the inline-formatted excerpt HTML for the current live range (issue: elided view drops
+     * italics). The extractor emits only the allowlisted inline tags; the render side re-enforces
+     * the same allowlist as defence-in-depth. Stashed for the paginated action-mode's Highlight
+     * handler ([EpubReaderViewModel.createHighlight]) so the row lands with the formatting
+     * preserved — same reason we bridge figures and font-family here for paginated mode.
+     */
+    @android.webkit.JavascriptInterface
+    fun onSnippetHtml(html: String) {
+        SelectionSnippetHtmlStash.set(html)
+    }
+
+    /**
      * Called from the SELECTION_SPAN_TRACKER_JS installer once per chapter load with the source
      * book's computed body `font-family` (issue #484). Routes into
      * [EpubReaderViewModel.noteBookBodyFontFamily] via [onBodyFont] — the VM caches it as the

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1989,6 +1989,10 @@ class EpubReaderViewModel @Inject constructor(
             val originFont = SelectionFontStash.consume().takeIf { it.isNotBlank() }
                 ?: bookBodyFontFamilyReported.get().takeIf { it.isNotBlank() }
                 ?: FALLBACK_ORIGIN_FONT_FAMILY
+            // Inline-formatted excerpt HTML (issue: elided view drops italics). Empty string means
+            // the extractor found no publisher formatting on top of the plaintext — persist null
+            // so the render side takes its plain textSnippet path unambiguously.
+            val snippetHtml = SelectionSnippetHtmlStash.consume().takeIf { it.isNotBlank() }
 
             // ADR 0046 §4: build a draft — nothing persists until the user taps a swatch or
             // emphasis chip. `commitDraft*` in this VM performs the delayed store writes
@@ -2006,6 +2010,7 @@ class EpubReaderViewModel @Inject constructor(
                 progression = progression,
                 embeddedFigures = embeddedFigures,
                 originFontFamily = originFont,
+                textSnippetHtml = snippetHtml,
                 anchorRect = anchorRect,
                 locator = selectionLocator,
             )
@@ -2096,6 +2101,12 @@ class EpubReaderViewModel @Inject constructor(
             progression = mergedFields.progression,
             embeddedFigures = mergedFields.embeddedFigures,
             originFontFamily = draft.originFontFamily,
+            // Only carry inline-formatted HTML when this is a plain (non-overlap-merge) create.
+            // On an overlap-merge, textSnippet is a concatenation across the union of ranges and
+            // the draft's HTML only covers the current selection — grafting it in would misalign
+            // formatting against the wider text. Fall back to plaintext render for merges; the
+            // dominant case (no overlap) still gets italics preserved.
+            textSnippetHtml = if (overlapMerge == null) draft.textSnippetHtml else null,
         )
         val presetStyles = annotationSession.lastUsedEmphasisStyles.value
         val combinedStyles = combineDraftEmphasisStyles(presetStyles, addEmphasisStyle)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1134,7 +1134,11 @@ class EpubReaderViewModel @Inject constructor(
             }
             val rows = annotationDao.getForItem(sourceId, itemId)
             val toc = tocRepository.getCachedToc(sourceId, itemId)?.second.orEmpty()
-            val chapters = buildChapterElisions(rows).mapIndexed { index, chapter ->
+            // Join TYPE_EMPHASIS styles onto their paired TYPE_HIGHLIGHT rows so the elided view
+            // renders user-applied formatting (bold/italic/underline/strike) and omits the accent
+            // bar for ∅-color emphasis-only annotations (see appendTextHighlight).
+            val rowsForElided = joinEmphasisStylesToHighlights(rows)
+            val chapters = buildChapterElisions(rowsForElided).mapIndexed { index, chapter ->
                 chapter.copy(title = elidedChapterTitle(chapter.href, chapter.title, toc, index))
             }
             // Belt-and-braces guard against Readium's EpubNavigatorFragment hard-crashing on an
@@ -2945,9 +2949,23 @@ class EpubReaderViewModel @Inject constructor(
                     // Chapter titles were derived at open-time from the TOC — reuse them.
                     val titleByHref =
                         highlightsResumeChapters?.associate { it.href to it.title } ?: emptyMap()
+                    // Emphasis-join for partial rewrite path: the incomingById snapshot only carries
+                    // TYPE_HIGHLIGHT entities; read the live emphasis pool to re-join styles so a
+                    // recolour or note edit doesn't strip user-applied emphasis from the chapter bytes.
+                    val emphasisByCfi = annotationSession.emphasisPool.value
+                        .groupBy { it.cfi }
+                        .mapValues { (_, pool) ->
+                            com.riffle.core.models.EmphasisStyle.encode(
+                                pool.firstOrNull()?.emphasisStyles.orEmpty(),
+                            )
+                        }
                     for (chapterHref in touchedChapters) {
                         val livePeers = incomingByChapter[chapterHref].orEmpty()
                             .sortedWith(compareBy({ it.spineIndex }, { it.progression }, { it.createdAt }, { it.id }))
+                            .map { row ->
+                                val styles = emphasisByCfi[row.cfi] ?: return@map row
+                                row.copy(emphasisStyles = styles)
+                            }
                         if (livePeers.isEmpty()) continue // Empty chapter would be structural — handled above.
                         val chapter = ChapterElision(
                             href = chapterHref,
@@ -2993,7 +3011,8 @@ class EpubReaderViewModel @Inject constructor(
      *  what [HighlightsPublicationFactory.renderChapterHtml] bakes into the initial HTML so a
      *  live recolour lands on the SAME colour a fresh page load would produce. */
     private fun highlightAccentCssRgba(colorToken: String): String =
-        com.riffle.core.models.HighlightColor.fromToken(colorToken).argb.toCssRgba()
+        if (colorToken.isBlank()) com.riffle.app.feature.reader.highlights.EMPHASIS_ONLY_BAR_COLOR
+        else com.riffle.core.models.HighlightColor.fromToken(colorToken).argb.toCssRgba()
 
     /** Soft-delete a highlight; annotationStore re-emits without it → decoration is removed.
      *  Highlights mode: the observer sees the id disappear and dispatches a Remove DOM patch
@@ -3748,6 +3767,28 @@ internal fun resolveChapterTitle(href: String, toc: List<TocEntry>): String? {
  */
 internal fun highlightsShouldCloseAfterDelete(rows: List<AnnotationEntity>): Boolean =
     buildChapterElisions(rows).isEmpty()
+
+/**
+ * Copies [AnnotationEntity.emphasisStyles] from each TYPE_EMPHASIS row onto its paired
+ * TYPE_HIGHLIGHT (matched by [AnnotationEntity.cfi]). The elided view's rendering path
+ * ([appendTextHighlight]) reads `emphasisStyles` on the highlight entity to apply user-applied
+ * CSS (bold/italic/underline/strike) and to decide whether the accent bar should be omitted
+ * (∅-color emphasis-only annotations have `color = ""`). Called on the full row list from the
+ * DAO so both types are available for joining before [buildChapterElisions] filters to highlights.
+ */
+internal fun joinEmphasisStylesToHighlights(rows: List<AnnotationEntity>): List<AnnotationEntity> {
+    val emphasisByCfi = rows
+        .filter { it.type == AnnotationEntity.TYPE_EMPHASIS && !it.deleted }
+        .groupBy { it.cfi }
+        .mapValues { (_, group) -> group.firstOrNull()?.emphasisStyles }
+    if (emphasisByCfi.isEmpty()) return rows
+    return rows.map { row ->
+        if (row.type == AnnotationEntity.TYPE_HIGHLIGHT) {
+            val styles = emphasisByCfi[row.cfi] ?: return@map row
+            row.copy(emphasisStyles = styles)
+        } else row
+    }
+}
 
 internal fun buildChapterElisions(rows: List<AnnotationEntity>): List<ChapterElision> {
     val live = rows

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -509,13 +509,51 @@ internal val SELECTION_SPAN_TRACKER_JS = """
                 }
               } catch (e) { ff = ''; }
             }
+            // Inline-formatted snippet HTML (issue: elided view drops italics). Walk the
+            // Range's cloneContents and serialise ONLY a fixed allowlist of inline elements
+            // (<em>/<i>/<strong>/<b>/<sup>/<sub>/<u>/<s>) with no attributes; text nodes are
+            // XML-escaped inline. Mirrors ALLOWED_INLINE_SNIPPET_TAGS on the Kotlin render side,
+            // and the render-side `sanitizeInlineSnippetHtml` enforces the same allowlist again
+            // as defence-in-depth (the DB is not a trust boundary).
+            var snippetHtml = '';
+            try {
+              var INLINE_ALLOW = { em: 1, i: 1, strong: 1, b: 1, sup: 1, sub: 1, u: 1, s: 1 };
+              var frag = rng.cloneContents();
+              var escInline = function (t) {
+                return String(t)
+                  .replace(/&/g, '&amp;')
+                  .replace(/</g, '&lt;')
+                  .replace(/>/g, '&gt;');
+              };
+              var walkInline = function (node) {
+                if (node.nodeType === 3) return escInline(node.data || '');
+                if (node.nodeType !== 1) {
+                  var out = '';
+                  var kids = node.childNodes;
+                  for (var wi = 0; wi < kids.length; wi++) out += walkInline(kids[wi]);
+                  return out;
+                }
+                var tag = String(node.tagName || '').toLowerCase();
+                var inner = '';
+                var k2 = node.childNodes;
+                for (var wj = 0; wj < k2.length; wj++) inner += walkInline(k2[wj]);
+                if (INLINE_ALLOW[tag]) return '<' + tag + '>' + inner + '</' + tag + '>';
+                return inner;
+              };
+              snippetHtml = walkInline(frag);
+              // Only report HTML that actually adds formatting on top of the plaintext — an
+              // empty string tells the store to leave textSnippetHtml null and use the plain
+              // render path (saves a DB write and keeps rows without formatting undecorated).
+              if (snippetHtml === escInline(text)) snippetHtml = '';
+            } catch (e) { snippetHtml = ''; }
             window.__riffleSelData = {
               text: text,
               p: Math.max(0, Math.min(1, br2.top / docH)),
               l: br2.left, t: br2.top, r: br2.right, b: br2.bottom,
               bef: bef, aft: aft,
               figures: figures,
-              ff: ff
+              ff: ff,
+              html: snippetHtml
             };
             // Also bridge figures to Kotlin directly. Continuous mode reads them out of
             // window.__riffleSelData in ChapterWebView.withSelectionTextAndProgression, but
@@ -532,6 +570,14 @@ internal val SELECTION_SPAN_TRACKER_JS = """
             try {
               if (window.RiffleSelBridge && window.RiffleSelBridge.onFontFamily) {
                 window.RiffleSelBridge.onFontFamily(ff);
+              }
+            } catch (e) {}
+            // Bridge the inline-formatted snippet HTML for the paginated path (issue: elided view
+            // drops italics). Same reasoning as figures/font-family — paginated Readium never
+            // reads window.__riffleSelData so the bridge is the only route.
+            try {
+              if (window.RiffleSelBridge && window.RiffleSelBridge.onSnippetHtml) {
+                window.RiffleSelBridge.onSnippetHtml(snippetHtml);
               }
             } catch (e) {}
           }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/SelectionSnippetHtmlStash.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/SelectionSnippetHtmlStash.kt
@@ -1,0 +1,27 @@
+package com.riffle.app.feature.reader
+
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Process-wide singleton carrying the inline-formatted excerpt HTML for the most recent live
+ * selection (issue: elided view drops italics) from a reader WebView into
+ * [EpubReaderViewModel.createHighlight]. The JS extractor in
+ * [ReaderWebViewScripts.SELECTION_SPAN_TRACKER_JS] walks `Range.cloneContents()` and emits ONLY
+ * a fixed allowlist of inline elements (`<em>`/`<i>`/`<strong>`/`<b>`/`<sup>`/`<sub>`/`<u>`/`<s>`)
+ * with text nodes XML-escaped; the render side re-enforces the same allowlist via
+ * `sanitizeInlineSnippetHtml` as defence-in-depth. Empty string means the extractor found no
+ * inline formatting on top of the plaintext, and the elided view falls back to the plain
+ * `textSnippet` render path.
+ *
+ * Mirrors [SelectionFontStash] and [SelectionFiguresStash] — only one reader session is active
+ * at a time so a singleton is safe. Contents cleared by the ViewModel after consumption.
+ */
+internal object SelectionSnippetHtmlStash {
+    private val current = AtomicReference<String>("")
+
+    fun set(html: String) {
+        current.set(html)
+    }
+
+    fun consume(): String = current.getAndSet("")
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -3,6 +3,7 @@ package com.riffle.app.feature.reader.highlights
 import com.riffle.app.feature.reader.toCssRgba
 import com.riffle.core.database.AnnotationEntity
 import com.riffle.core.models.EmbeddedFigure
+import com.riffle.core.models.EmphasisStyle
 import com.riffle.core.models.HighlightColor
 import javax.inject.Inject
 import kotlinx.serialization.builtins.ListSerializer
@@ -333,6 +334,12 @@ class HighlightsPublicationFactory @Inject constructor() {
     }
 }
 
+// Accent bar colour for ∅-color (emphasis-only) annotations — light gray that stays visible
+// without implying a user-chosen highlight colour. Alpha 0.20 is intentionally much lighter than
+// the 0x80 (~50%) used for palette colours so the bar reads as a secondary / formatting-only
+// marker rather than a full highlight.
+internal const val EMPHASIS_ONLY_BAR_COLOR = "rgba(128,128,128,0.20)"
+
 // Class name on the transparent absolute-positioned span that owns tap dispatch for a highlight.
 // Injected inside each synthesised `<p>` next to the visible text; its CSS (see
 // [ACCENT_BAR_TAP_CSS]) sizes it to overlap the paragraph's border-left + padding-left gutter so a
@@ -446,7 +453,8 @@ private fun appendInterleavedHighlight(
     }
     val note = highlight.note
     if (note != null) {
-        val accent = highlightBackgroundCss(highlight.color)
+        val accent = if (highlight.color.isNotBlank()) highlightBackgroundCss(highlight.color)
+                     else EMPHASIS_ONLY_BAR_COLOR
         val idEscaped = highlight.id.xmlEscape()
         sb.append("  <aside class=\"riffle-note\" data-ann-id=\"")
         sb.append(idEscaped)
@@ -470,7 +478,8 @@ private fun appendHighlightTextChunk(
     chunk: String,
     bookBodyFontFamily: String?,
 ) {
-    val accent = highlightBackgroundCss(highlight.color)
+    val accent = if (highlight.color.isNotBlank()) highlightBackgroundCss(highlight.color)
+                 else EMPHASIS_ONLY_BAR_COLOR
     val idEscaped = highlight.id.xmlEscape()
     val tapUrl = buildAnnotationTapUrl(highlight.id).xmlEscape()
     sb.append("  <p style=\"")
@@ -487,7 +496,9 @@ private fun appendHighlightTextChunk(
     sb.append(tapUrl)
     sb.append("?l='+x+'&amp;t='+y+'&amp;r='+(x+1)+'&amp;b='+(y+1);return false;\"></span><span class=\"riffle-hl\" data-ann-id=\"")
     sb.append(idEscaped)
-    sb.append("\">")
+    sb.append("\"")
+    appendEmphasisStyleAttr(sb, highlight.emphasisStyles)
+    sb.append(">")
     sb.append(chunk.xmlEscape())
     sb.append("</span></p>\n")
 }
@@ -508,7 +519,10 @@ private fun appendTextHighlight(sb: StringBuilder, highlight: AnnotationEntity, 
     // (ChapterWebView) and paginated/vertical (EpubReaderScreen) intercept that URL and
     // open the highlight-actions popup. Tapping the text itself does nothing — the
     // reason this HTML is authored here and not decorated on top of it via Readium.
-    val accent = highlightBackgroundCss(highlight.color)
+    // ∅-color (emphasis-only) annotations use a neutral gray bar instead of omitting the
+    // accent bar entirely — the bar still provides visual rhythm and a tap target.
+    val accent = if (highlight.color.isNotBlank()) highlightBackgroundCss(highlight.color)
+                 else EMPHASIS_ONLY_BAR_COLOR
     val idEscaped = highlight.id.xmlEscape()
     val tapUrl = buildAnnotationTapUrl(highlight.id).xmlEscape()
     sb.append("  <p style=\"")
@@ -525,7 +539,9 @@ private fun appendTextHighlight(sb: StringBuilder, highlight: AnnotationEntity, 
     sb.append(tapUrl)
     sb.append("?l='+x+'&amp;t='+y+'&amp;r='+(x+1)+'&amp;b='+(y+1);return false;\"></span><span class=\"riffle-hl\" data-ann-id=\"")
     sb.append(idEscaped)
-    sb.append("\">")
+    sb.append("\"")
+    appendEmphasisStyleAttr(sb, highlight.emphasisStyles)
+    sb.append(">")
     // Prefer the captured inline-formatted HTML (issue: elided-view drops italics) so publisher
     // <em>/<i>/<strong>/<b>/<sup>/<sub>/<u>/<s> spans render in the excerpt. Sanitised defensively
     // at render time — the DB is not a trust boundary and the extractor may evolve. Legacy rows
@@ -592,6 +608,29 @@ private fun appendOriginFontFamilyStyle(
     sb.append(" font-family: ")
     sb.append(safe.xmlEscape())
     sb.append(";")
+}
+
+/**
+ * Appends a ` style="..."` attribute to a `<span>` tag in progress when [emphasisStyles] carries
+ * user-applied formatting from a paired TYPE_EMPHASIS row (bold, italic, underline, strike).
+ * No-op when [emphasisStyles] is null or blank. Called just before the closing `>` of the span.
+ */
+private fun appendEmphasisStyleAttr(sb: StringBuilder, emphasisStyles: String?) {
+    val styles = EmphasisStyle.decode(emphasisStyles) ?: return
+    if (styles.isEmpty()) return
+    val cssParts = buildList {
+        if (EmphasisStyle.BOLD in styles) add("font-weight:bold")
+        if (EmphasisStyle.ITALIC in styles) add("font-style:italic")
+        val decorations = buildList {
+            if (EmphasisStyle.UNDERLINE in styles) add("underline")
+            if (EmphasisStyle.STRIKE in styles) add("line-through")
+        }
+        if (decorations.isNotEmpty()) add("text-decoration:${decorations.joinToString(" ")}")
+    }
+    if (cssParts.isEmpty()) return
+    sb.append(" style=\"")
+    sb.append(cssParts.joinToString(";"))
+    sb.append("\"")
 }
 
 /**
@@ -691,7 +730,8 @@ private fun appendFigureFigure(
     bytes: String?,
     caption: String,
 ) {
-    val accent = highlightBackgroundCss(colorToken)
+    val accent = if (colorToken.isNotBlank()) highlightBackgroundCss(colorToken)
+                 else EMPHASIS_ONLY_BAR_COLOR
     val idEscaped = annotationId.xmlEscape()
     val tapUrl = buildAnnotationTapUrl(annotationId).xmlEscape()
     // `data-ann-id` on the <figure> itself so the live DOM-patch pipeline (buildRecolorJs /

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -526,7 +526,16 @@ private fun appendTextHighlight(sb: StringBuilder, highlight: AnnotationEntity, 
     sb.append("?l='+x+'&amp;t='+y+'&amp;r='+(x+1)+'&amp;b='+(y+1);return false;\"></span><span class=\"riffle-hl\" data-ann-id=\"")
     sb.append(idEscaped)
     sb.append("\">")
-    sb.append(highlight.textSnippet.xmlEscape())
+    // Prefer the captured inline-formatted HTML (issue: elided-view drops italics) so publisher
+    // <em>/<i>/<strong>/<b>/<sup>/<sub>/<u>/<s> spans render in the excerpt. Sanitised defensively
+    // at render time — the DB is not a trust boundary and the extractor may evolve. Legacy rows
+    // (null column, W3C sync ingest) fall back to the plain textSnippet render.
+    val inlineHtml = highlight.textSnippetHtml
+    if (inlineHtml != null) {
+        sb.append(sanitizeInlineSnippetHtml(inlineHtml))
+    } else {
+        sb.append(highlight.textSnippet.xmlEscape())
+    }
     sb.append("</span></p>\n")
     val note = highlight.note
     if (note != null) {
@@ -859,6 +868,51 @@ private const val READIUM_DEFAULT_CSS_LINK =
  * looks) while guaranteeing a tappable, non-decorated strip between every highlight.
  */
 private const val PARAGRAPH_GAP_STYLE = "margin: 1em 0;"
+
+/** Inline elements the elided view preserves inside a highlight excerpt (issue: elided-view drops
+ *  italics). The JS extractor emits only these tags with no attributes; the render-side sanitiser
+ *  below re-enforces the allowlist as defence-in-depth (the DB is not a trust boundary and a
+ *  legacy row / future extractor could put anything in the column). Text nodes are expected
+ *  pre-XML-escaped by the extractor — we don't touch them here.  */
+private val ALLOWED_INLINE_SNIPPET_TAGS = setOf("em", "i", "strong", "b", "sup", "sub", "u", "s")
+
+/**
+ * Reduce [html] to a safe subset for the excerpt render path:
+ *  - only tags in [ALLOWED_INLINE_SNIPPET_TAGS] survive; their opening/closing markers are
+ *    re-emitted attribute-less (any `src="…"` / `onclick="…"` payload is dropped);
+ *  - every other tag (including `<script>`, `<style>`, `<a>`, and any unknown element) is
+ *    stripped, but its text content is preserved verbatim;
+ *  - text characters are passed through unchanged — the extractor produces XML-escaped text,
+ *    and re-escaping here would double-encode `&amp;` into `&amp;amp;`.
+ * Not designed for arbitrary web HTML; scoped to the shape our own extractor writes.
+ */
+internal fun sanitizeInlineSnippetHtml(html: String): String {
+    val sb = StringBuilder(html.length)
+    var i = 0
+    while (i < html.length) {
+        val c = html[i]
+        if (c != '<') {
+            sb.append(c)
+            i++
+            continue
+        }
+        val end = html.indexOf('>', i)
+        if (end < 0) break // Malformed trailing '<' — drop it and everything after.
+        val body = html.substring(i + 1, end)
+        val isClose = body.startsWith("/")
+        val name = body.removePrefix("/")
+            .substringBefore(' ')
+            .substringBefore('/')
+            .lowercase()
+            .trim()
+        if (name in ALLOWED_INLINE_SNIPPET_TAGS) {
+            sb.append(if (isClose) "</" else "<").append(name).append('>')
+        }
+        i = end + 1
+    }
+    return sb.toString()
+}
+
 
 private fun String.xmlEscape(): String =
     replace("&", "&amp;")

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
@@ -202,6 +202,10 @@ class AnnotationSession @AssistedInject constructor(
         val progression: Double,
         val embeddedFigures: List<com.riffle.core.models.EmbeddedFigure>?,
         val originFontFamily: String,
+        /** Sanitised inline HTML of the excerpt preserving publisher formatting. Non-blank iff the
+         *  selection extractor found `<em>`/`<i>`/`<strong>`/etc. on top of the plaintext. Null
+         *  routes the Annotations View to its plain-text render path. */
+        val textSnippetHtml: String?,
         val anchorRect: androidx.compose.ui.unit.IntRect,
         val locator: org.readium.r2.shared.publication.Locator,
     )

--- a/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModelTest.kt
@@ -72,7 +72,7 @@ class AnnotationSearchViewModelTest {
         override fun observeAnnotations(sourceId: String, itemId: String) = MutableStateFlow(emptyList<Annotation>())
         override fun observeAnnotationsForSource(sourceId: String) =
             annotationsFlow.map { all -> all.filter { it.sourceId == sourceId } }
-        override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.models.EmbeddedFigure>?, originFontFamily: String) = error("unused")
+        override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.models.EmbeddedFigure>?, originFontFamily: String, textSnippetHtml: String?) = error("unused")
         override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String, originFontFamily: String) = error("unused")
         override suspend fun createImageAnnotation(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, imageHref: String?, imageSvg: String?, imageBytes: String?, color: String) = error("unused")
         override suspend fun upgradeImageToCaptionHighlight(

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
@@ -81,7 +81,7 @@ class LibraryFilterEngineTest {
         override fun observeAnnotations(sourceId: String, itemId: String) = MutableStateFlow(emptyList<com.riffle.core.models.Annotation>())
         override fun observeAnnotationsForSource(sourceId: String) =
             annotationsFlow.map { all -> all.filter { it.sourceId == sourceId } }
-        override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.models.EmbeddedFigure>?, originFontFamily: String) = error("unused")
+        override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.models.EmbeddedFigure>?, originFontFamily: String, textSnippetHtml: String?) = error("unused")
         override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String, originFontFamily: String) = error("unused")
         override suspend fun createImageAnnotation(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, imageHref: String?, imageSvg: String?, imageBytes: String?, color: String) = error("unused")
         override suspend fun upgradeImageToCaptionHighlight(

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -84,7 +84,7 @@ class LibraryItemsViewModelTest {
             override fun observeAnnotations(sourceId: String, itemId: String) = MutableStateFlow(emptyList<com.riffle.core.models.Annotation>())
             override fun observeAnnotationsForSource(sourceId: String) =
                 annotationsFlow.map { all -> all.filter { it.sourceId == sourceId } }
-            override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.models.EmbeddedFigure>?, originFontFamily: String) = error("unused")
+            override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.models.EmbeddedFigure>?, originFontFamily: String, textSnippetHtml: String?) = error("unused")
             override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String, originFontFamily: String) = error("unused")
             override suspend fun createImageAnnotation(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, imageHref: String?, imageSvg: String?, imageBytes: String?, color: String) = error("unused")
             override suspend fun upgradeImageToCaptionHighlight(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
@@ -42,6 +42,7 @@ class BookmarksControllerTest {
             spineIndex: Int, progression: Double,
             embeddedFigures: List<com.riffle.core.models.EmbeddedFigure>?,
             originFontFamily: String,
+            textSnippetHtml: String?,
         ): Annotation {
             val a = Annotation(
                 id = "highlight-${created.size}",

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
@@ -737,9 +737,7 @@ class HighlightsPublicationFactoryTest {
             urlFactory = ::testUrlFactory,
         )
         val html = readChapterHtml(pub, 0)
-        assertTrue("underline in text-decoration", html.contains("underline"))
-        assertTrue("line-through in text-decoration", html.contains("line-through"))
-        assertTrue("text-decoration property present", html.contains("text-decoration"))
+        assertTrue("combined text-decoration value", html.contains("text-decoration:underline line-through"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
@@ -1,11 +1,13 @@
 package com.riffle.app.feature.reader.highlights
 
 import android.net.FakeUri
+import com.riffle.app.feature.reader.joinEmphasisStylesToHighlights
 import com.riffle.app.feature.reader.toCssRgba
 import com.riffle.core.database.AnnotationEntity
 import com.riffle.core.models.HighlightColor
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.readium.r2.shared.ExperimentalReadiumApi
@@ -553,6 +555,7 @@ class HighlightsPublicationFactoryTest {
         color: String = AnnotationEntity.COLOR_YELLOW,
         originFontFamily: String? = null,
         textSnippetHtml: String? = null,
+        emphasisStyles: String? = null,
     ): AnnotationEntity =
         AnnotationEntity(
             id = id,
@@ -572,6 +575,7 @@ class HighlightsPublicationFactoryTest {
             lastModifiedByDeviceId = "test",
             originFontFamily = originFontFamily,
             textSnippetHtml = textSnippetHtml,
+            emphasisStyles = emphasisStyles,
         )
 
     // ===== textSnippetHtml render + sanitizer =====
@@ -651,6 +655,150 @@ class HighlightsPublicationFactoryTest {
         assertTrue("href attribute stripped", !html.contains("http://evil"))
         // Text content of stripped tags is preserved.
         assertTrue("text of stripped <a> preserved", html.contains("hi"))
+    }
+
+    // ===== emphasis styles (Case 2 — user-applied B/I/U/S) =====
+
+    @Test
+    fun noColorHighlightUsesNeutralGrayBar() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "Ch",
+                    listOf(hl(id = "h1", snippet = "plain text", color = "")),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val html = readChapterHtml(pub, 0)
+        assertTrue("border-left still present for empty color", html.contains("border-left"))
+        assertTrue("neutral gray bar color", html.contains(EMPHASIS_ONLY_BAR_COLOR))
+    }
+
+    @Test
+    fun colorHighlightUsesAccentColorNotGray() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "Ch",
+                    listOf(hl(id = "h1", snippet = "text", color = AnnotationEntity.COLOR_YELLOW)),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val html = readChapterHtml(pub, 0)
+        assertTrue("border-left present", html.contains("border-left"))
+        assertTrue("palette color used, not gray", !html.contains(EMPHASIS_ONLY_BAR_COLOR))
+    }
+
+    @Test
+    fun emphasisStylesBoldAndItalicAppliedToSpan() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "Ch",
+                    listOf(
+                        hl(
+                            id = "h1",
+                            snippet = "formatted text",
+                            color = "",
+                            emphasisStyles = "bold,italic",
+                        ),
+                    ),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val html = readChapterHtml(pub, 0)
+        assertTrue("font-weight:bold in span style", html.contains("font-weight:bold"))
+        assertTrue("font-style:italic in span style", html.contains("font-style:italic"))
+    }
+
+    @Test
+    fun emphasisStylesUnderlineAndStrikeAppliedToSpan() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "Ch",
+                    listOf(
+                        hl(
+                            id = "h1",
+                            snippet = "formatted text",
+                            color = "green",
+                            emphasisStyles = "underline,strike",
+                        ),
+                    ),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val html = readChapterHtml(pub, 0)
+        assertTrue("underline in text-decoration", html.contains("underline"))
+        assertTrue("line-through in text-decoration", html.contains("line-through"))
+        assertTrue("text-decoration property present", html.contains("text-decoration"))
+    }
+
+    @Test
+    fun noEmphasisStylesEmitsNoStyleAttr() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "Ch",
+                    listOf(hl(id = "h1", snippet = "plain", emphasisStyles = null)),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val html = readChapterHtml(pub, 0)
+        // riffle-hl span should have no style attribute when there are no emphasis styles
+        val spanIdx = html.indexOf("class=\"riffle-hl\"")
+        assertTrue("riffle-hl span found", spanIdx >= 0)
+        val afterSpan = html.indexOf('>', spanIdx)
+        val spanTag = html.substring(spanIdx, afterSpan)
+        assertTrue("no style attr on riffle-hl span", !spanTag.contains("style="))
+    }
+
+    // ===== joinEmphasisStylesToHighlights =====
+
+    @Test
+    fun joinEmphasisStylesToHighlightsJoinsEmphasisOntoHighlight() {
+        val highlight = AnnotationEntity(
+            id = "h1", sourceId = "S", itemId = "B",
+            type = AnnotationEntity.TYPE_HIGHLIGHT,
+            cfi = "epubcfi(/6/2!/1)", textSnippet = "text", chapterHref = "ch.xhtml",
+            createdAt = 0L, updatedAt = 0L,
+            originDeviceId = "d", lastModifiedByDeviceId = "d",
+        )
+        val emphasis = AnnotationEntity(
+            id = "e1", sourceId = "S", itemId = "B",
+            type = AnnotationEntity.TYPE_EMPHASIS,
+            cfi = "epubcfi(/6/2!/1)", textSnippet = "text", chapterHref = "ch.xhtml",
+            createdAt = 0L, updatedAt = 0L,
+            originDeviceId = "d", lastModifiedByDeviceId = "d",
+            emphasisStyles = "bold,italic",
+        )
+        val result = joinEmphasisStylesToHighlights(listOf(highlight, emphasis))
+        val joinedHighlight = result.first { it.id == "h1" }
+        assertEquals("emphasis styles joined onto highlight", "bold,italic", joinedHighlight.emphasisStyles)
+    }
+
+    @Test
+    fun joinEmphasisStylesToHighlightsNoOpWhenNoEmphasisRows() {
+        val highlight = AnnotationEntity(
+            id = "h1", sourceId = "S", itemId = "B",
+            type = AnnotationEntity.TYPE_HIGHLIGHT,
+            cfi = "epubcfi(/6/2!/1)", textSnippet = "text", chapterHref = "ch.xhtml",
+            createdAt = 0L, updatedAt = 0L,
+            originDeviceId = "d", lastModifiedByDeviceId = "d",
+        )
+        val result = joinEmphasisStylesToHighlights(listOf(highlight))
+        val joinedHighlight = result.first { it.id == "h1" }
+        assertNull("emphasisStyles stays null when no emphasis rows", joinedHighlight.emphasisStyles)
     }
 
     private fun readChapterHtml(pub: Publication, index: Int): String {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
@@ -552,6 +552,7 @@ class HighlightsPublicationFactoryTest {
         progression: Double = 0.0,
         color: String = AnnotationEntity.COLOR_YELLOW,
         originFontFamily: String? = null,
+        textSnippetHtml: String? = null,
     ): AnnotationEntity =
         AnnotationEntity(
             id = id,
@@ -570,7 +571,87 @@ class HighlightsPublicationFactoryTest {
             originDeviceId = "test",
             lastModifiedByDeviceId = "test",
             originFontFamily = originFontFamily,
+            textSnippetHtml = textSnippetHtml,
         )
+
+    // ===== textSnippetHtml render + sanitizer =====
+
+    @Test
+    fun rendersInlineFormattedSnippetHtmlWhenPresent() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "Chapter One",
+                    listOf(
+                        hl(
+                            id = "h1",
+                            snippet = "italic bit here",
+                            textSnippetHtml = "<em>italic bit</em> here",
+                        ),
+                    ),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val html = readChapterHtml(pub, 0)
+        assertTrue("render uses formatted HTML span", html.contains("<em>italic bit</em> here"))
+        assertTrue("plaintext snippet is NOT emitted separately", !html.contains(">italic bit here<"))
+    }
+
+    @Test
+    fun fallsBackToPlainTextSnippetWhenHtmlIsNull() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "Chapter One",
+                    listOf(hl(id = "h1", snippet = "plain excerpt", textSnippetHtml = null)),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val html = readChapterHtml(pub, 0)
+        assertTrue("plain snippet still rendered", html.contains(">plain excerpt<"))
+        assertTrue("no stray <em>", !html.contains("<em>"))
+    }
+
+    @Test
+    fun stripsDisallowedTagsAndAttributesFromSnippetHtml() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "Chapter One",
+                    listOf(
+                        hl(
+                            id = "h1",
+                            snippet = "hello world",
+                            // Simulates a malicious/legacy value in the DB: an <a onclick> tag,
+                            // an <em class="…"> with attributes, and a <script> block that must
+                            // be dropped entirely by the render-side allowlist.
+                            textSnippetHtml =
+                                "<a href=\"http://evil\" onclick=\"x()\">hi</a> " +
+                                    "<em class=\"x\">world</em>" +
+                                    "<script>alert(1)</script>",
+                        ),
+                    ),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val html = readChapterHtml(pub, 0)
+        assertTrue("attribute-less <em> survives", html.contains("<em>world</em>"))
+        assertTrue("<a> stripped", !html.contains("<a "))
+        assertTrue("<a> stripped (closing)", !html.contains("</a>"))
+        assertTrue("<script> stripped", !html.contains("<script"))
+        // Note: the accent-bar tap span emits its own onclick — assert on the injected payload,
+        // not the presence of the substring "onclick" in the chapter HTML overall.
+        assertTrue("injected onclick payload stripped", !html.contains("x()"))
+        assertTrue("href attribute stripped", !html.contains("http://evil"))
+        // Text content of stripped tags is preserved.
+        assertTrue("text of stripped <a> preserved", html.contains("hi"))
+    }
 
     private fun readChapterHtml(pub: Publication, index: Int): String {
         val link = pub.readingOrder[index]

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -71,6 +71,7 @@ class AnnotationSessionTest {
             spineIndex: Int, progression: Double,
             embeddedFigures: List<com.riffle.core.models.EmbeddedFigure>?,
             originFontFamily: String,
+            textSnippetHtml: String?,
         ): Annotation {
             createHighlightCalls.add(
                 CreateHighlightArgs(sourceId, itemId, cfi, textSnippet, chapterHref, textBefore, textAfter, color, spineIndex, progression, originFontFamily)

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -156,6 +156,7 @@ class ReaderSessionLifecycleTest {
             textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double,
             embeddedFigures: List<com.riffle.core.models.EmbeddedFigure>?,
             originFontFamily: String,
+            textSnippetHtml: String?,
         ): Annotation = error("not needed")
         override suspend fun createBookmark(
             sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String,

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationMergeOrchestrator.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationMergeOrchestrator.kt
@@ -159,6 +159,16 @@ internal class AnnotationMergeOrchestrator(
                     // didn't emit the styles token leaves the column null; that combined with
                     // type=TYPE_EMPHASIS is an inert row the renderer ignores.
                     emphasisStyles = w3cAnnotation.emphasisStyles ?: existing?.emphasisStyles,
+                    // originFontFamily is not on the W3C wire format — preserve the local value
+                    // across sync round-trips. Without this, every merge rewrites healed/probed
+                    // rows to null, plurality in the elided view returns null, and excerpts fall
+                    // back to browser-default serif (the "reload reverts to serif" bug that
+                    // survived two prior render-side fixes: #571 and #578).
+                    originFontFamily = existing?.originFontFamily,
+                    // textSnippetHtml is not on the W3C wire format either — preserve local so
+                    // sync round-trips don't flatten the excerpt back to plaintext and drop the
+                    // publisher's inline formatting (<em>, <b>, <sup>, …) from the elided view.
+                    textSnippetHtml = existing?.textSnippetHtml,
                 )
             }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
@@ -64,6 +64,7 @@ class AnnotationStoreImpl(
         progression: Double,
         embeddedFigures: List<EmbeddedFigure>?,
         originFontFamily: String,
+        textSnippetHtml: String?,
     ): Annotation {
         require(originFontFamily.isNotBlank()) {
             "originFontFamily must be non-blank for locally-created highlights (issue #484)"
@@ -92,6 +93,7 @@ class AnnotationStoreImpl(
             deleted = false,
             embeddedFigures = embeddedFigures.toEntityJson(),
             originFontFamily = originFontFamily,
+            textSnippetHtml = textSnippetHtml,
         )
         dao.upsert(entity)
         return entity.toDomain()
@@ -453,6 +455,7 @@ internal fun Annotation.toEntity() = AnnotationEntity(
     imageBytes = imageBytes,
     originFontFamily = originFontFamily,
     emphasisStyles = EmphasisStyle.encode(emphasisStyles.orEmpty()),
+    textSnippetHtml = textSnippetHtml,
 )
 
 internal fun AnnotationEntity.toDomain() = Annotation(
@@ -478,4 +481,5 @@ internal fun AnnotationEntity.toDomain() = Annotation(
     imageBytes = imageBytes,
     originFontFamily = originFontFamily,
     emphasisStyles = EmphasisStyle.decode(emphasisStyles),
+    textSnippetHtml = textSnippetHtml,
 )

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -98,6 +98,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_55_56,
                 RiffleDatabase.MIGRATION_56_57,
                 RiffleDatabase.MIGRATION_57_58,
+                RiffleDatabase.MIGRATION_58_59,
             )
             .build()
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
@@ -859,6 +859,67 @@ class AnnotationSyncControllerLifecycleTest {
         assertEquals("cross-device: adopt peer chapterHref via extension", "c1", upserted.chapterHref)
     }
 
+    // ===== Fix 4: syncOnOpen preserves originFontFamily on existing rows =====
+
+    @Test
+    fun `syncOnOpen preserves originFontFamily on existing rows`() = runTest {
+        // Seed Room with a highlight whose originFontFamily has been captured/healed to the real
+        // publisher face (issue #484 pipeline). The W3C wire format does NOT carry this column,
+        // so a naive rebuild of the entity from the parsed W3CAnnotation drops the value — every
+        // sync round-trip then rewrites the row with originFontFamily = null, plurality in the
+        // elided view returns null, and excerpts fall back to browser-default serif. That's the
+        // "reload elided view → serif" regression that survived two prior render-side fixes
+        // (#571 and #578). Regression: originFontFamily must survive the sync round-trip.
+        val publisherFont = "Nimbusromno9l"
+        val local = highlightEntity("uuid-font-preserve", updatedAt = 1000L)
+            .copy(originFontFamily = publisherFont)
+        dao.localAnnotations += local
+
+        // Own device's file on WebDAV (right after a push): same id, same updatedAt, same
+        // deviceId — same setup as the chapterHref / spineIndex preservation tests above.
+        target.files["annotations-own.jsonld"] = jsonArrayOf(
+            w3c("uuid-font-preserve", updatedAt = 1000L, deviceId = DEVICE_ID),
+        )
+
+        newController().syncOnOpen(SRV, NS, ITEM)
+
+        val upserted = dao.upserts.single { it.id == "uuid-font-preserve" }
+        assertEquals(
+            "originFontFamily must survive the sync round-trip",
+            publisherFont,
+            upserted.originFontFamily,
+        )
+    }
+
+    // ===== Fix 5: syncOnOpen preserves textSnippetHtml on existing rows =====
+
+    @Test
+    fun `syncOnOpen preserves textSnippetHtml on existing rows`() = runTest {
+        // Seed Room with a highlight whose textSnippetHtml carries publisher inline formatting
+        // (issue: elided view drops italics). The W3C wire format does NOT carry this column,
+        // so a naive rebuild of the entity from the parsed W3CAnnotation drops the value and
+        // every sync round-trip rewrites the row with textSnippetHtml = null — the elided view
+        // then flattens the excerpt back to plaintext and italic spans disappear on reload.
+        // Regression: textSnippetHtml must survive the sync round-trip.
+        val formatted = "<em>italic bit</em> here"
+        val local = highlightEntity("uuid-html-preserve", updatedAt = 1000L)
+            .copy(textSnippetHtml = formatted)
+        dao.localAnnotations += local
+
+        target.files["annotations-own.jsonld"] = jsonArrayOf(
+            w3c("uuid-html-preserve", updatedAt = 1000L, deviceId = DEVICE_ID),
+        )
+
+        newController().syncOnOpen(SRV, NS, ITEM)
+
+        val upserted = dao.upserts.single { it.id == "uuid-html-preserve" }
+        assertEquals(
+            "textSnippetHtml must survive the sync round-trip",
+            formatted,
+            upserted.textSnippetHtml,
+        )
+    }
+
     // ===== stamp + report + enqueue-on-failure =====
 
     @Test

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/59.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/59.json
@@ -1,0 +1,1901 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 59,
+    "identityHash": "09ecbbe04b52643ff7e2a5f76a49d798",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER NOT NULL, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, `pageCount` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesSequence",
+            "columnName": "seriesSequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "scope"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, `originFontFamily` TEXT, `emphasisStyles` TEXT, `textSnippetHtml` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedFigures",
+            "columnName": "embeddedFigures",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageHref",
+            "columnName": "imageHref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageSvg",
+            "columnName": "imageSvg",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBytes",
+            "columnName": "imageBytes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originFontFamily",
+            "columnName": "originFontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "emphasisStyles",
+            "columnName": "emphasisStyles",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippetHtml",
+            "columnName": "textSnippetHtml",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "local_files_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `treeUri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `addedAtEpochMs` INTEGER NOT NULL, `libraryId` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `treeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtEpochMs",
+            "columnName": "addedAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "treeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `originalUri` TEXT NOT NULL, `copiedPath` TEXT NOT NULL, `coverPath` TEXT, `format` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `mtimeEpochMs` INTEGER NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUri",
+            "columnName": "originalUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "copiedPath",
+            "columnName": "copiedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtimeEpochMs",
+            "columnName": "mtimeEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_files_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_file_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `folderTreeUri` TEXT NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`, `folderTreeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderTreeUri",
+            "columnName": "folderTreeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId",
+            "folderTreeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_file_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_local_files_file_folders_sourceId_folderTreeUri",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "folderTreeUri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId_folderTreeUri` ON `${TABLE_NAME}` (`sourceId`, `folderTreeUri`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_item_freshness",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `lastFetchedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFetchedAt",
+            "columnName": "lastFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `rootId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootId",
+            "columnName": "rootId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_playlists_rootId",
+            "unique": false,
+            "columnNames": [
+              "rootId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_rootId` ON `${TABLE_NAME}` (`rootId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `orderIndex` INTEGER NOT NULL, PRIMARY KEY(`playlistId`, `sourceId`, `itemId`), FOREIGN KEY(`sourceId`, `playlistId`) REFERENCES `playlists`(`sourceId`, `id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "orderIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId",
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_items_sourceId_playlistId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_items_sourceId_playlistId` ON `${TABLE_NAME}` (`sourceId`, `playlistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId",
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "sourceId",
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '09ecbbe04b52643ff7e2a5f76a49d798')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1919,7 +1919,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 58, true,
+            TEST_DB, 59, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -1977,6 +1977,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_55_56,
             RiffleDatabase.MIGRATION_56_57,
             RiffleDatabase.MIGRATION_57_58,
+            RiffleDatabase.MIGRATION_58_59,
         )
 
         db.query("SELECT url, username, serverType, absUserId, type FROM sources WHERE id = 's1'").use { cursor ->
@@ -2700,6 +2701,69 @@ class MigrationTest {
         }
         db.query("SELECT COUNT(*) FROM playlist_items").use { c ->
             assertTrue(c.moveToFirst()); assertEquals(0, c.getInt(0))
+        }
+
+        db.close()
+    }
+
+    // v58 → v59 adds `textSnippetHtml` (nullable TEXT) to `annotations` so the elided view can
+    // render publisher inline formatting (<em>/<i>/<strong>/<b>/<sup>/<sub>/<u>/<s>) in each
+    // excerpt (issue: elided view drops italics). Legacy rows keep their text; new column
+    // defaults NULL and only receives values from the reader's selection extractor on new
+    // highlights created after the migration.
+    @Test
+    fun migration58To59_addsAnnotationsTextSnippetHtmlColumn() {
+        helper.createDatabase(TEST_DB, 58).apply {
+            execSQL(
+                "INSERT INTO sources (id, url, isActive, insecureConnectionAllowed, username, serverType, absUserId, type) " +
+                    "VALUES ('s1', 'http://abs', 1, 0, '', 'AUDIOBOOKSHELF', NULL, 'ABS')"
+            )
+            execSQL(
+                """
+                INSERT INTO annotations
+                  (id, sourceId, itemId, type, cfi, color, note, textSnippet, textBefore, textAfter,
+                   chapterHref, spineIndex, progression, bookmarkTitle, createdAt, updatedAt,
+                   originDeviceId, lastModifiedByDeviceId, deleted, lastSyncedAt,
+                   embeddedFigures, imageHref, imageSvg, imageBytes, originFontFamily, emphasisStyles)
+                VALUES
+                  ('a-legacy','s1','i1','HIGHLIGHT','epubcfi(/6/2!/4/2,/1:0,/1:6)','yellow',NULL,
+                   'italic text','','','ch1.xhtml',0,0.4,'',1000,1000,'d1','d1',0,0,
+                   NULL,NULL,NULL,NULL,NULL,NULL)
+                """.trimIndent()
+            )
+            close()
+        }
+
+        val db = helper.runMigrationsAndValidate(TEST_DB, 59, true, RiffleDatabase.MIGRATION_58_59)
+
+        db.query(
+            "SELECT id, textSnippet, textSnippetHtml FROM annotations WHERE id = 'a-legacy'"
+        ).use { c ->
+            assertEquals(1, c.count)
+            assertTrue(c.moveToFirst())
+            assertEquals("a-legacy", c.getString(0))
+            assertEquals("italic text", c.getString(1))
+            assertTrue("legacy row has textSnippetHtml = NULL after migration", c.isNull(2))
+        }
+
+        // New row round-trips a formatted HTML snippet (sanitised allowlist output shape).
+        db.execSQL(
+            """
+            INSERT INTO annotations
+              (id, sourceId, itemId, type, cfi, color, note, textSnippet, textBefore, textAfter,
+               chapterHref, spineIndex, progression, bookmarkTitle, createdAt, updatedAt,
+               originDeviceId, lastModifiedByDeviceId, deleted, lastSyncedAt,
+               embeddedFigures, imageHref, imageSvg, imageBytes, originFontFamily, emphasisStyles,
+               textSnippetHtml)
+            VALUES
+              ('a-formatted','s1','i1','HIGHLIGHT','epubcfi(/6/2!/4/2,/1:0,/1:12)','yellow',NULL,
+               'italic bit here','','','ch1.xhtml',0,0.5,'',2000,2000,'d1','d1',0,0,
+               NULL,NULL,NULL,NULL,NULL,NULL,'<em>italic bit</em> here')
+            """.trimIndent()
+        )
+        db.query("SELECT textSnippetHtml FROM annotations WHERE id = 'a-formatted'").use { c ->
+            assertTrue(c.moveToFirst())
+            assertEquals("<em>italic bit</em> here", c.getString(0))
         }
 
         db.close()

--- a/core/database/src/main/kotlin/com/riffle/core/database/AnnotationEntity.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/AnnotationEntity.kt
@@ -82,6 +82,15 @@ data class AnnotationEntity(
      * Null (or empty) on every other type. See ADR 0046.
      */
     val emphasisStyles: String? = null,
+    /**
+     * The highlight's excerpt as sanitised inline HTML, preserving publisher inline formatting
+     * (`<em>`, `<i>`, `<strong>`, `<b>`, `<sup>`, `<sub>`, `<u>`, `<s>`) captured from the source
+     * EPUB DOM at annotation-create time. Rendered by the Annotations View in place of the plain
+     * [textSnippet] so italicised / bolded spans survive round-trip into the elided reader.
+     * Nullable — legacy rows and rows received via W3C sync (wire format doesn't carry this) fall
+     * back to the plain-text render path in [HighlightsPublicationFactory].
+     */
+    val textSnippetHtml: String? = null,
 ) {
     companion object {
         const val TYPE_HIGHLIGHT = "HIGHLIGHT"

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -34,7 +34,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         PlaylistEntity::class,
         PlaylistItemEntity::class,
     ],
-    version = 58,
+    version = 59,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -1619,6 +1619,18 @@ abstract class RiffleDatabase : RoomDatabase() {
                     "CREATE INDEX IF NOT EXISTS `index_playlist_items_sourceId_playlistId` " +
                         "ON `playlist_items` (`sourceId`, `playlistId`)"
                 )
+            }
+        }
+
+        // textSnippetHtml preserves the highlight's inline publisher formatting (<em>, <i>,
+        // <strong>, <b>, <sup>, <sub>, <u>, <s>) captured from the source EPUB DOM at
+        // annotation-create time so the elided view can render italicised / bold spans in each
+        // excerpt instead of flattening the selection to plain text. Nullable so legacy rows
+        // and sync-received rows (W3C wire format doesn't carry it) fall back to the plain
+        // textSnippet render path.
+        val MIGRATION_58_59 = object : Migration(58, 59) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `annotations` ADD COLUMN `textSnippetHtml` TEXT DEFAULT NULL")
             }
         }
     }

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationStore.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AnnotationStore.kt
@@ -45,6 +45,13 @@ interface AnnotationStore {
          *  write path must resolve this from the WebView's `getComputedStyle` at selection
          *  time and fall back to the book's body font — never null in production. */
         originFontFamily: String,
+        /** Sanitised inline HTML of the selection preserving publisher formatting (`<em>`, `<i>`,
+         *  `<strong>`, `<b>`, `<sup>`, `<sub>`, `<u>`, `<s>`). Rendered by the Annotations View
+         *  in place of the plain [textSnippet] so italicised / bolded spans survive into the
+         *  elided reader. Nullable — the reader's selection tracker may not always resolve HTML
+         *  (e.g. programmatic caption highlights, sync round-trips), in which case the plaintext
+         *  fallback renders. */
+        textSnippetHtml: String? = null,
     ): Annotation
 
     suspend fun createBookmark(

--- a/core/models/src/main/kotlin/com/riffle/core/models/Annotation.kt
+++ b/core/models/src/main/kotlin/com/riffle/core/models/Annotation.kt
@@ -34,6 +34,13 @@ data class Annotation(
      * `null` on every other type. Persisted as a comma-separated token string on the entity.
      */
     val emphasisStyles: Set<EmphasisStyle>? = null,
+    /**
+     * Sanitised inline HTML of the excerpt preserving publisher formatting (`<em>`, `<i>`, `<strong>`,
+     * `<b>`, `<sup>`, `<sub>`, `<u>`, `<s>`). The Annotations View renders this in place of the
+     * plain [textSnippet] when present so italicised / bolded spans survive into the elided
+     * reader. Nullable — legacy rows and rows received via W3C sync fall back to plaintext.
+     */
+    val textSnippetHtml: String? = null,
 )
 
 /**


### PR DESCRIPTION
## What changed

**1. Publisher italic / inline HTML preserved in elided view**

When a selection contains inline HTML (`<em>`, `<i>`, etc.), the captured `textSnippetHtml` column is now used as the inner content of the `riffle-hl` span in the synthesised XHTML. Previously the plain-text snippet was always used, stripping italic formatting.

**2. User emphasis styles (B / I / U / S) rendered in elided view**

A new `joinEmphasisStylesToHighlights` helper copies `emphasisStyles` from paired `TYPE_EMPHASIS` rows onto their sibling `TYPE_HIGHLIGHT` rows (matched by CFI) before the elision build. `appendEmphasisStyleAttr` then emits the corresponding CSS (`font-weight:bold`, `font-style:italic`, `text-decoration:underline line-through`) on the `riffle-hl` span.

**3. No-color annotations use a neutral gray bar**

Annotations with no color (`color = ""`) now render a light gray left-border (`rgba(128,128,128,0.20)`) instead of falling through to the yellow default. The fix covers both the baked XHTML (`appendTextHighlight`, `appendHighlightTextChunk`, `appendFigureFigure`, interleaved note aside) and the live DOM recolor patch (`highlightAccentCssRgba`).

## Tests added

- `noColorHighlightUsesNeutralGrayBar`
- `colorHighlightUsesAccentColorNotGray`
- `emphasisStylesBoldAndItalicAppliedToSpan`
- `emphasisStylesUnderlineAndStrikeAppliedToSpan` — pinned as combined `text-decoration:underline line-through`
- `noEmphasisStylesEmitsNoStyleAttr`
- `joinEmphasisStylesToHighlightsJoinsEmphasisOntoHighlight`
- `joinEmphasisStylesToHighlightsNoOpWhenNoEmphasisRows`

## Review notes

The `sameById` fast-path in `ensureHighlightsObserver` won't re-render if emphasis changes while the elided view is open. Out-of-scope here because the elided view is read-only XHTML — the user cannot edit annotations while it is shown.