### PR TITLE
fix(reader): fix continuous-mode selections near top of page on API-25 emulator

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousReaderViewSelectionInterceptTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousReaderViewSelectionInterceptTest.kt
@@ -141,7 +141,7 @@ class ContinuousReaderViewSelectionInterceptTest {
     @Test
     fun requestChildFocus_doesNotCrashAndCancelsScroller() {
         // Smoke test: NestedScrollView.requestChildFocus fires scrollToChild→scrollBy, which our
-        // override short-circuits via the inRequestChildFocus flag. The deferred path (when
+        // override short-circuits via the suppressScrollByDepth counter. The deferred path (when
         // mIsLayoutDirty=true at call time) is guarded by the onLayout override. We can't easily
         // assert the absence of scroll on an unattached view, but we can verify no crash.
         val v = view()

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousReaderViewSelectionInterceptTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousReaderViewSelectionInterceptTest.kt
@@ -140,10 +140,10 @@ class ContinuousReaderViewSelectionInterceptTest {
 
     @Test
     fun requestChildFocus_doesNotCrashAndCancelsScroller() {
-        // Smoke test: NestedScrollView.requestChildFocus would queue a scroll-into-view via the
-        // private mScroller. Our override calls abortFling() after super to cancel that scroll.
-        // We can't easily prove the absence of scrolling on an unattached view, but we can prove
-        // the override doesn't crash and that the view doesn't end up in an inconsistent state.
+        // Smoke test: NestedScrollView.requestChildFocus fires scrollToChild→scrollBy, which our
+        // override short-circuits via the inRequestChildFocus flag. The deferred path (when
+        // mIsLayoutDirty=true at call time) is guarded by the onLayout override. We can't easily
+        // assert the absence of scroll on an unattached view, but we can verify no crash.
         val v = view()
         val child = android.view.View(context)
         onMain {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -813,6 +813,14 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
  * already inside the visible band), the original top/bottom pass through unchanged. See the
  * call-site in [ChapterWebView.wrapSelectionCallback] for why this clamping is necessary on
  * edge-to-edge displays.
+ *
+ * Top clamping is skipped when [viewLocationInWindowY] >= 0. On API < 30,
+ * [android.view.View.getWindowVisibleDisplayFrame] returns a non-zero top equal to the status-bar
+ * height even when the app draws edge-to-edge, which would produce a spurious positive topLocal.
+ * A selection in the opening lines of a chapter (rectBottom < statusBarHeight) then collapses to
+ * a zero-height rect that Chrome 55's FloatingToolbar cannot anchor to, making the menu invisible.
+ * Top clamping is only needed when the WebView is genuinely scrolled above the window origin
+ * (viewLocationInWindowY < 0) and the selection is off-screen above.
  */
 internal fun clampSelectionYBandToWindow(
     rectTop: Int,
@@ -822,7 +830,7 @@ internal fun clampSelectionYBandToWindow(
     viewLocationInWindowY: Int,
     viewHeight: Int,
 ): Pair<Int, Int> {
-    val topLocal = (viewportTop - viewLocationInWindowY).coerceAtLeast(0)
+    val topLocal = if (viewLocationInWindowY < 0) (viewportTop - viewLocationInWindowY).coerceAtLeast(0) else 0
     val bottomLocal = (viewportBottom - viewLocationInWindowY).coerceAtMost(viewHeight)
     if (bottomLocal <= topLocal) return rectTop to rectBottom
     return rectTop.coerceIn(topLocal, bottomLocal) to rectBottom.coerceIn(topLocal, bottomLocal)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -305,35 +305,39 @@ internal class ContinuousReaderView @JvmOverloads constructor(
      *
      * (a) Synchronous: when [NestedScrollView]'s mIsLayoutDirty is false, requestChildFocus calls
      *     scrollToChild → scrollBy immediately. We block this by short-circuiting [scrollBy] while
-     *     [inRequestChildFocus] is set.
+     *     [suppressScrollByDepth] > 0.
      *
      * (b) Deferred: when mIsLayoutDirty is true (old Chromium / Chrome 55 on the API-25 emulator
      *     calls requestFocus during a layout invalidation), NestedScrollView queues the scroll in
      *     mChildToScrollTo and fires it from its onLayout. We cover that path in [onLayout] by
-     *     holding [inRequestChildFocus] true across the entire super.onLayout call.
+     *     holding [suppressScrollByDepth] > 0 across the entire super.onLayout call.
+     *
+     * A depth counter (not a boolean) is required for correctness: if Chrome 55 calls
+     * requestFocus from inside a WebView.onLayout that fires during our super.onLayout, the nested
+     * requestChildFocus call must not decrement the counter below the onLayout guard's level.
      */
-    private var inRequestChildFocus = false
+    private var suppressScrollByDepth = 0
 
     override fun requestChildFocus(child: android.view.View?, focused: android.view.View?) {
-        inRequestChildFocus = true
+        suppressScrollByDepth++
         try {
             super.requestChildFocus(child, focused)
         } finally {
-            inRequestChildFocus = false
+            suppressScrollByDepth--
         }
     }
 
     override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
-        inRequestChildFocus = true
+        suppressScrollByDepth++
         try {
             super.onLayout(changed, l, t, r, b)
         } finally {
-            inRequestChildFocus = false
+            suppressScrollByDepth--
         }
     }
 
     override fun scrollBy(x: Int, y: Int) {
-        if (inRequestChildFocus) return
+        if (suppressScrollByDepth > 0) return
         super.scrollBy(x, y)
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -300,13 +300,17 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     override fun onStartNestedScroll(child: android.view.View, target: android.view.View, axes: Int, type: Int): Boolean = false
 
     /**
-     * Suppress NestedScrollView's "scroll the focused child into view" inside super.requestChildFocus.
-     * Modern Chromium WebView calls requestFocus on itself when a long-press completes a selection;
-     * NestedScrollView.scrollToChild then synchronously scrollBy()s to reposition the word toward
-     * the middle — the "page jump on long-press near an edge" bug.
+     * Suppress NestedScrollView's "scroll the focused child into view" triggered by a long-press
+     * selection. Two paths lead to the scroll:
      *
-     * We can't override scrollToChild (package-private). Instead we set a flag for the duration of
-     * super.requestChildFocus and short-circuit [scrollBy] while it's set.
+     * (a) Synchronous: when [NestedScrollView]'s mIsLayoutDirty is false, requestChildFocus calls
+     *     scrollToChild → scrollBy immediately. We block this by short-circuiting [scrollBy] while
+     *     [inRequestChildFocus] is set.
+     *
+     * (b) Deferred: when mIsLayoutDirty is true (old Chromium / Chrome 55 on the API-25 emulator
+     *     calls requestFocus during a layout invalidation), NestedScrollView queues the scroll in
+     *     mChildToScrollTo and fires it from its onLayout. We cover that path in [onLayout] by
+     *     holding [inRequestChildFocus] true across the entire super.onLayout call.
      */
     private var inRequestChildFocus = false
 
@@ -314,6 +318,15 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         inRequestChildFocus = true
         try {
             super.requestChildFocus(child, focused)
+        } finally {
+            inRequestChildFocus = false
+        }
+    }
+
+    override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
+        inRequestChildFocus = true
+        try {
+            super.onLayout(changed, l, t, r, b)
         } finally {
             inRequestChildFocus = false
         }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWebViewSelectionClampTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWebViewSelectionClampTest.kt
@@ -74,6 +74,26 @@ class ChapterWebViewSelectionClampTest {
     }
 
     @Test
+    fun `selection at top of page on API-25 emulator is not squashed to zero-height rect`() {
+        // API-25 with edge-to-edge layout: the WebView sits at window y=0 (viewLocationInWindowY=0)
+        // but getWindowVisibleDisplayFrame().top returns the status-bar height (e.g. 66px) because
+        // API < 30 does not zero that field even with edge-to-edge flags set. Previously this
+        // produced topLocal=66, and a selection in the opening lines of a chapter (rectBottom < 66)
+        // was clamped to a zero-height rect at y=66 — making Chrome 55's floating toolbar invisible.
+        // The fix: skip top-clamping when viewLocationInWindowY >= 0.
+        val (top, bottom) = clampSelectionYBandToWindow(
+            rectTop = 0,
+            rectBottom = 30,
+            viewportTop = 66,   // API-25 status-bar height in getWindowVisibleDisplayFrame
+            viewportBottom = 1794,
+            viewLocationInWindowY = 0,  // WebView at window top in edge-to-edge layout
+            viewHeight = 20000,
+        )
+        assertEquals(0, top)
+        assertEquals(30, bottom)
+    }
+
+    @Test
     fun `selection partially below window viewport has its bottom pulled up to the band`() {
         // Visible band in view-local: 0 .. 1819 (same as case 1). Rect straddles the bottom edge.
         val (top, bottom) = clampSelectionYBandToWindow(


### PR DESCRIPTION
Two root causes for "selector menu invisible + page jumps" when selecting text in the opening lines of a chapter in continuous mode on the API-25 / Chrome 55 emulator. Not reproducible on real devices (API 35, modern Chrome).

## Menu invisible — `clampSelectionYBandToWindow`

`topLocal` was computed as `(wvdf.top − locWin[1]).coerceAtLeast(0)`. On API < 30, `getWindowVisibleDisplayFrame().top` returns the status-bar height (~66 px) even with edge-to-edge flags, while the chapter WebView sits at `locWin[1] = 0`. That yielded `topLocal = 66`. A selection in the first text-lines (where `rectBottom < 66`) had both edges clamped to 66 → zero-height rect → Chrome 55's FloatingToolbar had nowhere to anchor and rendered invisibly.

Fix: only compute `topLocal > 0` when `viewLocationInWindowY < 0` (WebView genuinely scrolled above the window origin). On API 35 with edge-to-edge, `wvdf.top = 0` so this path never triggered.

## Page jumps — deferred `scrollToChild` in `onLayout`

`NestedScrollView.requestChildFocus` has two paths to `scrollToChild`:
- **Synchronous** (`mIsLayoutDirty = false`): blocked by the `suppressScrollByDepth` guard in `scrollBy`.
- **Deferred** (`mIsLayoutDirty = true`): queued via `mChildToScrollTo`, fires from `onLayout` — after `requestChildFocus` returns and the guard is back to 0.

Chrome 55 calls `requestFocus` during a layout invalidation (deferred path). Modern Chrome calls it after layout settles (synchronous path). Fix: added `onLayout` override that holds `suppressScrollByDepth > 0` across the entire `super.onLayout()`, blocking the deferred scroll.

## Reentrancy fix (review)

Replaced the `inRequestChildFocus` boolean with a `suppressScrollByDepth` depth counter. A nested `requestChildFocus` call from within `super.onLayout` would have decremented a boolean back to `false` while the `onLayout` guard was still active. A counter handles nesting correctly.

## Tests

- New JVM regression test: `rectBottom < viewportTop` with `viewLocationInWindowY = 0` now passes through unclamped (previously zero-height rect).
- All existing `ChapterWebViewSelectionClampTest` cases still pass.