### PR TITLE
fix(reader): formatting annotations not tappable in paginated/vertical mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
@@ -122,9 +122,7 @@ internal class ReadiumHighlightRenderer(
         // ADR 0046: layered emphasis paints via companion decorations. Underline uses Readium's
         // built-in Style.Underline; strike/bold/italic v1 render as tinted overlays (bold + italic
         // are approximations pending true DOM mutation — captured as follow-up).
-        // DOM injection already ran above — pass skipDomInjection = true so emphasis overlays
-        // (underline/strike) apply without repeating the bold/italic span injection.
-        applyEmphasisCompanions(renders, skipDomInjection = true)
+        applyEmphasisCompanions(renders)
         // Post-apply layout shifts (page-load completion, reflow, orientation) are covered by the
         // outer LaunchedEffect in EpubReaderScreen re-keying on pageLoadGeneration / reflowGeneration
         // and re-invoking applyAnnotations. A fixed local settle loop here forced 2.6s of
@@ -187,7 +185,6 @@ internal class ReadiumHighlightRenderer(
     }
 
     /**
-     * Queues the bold/italic DOM injection script to the WebView's JS thread.
      * Called before [applyDecorationsWithClear] so Readium measures tap-target rects from the
      * already-reflowed (post-bold/italic) DOM rather than from a pre-reflow snapshot.
      */
@@ -199,10 +196,7 @@ internal class ReadiumHighlightRenderer(
         }
     }
 
-    private suspend fun applyEmphasisCompanions(
-        renders: List<EpubReaderViewModel.HighlightRender>,
-        skipDomInjection: Boolean = false,
-    ) {
+    private suspend fun applyEmphasisCompanions(renders: List<EpubReaderViewModel.HighlightRender>) {
         val decorations = renders.flatMap { h ->
             if (h.emphasisStyles.isEmpty()) return@flatMap emptyList()
             buildList {
@@ -224,12 +218,9 @@ internal class ReadiumHighlightRenderer(
                         )
                     )
                 }
-                // ADR 0046: bold and italic no longer paint tint overlays — the DOM injector
-                // (see [EmphasisDomInjector]) wraps the range in a styled `<span>` that actually
-                // reflows the text with `font-weight: bold` / `font-style: italic`. A tint
-                // overlay on top of real bold text would just add a distracting colored
-                // background. The DOM wrap runs via [injectEmphasisDom] before the decoration
-                // apply so rects are measured from the already-reflowed DOM.
+                // ADR 0046: bold and italic reflow text via DOM span injection ([injectEmphasisDom])
+                // rather than painting tint overlays — a tint overlay on top of real bold text
+                // would add a distracting colored background.
             }
         }
         // Apply overlay decorations (underline / strike). Empty list = clear the group.
@@ -242,21 +233,9 @@ internal class ReadiumHighlightRenderer(
             applyDecorationsWithClear(decorations, "emphasis")
             hasEmphasisDecorations = true
         }
-        // ADR 0046: DOM injection for bold/italic — MUST fire unconditionally (when not skipped),
-        // not gated on underline/strike overlays. A range with only bold and/or italic produces
-        // zero companion decorations above (they use DOM mutation, not overlays), so skipping here
-        // when no overlays exist would leave bold/italic never applied. The script also self-cleans
-        // old wrappers each run, so calling it with an empty range list is the correct way to
-        // remove a previously-injected bold/italic when the user toggles it off.
-        // [skipDomInjection] is true when [applyAnnotations] has already called [injectEmphasisDom]
-        // before the decoration apply — running it again here would be redundant.
-        if (!skipDomInjection) {
-            evaluateJavascript?.let { runJs ->
-                val ranges = emphasisRangeProvider()
-                    .filter { it.styles.any { s -> s == EmphasisStyle.BOLD || s == EmphasisStyle.ITALIC } }
-                runJs(EmphasisDomInjector.script(ranges))
-            }
-        }
+        // Bold/italic DOM injection is handled by [injectEmphasisDom] in [applyAnnotations],
+        // called before [applyDecorationsWithClear] so Readium measures tap-target rects from the
+        // already-reflowed DOM. Nothing to do here — this function only applies overlay decorations.
         // Post-apply layout shifts are covered by the outer LaunchedEffect re-keying on
         // pageLoadGeneration / reflowGeneration. Local settle loop removed for parity with
         // applyAnnotations — see the comment there for rationale.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
@@ -105,6 +105,14 @@ internal class ReadiumHighlightRenderer(
             }
             return
         }
+        // Queue bold/italic DOM injection BEFORE Readium measures decoration positions.
+        // EmphasisDomInjector wraps bold/italic text in <span> elements, causing text reflow.
+        // evaluateJavascript calls are serialized through the same WebView JS thread queue, so
+        // injecting first guarantees bold/italic spans exist when Readium's applyDecorations JS
+        // runs — the measured tap-target rects reflect the already-reflowed layout.
+        // Without this ordering, rects are baked from the pre-bold DOM, then the DOM reflows after,
+        // leaving tap targets at stale coordinates (the annotation-not-tappable bug).
+        injectEmphasisDom()
         // Initial apply uses clear+apply too — Readium's decoration diff treats an identical
         // (id, locator, style) list as a no-op, so a re-fire of the same list (theme change bumps
         // pageLoadGeneration, LaunchedEffect keys the same renders) would keep the stale pre-reflow
@@ -114,7 +122,9 @@ internal class ReadiumHighlightRenderer(
         // ADR 0046: layered emphasis paints via companion decorations. Underline uses Readium's
         // built-in Style.Underline; strike/bold/italic v1 render as tinted overlays (bold + italic
         // are approximations pending true DOM mutation — captured as follow-up).
-        applyEmphasisCompanions(renders)
+        // DOM injection already ran above — pass skipDomInjection = true so emphasis overlays
+        // (underline/strike) apply without repeating the bold/italic span injection.
+        applyEmphasisCompanions(renders, skipDomInjection = true)
         // Post-apply layout shifts (page-load completion, reflow, orientation) are covered by the
         // outer LaunchedEffect in EpubReaderScreen re-keying on pageLoadGeneration / reflowGeneration
         // and re-invoking applyAnnotations. A fixed local settle loop here forced 2.6s of
@@ -177,15 +187,22 @@ internal class ReadiumHighlightRenderer(
     }
 
     /**
-     * ADR 0046: paint emphasis marks as companion decorations layered over the highlight decoration.
-     * Only [EmphasisStyle.UNDERLINE] uses Readium's built-in [Decoration.Style.Underline]; the
-     * other three styles are painted as tinted [Decoration.Style.Highlight] overlays with
-     * distinctive colors so the user sees SOMETHING for every stored style — proper text-style
-     * reflow for bold/italic/strike requires WebView DOM mutation and is captured as a follow-up.
-     * Grouped separately from "annotations" so a highlight recolor doesn't rebuild the emphasis
-     * overlays and vice versa.
+     * Queues the bold/italic DOM injection script to the WebView's JS thread.
+     * Called before [applyDecorationsWithClear] so Readium measures tap-target rects from the
+     * already-reflowed (post-bold/italic) DOM rather than from a pre-reflow snapshot.
      */
-    private suspend fun applyEmphasisCompanions(renders: List<EpubReaderViewModel.HighlightRender>) {
+    private suspend fun injectEmphasisDom() {
+        evaluateJavascript?.let { runJs ->
+            val ranges = emphasisRangeProvider()
+                .filter { it.styles.any { s -> s == EmphasisStyle.BOLD || s == EmphasisStyle.ITALIC } }
+            runJs(EmphasisDomInjector.script(ranges))
+        }
+    }
+
+    private suspend fun applyEmphasisCompanions(
+        renders: List<EpubReaderViewModel.HighlightRender>,
+        skipDomInjection: Boolean = false,
+    ) {
         val decorations = renders.flatMap { h ->
             if (h.emphasisStyles.isEmpty()) return@flatMap emptyList()
             buildList {
@@ -211,8 +228,8 @@ internal class ReadiumHighlightRenderer(
                 // (see [EmphasisDomInjector]) wraps the range in a styled `<span>` that actually
                 // reflows the text with `font-weight: bold` / `font-style: italic`. A tint
                 // overlay on top of real bold text would just add a distracting colored
-                // background. The DOM wrap runs from [applyEmphasisCompanions] via
-                // [evaluateJavascript] below.
+                // background. The DOM wrap runs via [injectEmphasisDom] before the decoration
+                // apply so rects are measured from the already-reflowed DOM.
             }
         }
         // Apply overlay decorations (underline / strike). Empty list = clear the group.
@@ -225,16 +242,20 @@ internal class ReadiumHighlightRenderer(
             applyDecorationsWithClear(decorations, "emphasis")
             hasEmphasisDecorations = true
         }
-        // ADR 0046: DOM injection for bold/italic — MUST fire unconditionally, not gated on
-        // underline/strike overlays. A range with only bold and/or italic produces zero
-        // companion decorations above (they use DOM mutation, not overlays), so an early
-        // return here would leave bold/italic never applied. The script also self-cleans old
-        // wrappers each run, so calling it with an empty range list is the correct way to
+        // ADR 0046: DOM injection for bold/italic — MUST fire unconditionally (when not skipped),
+        // not gated on underline/strike overlays. A range with only bold and/or italic produces
+        // zero companion decorations above (they use DOM mutation, not overlays), so skipping here
+        // when no overlays exist would leave bold/italic never applied. The script also self-cleans
+        // old wrappers each run, so calling it with an empty range list is the correct way to
         // remove a previously-injected bold/italic when the user toggles it off.
-        evaluateJavascript?.let { runJs ->
-            val ranges = emphasisRangeProvider()
-                .filter { it.styles.any { s -> s == EmphasisStyle.BOLD || s == EmphasisStyle.ITALIC } }
-            runJs(EmphasisDomInjector.script(ranges))
+        // [skipDomInjection] is true when [applyAnnotations] has already called [injectEmphasisDom]
+        // before the decoration apply — running it again here would be redundant.
+        if (!skipDomInjection) {
+            evaluateJavascript?.let { runJs ->
+                val ranges = emphasisRangeProvider()
+                    .filter { it.styles.any { s -> s == EmphasisStyle.BOLD || s == EmphasisStyle.ITALIC } }
+                runJs(EmphasisDomInjector.script(ranges))
+            }
         }
         // Post-apply layout shifts are covered by the outer LaunchedEffect re-keying on
         // pageLoadGeneration / reflowGeneration. Local settle loop removed for parity with

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
@@ -2,12 +2,14 @@
 
 package com.riffle.app.feature.reader
 
+import com.riffle.core.models.EmphasisStyle
 import com.riffle.core.models.HighlightColor
 import com.riffle.core.domain.SentenceQuote
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.readium.r2.navigator.Decoration
@@ -106,6 +108,52 @@ class ReadiumHighlightRendererTest {
         assertEquals(2, annotationCalls[1].first.size)
         assertEquals("h1", annotationCalls[1].first[0].id)
         assertEquals("h2", annotationCalls[1].first[1].id)
+    }
+
+    // Regression: bold/italic DOM injection must be queued BEFORE Readium measures decoration
+    // positions. EmphasisDomInjector wraps bold/italic text in <span> elements causing text
+    // reflow; if injected after applyDecorationsWithClear, Readium's baked tap-target rects
+    // become stale and the annotation is not tappable until close/reopen.
+    // This test fails if someone reverts the injectEmphasisDom() call to run after the
+    // applyDecorationsWithClear call (the annotation-not-tappable bug).
+    @Test
+    fun `applyAnnotations with bold emphasis queues DOM injection before decoration apply`() = runTest {
+        val callOrder = mutableListOf<String>()
+        val rendererWithDomInjector = ReadiumHighlightRenderer(
+            applyDecorationsBlock = { _, group -> callOrder.add("decorate:$group") },
+            fragmentLocator = { ref, _ ->
+                if (ref.isNotBlank()) minimalLocator(ref.substringBefore('#')) else null
+            },
+            evaluateJavascript = { callOrder.add("domInject") },
+            emphasisRangeProvider = {
+                listOf(
+                    EmphasisDomInjector.EmphasisRange(
+                        id = "h1",
+                        textSnippet = "bold text",
+                        textBefore = "",
+                        styles = setOf(EmphasisStyle.BOLD),
+                    )
+                )
+            },
+        )
+        val render = EpubReaderViewModel.HighlightRender(
+            id = "h1",
+            locator = minimalLocator("c.xhtml"),
+            color = "yellow",
+            note = null,
+            emphasisStyles = setOf(EmphasisStyle.BOLD),
+        )
+
+        rendererWithDomInjector.applyAnnotations(listOf(render))
+
+        val domInjectIndex = callOrder.indexOf("domInject")
+        val firstDecorateAnnotationsIndex = callOrder.indexOfFirst { it == "decorate:annotations" }
+        assertTrue("domInject index should exist", domInjectIndex >= 0)
+        assertTrue("decorate:annotations index should exist", firstDecorateAnnotationsIndex >= 0)
+        assertTrue(
+            "DOM injection must be queued before decoration apply (got order: $callOrder)",
+            domInjectIndex < firstDecorateAnnotationsIndex,
+        )
     }
 
     // Regression: the settle loop MUST stay out. Its return would re-introduce the cold-open


### PR DESCRIPTION
## Root cause

In `ReadiumHighlightRenderer.applyAnnotations()`, `applyDecorationsWithClear` was called before `applyEmphasisCompanions`, which ran `EmphasisDomInjector.script()` at its end. The injector wraps bold/italic text in `<span>` elements — a DOM mutation that causes text reflow. Readium had already baked tap-target bounding boxes from the pre-reflow DOM, leaving them stale after the reflow. Taps on formatting annotations hit the correct on-screen text but missed the stale decorated range, so `onDecorationActivated` never fired and the annotation couldn't be edited.

**Why intermittent:** On book open, loading saved `formattingPrefs` triggers `reflowGeneration` settle ticks (150/350/700ms), which drive a second `applyAnnotations`. By then the bold spans are already in the DOM, so Readium measures correct positions on the second pass. Users who tap before the 150ms tick see the bug; those who tap after don't.

**Why close/reopen "fixes" it:** Reopening loads formattingPrefs from storage, coincidentally triggering the reflowGeneration bumps that drive the corrective second apply.

**Unaffected:** Color-only highlights (no bold/italic) produce no DOM mutation — their positions are never stale.

## Fix

Add `injectEmphasisDom()` called before `applyDecorationsWithClear(decorations, "annotations")`. Since `evaluateJavascript` calls are serialized through the WebView's JS thread queue, queueing the DOM injection first guarantees bold/italic spans exist when Readium's applyDecorations JS runs and measures positions. `applyEmphasisCompanions` no longer handles DOM injection — it's purely overlay decorations (underline/strike) now.

## Regression test

`applyAnnotations with bold emphasis queues DOM injection before decoration apply` — asserts `domInject` appears before `decorate:annotations` in the call order; flips red if the ordering is reverted.