### PR TITLE
fix(reader): merge adjacent highlights at create time

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -2077,12 +2077,42 @@ class EpubReaderViewModel @Inject constructor(
         // If we merged, rebuild the persisted range fields from the union so the stored highlight
         // covers the full `[mergedStart, mergedEnd)` span. Fall back to draft fields when no
         // overlap was detected (the common path) or the DOM rebuild fails (safety net).
-        val mergedFields: MergedDraftFields = if (overlapMerge != null && html != null) {
+        val overlapFields: MergedDraftFields = if (overlapMerge != null && html != null) {
             buildMergedDraftFields(html, draft.spineIndex, draft.embeddedFigures, overlapMerge, candidates)
                 ?: draft.toDraftFields()
         } else {
             draft.toDraftFields()
         }
+        // Adjacency merge: after handling true overlaps, check whether the new draft sits
+        // immediately before or after an existing same-colour highlight (with only whitespace or a
+        // paragraph break between them). This is the create-time half of the auto-merge spec —
+        // the edit-time half runs in [mergeAdjacentIntoHighlight] on recolour/note-clear.
+        val overlapVictimIds = overlapMerge?.victimIds?.toSet() ?: emptySet()
+        val adjacentCandidates = candidates.filter { it.id !in overlapVictimIds }
+        val adjacentMerge = html?.let {
+            computeAdjacentCreateMerge(
+                html = it,
+                draftSnippet = overlapFields.textSnippet,
+                draftTextBefore = overlapFields.textBefore,
+                draftTextAfter = overlapFields.textAfter,
+                draftProgression = overlapFields.progression,
+                draftSpineIndex = draft.spineIndex,
+                draftChapterHref = draft.chapterHref,
+                draftColor = initialColor,
+                draftEmbeddedFigures = overlapFields.embeddedFigures,
+                candidates = adjacentCandidates,
+            )
+        }
+        adjacentMerge?.victimIds?.forEach { victimId ->
+            val victim = adjacentCandidates.firstOrNull { it.id == victimId }
+            if (victim != null) {
+                annotationSession.emphasisPool.value
+                    .filter { it.cfi == victim.cfi }
+                    .forEach { annotationStore.delete(it.id) }
+            }
+            annotationStore.delete(victimId)
+        }
+        val mergedFields = adjacentMerge?.fields ?: overlapFields
         // Standalone TYPE_IMAGE absorption for figures the merged highlight now encloses.
         val absorbedFilenames = mergedFields.embeddedFigures?.mapNotNull { it.href }?.map(::figureHrefFilename)?.toSet().orEmpty()
         if (absorbedFilenames.isNotEmpty()) {
@@ -2414,20 +2444,6 @@ class EpubReaderViewModel @Inject constructor(
                 svg = fig.svg ?: key?.let(svgByFilename::get),
             )
         }
-    }
-
-    /**
-     * Content equality ignoring all whitespace. The composed snippet carries Readium's captured
-     * whitespace between source snippets (single space, NBSP, `\n` at paragraph boundaries) but
-     * the DOM extract's whitespace comes from the readable char model, which does not count
-     * paragraph breaks as chars. Stripping whitespace on both sides compares just the letters —
-     * enough to catch false-positive adjacency matches (extra CONTENT between the endpoints)
-     * without tripping on the paragraph-break case.
-     */
-    private fun snippetsAgreeIgnoringWhitespace(a: String, b: String): Boolean {
-        val na = a.filterNot { it.isWhitespace() }
-        val nb = b.filterNot { it.isWhitespace() }
-        return na.equals(nb, ignoreCase = true)
     }
 
     /** Per-neighbour reason line, so a "why no merge?" can be answered from a single logcat grep. */

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -2135,12 +2135,11 @@ class EpubReaderViewModel @Inject constructor(
             progression = mergedFields.progression,
             embeddedFigures = mergedFields.embeddedFigures,
             originFontFamily = draft.originFontFamily,
-            // Only carry inline-formatted HTML when this is a plain (non-overlap-merge) create.
-            // On an overlap-merge, textSnippet is a concatenation across the union of ranges and
-            // the draft's HTML only covers the current selection — grafting it in would misalign
-            // formatting against the wider text. Fall back to plaintext render for merges; the
-            // dominant case (no overlap) still gets italics preserved.
-            textSnippetHtml = if (overlapMerge == null) draft.textSnippetHtml else null,
+            // Only carry inline-formatted HTML when this is a plain (no-merge) create. On any
+            // merge (overlap or adjacency), textSnippet spans more than the draft's original
+            // selection and the draft's HTML only covers the narrow selection — grafting it in
+            // would misalign formatting against the wider text.
+            textSnippetHtml = if (overlapMerge == null && adjacentMerge == null) draft.textSnippetHtml else null,
         )
         val presetStyles = annotationSession.lastUsedEmphasisStyles.value
         val combinedStyles = combineDraftEmphasisStyles(presetStyles, addEmphasisStyle)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightMerge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightMerge.kt
@@ -181,6 +181,17 @@ private fun matchAtEnd(context: String, target: String): String? {
     return context.substring(i)
 }
 
+/**
+ * True when [a] and [b] contain the same non-whitespace characters (case-insensitive). Used as a
+ * safety guard after adjacency-chain assembly: if the DOM-derived snippet and the composed snippet
+ * diverge beyond whitespace, the adjacency match was a coincidence and the merge should be aborted.
+ */
+internal fun snippetsAgreeIgnoringWhitespace(a: String, b: String): Boolean {
+    val na = a.filterNot { it.isWhitespace() }
+    val nb = b.filterNot { it.isWhitespace() }
+    return na.equals(nb, ignoreCase = true)
+}
+
 /** Collapse every run of whitespace (any Unicode WS) to a single ASCII space. */
 private fun normaliseWs(s: String): String {
     val out = StringBuilder(s.length)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRangeOverlap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRangeOverlap.kt
@@ -5,6 +5,12 @@ import com.riffle.core.models.EmbeddedFigure
 import com.riffle.core.domain.countBodyChars
 import org.jsoup.Jsoup
 
+/** Result of a create-time adjacency merge: updated draft fields + IDs of annotations absorbed. */
+internal data class AdjacentCreateMerge(
+    val fields: MergedDraftFields,
+    val victimIds: List<String>,
+)
+
 /** Overlap-merge context length: how much text to snapshot either side of the merged range as
  *  the persisted textBefore/textAfter. Matches [OVERLAP_CONTEXT_LEN] used by the legacy detector. */
 private const val MERGED_CONTEXT_LEN = 60
@@ -154,6 +160,105 @@ internal fun buildMergedDraftFields(
         textAfter = textAfter,
         progression = progression,
         embeddedFigures = figures,
+    )
+}
+
+/**
+ * Create-time adjacency merge: detect candidates that are text-adjacent to the new draft and
+ * absorb them into a single highlight before persisting. Mirror of the edit-time
+ * `mergeAdjacentIntoHighlight` path in EpubReaderViewModel, but runs purely on draft fields
+ * (no annotation ID yet) so there is no race on `annotationSession.annotations`.
+ *
+ * Returns null when no adjacent neighbour is found (the common path). On success, returns the
+ * updated [MergedDraftFields] spanning the full merged range and the [AdjacentCreateMerge.victimIds]
+ * the caller must delete (with their sibling emphasis rows) before persisting the merged highlight.
+ *
+ * [candidates] should already be filtered to same-chapter TYPE_HIGHLIGHT rows with overlap victims
+ * excluded so they aren't double-processed.
+ */
+internal fun computeAdjacentCreateMerge(
+    html: String,
+    draftSnippet: String,
+    draftTextBefore: String,
+    draftTextAfter: String,
+    draftProgression: Double,
+    draftSpineIndex: Int,
+    draftChapterHref: String,
+    draftColor: String,
+    draftEmbeddedFigures: List<EmbeddedFigure>?,
+    candidates: List<Annotation>,
+): AdjacentCreateMerge? {
+    var trialAnchor = MergeAnchor(
+        spineIndex = draftSpineIndex,
+        color = draftColor,
+        note = null,
+        textSnippet = draftSnippet,
+        textBefore = draftTextBefore,
+        textAfter = draftTextAfter,
+        progression = draftProgression,
+        chapterHref = draftChapterHref,
+    )
+    var leftmost = trialAnchor
+    var rightmost = trialAnchor
+    val toAbsorb = mutableListOf<Annotation>()
+    val absorbedIds = mutableSetOf<String>()
+    while (true) {
+        val match = findAnyMergeableNeighbor(trialAnchor, candidates, absorbedIds, html) ?: break
+        when (match.side) {
+            MergeSide.CANDIDATE_BEFORE_ANCHOR -> leftmost = match.neighbor.toMergeAnchor()
+            MergeSide.CANDIDATE_AFTER_ANCHOR -> rightmost = match.neighbor.toMergeAnchor()
+        }
+        toAbsorb += match.neighbor
+        absorbedIds += match.neighbor.id
+        trialAnchor = applyMerge(trialAnchor, match)
+    }
+    if (toAbsorb.isEmpty()) return null
+    // Rebuild the merged range from DOM positions — same as mergeAdjacentIntoHighlight.
+    val totalChars = countBodyChars(Jsoup.parse(html).body())
+    if (totalChars <= 0L) return null
+    val startChar = locateSnippetInBody(html, leftmost.textSnippet, leftmost.textBefore) ?: return null
+    val rightmostStart = locateSnippetInBody(html, rightmost.textSnippet, rightmost.textBefore) ?: return null
+    val endChar = snippetEndCharInBody(html, rightmostStart, rightmost.textSnippet).coerceAtMost(totalChars)
+    if (endChar <= startChar) return null
+    val domSnippet = readableTextBetween(html, startChar, endChar) ?: return null
+    if (!snippetsAgreeIgnoringWhitespace(domSnippet, trialAnchor.textSnippet)) return null
+    val spineStep = (draftSpineIndex + 1) * 2
+    val cfiRange = buildHighlightCfiRange(spineStep, html, startChar, endChar - 1L) ?: return null
+    val body = readableBodyText(html)
+    val startInt = startChar.toInt().coerceIn(0, body.length)
+    val endInt = endChar.toInt().coerceIn(0, body.length)
+    val textBefore = body.substring(0, startInt).takeLast(MERGED_CONTEXT_LEN)
+    val textAfter = body.substring(endInt).take(MERGED_CONTEXT_LEN)
+    val progression = startChar.toDouble() / totalChars.toDouble()
+    val victimFigures = toAbsorb.flatMap { it.embeddedFigures.orEmpty() }
+    val walkedFigures = findEnclosedFiguresInHtml(html, startChar, endChar - 1L)
+    val figures = if (walkedFigures.isEmpty()) null else {
+        val bytesByFile = mutableMapOf<String, String>()
+        val svgByFile = mutableMapOf<String, String>()
+        (draftEmbeddedFigures.orEmpty() + victimFigures).forEach { fig ->
+            val key = fig.href?.let(::figureHrefFilename) ?: return@forEach
+            fig.imageBytes?.takeIf { it.isNotBlank() }?.let { bytesByFile.putIfAbsent(key, it) }
+            fig.svg?.takeIf { it.isNotBlank() }?.let { svgByFile.putIfAbsent(key, it) }
+        }
+        walkedFigures.mapIndexed { i, fig ->
+            val key = fig.href?.let(::figureHrefFilename)
+            fig.copy(
+                order = i,
+                imageBytes = fig.imageBytes ?: key?.let(bytesByFile::get),
+                svg = fig.svg ?: key?.let(svgByFile::get),
+            )
+        }
+    }
+    return AdjacentCreateMerge(
+        fields = MergedDraftFields(
+            cfiRange = cfiRange,
+            textSnippet = domSnippet,
+            textBefore = textBefore,
+            textAfter = textAfter,
+            progression = progression,
+            embeddedFigures = figures,
+        ),
+        victimIds = toAbsorb.map { it.id },
     )
 }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightRangeOverlapTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightRangeOverlapTest.kt
@@ -202,9 +202,9 @@ class HighlightRangeOverlapTest {
 
     @Test
     fun touchingExisting_notMerged() {
-        // Adjacent (touching) highlights are handled by the edit-time merge path, not the create-
-        // time overlap merger. Ensure we don't merge them here — that would surprise users who
-        // deliberately created two separate same-color neighbours (2026-07-05 design intent).
+        // Adjacent (touching) highlights are not handled by the range-overlap detector — that
+        // path is for true positional overlaps only. Adjacency is handled by
+        // [computeAdjacentCreateMerge] (create-time) and [mergeAdjacentIntoHighlight] (edit-time).
         val existing = annotation(
             id = "neighbor",
             textSnippet = "eight sons.",
@@ -300,6 +300,141 @@ class HighlightRangeOverlapTest {
         )
         assertNotNull(result)
         assertEquals(listOf("cross-para"), result!!.victimIds)
+    }
+
+    // ---- computeAdjacentCreateMerge — create-time adjacency merge ----
+
+    private fun adjacentAnnotation(
+        id: String,
+        textSnippet: String,
+        textBefore: String,
+        textAfter: String = "",
+        color: String = "yellow",
+    ) = Annotation(
+        id = id,
+        sourceId = "srv",
+        itemId = "item",
+        type = AnnotationEntity.TYPE_HIGHLIGHT,
+        cfi = "epubcfi(/6/2!/4/2,/1:0,/1:5)",
+        color = color,
+        note = null,
+        textSnippet = textSnippet,
+        textBefore = textBefore,
+        textAfter = textAfter,
+        chapterHref = "ch1.xhtml",
+        spineIndex = 0,
+        progression = 0.1,
+        bookmarkTitle = "",
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    @Test
+    fun adjacentTouching_singleParagraph_mergedAtCreateTime() {
+        // Existing "eight sons." immediately before the new draft "Apart from".
+        // computeOverlapMerge returns null (touching, not overlapping), but adjacency merge fires.
+        val existing = adjacentAnnotation(
+            id = "neighbor",
+            textSnippet = "eight sons.",
+            textBefore = "he had ",
+            textAfter = " Apart from that",
+        )
+        val result = computeAdjacentCreateMerge(
+            html = html,
+            draftSnippet = "Apart from that",
+            draftTextBefore = "eight sons. ",
+            draftTextAfter = ", he was nothing",
+            draftProgression = 0.3,
+            draftSpineIndex = 0,
+            draftChapterHref = "ch1.xhtml",
+            draftColor = "yellow",
+            draftEmbeddedFigures = null,
+            candidates = listOf(existing),
+        )
+        assertNotNull(result)
+        assertEquals(listOf("neighbor"), result!!.victimIds)
+        assertTrue(
+            "merged snippet must span both halves",
+            result.fields.textSnippet.contains("eight sons.") && result.fields.textSnippet.contains("Apart from that"),
+        )
+    }
+
+    @Test
+    fun adjacentDifferentColor_notMerged() {
+        // Different colour: eligibility gate must block the merge.
+        val existing = adjacentAnnotation(
+            id = "other",
+            textSnippet = "eight sons.",
+            textBefore = "he had ",
+            textAfter = " Apart from that",
+            color = "blue",
+        )
+        val result = computeAdjacentCreateMerge(
+            html = html,
+            draftSnippet = "Apart from that",
+            draftTextBefore = "eight sons. ",
+            draftTextAfter = ", he was nothing",
+            draftProgression = 0.3,
+            draftSpineIndex = 0,
+            draftChapterHref = "ch1.xhtml",
+            draftColor = "yellow",
+            draftEmbeddedFigures = null,
+            candidates = listOf(existing),
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun adjacentAcrossLineBreak_multiParagraph_mergedAtCreateTime() {
+        // Existing on para-1 tail, draft on para-2 head — a paragraph break sits between them.
+        // The textAfter of the existing carries the para-2 text (with leading \n from Readium);
+        // findAdjacency normalises whitespace and still matches.
+        val existing = adjacentAnnotation(
+            id = "para1",
+            textSnippet = "first sentence in paragraph one.",
+            textBefore = "The ",
+            textAfter = "\nThe second sentence in paragraph two.",
+        )
+        val result = computeAdjacentCreateMerge(
+            html = multiParaHtml,
+            draftSnippet = "The second sentence in paragraph two.",
+            draftTextBefore = "paragraph one.\n",
+            draftTextAfter = "",
+            draftProgression = 0.5,
+            draftSpineIndex = 0,
+            draftChapterHref = "ch1.xhtml",
+            draftColor = "yellow",
+            draftEmbeddedFigures = null,
+            candidates = listOf(existing),
+        )
+        assertNotNull("adjacent across a line break must merge at create time", result)
+        assertEquals(listOf("para1"), result!!.victimIds)
+        val snippet = result.fields.textSnippet
+        assertTrue(
+            "merged snippet must contain para-1 text",
+            snippet.contains("paragraph one"),
+        )
+        assertTrue(
+            "merged snippet must contain para-2 text",
+            snippet.contains("paragraph two"),
+        )
+    }
+
+    @Test
+    fun adjacentNoCandidate_returnsNull() {
+        val result = computeAdjacentCreateMerge(
+            html = html,
+            draftSnippet = "Apart from that",
+            draftTextBefore = "eight sons. ",
+            draftTextAfter = ", he was nothing",
+            draftProgression = 0.3,
+            draftSpineIndex = 0,
+            draftChapterHref = "ch1.xhtml",
+            draftColor = "yellow",
+            draftEmbeddedFigures = null,
+            candidates = emptyList(),
+        )
+        assertNull(result)
     }
 
     @Test


### PR DESCRIPTION
## What

Adjacent highlights (touching or separated only by whitespace/line breaks) were not merged when a new highlight was created next to an existing same-colour one. They correctly merged only when the user subsequently edited the annotation (e.g. changed colour), because `mergeAdjacentIntoHighlight` ran at edit time but never at create time.

`commitDraft` only called `computeOverlapMerge` (strict half-open interval overlap), which excludes touching/adjacent ranges. The adjacency detection logic in `HighlightMerge.kt` was always intended to run at both create time and edit time (the file comment says "both the create-time path... and the edit-time path can drive the same merge decision") but the create-time wiring was missing.

## Changes

- **`HighlightRangeOverlap.kt`**: New `computeAdjacentCreateMerge` — runs the same text-adjacency chain as `mergeAdjacentIntoHighlight` but against draft fields (no annotation ID yet), so there is no race on `annotationSession.annotations`. Returns `AdjacentCreateMerge(fields, victimIds)`.
- **`EpubReaderViewModel.kt` — `commitDraft`**: After the overlap merge step, calls `computeAdjacentCreateMerge`; deletes absorbed neighbours (with emphasis cascade); uses the merged fields for `createHighlight`. Also fixes `textSnippetHtml` guard: was `if (overlapMerge == null)`, now `if (overlapMerge == null && adjacentMerge == null)` — adjacency merges also produce a wider `textSnippet` than the draft's HTML covers.
- **`HighlightMerge.kt`**: Extracted `snippetsAgreeIgnoringWhitespace` from a private `EpubReaderViewModel` method to a package-level `internal` function so both paths share it.
- **`HighlightRangeOverlapTest.kt`**: 4 new regression tests for `computeAdjacentCreateMerge`: touching same-colour merge, cross-line-break multi-paragraph merge, different-colour gate, empty candidates.

## Review notes

Dismissed efficiency findings (multiple Jsoup re-parses per call, anchor-position recomputed per candidate in `hasFigureInGap`): pre-existing in the edit-time path too, not regressions from this PR.

Dismissed `originFontFamily` finding: narrow case (bookmark-toggle sentinel font path + adjacency merge in same commit). Overlap merge has the same gap; leaving for a dedicated pass.