### PR TITLE
feat(reader): enter immersive mode on scroll when chrome is visible

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -485,6 +485,7 @@ fun EpubReaderScreen(
                             }
                         },
                         onTap = immersiveState::toggle,
+                        onScrollStart = immersiveState::dismissOverlay,
                         onUserInteracted = viewModel::onUserInteracted,
                         onSelectionEnded = {
                             // Belt-and-braces: sticky IMMERSIVE (see immersiveSystemBarsBehavior)
@@ -1406,6 +1407,7 @@ private fun EpubNavigatorView(
      *  don't trigger backward↔forward oscillation. Defaults to false so the full-book path keeps
      *  its memory-capped configuration. */
     isElidedContinuous: Boolean = false,
+    onScrollStart: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -2756,6 +2758,7 @@ private fun EpubNavigatorView(
                 container.onPullEnded = { pullActive = false }
                 container.onPullProgress = { p -> pullProgress = p }
                 container.onUserTouch = { onUserInteracted() }
+                container.onScrollStart = { onScrollStart() }
 
                 val fragmentContainer = (container.getChildAt(0) as? android.view.ViewGroup)
                     ?.getChildAt(0) as? FragmentContainerView

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ImmersiveModeState.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ImmersiveModeState.kt
@@ -156,12 +156,12 @@ class ImmersiveModeState internal constructor(
         }
     }
 
-    // Called on position change: only auto-hides the AppBar when bars are already hidden,
-    // so position changes in normal (bars-visible) mode don't dismiss the overlay.
-    // Suppressed for TOGGLE_COOLDOWN_MS after the user taps to reveal the bar.
+    // Called on position change: hides the AppBar (and enters full immersive if bars are
+    // visible) on scroll. Suppressed for TOGGLE_COOLDOWN_MS after the user taps to reveal.
     fun dismissOverlay() {
         val now = clock()
-        if (systemBarsHidden && now - lastToggleMs > TOGGLE_COOLDOWN_MS) isImmersive = true
+        if (now - lastToggleMs <= TOGGLE_COOLDOWN_MS) return
+        if (systemBarsHidden) isImmersive = true else hide()
     }
 
     // Guard: only call controller.hide() if bars are not already hidden.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ScrollBoundaryNavigationContainer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ScrollBoundaryNavigationContainer.kt
@@ -151,7 +151,8 @@ class ScrollBoundaryNavigationContainer(context: Context) : FrameLayout(context)
                     resetPull()
                 }
                 MotionEvent.ACTION_MOVE -> {
-                    if (!scrollStartFired && abs(ev.y - downY) > touchSlopPx) {
+                    val dy = abs(ev.y - downY)
+                    if (!scrollStartFired && dy > touchSlopPx && dy >= abs(ev.x - downX)) {
                         scrollStartFired = true
                         onScrollStart?.invoke()
                     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ScrollBoundaryNavigationContainer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ScrollBoundaryNavigationContainer.kt
@@ -41,11 +41,18 @@ class ScrollBoundaryNavigationContainer(context: Context) : FrameLayout(context)
      */
     var onUserTouch: (() -> Unit)? = null
 
+    /**
+     * Fires once per gesture the first time vertical movement exceeds touch-slop in scroll mode.
+     * Used to enter immersive mode at scroll start rather than waiting for a Readium locator event.
+     */
+    var onScrollStart: (() -> Unit)? = null
+
     private var lastNavigationMs = 0L
     private var lastVolumeNavMs = 0L
     private var lastTouchY = 0f
     private var downX = 0f
     private var downY = 0f
+    private var scrollStartFired = false
     private var lastMoveTimeMs = 0L
     private var pullDirection = 0 // 1 = forward pull, -1 = backward pull, 0 = inactive
     private var pullDistancePx = 0f
@@ -140,10 +147,20 @@ class ScrollBoundaryNavigationContainer(context: Context) : FrameLayout(context)
                     lastTouchY = ev.y
                     downX = ev.x
                     downY = ev.y
+                    scrollStartFired = false
                     resetPull()
                 }
-                MotionEvent.ACTION_MOVE -> handlePullMove(ev.x, ev.y)
-                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> resetPull()
+                MotionEvent.ACTION_MOVE -> {
+                    if (!scrollStartFired && abs(ev.y - downY) > touchSlopPx) {
+                        scrollStartFired = true
+                        onScrollStart?.invoke()
+                    }
+                    handlePullMove(ev.x, ev.y)
+                }
+                MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                    scrollStartFired = false
+                    resetPull()
+                }
             }
         }
         return super.dispatchTouchEvent(ev)

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ImmersiveModeStateTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ImmersiveModeStateTest.kt
@@ -121,10 +121,23 @@ class ImmersiveModeStateTest {
     }
 
     @Test
-    fun `dismissOverlay does nothing when bars are visible`() {
+    fun `dismissOverlay does nothing within TOGGLE_COOLDOWN_MS of construction`() {
+        // lastToggleMs starts at 0; at nowMs=0 the cooldown guard fires before any bars check.
         state.dismissOverlay()
 
         assertFalse(state.isImmersive)
+        assertEquals(0, controller.hideCount)
+    }
+
+    @Test
+    fun `dismissOverlay enters full immersive on scroll when bars are visible and cooldown elapsed`() {
+        // Simulate user having tapped out of immersive: bars visible, cooldown has since passed.
+        nowMs = ImmersiveModeState.TOGGLE_COOLDOWN_MS + 1
+        state.dismissOverlay()
+
+        assertTrue(state.isImmersive)
+        assertTrue(state.systemBarsHiddenForTest)
+        assertEquals(1, controller.hideCount)
     }
 
     @Test


### PR DESCRIPTION
## What

When the reader chrome (top bar + system bars) is visible and the user starts scrolling, the reader now enters immersive mode immediately — consistent with the existing behaviour of re-hiding the top bar when the system bars are already hidden.

Covers all three reader modes:
- **Continuous**: already received scroll-start triggers via per-frame `onPositionChanged` events; `dismissOverlay()` now acts on them when bars are visible.
- **Vertical**: previously waited for a Readium locator event that only fires after scroll ends. New `onScrollStart` callback in `ScrollBoundaryNavigationContainer` fires as soon as vertical movement exceeds touch-slop, giving scroll-start entry.
- **Paginated**: unchanged — taps toggle immersive as before.

The existing 500 ms `TOGGLE_COOLDOWN_MS` guard remains, preventing a tap-to-reveal from immediately fighting itself.

## Changes

- `ImmersiveModeState.dismissOverlay()` — when system bars are visible and the cooldown has elapsed, calls `hide()` (full immersive entry) instead of being a no-op.
- `ScrollBoundaryNavigationContainer` — adds `onScrollStart: (() -> Unit)?` callback; fires once per gesture when vertical displacement exceeds touch-slop and dominates horizontal displacement (guards against chapter-swipes with minor vertical drift).
- `EpubNavigatorView` — new `onScrollStart` parameter wired to `container.onScrollStart` in the `AndroidView` update block.
- `EpubReaderScreen` — passes `immersiveState::dismissOverlay` as `onScrollStart`.

## Tests

- `ImmersiveModeStateTest`: renamed the misleading `"does nothing when bars are visible"` test; added `"enters full immersive on scroll when bars are visible and cooldown elapsed"` asserting `hide()` is called.