### PR TITLE
fix(reader): elided-view delete + emphasis refresh without full reload

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1225,7 +1225,6 @@ class EpubReaderViewModel @Inject constructor(
                     bookBodyFontFamily = elidedBodyFontFamily,
                     resourceFetcher = figureFetcher
                         ?: com.riffle.app.feature.reader.highlights.ResourceFetcher { null },
-                    emphasisByCfi = emphasisByCfi,
                 )
             } finally {
                 figureFetcher?.close()
@@ -3000,7 +2999,7 @@ class EpubReaderViewModel @Inject constructor(
                     // Emphasis-join for partial rewrite path: the incomingById snapshot only carries
                     // TYPE_HIGHLIGHT entities; read the live emphasis pool to re-join styles so a
                     // recolour or note edit doesn't strip user-applied emphasis from the chapter bytes.
-                    val emphasisByCfi = annotationSession.emphasisPool.value
+                    val encodedEmphasisByCfi = annotationSession.emphasisPool.value
                         .groupBy { it.cfi }
                         .mapValues { (_, pool) ->
                             com.riffle.core.models.EmphasisStyle.encode(
@@ -3011,7 +3010,7 @@ class EpubReaderViewModel @Inject constructor(
                         val livePeers = incomingByChapter[chapterHref].orEmpty()
                             .sortedWith(compareBy({ it.spineIndex }, { it.progression }, { it.createdAt }, { it.id }))
                             .map { row ->
-                                val styles = emphasisByCfi[row.cfi] ?: return@map row
+                                val styles = encodedEmphasisByCfi[row.cfi] ?: return@map row
                                 row.copy(emphasisStyles = styles)
                             }
                         if (livePeers.isEmpty()) continue // Empty chapter would be structural — handled above.
@@ -3026,7 +3025,6 @@ class EpubReaderViewModel @Inject constructor(
                             dataUriByHref = highlightsPublicationHandle?.figureBytesByHref.orEmpty(),
                             publisherFontFaceCss = highlightsPublicationHandle
                                 ?.publisherFontFaceCss.orEmpty(),
-                            emphasisByCfi = emphasisByCfi,
                         )
                         handle.setChapterBytes(chapterHref, freshHtml)
                     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -529,6 +529,11 @@ class EpubReaderViewModel @Inject constructor(
     // to a full [reloadHighlightsView] rebuild (new-chapter add, chapter emptied, spine shape
     // change). Updated at the end of every openBook() and after each successful patch dispatch.
     private var highlightsRenderedById: Map<String, AnnotationEntity> = emptyMap()
+    // Emphasis snapshot parallel to [highlightsRenderedById]: the union of EmphasisStyle values from
+    // all live TYPE_EMPHASIS rows at each highlight's CFI, keyed by highlight id. Used to detect
+    // emphasis changes between observer emissions so a SetEmphasis DOM patch is emitted and the
+    // chapter bytes are rewritten without a full reload.
+    private var highlightsRenderedEmphasisById: Map<String, Set<com.riffle.core.models.EmphasisStyle>> = emptyMap()
     // Handle to the currently-loaded Highlights Publication, kept so per-annotation patches can
     // rewrite ONE chapter's synthesised HTML in place (see [HighlightsPublicationHandle.setChapterBytes])
     // — so a subsequent chapter-back navigation still renders the fresh state without a rebuild.
@@ -1154,14 +1159,28 @@ class EpubReaderViewModel @Inject constructor(
             // Snapshot what we just rendered so the observer can diff each incoming emission
             // per-annotation and pick the right response: targeted DOM patch for a colour/note/
             // delete/in-chapter-add, or a full rebuild for a structural change. Filter to
-            // TYPE_HIGHLIGHT so this baseline matches the observer's own filter — otherwise every
-            // bookmark on the book appears as a "removed" id on the first emission, triggers the
-            // structural-change path, and reloadHighlightsView loops (open → observer → reload →
-            // open → …) with a WebDAV syncOnOpen fired on every cycle (issue: elided-view infinite
-            // load + repeated WebDAV pushes when the book has bookmarks).
+            // TYPE_HIGHLIGHT and TYPE_IMAGE (both are rendered in the elided view); exclude
+            // TYPE_BOOKMARK / TYPE_EMPHASIS so a bookmark add/remove or emphasis row doesn't appear
+            // as a "removed" id on the first emission and trigger the structural-change path that
+            // would loop reloadHighlightsView (issue: elided-view infinite load + repeated WebDAV
+            // pushes when the book has bookmarks).
+            val emphasisByCfi = rows
+                .filter { it.type == AnnotationEntity.TYPE_EMPHASIS && !it.deleted }
+                .groupBy { it.cfi }
+                .mapValues { (_, emphRows) ->
+                    emphRows.flatMap {
+                        com.riffle.core.models.EmphasisStyle.decode(it.emphasisStyles).orEmpty()
+                    }.toSet()
+                }
             highlightsRenderedById = rows
-                .filter { it.type == AnnotationEntity.TYPE_HIGHLIGHT && !it.deleted }
+                .filter {
+                    (it.type == AnnotationEntity.TYPE_HIGHLIGHT || it.type == AnnotationEntity.TYPE_IMAGE) &&
+                        !it.deleted
+                }
                 .associateBy { it.id }
+            highlightsRenderedEmphasisById = highlightsRenderedById.mapValues { (_, ann) ->
+                emphasisByCfi[ann.cfi] ?: emptySet()
+            }
             // Start observing (once per (sourceId, itemId)). Kept alive across the openBook()
             // reruns triggered by reloadHighlightsView, since cancelling and re-launching each
             // rebuild would drop emissions during the Loading→Ready gap.
@@ -1206,6 +1225,7 @@ class EpubReaderViewModel @Inject constructor(
                     bookBodyFontFamily = elidedBodyFontFamily,
                     resourceFetcher = figureFetcher
                         ?: com.riffle.app.feature.reader.highlights.ResourceFetcher { null },
+                    emphasisByCfi = emphasisByCfi,
                 )
             } finally {
                 figureFetcher?.close()
@@ -2862,19 +2882,35 @@ class EpubReaderViewModel @Inject constructor(
             debouncedHighlightsFlow(
                 annotationDao.observeAnnotationsByPosition(sourceId, itemId),
             ).collect { annotations ->
-                // Filter to highlights only — the elided reader's spine, chapter HTML, and every
-                // downstream patch/rewrite is highlights-only. If we left bookmarks in this stream:
-                //  (1) a chapter's byte rewrite would render bookmarks as fake highlight paragraphs
-                //      (renderChapterHtml paints every row as an accent-bar <p>);
-                //  (2) the empty-set close check would fire late when a chapter had highlights
-                //      deleted but a bookmark remained, blocking [reloadOrCloseHighlightsAfterDelete];
-                //  (3) a bookmark ADD would count as a structural change and re-introduce the
-                //      full-rebuild flash the DOM-patch pipeline was written to eliminate.
+                // Filter to displayed annotation types only (TYPE_HIGHLIGHT + TYPE_IMAGE). Exclude
+                // TYPE_BOOKMARK so a bookmark add/remove doesn't appear as "removed" on the first
+                // emission and trigger the structural-change loop (issue: elided-view infinite load
+                // + repeated WebDAV pushes). TYPE_EMPHASIS rows drive a separate emphasis snapshot
+                // below and are intentionally excluded from incomingById.
                 val incomingById = annotations
                     .asSequence()
-                    .filter { it.type == AnnotationEntity.TYPE_HIGHLIGHT && !it.deleted }
+                    .filter {
+                        (it.type == AnnotationEntity.TYPE_HIGHLIGHT || it.type == AnnotationEntity.TYPE_IMAGE) &&
+                            !it.deleted
+                    }
                     .associateBy { it.id }
-                if (sameById(incomingById, highlightsRenderedById)) return@collect
+                // Build a per-highlight emphasis snapshot: union of EmphasisStyle values from all
+                // live TYPE_EMPHASIS rows whose CFI matches the highlight's CFI.
+                val emphasisByCfi = annotations
+                    .asSequence()
+                    .filter { it.type == AnnotationEntity.TYPE_EMPHASIS && !it.deleted }
+                    .groupBy { it.cfi }
+                    .mapValues { (_, emphRows) ->
+                        emphRows.flatMap {
+                            com.riffle.core.models.EmphasisStyle.decode(it.emphasisStyles).orEmpty()
+                        }.toSet()
+                    }
+                val incomingEmphasisById = incomingById.mapValues { (_, ann) ->
+                    emphasisByCfi[ann.cfi] ?: emptySet()
+                }
+                if (sameById(incomingById, highlightsRenderedById) &&
+                    incomingEmphasisById == highlightsRenderedEmphasisById
+                ) return@collect
 
                 val handle = highlightsPublicationHandle
                 val previous = highlightsRenderedById
@@ -2893,7 +2929,9 @@ class EpubReaderViewModel @Inject constructor(
                     val next = incomingById.getValue(id)
                     prev.color != next.color ||
                         prev.note != next.note ||
-                        prev.chapterHref != next.chapterHref
+                        prev.chapterHref != next.chapterHref ||
+                        (incomingEmphasisById[id] ?: emptySet<com.riffle.core.models.EmphasisStyle>()) !=
+                            (highlightsRenderedEmphasisById[id] ?: emptySet<com.riffle.core.models.EmphasisStyle>())
                 }
 
                 // Structural changes → full rebuild.
@@ -2939,6 +2977,16 @@ class EpubReaderViewModel @Inject constructor(
                                 .SetNote(id, accent, next.note),
                         )
                     }
+                    val prevEmphasis = highlightsRenderedEmphasisById[id] ?: emptySet()
+                    val nextEmphasis = incomingEmphasisById[id] ?: emptySet()
+                    if (prevEmphasis != nextEmphasis) {
+                        _highlightDomPatches.tryEmit(
+                            com.riffle.app.feature.reader.highlights.HighlightsDomPatch.SetEmphasis(
+                                id,
+                                com.riffle.app.feature.reader.highlights.buildEmphasisInlineCss(nextEmphasis),
+                            ),
+                        )
+                    }
                     touchedChapters += next.chapterHref
                 }
 
@@ -2978,15 +3026,17 @@ class EpubReaderViewModel @Inject constructor(
                             dataUriByHref = highlightsPublicationHandle?.figureBytesByHref.orEmpty(),
                             publisherFontFaceCss = highlightsPublicationHandle
                                 ?.publisherFontFaceCss.orEmpty(),
+                            emphasisByCfi = emphasisByCfi,
                         )
                         handle.setChapterBytes(chapterHref, freshHtml)
                     }
                 }
 
-                // Refresh the by-id snapshot to what's now on screen. Without this the NEXT
-                // emission would re-observe the same "changed" annotation and re-emit the same
-                // patch on every Room re-emit.
+                // Refresh both snapshots to what's now on screen. Without this the NEXT emission
+                // would re-observe the same "changed" annotation and re-emit the same patch on
+                // every Room re-emit.
                 highlightsRenderedById = incomingById
+                highlightsRenderedEmphasisById = incomingEmphasisById
             }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatch.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatch.kt
@@ -43,6 +43,16 @@ sealed class HighlightsDomPatch {
     data class Remove(val annotationId: String) : HighlightsDomPatch() {
         override fun applyJs(): String = buildRemoveJs(annotationId)
     }
+
+    /**
+     * Apply (or clear) emphasis formatting on a highlight's `<span class="riffle-hl">` in the
+     * elided view. [emphasisCss] is a pre-computed inline CSS string (e.g.
+     * `"font-weight:bold !important;font-style:italic !important;"`) produced by
+     * [buildEmphasisInlineCss]; an empty string clears any previously-set emphasis.
+     */
+    data class SetEmphasis(val annotationId: String, val emphasisCss: String) : HighlightsDomPatch() {
+        override fun applyJs(): String = buildSetEmphasisJs(annotationId, emphasisCss)
+    }
 }
 
 // ─── Rendering helpers — small enough to inline; kept package-private so tests can pin. ─────────
@@ -145,6 +155,42 @@ internal fun buildRemoveJs(annotationId: String): String {
         |  for (var j = 0; j < figs.length; j++) figs[j].remove();
         |})();
     """.trimMargin()
+}
+
+internal fun buildSetEmphasisJs(annotationId: String, emphasisCss: String): String {
+    val idJs = jsQuoteString(annotationId)
+    val cssJs = jsQuoteString(emphasisCss)
+    // Target every `<span class="riffle-hl">` for this annotation (multi-chunk highlights produce
+    // multiple spans across `<p>` blocks). Set `style.cssText` to the pre-computed CSS string so a
+    // single assignment covers all four emphasis axes (bold / italic / underline / strike). An empty
+    // string clears any previously set emphasis without touching the paragraph's own `border-left`
+    // (which lives on the `<p>`, not the span).
+    return """
+        |(function(){
+        |  var id = $idJs;
+        |  var css = $cssJs;
+        |  var spans = document.querySelectorAll('span.riffle-hl[data-ann-id="' + id + '"]');
+        |  for (var i = 0; i < spans.length; i++) { spans[i].style.cssText = css; }
+        |})();
+    """.trimMargin()
+}
+
+/**
+ * Build the `style.cssText` string for a `<span class="riffle-hl">` carrying [styles]. Returns an
+ * empty string when [styles] is empty (clears any prior inline style). The produced CSS uses
+ * `!important` so ReadiumCSS theme rules cannot override the user's explicit formatting choice.
+ */
+internal fun buildEmphasisInlineCss(styles: Set<com.riffle.core.models.EmphasisStyle>): String {
+    if (styles.isEmpty()) return ""
+    val sb = StringBuilder()
+    if (com.riffle.core.models.EmphasisStyle.BOLD in styles) sb.append("font-weight:bold !important;")
+    if (com.riffle.core.models.EmphasisStyle.ITALIC in styles) sb.append("font-style:italic !important;")
+    val decos = buildList {
+        if (com.riffle.core.models.EmphasisStyle.UNDERLINE in styles) add("underline")
+        if (com.riffle.core.models.EmphasisStyle.STRIKE in styles) add("line-through")
+    }
+    if (decos.isNotEmpty()) sb.append("text-decoration:${decos.joinToString(" ")} !important;")
+    return sb.toString()
 }
 
 /** Minimal safe JS string literal — escapes the four characters that can break out of `"..."`. */

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -118,8 +118,9 @@ class HighlightsPublicationFactory @Inject constructor() {
         urlFactory: (String) -> Url? = { Url(it) },
         resourceFetcher: ResourceFetcher = ResourceFetcher { null },
         bookBodyFontFamily: String? = null,
+        emphasisByCfi: Map<String, Set<EmphasisStyle>> = emptyMap(),
     ): Publication =
-        buildHandle(sourceId, itemId, bookTitle, chapters, urlFactory, resourceFetcher, bookBodyFontFamily)
+        buildHandle(sourceId, itemId, bookTitle, chapters, urlFactory, resourceFetcher, bookBodyFontFamily, emphasisByCfi)
             .publication
 
     /**
@@ -141,6 +142,7 @@ class HighlightsPublicationFactory @Inject constructor() {
         urlFactory: (String) -> Url? = { Url(it) },
         resourceFetcher: ResourceFetcher = ResourceFetcher { null },
         bookBodyFontFamily: String? = null,
+        emphasisByCfi: Map<String, Set<EmphasisStyle>> = emptyMap(),
     ): HighlightsPublicationHandle {
         val nonEmptyChapters = chapters.filter { it.highlights.isNotEmpty() }
 
@@ -202,7 +204,7 @@ class HighlightsPublicationFactory @Inject constructor() {
             val href = "highlights/ch$index.xhtml"
             val url = requireNotNull(urlFactory(href)) { "Failed to build synthetic Url for $href" }
             entries[url] = renderChapterHtml(
-                chapter, bookBodyFontFamily, dataUriByHref, publisherFontFaceCss,
+                chapter, bookBodyFontFamily, dataUriByHref, publisherFontFaceCss, emphasisByCfi,
             ).toByteArray(Charsets.UTF_8)
             chapterUrls[chapter.href] = url
             readingOrder += Link(
@@ -270,6 +272,7 @@ class HighlightsPublicationFactory @Inject constructor() {
         bookBodyFontFamily: String? = null,
         dataUriByHref: Map<String, String> = emptyMap(),
         publisherFontFaceCss: String = "",
+        emphasisByCfi: Map<String, Set<EmphasisStyle>> = emptyMap(),
     ): String {
         val body = buildString {
             for (annotation in chapter.highlights) {
@@ -284,7 +287,10 @@ class HighlightsPublicationFactory @Inject constructor() {
                         // whole highlight falls back to "text first, then figures" — the v1
                         // behaviour matches what shipped before offsets existed. See
                         // appendInterleavedHighlight's KDoc.
-                        appendInterleavedHighlight(this, annotation, bookBodyFontFamily, dataUriByHref)
+                        val emphasisStyles = emphasisByCfi[annotation.cfi] ?: emptySet()
+                        appendInterleavedHighlight(
+                            this, annotation, bookBodyFontFamily, dataUriByHref, emphasisStyles,
+                        )
                     }
                 }
             }
@@ -384,6 +390,7 @@ private fun appendInterleavedHighlight(
     highlight: com.riffle.core.database.AnnotationEntity,
     bookBodyFontFamily: String?,
     dataUriByHref: Map<String, String> = emptyMap(),
+    emphasisStyles: Set<EmphasisStyle> = emptySet(),
 ) {
     val figures = highlight.decodedEmbeddedFigures()?.sortedBy { it.order }.orEmpty()
     val normalizedSnippetOuter = com.riffle.app.feature.reader.normalizeCaptionText(highlight.textSnippet)
@@ -414,10 +421,10 @@ private fun appendInterleavedHighlight(
             )
         if (isCaptionHighlight) {
             appendFigureBlock(sb, singleFigure!!.copy(caption = ""), highlight.id, highlight.color, dataUriByHref)
-            appendTextHighlight(sb, highlight, bookBodyFontFamily)
+            appendTextHighlight(sb, highlight, bookBodyFontFamily, emphasisStyles)
             return
         }
-        appendTextHighlight(sb, highlight, bookBodyFontFamily)
+        appendTextHighlight(sb, highlight, bookBodyFontFamily, emphasisStyles)
         figures.forEach { fig ->
             val effective = if (
                 fig.caption.isNotBlank() &&
@@ -435,7 +442,7 @@ private fun appendInterleavedHighlight(
     // Emit alternating: chunk[0], figure[0], chunk[1], figure[1], ..., chunk[last].
     chunks.forEachIndexed { index, chunk ->
         if (chunk.isNotEmpty()) {
-            appendHighlightTextChunk(sb, highlight, chunk, bookBodyFontFamily)
+            appendHighlightTextChunk(sb, highlight, chunk, bookBodyFontFamily, emphasisStyles)
         }
         figures.getOrNull(index)?.let { fig ->
             // Caption-highlight dedup: when the figure's own caption is identical to the highlight's
@@ -477,6 +484,7 @@ private fun appendHighlightTextChunk(
     highlight: com.riffle.core.database.AnnotationEntity,
     chunk: String,
     bookBodyFontFamily: String?,
+    emphasisStyles: Set<EmphasisStyle> = emptySet(),
 ) {
     val accent = if (highlight.color.isNotBlank()) highlightBackgroundCss(highlight.color)
                  else EMPHASIS_ONLY_BAR_COLOR
@@ -497,7 +505,12 @@ private fun appendHighlightTextChunk(
     sb.append("?l='+x+'&amp;t='+y+'&amp;r='+(x+1)+'&amp;b='+(y+1);return false;\"></span><span class=\"riffle-hl\" data-ann-id=\"")
     sb.append(idEscaped)
     sb.append("\"")
-    appendEmphasisStyleAttr(sb, highlight.emphasisStyles)
+    val emphasisCss = buildEmphasisInlineCss(emphasisStyles)
+    if (emphasisCss.isNotEmpty()) {
+        sb.append(" style=\"")
+        sb.append(emphasisCss.xmlEscape())
+        sb.append("\"")
+    }
     sb.append(">")
     sb.append(chunk.xmlEscape())
     sb.append("</span></p>\n")
@@ -509,7 +522,12 @@ private fun appendHighlightTextChunk(
  * emission (TYPE_IMAGE, embedded figures) can be dispatched independently. Now also serves as the
  * `charOffset == null` fallback path from [appendInterleavedHighlight].
  */
-private fun appendTextHighlight(sb: StringBuilder, highlight: AnnotationEntity, bookBodyFontFamily: String?) {
+private fun appendTextHighlight(
+    sb: StringBuilder,
+    highlight: AnnotationEntity,
+    bookBodyFontFamily: String?,
+    emphasisStyles: Set<EmphasisStyle> = emptySet(),
+) {
     // The highlight is presented as a left accent bar in the palette colour, matching
     // Riffle's [Book Search] results card style — the text itself renders in the
     // theme's normal body colour so dense highlights don't fatigue the eye. `!important`
@@ -540,11 +558,15 @@ private fun appendTextHighlight(sb: StringBuilder, highlight: AnnotationEntity, 
     sb.append("?l='+x+'&amp;t='+y+'&amp;r='+(x+1)+'&amp;b='+(y+1);return false;\"></span><span class=\"riffle-hl\" data-ann-id=\"")
     sb.append(idEscaped)
     sb.append("\"")
-    appendEmphasisStyleAttr(sb, highlight.emphasisStyles)
+    val emphasisCss = buildEmphasisInlineCss(emphasisStyles)
+    if (emphasisCss.isNotEmpty()) {
+        sb.append(" style=\"")
+        sb.append(emphasisCss.xmlEscape())
+        sb.append("\"")
+    }
     sb.append(">")
-    // Prefer the captured inline-formatted HTML (issue: elided-view drops italics) so publisher
-    // <em>/<i>/<strong>/<b>/<sup>/<sub>/<u>/<s> spans render in the excerpt. Sanitised defensively
-    // at render time — the DB is not a trust boundary and the extractor may evolve. Legacy rows
+    // Prefer the captured inline-formatted HTML so publisher <em>/<i>/<strong>/<b>/<sup>/<sub>/
+    // <u>/<s> spans render in the excerpt. Sanitised defensively at render time. Legacy rows
     // (null column, W3C sync ingest) fall back to the plain textSnippet render.
     val inlineHtml = highlight.textSnippetHtml
     if (inlineHtml != null) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -118,9 +118,8 @@ class HighlightsPublicationFactory @Inject constructor() {
         urlFactory: (String) -> Url? = { Url(it) },
         resourceFetcher: ResourceFetcher = ResourceFetcher { null },
         bookBodyFontFamily: String? = null,
-        emphasisByCfi: Map<String, Set<EmphasisStyle>> = emptyMap(),
     ): Publication =
-        buildHandle(sourceId, itemId, bookTitle, chapters, urlFactory, resourceFetcher, bookBodyFontFamily, emphasisByCfi)
+        buildHandle(sourceId, itemId, bookTitle, chapters, urlFactory, resourceFetcher, bookBodyFontFamily)
             .publication
 
     /**
@@ -142,7 +141,6 @@ class HighlightsPublicationFactory @Inject constructor() {
         urlFactory: (String) -> Url? = { Url(it) },
         resourceFetcher: ResourceFetcher = ResourceFetcher { null },
         bookBodyFontFamily: String? = null,
-        emphasisByCfi: Map<String, Set<EmphasisStyle>> = emptyMap(),
     ): HighlightsPublicationHandle {
         val nonEmptyChapters = chapters.filter { it.highlights.isNotEmpty() }
 
@@ -204,7 +202,7 @@ class HighlightsPublicationFactory @Inject constructor() {
             val href = "highlights/ch$index.xhtml"
             val url = requireNotNull(urlFactory(href)) { "Failed to build synthetic Url for $href" }
             entries[url] = renderChapterHtml(
-                chapter, bookBodyFontFamily, dataUriByHref, publisherFontFaceCss, emphasisByCfi,
+                chapter, bookBodyFontFamily, dataUriByHref, publisherFontFaceCss,
             ).toByteArray(Charsets.UTF_8)
             chapterUrls[chapter.href] = url
             readingOrder += Link(
@@ -272,7 +270,6 @@ class HighlightsPublicationFactory @Inject constructor() {
         bookBodyFontFamily: String? = null,
         dataUriByHref: Map<String, String> = emptyMap(),
         publisherFontFaceCss: String = "",
-        emphasisByCfi: Map<String, Set<EmphasisStyle>> = emptyMap(),
     ): String {
         val body = buildString {
             for (annotation in chapter.highlights) {
@@ -287,9 +284,8 @@ class HighlightsPublicationFactory @Inject constructor() {
                         // whole highlight falls back to "text first, then figures" — the v1
                         // behaviour matches what shipped before offsets existed. See
                         // appendInterleavedHighlight's KDoc.
-                        val emphasisStyles = emphasisByCfi[annotation.cfi] ?: emptySet()
                         appendInterleavedHighlight(
-                            this, annotation, bookBodyFontFamily, dataUriByHref, emphasisStyles,
+                            this, annotation, bookBodyFontFamily, dataUriByHref,
                         )
                     }
                 }
@@ -390,7 +386,6 @@ private fun appendInterleavedHighlight(
     highlight: com.riffle.core.database.AnnotationEntity,
     bookBodyFontFamily: String?,
     dataUriByHref: Map<String, String> = emptyMap(),
-    emphasisStyles: Set<EmphasisStyle> = emptySet(),
 ) {
     val figures = highlight.decodedEmbeddedFigures()?.sortedBy { it.order }.orEmpty()
     val normalizedSnippetOuter = com.riffle.app.feature.reader.normalizeCaptionText(highlight.textSnippet)
@@ -421,10 +416,10 @@ private fun appendInterleavedHighlight(
             )
         if (isCaptionHighlight) {
             appendFigureBlock(sb, singleFigure!!.copy(caption = ""), highlight.id, highlight.color, dataUriByHref)
-            appendTextHighlight(sb, highlight, bookBodyFontFamily, emphasisStyles)
+            appendTextHighlight(sb, highlight, bookBodyFontFamily)
             return
         }
-        appendTextHighlight(sb, highlight, bookBodyFontFamily, emphasisStyles)
+        appendTextHighlight(sb, highlight, bookBodyFontFamily)
         figures.forEach { fig ->
             val effective = if (
                 fig.caption.isNotBlank() &&
@@ -442,7 +437,7 @@ private fun appendInterleavedHighlight(
     // Emit alternating: chunk[0], figure[0], chunk[1], figure[1], ..., chunk[last].
     chunks.forEachIndexed { index, chunk ->
         if (chunk.isNotEmpty()) {
-            appendHighlightTextChunk(sb, highlight, chunk, bookBodyFontFamily, emphasisStyles)
+            appendHighlightTextChunk(sb, highlight, chunk, bookBodyFontFamily)
         }
         figures.getOrNull(index)?.let { fig ->
             // Caption-highlight dedup: when the figure's own caption is identical to the highlight's
@@ -484,7 +479,6 @@ private fun appendHighlightTextChunk(
     highlight: com.riffle.core.database.AnnotationEntity,
     chunk: String,
     bookBodyFontFamily: String?,
-    emphasisStyles: Set<EmphasisStyle> = emptySet(),
 ) {
     val accent = if (highlight.color.isNotBlank()) highlightBackgroundCss(highlight.color)
                  else EMPHASIS_ONLY_BAR_COLOR
@@ -505,12 +499,7 @@ private fun appendHighlightTextChunk(
     sb.append("?l='+x+'&amp;t='+y+'&amp;r='+(x+1)+'&amp;b='+(y+1);return false;\"></span><span class=\"riffle-hl\" data-ann-id=\"")
     sb.append(idEscaped)
     sb.append("\"")
-    val emphasisCss = buildEmphasisInlineCss(emphasisStyles)
-    if (emphasisCss.isNotEmpty()) {
-        sb.append(" style=\"")
-        sb.append(emphasisCss.xmlEscape())
-        sb.append("\"")
-    }
+    appendEmphasisStyleAttr(sb, highlight.emphasisStyles)
     sb.append(">")
     sb.append(chunk.xmlEscape())
     sb.append("</span></p>\n")
@@ -526,7 +515,6 @@ private fun appendTextHighlight(
     sb: StringBuilder,
     highlight: AnnotationEntity,
     bookBodyFontFamily: String?,
-    emphasisStyles: Set<EmphasisStyle> = emptySet(),
 ) {
     // The highlight is presented as a left accent bar in the palette colour, matching
     // Riffle's [Book Search] results card style — the text itself renders in the
@@ -558,15 +546,11 @@ private fun appendTextHighlight(
     sb.append("?l='+x+'&amp;t='+y+'&amp;r='+(x+1)+'&amp;b='+(y+1);return false;\"></span><span class=\"riffle-hl\" data-ann-id=\"")
     sb.append(idEscaped)
     sb.append("\"")
-    val emphasisCss = buildEmphasisInlineCss(emphasisStyles)
-    if (emphasisCss.isNotEmpty()) {
-        sb.append(" style=\"")
-        sb.append(emphasisCss.xmlEscape())
-        sb.append("\"")
-    }
+    appendEmphasisStyleAttr(sb, highlight.emphasisStyles)
     sb.append(">")
-    // Prefer the captured inline-formatted HTML so publisher <em>/<i>/<strong>/<b>/<sup>/<sub>/
-    // <u>/<s> spans render in the excerpt. Sanitised defensively at render time. Legacy rows
+    // Prefer the captured inline-formatted HTML (issue: elided-view drops italics) so publisher
+    // <em>/<i>/<strong>/<b>/<sup>/<sub>/<u>/<s> spans render in the excerpt. Sanitised defensively
+    // at render time — the DB is not a trust boundary and the extractor may evolve. Legacy rows
     // (null column, W3C sync ingest) fall back to the plain textSnippet render.
     val inlineHtml = highlight.textSnippetHtml
     if (inlineHtml != null) {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatchTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatchTest.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.reader.highlights
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -92,6 +93,78 @@ class HighlightsDomPatchTest {
             "Remove JS must iterate span.riffle-hl matches (querySelectorAll) to catch every chunk",
             js.contains("querySelectorAll('span.riffle-hl["),
         )
+    }
+
+    @Test
+    fun `SetEmphasis with non-empty styles sets cssText on riffle-hl spans`() {
+        val js = HighlightsDomPatch.SetEmphasis(
+            annotationId = "id-bold",
+            emphasisCss = "font-weight:bold !important;",
+        ).applyJs()
+        assertTrue(js, js.contains("\"id-bold\""))
+        assertTrue("must target span.riffle-hl by data-ann-id", js.contains("span.riffle-hl[data-ann-id="))
+        assertTrue("must set style.cssText", js.contains("style.cssText"))
+        assertTrue("must contain the provided css value", js.contains("font-weight:bold"))
+    }
+
+    @Test
+    fun `SetEmphasis with empty css clears inline style on riffle-hl spans`() {
+        val js = HighlightsDomPatch.SetEmphasis(
+            annotationId = "id-clear",
+            emphasisCss = "",
+        ).applyJs()
+        assertTrue(js, js.contains("\"id-clear\""))
+        // An empty css string still sets cssText (to ""), clearing any prior emphasis.
+        assertTrue("must set style.cssText even for empty css", js.contains("style.cssText"))
+    }
+
+    @Test
+    fun `buildEmphasisInlineCss returns empty string for empty styles`() {
+        assertEquals("", buildEmphasisInlineCss(emptySet()))
+    }
+
+    @Test
+    fun `buildEmphasisInlineCss encodes bold`() {
+        val css = buildEmphasisInlineCss(setOf(com.riffle.core.models.EmphasisStyle.BOLD))
+        assertTrue(css.contains("font-weight:bold"))
+        assertTrue(css.contains("!important"))
+    }
+
+    @Test
+    fun `buildEmphasisInlineCss encodes italic`() {
+        val css = buildEmphasisInlineCss(setOf(com.riffle.core.models.EmphasisStyle.ITALIC))
+        assertTrue(css.contains("font-style:italic"))
+        assertTrue(css.contains("!important"))
+    }
+
+    @Test
+    fun `buildEmphasisInlineCss encodes underline and strike as text-decoration`() {
+        val css = buildEmphasisInlineCss(
+            setOf(
+                com.riffle.core.models.EmphasisStyle.UNDERLINE,
+                com.riffle.core.models.EmphasisStyle.STRIKE,
+            ),
+        )
+        assertTrue(css.contains("text-decoration:"))
+        assertTrue(css.contains("underline"))
+        assertTrue(css.contains("line-through"))
+        assertTrue(css.contains("!important"))
+    }
+
+    @Test
+    fun `buildEmphasisInlineCss combines all four styles`() {
+        val css = buildEmphasisInlineCss(
+            setOf(
+                com.riffle.core.models.EmphasisStyle.BOLD,
+                com.riffle.core.models.EmphasisStyle.ITALIC,
+                com.riffle.core.models.EmphasisStyle.UNDERLINE,
+                com.riffle.core.models.EmphasisStyle.STRIKE,
+            ),
+        )
+        assertTrue(css.contains("font-weight:bold"))
+        assertTrue(css.contains("font-style:italic"))
+        assertTrue(css.contains("underline"))
+        assertTrue(css.contains("line-through"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
@@ -4,7 +4,6 @@ import android.net.FakeUri
 import com.riffle.app.feature.reader.joinEmphasisStylesToHighlights
 import com.riffle.app.feature.reader.toCssRgba
 import com.riffle.core.database.AnnotationEntity
-import com.riffle.core.models.EmphasisStyle
 import com.riffle.core.models.HighlightColor
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -550,14 +549,13 @@ class HighlightsPublicationFactoryTest {
     // ─── Emphasis rendering ───────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `renderChapterHtml applies bold CSS to riffle-hl span when emphasisByCfi matches`() {
-        val annotation = hl("h1", "Some bold text", spineIndex = 0)
+    fun `renderChapterHtml applies bold CSS to riffle-hl span when entity emphasisStyles is set`() {
+        val annotation = hl("h1", "Some bold text", spineIndex = 0, emphasisStyles = "bold")
         val chapter = ChapterElision("ch0.xhtml", "Ch", listOf(annotation))
-        val emphasisByCfi = mapOf(annotation.cfi to setOf(EmphasisStyle.BOLD))
-        val html = factory.renderChapterHtml(chapter, emphasisByCfi = emphasisByCfi)
+        val html = factory.renderChapterHtml(chapter)
         assertTrue(
-            "riffle-hl span must carry bold CSS when emphasis is set, got: $html",
-            html.contains("class=\"riffle-hl\" data-ann-id=\"h1\" style=\"font-weight:bold !important;\""),
+            "riffle-hl span must carry bold CSS when emphasisStyles on entity is 'bold', got: $html",
+            html.contains("class=\"riffle-hl\" data-ann-id=\"h1\" style=\"font-weight:bold\""),
         )
     }
 
@@ -565,7 +563,7 @@ class HighlightsPublicationFactoryTest {
     fun `renderChapterHtml does not add style attribute to riffle-hl span when no emphasis`() {
         val annotation = hl("h2", "Plain text", spineIndex = 0)
         val chapter = ChapterElision("ch0.xhtml", "Ch", listOf(annotation))
-        val html = factory.renderChapterHtml(chapter, emphasisByCfi = emptyMap())
+        val html = factory.renderChapterHtml(chapter)
         assertTrue(
             "riffle-hl span must NOT carry a style attribute when no emphasis, got: $html",
             html.contains("class=\"riffle-hl\" data-ann-id=\"h2\">"),
@@ -573,32 +571,27 @@ class HighlightsPublicationFactoryTest {
     }
 
     @Test
-    fun `renderChapterHtml applies italic and underline together`() {
-        val annotation = hl("h3", "Italic underlined", spineIndex = 0)
+    fun `renderChapterHtml applies italic and underline together from entity emphasisStyles`() {
+        val annotation = hl("h3", "Italic underlined", spineIndex = 0, emphasisStyles = "italic,underline")
         val chapter = ChapterElision("ch0.xhtml", "Ch", listOf(annotation))
-        val emphasisByCfi = mapOf(
-            annotation.cfi to setOf(EmphasisStyle.ITALIC, EmphasisStyle.UNDERLINE),
-        )
-        val html = factory.renderChapterHtml(chapter, emphasisByCfi = emphasisByCfi)
-        assertTrue("must include italic", html.contains("font-style:italic !important;"))
+        val html = factory.renderChapterHtml(chapter)
+        assertTrue("must include italic", html.contains("font-style:italic"))
         assertTrue("must include underline in text-decoration", html.contains("underline"))
     }
 
     @Test
-    fun `buildHandle renders emphasis on initial HTML when emphasisByCfi supplied`() {
-        val annotation = hl("h4", "Strike text", spineIndex = 0)
-        val emphasisByCfi = mapOf(annotation.cfi to setOf(EmphasisStyle.STRIKE))
+    fun `build renders emphasis on initial HTML when entity emphasisStyles is set`() {
+        val annotation = hl("h4", "Strike text", spineIndex = 0, emphasisStyles = "strike")
         val pub = factory.build(
             sourceId = "S1",
             itemId = "B1",
             bookTitle = null,
             chapters = listOf(ChapterElision("ch0.xhtml", "Ch", listOf(annotation))),
             urlFactory = ::testUrlFactory,
-            emphasisByCfi = emphasisByCfi,
         )
         val html = readChapterHtml(pub, index = 0)
         assertTrue(
-            "initial HTML from buildHandle must apply emphasis from emphasisByCfi, got: $html",
+            "initial HTML from build must apply emphasis from entity emphasisStyles, got: $html",
             html.contains("line-through"),
         )
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
@@ -4,6 +4,7 @@ import android.net.FakeUri
 import com.riffle.app.feature.reader.joinEmphasisStylesToHighlights
 import com.riffle.app.feature.reader.toCssRgba
 import com.riffle.core.database.AnnotationEntity
+import com.riffle.core.models.EmphasisStyle
 import com.riffle.core.models.HighlightColor
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -543,6 +544,62 @@ class HighlightsPublicationFactoryTest {
         assertTrue(
             "elided Publication must expose a SearchService for the reader's search top-bar to return results",
             service != null,
+        )
+    }
+
+    // ─── Emphasis rendering ───────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `renderChapterHtml applies bold CSS to riffle-hl span when emphasisByCfi matches`() {
+        val annotation = hl("h1", "Some bold text", spineIndex = 0)
+        val chapter = ChapterElision("ch0.xhtml", "Ch", listOf(annotation))
+        val emphasisByCfi = mapOf(annotation.cfi to setOf(EmphasisStyle.BOLD))
+        val html = factory.renderChapterHtml(chapter, emphasisByCfi = emphasisByCfi)
+        assertTrue(
+            "riffle-hl span must carry bold CSS when emphasis is set, got: $html",
+            html.contains("class=\"riffle-hl\" data-ann-id=\"h1\" style=\"font-weight:bold !important;\""),
+        )
+    }
+
+    @Test
+    fun `renderChapterHtml does not add style attribute to riffle-hl span when no emphasis`() {
+        val annotation = hl("h2", "Plain text", spineIndex = 0)
+        val chapter = ChapterElision("ch0.xhtml", "Ch", listOf(annotation))
+        val html = factory.renderChapterHtml(chapter, emphasisByCfi = emptyMap())
+        assertTrue(
+            "riffle-hl span must NOT carry a style attribute when no emphasis, got: $html",
+            html.contains("class=\"riffle-hl\" data-ann-id=\"h2\">"),
+        )
+    }
+
+    @Test
+    fun `renderChapterHtml applies italic and underline together`() {
+        val annotation = hl("h3", "Italic underlined", spineIndex = 0)
+        val chapter = ChapterElision("ch0.xhtml", "Ch", listOf(annotation))
+        val emphasisByCfi = mapOf(
+            annotation.cfi to setOf(EmphasisStyle.ITALIC, EmphasisStyle.UNDERLINE),
+        )
+        val html = factory.renderChapterHtml(chapter, emphasisByCfi = emphasisByCfi)
+        assertTrue("must include italic", html.contains("font-style:italic !important;"))
+        assertTrue("must include underline in text-decoration", html.contains("underline"))
+    }
+
+    @Test
+    fun `buildHandle renders emphasis on initial HTML when emphasisByCfi supplied`() {
+        val annotation = hl("h4", "Strike text", spineIndex = 0)
+        val emphasisByCfi = mapOf(annotation.cfi to setOf(EmphasisStyle.STRIKE))
+        val pub = factory.build(
+            sourceId = "S1",
+            itemId = "B1",
+            bookTitle = null,
+            chapters = listOf(ChapterElision("ch0.xhtml", "Ch", listOf(annotation))),
+            urlFactory = ::testUrlFactory,
+            emphasisByCfi = emphasisByCfi,
+        )
+        val html = readChapterHtml(pub, index = 0)
+        assertTrue(
+            "initial HTML from buildHandle must apply emphasis from emphasisByCfi, got: $html",
+            html.contains("line-through"),
         )
     }
 


### PR DESCRIPTION
## What

Two fixes for the elided annotations view (Highlights mode, `ReaderSource.Highlights`):

1. **Deleting a TYPE_IMAGE annotation now refreshes the elided view** — the observer filtered `incomingById` to `TYPE_HIGHLIGHT` only, so a figure-annotation deletion wasn't detected. Adding `TYPE_IMAGE` to the filter means `sameById` returns false → `Remove` DOM patch fires (or `reloadHighlightsView` for the last annotation in a chapter).

2. **Changing emphasis (bold/italic/underline/strike) on an annotation now updates the elided view live** — without a full reload. TYPE_EMPHASIS rows were not tracked at all. Fix adds:
   - `highlightsRenderedEmphasisById` snapshot (annotation id → `Set<EmphasisStyle>`) tracking emphasis per TYPE_EMPHASIS row
   - `incomingEmphasisById` computed each observer emission; compared with snapshot to detect changes
   - `SetEmphasis` DOM patch type in `HighlightsDomPatch` — targets `span.riffle-hl[data-ann-id]` and sets `style.cssText`
   - Observer emits `SetEmphasis` on emphasis change (in addition to `Recolor`/`SetNote`/`Remove`)
   - `setChapterBytes` path pre-joins emphasis onto TYPE_HIGHLIGHT entities via `encodedEmphasisByCfi` → `entity.emphasisStyles` → `appendEmphasisStyleAttr` reads it on rerender

Colors already worked; this targets only emphasis (the `emphasisStyles` column on TYPE_EMPHASIS rows via `joinEmphasisStylesToHighlights`).

## Tests

- `HighlightsDomPatchTest`: 7 new tests covering `SetEmphasis.applyJs()` and `buildEmphasisInlineCss` (all four emphasis axes, combining styles, empty string clears)
- `HighlightsPublicationFactoryTest`: 4 new tests covering emphasis rendering via entity field (bold, no-style, italic+underline, strike via `build`)

## Notes

- All three reader modes covered: paginated/vertical (Readium patches the WebView), continuous (`ContinuousWindowController.applyHighlightDomPatch` fans JS to all chapter WebViews)
- Rebase conflict in `HighlightsPublicationFactory.kt` resolved: adopted HEAD's cleaner entity-field approach (`appendEmphasisStyleAttr`) and `sanitizeInlineSnippetHtml` for publisher inline HTML (bold/italic in publisher source)