### PR TITLE
fix(reader): eliminate ~1s annotation-popup close lag on scroll-dismiss

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -946,6 +946,10 @@ class EpubReaderViewModel @Inject constructor(
             val presetEmphasis = annotationSession.lastUsedEmphasisStyles.value
             if (shouldAutoCommitDraftOnDismiss(presetColorIsNone, presetEmphasis)) {
                 val colorToken = if (presetColorIsNone) "" else annotationSession.lastUsedHighlightColor.value.token
+                // Clear the edit target synchronously so the popup disappears on the next frame
+                // without waiting for the commitDraft suspend chain (readChapterHtml + Room writes +
+                // DataStore writes). The draft itself is cleared by consumeDraft() inside commitDraft.
+                annotationSession.forceCloseHighlightEditTarget()
                 viewModelScope.launch { commitDraft(initialColor = colorToken, keepSheetOpen = false) }
                 return
             }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -23,9 +23,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -784,6 +786,42 @@ class AnnotationSessionTest {
         session.dismissHighlightActions()
 
         assertEquals(0, mergeCalls.size)
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
+
+    /**
+     * Regression: popup close lag when scrolling with a draft open (2026-07-24).
+     *
+     * [EpubReaderViewModel.dismissHighlightActions] must call [AnnotationSession.forceCloseHighlightEditTarget]
+     * synchronously BEFORE launching `commitDraft`, so the popup's `if (editTarget != null)` gate
+     * in [EpubReaderScreen] flips to false on the next recomposition frame rather than waiting for
+     * the whole suspend chain (readChapterHtml + Room writes + DataStore writes) to complete.
+     *
+     * This test pins that [forceCloseHighlightEditTarget] is synchronous — if it were made async,
+     * or if the call were removed from the VM's dismiss-auto-commit path, the popup would linger
+     * for ~1 second while commitDraft ran.
+     */
+    @Test
+    fun `forceCloseHighlightEditTarget clears highlightToEdit synchronously before coroutines run`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val session = makeSession(syncOps = FakeSyncOps(), scope = sessionScope)
+        defaultBind(session)
+        runCurrent()
+
+        session.openHighlightActions(AnnotationSession.DRAFT_ANNOTATION_ID, androidx.compose.ui.unit.IntRect(0, 0, 100, 50))
+        runCurrent()
+        assertNotNull(session.highlightToEdit.value)
+
+        // The VM's dismiss-auto-commit path calls this before launching commitDraft. Verify it
+        // clears state synchronously — no coroutine yield required.
+        session.forceCloseHighlightEditTarget()
+
+        // Must be null without running any coroutine — StandardTestDispatcher only advances on
+        // explicit runCurrent() / advanceTimeBy(), so if forceCloseHighlightEditTarget() were
+        // async this assertion would see the stale non-null value.
+        assertNull(session.highlightToEdit.value)
+
         sessionScope.coroutineContext[Job]?.cancel()
     }
 


### PR DESCRIPTION
## What

When the user scrolled the page while a draft annotation popup was open, the popup lingered for ~1 second before disappearing. It should vanish on the next frame.

## Root cause

`dismissHighlightActions()` launched `commitDraft` without first clearing `_highlightToEdit`. The popup's visibility gate (`if (editTarget != null)` in `EpubReaderScreen`) stayed `true` until the entire async commit chain finished — `readChapterHtml` + Room writes + DataStore writes — roughly 1 second.

## Fix

Call `forceCloseHighlightEditTarget()` synchronously **before** launching `commitDraft`. The popup gate flips to `false` on the very next recomposition frame. The draft annotation itself is still cleared by `consumeDraft()` at the end of `commitDraft`.

## Regression test

`AnnotationSessionTest.forceCloseHighlightEditTarget clears highlightToEdit synchronously before coroutines run` — uses `StandardTestDispatcher` (no implicit advancement) to assert the value is null immediately after the call, with no `runCurrent()`. Any async re-implementation of `forceCloseHighlightEditTarget` would flip this red.