### PR TITLE
fix(nav): close burger-tap white-screen freeze via drawer BackHandler animation gap

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -163,7 +163,14 @@ fun MainScreen(
     // Material3's ModalNavigationDrawer doesn't install its own BackHandler — so when the
     // drawer is open we add one here. Registered above the NavHost so screen-level handlers
     // (e.g. LibraryItemsScreen) don't override it.
-    BackHandler(enabled = !usePermanentDrawer && drawerState.isOpen) {
+    //
+    // Gate on targetValue, not isOpen: `isOpen` (== currentValue == Open) only flips true after
+    // the open animation completes, leaving a mid-animation window during which Back falls
+    // through to the NavHost callback and pops the library entry. That surfaces HOME, whose
+    // LaunchedEffect re-runs getStartDestination() — and any transient hang there leaves the
+    // user on a permanent white-with-spinner screen (see PR #156 for the prior form of this
+    // race, which used to blank the NavHost outright before HOME became a permanent base).
+    BackHandler(enabled = shouldInterceptBackForDrawer(usePermanentDrawer, drawerState.targetValue == DrawerValue.Open)) {
         scope.launch { drawerState.close() }
     }
 
@@ -896,6 +903,16 @@ internal fun NavController.navigateAsRoot(route: String) {
         launchSingleTop = true
     }
 }
+
+/**
+ * Whether the top-level BackHandler should intercept Back and close the drawer instead of
+ * letting the NavHost pop the current destination.
+ *
+ * Extracted so the rule is unit-testable at the JVM level (the call site's use of
+ * `drawerState.targetValue == DrawerValue.Open` is what pins Back-during-open-animation).
+ */
+internal fun shouldInterceptBackForDrawer(usePermanentDrawer: Boolean, drawerTargetOpen: Boolean): Boolean =
+    !usePermanentDrawer && drawerTargetOpen
 
 internal fun isReaderRoute(route: String?): Boolean =
     route?.startsWith(EPUB_READER.substringBefore("{")) == true ||

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -161,16 +161,19 @@ fun MainScreen(
     val hidePermanentDrawerPanel = isReaderRoute(currentRoute)
 
     // Material3's ModalNavigationDrawer doesn't install its own BackHandler — so when the
-    // drawer is open we add one here. Registered above the NavHost so screen-level handlers
-    // (e.g. LibraryItemsScreen) don't override it.
+    // drawer is open or animating we add one here. Registered above the NavHost so screen-level
+    // handlers (e.g. LibraryItemsScreen) don't override it.
     //
-    // Gate on targetValue, not isOpen: `isOpen` (== currentValue == Open) only flips true after
-    // the open animation completes, leaving a mid-animation window during which Back falls
-    // through to the NavHost callback and pops the library entry. That surfaces HOME, whose
-    // LaunchedEffect re-runs getStartDestination() — and any transient hang there leaves the
-    // user on a permanent white-with-spinner screen (see PR #156 for the prior form of this
-    // race, which used to blank the NavHost outright before HOME became a permanent base).
-    BackHandler(enabled = shouldInterceptBackForDrawer(usePermanentDrawer, drawerState.targetValue == DrawerValue.Open)) {
+    // Check both currentValue and targetValue: targetValue flips to Open the instant
+    // drawerState.open() is called (catches Back during the open animation), and currentValue
+    // stays Open until the close animation finishes (catches Back during the close animation).
+    // Using only targetValue misses the close-animation window; using only isOpen (currentValue)
+    // misses the open-animation window that caused the burger-tap white-screen freeze.
+    BackHandler(enabled = shouldInterceptBackForDrawer(
+        usePermanentDrawer,
+        drawerCurrentOpen = drawerState.currentValue == DrawerValue.Open,
+        drawerTargetOpen = drawerState.targetValue == DrawerValue.Open,
+    )) {
         scope.launch { drawerState.close() }
     }
 
@@ -536,7 +539,11 @@ fun MainScreen(
                 LibraryItemsScreen(
                     libraryName = libraryName,
                     onOpenDrawer = { scope.launch { drawerState.open() } },
-                    backEnabled = !drawerState.isOpen,
+                    backEnabled = !shouldInterceptBackForDrawer(
+                        usePermanentDrawer,
+                        drawerCurrentOpen = drawerState.currentValue == DrawerValue.Open,
+                        drawerTargetOpen = drawerState.targetValue == DrawerValue.Open,
+                    ),
                     onSeriesSelected = { series ->
                         navController.navigate(seriesDetailRoute(libraryId, series.id, series.name))
                     },
@@ -905,14 +912,20 @@ internal fun NavController.navigateAsRoot(route: String) {
 }
 
 /**
- * Whether the top-level BackHandler should intercept Back and close the drawer instead of
- * letting the NavHost pop the current destination.
+ * Whether the top-level BackHandler (and the library screen's backEnabled) should intercept
+ * Back and close the drawer instead of letting the NavHost pop the current destination.
  *
- * Extracted so the rule is unit-testable at the JVM level (the call site's use of
- * `drawerState.targetValue == DrawerValue.Open` is what pins Back-during-open-animation).
+ * Both [drawerCurrentOpen] and [drawerTargetOpen] must be checked:
+ * - [drawerTargetOpen] flips true the instant `drawerState.open()` is called → covers Back
+ *   pressed during the open animation.
+ * - [drawerCurrentOpen] stays true until the close animation finishes → covers Back pressed
+ *   during the close animation (targetValue is already Closed at that point).
  */
-internal fun shouldInterceptBackForDrawer(usePermanentDrawer: Boolean, drawerTargetOpen: Boolean): Boolean =
-    !usePermanentDrawer && drawerTargetOpen
+internal fun shouldInterceptBackForDrawer(
+    usePermanentDrawer: Boolean,
+    drawerCurrentOpen: Boolean,
+    drawerTargetOpen: Boolean,
+): Boolean = !usePermanentDrawer && (drawerCurrentOpen || drawerTargetOpen)
 
 internal fun isReaderRoute(route: String?): Boolean =
     route?.startsWith(EPUB_READER.substringBefore("{")) == true ||

--- a/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
@@ -7,33 +7,50 @@ import org.junit.Test
 /**
  * Pins the fix for the burger-tap freeze (permanent white-screen-with-spinner):
  *
- * Before, the top-level drawer BackHandler was gated on `drawerState.isOpen`, which reads
- * `currentValue == Open` — only true after the open animation completes. A Back pressed during
- * the animation window fell through to the NavHost callback, popped the library entry, and
- * surfaced HOME; HOME's LaunchedEffect re-ran getStartDestination(), and any transient hang
- * inside wedged the app on a white spinner with no escape.
+ * The top-level drawer BackHandler was originally gated on `drawerState.isOpen`
+ * (== currentValue == Open), which only becomes true after the open animation completes.
+ * A Back pressed during the open-animation window fell through to the NavHost callback,
+ * popped the library entry, surfaced HOME, and any transient hang in getStartDestination()
+ * wedged the app on a white spinner with no escape.
  *
- * The fix gates on `drawerState.targetValue == Open` — which flips true the instant
- * `drawerState.open()` is invoked from the burger tap. This test locks in the pure decision;
- * `MainScreen.kt`'s call site must pass `targetValue == DrawerValue.Open` into the second
- * argument. If someone flips it back to `isOpen`, the composable's expression stops mapping to
- * "target open," but the intent still holds only if the predicate contract stays as tested here.
+ * The fix gates on BOTH currentValue and targetValue:
+ * - targetValue flips to Open the instant drawerState.open() is called → catches Back
+ *   during the open animation.
+ * - currentValue stays Open until the close animation completes → catches Back during
+ *   the close animation (targetValue is already Closed at that point, so isOpen alone
+ *   would miss it in the opposite direction).
+ *
+ * The same predicate also gates LibraryItemsScreen's backEnabled, because that child
+ * BackHandler has LIFO priority over the top-level handler and would otherwise intercept
+ * Back first during the animation windows.
  */
 class ShouldInterceptBackForDrawerTest {
 
     @Test
-    fun `intercepts when drawer is targeting open on a phone (modal drawer)`() {
-        assertTrue(shouldInterceptBackForDrawer(usePermanentDrawer = false, drawerTargetOpen = true))
+    fun `intercepts when drawer is fully open on a phone`() {
+        assertTrue(shouldInterceptBackForDrawer(usePermanentDrawer = false, drawerCurrentOpen = true, drawerTargetOpen = true))
     }
 
     @Test
-    fun `does not intercept when drawer is targeting closed`() {
-        assertFalse(shouldInterceptBackForDrawer(usePermanentDrawer = false, drawerTargetOpen = false))
+    fun `intercepts during open animation — targetValue flipped but currentValue not yet`() {
+        assertTrue(shouldInterceptBackForDrawer(usePermanentDrawer = false, drawerCurrentOpen = false, drawerTargetOpen = true))
+    }
+
+    @Test
+    fun `intercepts during close animation — currentValue still Open but targetValue already Closed`() {
+        assertTrue(shouldInterceptBackForDrawer(usePermanentDrawer = false, drawerCurrentOpen = true, drawerTargetOpen = false))
+    }
+
+    @Test
+    fun `does not intercept when drawer is fully closed`() {
+        assertFalse(shouldInterceptBackForDrawer(usePermanentDrawer = false, drawerCurrentOpen = false, drawerTargetOpen = false))
     }
 
     @Test
     fun `never intercepts on tablets (permanent drawer has no Back semantics)`() {
-        assertFalse(shouldInterceptBackForDrawer(usePermanentDrawer = true, drawerTargetOpen = true))
-        assertFalse(shouldInterceptBackForDrawer(usePermanentDrawer = true, drawerTargetOpen = false))
+        assertFalse(shouldInterceptBackForDrawer(usePermanentDrawer = true, drawerCurrentOpen = true, drawerTargetOpen = true))
+        assertFalse(shouldInterceptBackForDrawer(usePermanentDrawer = true, drawerCurrentOpen = false, drawerTargetOpen = true))
+        assertFalse(shouldInterceptBackForDrawer(usePermanentDrawer = true, drawerCurrentOpen = true, drawerTargetOpen = false))
+        assertFalse(shouldInterceptBackForDrawer(usePermanentDrawer = true, drawerCurrentOpen = false, drawerTargetOpen = false))
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
@@ -1,0 +1,39 @@
+package com.riffle.app.navigation
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the fix for the burger-tap freeze (permanent white-screen-with-spinner):
+ *
+ * Before, the top-level drawer BackHandler was gated on `drawerState.isOpen`, which reads
+ * `currentValue == Open` — only true after the open animation completes. A Back pressed during
+ * the animation window fell through to the NavHost callback, popped the library entry, and
+ * surfaced HOME; HOME's LaunchedEffect re-ran getStartDestination(), and any transient hang
+ * inside wedged the app on a white spinner with no escape.
+ *
+ * The fix gates on `drawerState.targetValue == Open` — which flips true the instant
+ * `drawerState.open()` is invoked from the burger tap. This test locks in the pure decision;
+ * `MainScreen.kt`'s call site must pass `targetValue == DrawerValue.Open` into the second
+ * argument. If someone flips it back to `isOpen`, the composable's expression stops mapping to
+ * "target open," but the intent still holds only if the predicate contract stays as tested here.
+ */
+class ShouldInterceptBackForDrawerTest {
+
+    @Test
+    fun `intercepts when drawer is targeting open on a phone (modal drawer)`() {
+        assertTrue(shouldInterceptBackForDrawer(usePermanentDrawer = false, drawerTargetOpen = true))
+    }
+
+    @Test
+    fun `does not intercept when drawer is targeting closed`() {
+        assertFalse(shouldInterceptBackForDrawer(usePermanentDrawer = false, drawerTargetOpen = false))
+    }
+
+    @Test
+    fun `never intercepts on tablets (permanent drawer has no Back semantics)`() {
+        assertFalse(shouldInterceptBackForDrawer(usePermanentDrawer = true, drawerTargetOpen = true))
+        assertFalse(shouldInterceptBackForDrawer(usePermanentDrawer = true, drawerTargetOpen = false))
+    }
+}


### PR DESCRIPTION
Root cause: BackHandler gated on drawerState.isOpen (currentValue==Open), false during open animation. Back fell through to NavHost, popped library, surfaced HomeScreen spinner. Fix: check currentValue==Open OR targetValue==Open, applied to both BackHandler and LibraryItemsScreen backEnabled. Tests cover all four animation states.