### PR TITLE
perf(reader,data): fix O(N²) annotation load — batch upsert, chapter/render caches

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubCfiRange.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubCfiRange.kt
@@ -95,6 +95,12 @@ internal fun highlightStartProgression(rangeCfi: String, html: String): Double? 
     return cfiDocPathToProgression(startDocPath, html)
 }
 
+/** Pre-parsed-document overload — avoids re-parsing [doc] when multiple highlights share a chapter. */
+internal fun highlightStartProgression(rangeCfi: String, doc: org.jsoup.nodes.Document): Double? {
+    val startDocPath = rangeStartDocPath(rangeCfi) ?: return null
+    return cfiDocPathToProgression(startDocPath, doc)
+}
+
 /**
  * Concatenation of the body's readable-text (blank-only text nodes skipped) — the "flat" view of
  * the chapter that [countBodyChars] measures. All char offsets used by highlight merging are

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubCfiRange.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubCfiRange.kt
@@ -101,6 +101,12 @@ internal fun highlightStartProgression(rangeCfi: String, doc: org.jsoup.nodes.Do
     return cfiDocPathToProgression(startDocPath, doc)
 }
 
+/** Pre-parsed-document + pre-counted totalChars overload — avoids both re-parsing and re-counting. */
+internal fun highlightStartProgression(rangeCfi: String, doc: org.jsoup.nodes.Document, totalChars: Long): Double? {
+    val startDocPath = rangeStartDocPath(rangeCfi) ?: return null
+    return cfiDocPathToProgression(startDocPath, doc, totalChars)
+}
+
 /**
  * Concatenation of the body's readable-text (blank-only text nodes skipped) — the "flat" view of
  * the chapter that [countBodyChars] measures. All char offsets used by highlight merging are

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -506,6 +506,22 @@ class EpubReaderViewModel @Inject constructor(
     // lifecycle.matchedSync.value; teardown via lifecycle.onCleared().
     private val chapterHtmlCache = mutableMapOf<Int, String>()
     private val chapterDocCache = mutableMapOf<Int, org.jsoup.nodes.Document>()
+    private val chapterTotalCharsCache = mutableMapOf<Int, Long>()
+
+    // Key for the annotation render result cache — covers every field that affects the output of
+    // annotationToRender so cache hits are only returned when the render would be byte-identical.
+    private data class AnnotationRenderKey(
+        val cfi: String,
+        val textSnippet: String,
+        val textBefore: String,
+        val textAfter: String,
+        val embeddedFigures: List<com.riffle.core.models.EmbeddedFigure>?,
+        val color: String,
+        val note: String?,
+        val emphasisStyles: Set<com.riffle.core.models.EmphasisStyle>,
+    )
+    private val annotationRenderCache =
+        mutableMapOf<String, Pair<AnnotationRenderKey, List<HighlightRender>>>()
 
     // Highlights mode only (Task 10, ADR 0041): the chapter grouping + resolved server id from the
     // last [openBook] build, kept so the resume-position collector below can map a synthesised-href
@@ -3202,12 +3218,41 @@ class EpubReaderViewModel @Inject constructor(
      * with a `#segN` suffix so `annotationIdOf` can strip it back at tap-dispatch time.
      */
     private suspend fun annotationToRender(a: Annotation): List<HighlightRender> {
+        // ADR 0046: union every TYPE_EMPHASIS row whose CFI matches this highlight's CFI.
+        // Computed first so it feeds the cache key — a style toggle invalidates the cache entry.
+        val emphasisStyles = annotationSession.emphasisPool.value
+            .filter { it.cfi == a.cfi }
+            .flatMap { it.emphasisStyles.orEmpty() }
+            .toSet()
+
+        // Return the cached result when nothing affecting the render has changed. This makes
+        // repeated emissions (live-sync re-upserts unchanged rows, store-combine re-fires when
+        // the editing target or draft changes) free for annotations that haven't moved.
+        val cacheKey = AnnotationRenderKey(
+            cfi = a.cfi,
+            textSnippet = a.textSnippet,
+            textBefore = a.textBefore,
+            textAfter = a.textAfter,
+            embeddedFigures = a.embeddedFigures,
+            color = a.color,
+            note = a.note,
+            emphasisStyles = emphasisStyles,
+        )
+        annotationRenderCache[a.id]?.let { (key, renders) ->
+            if (key == cacheKey) return renders
+        }
+
         val pub = lifecycle.publication.value ?: return emptyList()
         val spineIndex = epubCfiToSpineIndex(a.cfi) ?: return emptyList()
         val link = pub.readingOrder.getOrNull(spineIndex) ?: return emptyList()
         val html = readChapterHtml(spineIndex) ?: return emptyList()
         val doc = readChapterDoc(spineIndex, html)
-        val progression = highlightStartProgression(a.cfi, doc) ?: return emptyList()
+        // countBodyChars is O(DOM) but constant per chapter — cache it so N annotations in the
+        // same chapter only traverse the body once instead of N times.
+        val totalChars = chapterTotalCharsCache.getOrPut(spineIndex) {
+            com.riffle.core.domain.countBodyChars(doc.body())
+        }
+        val progression = highlightStartProgression(a.cfi, doc, totalChars) ?: return emptyList()
         val href = link.href.toString()
         // Split points inside the snippet where a figure sits. Legacy rows without offsets → one
         // segment covering the whole snippet (v1 behaviour).
@@ -3220,7 +3265,7 @@ class EpubReaderViewModel @Inject constructor(
         } else {
             splitSnippetForFiguresAt(a.textSnippet, offsets)
         }
-        return segments
+        val renders = segments
             .mapIndexedNotNull { index, segmentText ->
                 if (segmentText.isBlank()) return@mapIndexedNotNull null
                 val locator = try {
@@ -3238,17 +3283,10 @@ class EpubReaderViewModel @Inject constructor(
                     null
                 } ?: return@mapIndexedNotNull null
                 val decorationId = if (segments.size == 1) a.id else "${a.id}#seg$index"
-                // ADR 0046: union every TYPE_EMPHASIS row whose CFI matches this highlight's CFI.
-                // Multiple rows can layer via different styles sets (same-styles rows auto-merge),
-                // so union-at-render gives the correct visual result without touching storage.
-                // Read from `emphasisPool` (not `annotations`) — the panel-side flow excludes
-                // emphasis rows to protect the piggyback rule, so `annotations` would be empty here.
-                val emphasisStyles = annotationSession.emphasisPool.value
-                    .filter { it.cfi == a.cfi }
-                    .flatMap { it.emphasisStyles.orEmpty() }
-                    .toSet()
                 HighlightRender(decorationId, locator, a.color, a.note, emphasisStyles = emphasisStyles)
             }
+        annotationRenderCache[a.id] = cacheKey to renders
+        return renders
     }
 
     private suspend fun readChapterHtml(spineIndex: Int): String? {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1126,6 +1126,12 @@ class EpubReaderViewModel @Inject constructor(
     }
 
     private suspend fun openBook() {
+        // Clear per-chapter and render caches so reloadHighlightsView() picks up the rebuilt
+        // spine rather than returning Documents/renders from the previous publication layout.
+        chapterHtmlCache.clear()
+        chapterDocCache.clear()
+        chapterTotalCharsCache.clear()
+        annotationRenderCache.clear()
         // Highlights mode (ADR 0041): the reader displays a synthesised, elided Publication built
         // from this book's stored highlights rather than the real ABS EPUB container. Diverted
         // before lifecycle.open() so the ABS fetch, matched-sync resolution, readaloud binding, and
@@ -3145,6 +3151,7 @@ class EpubReaderViewModel @Inject constructor(
      *  if needed. Highlights mode: observer takes over as with [deleteHighlight]. Sibling
      *  emphasis cascade is handled in [AnnotationSession.deleteAnnotation]. */
     fun deleteAnnotation(id: String) {
+        annotationRenderCache.remove(id)
         viewModelScope.launch {
             annotationSession.deleteAnnotation(id)
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -505,6 +505,7 @@ class EpubReaderViewModel @Inject constructor(
     // now live on [lifecycle] (issue #376). Reads route through lifecycle.publication.value and
     // lifecycle.matchedSync.value; teardown via lifecycle.onCleared().
     private val chapterHtmlCache = mutableMapOf<Int, String>()
+    private val chapterDocCache = mutableMapOf<Int, org.jsoup.nodes.Document>()
 
     // Highlights mode only (Task 10, ADR 0041): the chapter grouping + resolved server id from the
     // last [openBook] build, kept so the resume-position collector below can map a synthesised-href
@@ -3205,7 +3206,8 @@ class EpubReaderViewModel @Inject constructor(
         val spineIndex = epubCfiToSpineIndex(a.cfi) ?: return emptyList()
         val link = pub.readingOrder.getOrNull(spineIndex) ?: return emptyList()
         val html = readChapterHtml(spineIndex) ?: return emptyList()
-        val progression = highlightStartProgression(a.cfi, html) ?: return emptyList()
+        val doc = readChapterDoc(spineIndex, html)
+        val progression = highlightStartProgression(a.cfi, doc) ?: return emptyList()
         val href = link.href.toString()
         // Split points inside the snippet where a figure sits. Legacy rows without offsets → one
         // segment covering the whole snippet (v1 behaviour).
@@ -3263,6 +3265,9 @@ class EpubReaderViewModel @Inject constructor(
             } catch (_: Exception) { null }
         }
     }
+
+    private fun readChapterDoc(spineIndex: Int, html: String): org.jsoup.nodes.Document =
+        chapterDocCache.getOrPut(spineIndex) { org.jsoup.Jsoup.parse(html) }
 
     override fun onCleared() {
         super.onCleared()

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubCfiRangeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubCfiRangeTest.kt
@@ -83,6 +83,18 @@ class EpubCfiRangeTest {
     }
 
     @Test
+    fun `highlightStartProgression with pre-computed totalChars matches the auto-count overload`() {
+        val cfi = buildHighlightCfiRangeForSelection(
+            spineStep = 4, html = simpleHtml, startProgression = 0.0, selectedText = "Hello",
+        )!!
+        val doc = org.jsoup.Jsoup.parse(simpleHtml)
+        val totalChars = com.riffle.core.domain.countBodyChars(doc.body())
+        val expected = highlightStartProgression(cfi, doc)
+        val actual   = highlightStartProgression(cfi, doc, totalChars)
+        assertEquals(expected, actual)
+    }
+
+    @Test
     fun `readableTextBetween returns the exact readable substring across nodes`() {
         // body readable chars: "Hello world"(0..10) + "Second paragraph"(11..26)
         assertEquals("Hello", readableTextBetween(simpleHtml, 0, 5))

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -309,6 +309,47 @@ class AnnotationSessionTest {
     }
 
     /**
+     * Regression: repeated store emissions with unchanged annotations must produce stable renders.
+     * The annotationToRender resolver in the VM caches results keyed on annotation content, so a
+     * live-sync re-upsert of identical rows (upsertAll with no deltas) must not corrupt the render
+     * list or produce different ids/colors from the first emission.
+     */
+    @Test
+    fun `highlightRenders are stable when the same annotations are re-emitted`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val store = FakeAnnotationStore()
+        val session = makeSession(store = store, syncOps = FakeSyncOps(), scope = sessionScope)
+        val annotations = listOf(
+            fakeAnnotation(id = "a1", color = "yellow"),
+            fakeAnnotation(id = "a2", color = "green"),
+            fakeAnnotation(id = "a3", color = "blue"),
+        )
+        val locator = buildLocator()
+        val resolver: suspend (Annotation) -> List<EpubReaderViewModel.HighlightRender> = { a ->
+            listOf(EpubReaderViewModel.HighlightRender(a.id, locator, a.color, a.note))
+        }
+        session.bind(
+            sourceId = "srv1", namespace = "ns1", itemId = "item1",
+            highlightRenderResolver = resolver, cfiLocatorResolver = { null },
+        )
+
+        store.allAnnotations.value = annotations
+        val firstIds    = session.highlightRenders.value.map { it.id }
+        val firstColors = session.highlightRenders.value.map { it.color }
+        assertEquals(3, firstIds.size)
+
+        // Re-emit identical list (simulates live-sync that found no peer changes → upsertAll
+        // same rows → single Room emission → flatMap re-runs; VM cache must return same renders).
+        store.allAnnotations.value = annotations.toList()
+        assertEquals("re-emission must not change render count",  firstIds.size, session.highlightRenders.value.size)
+        assertEquals("render ids must be stable across re-emission", firstIds, session.highlightRenders.value.map { it.id })
+        assertEquals("render colors must be stable across re-emission", firstColors, session.highlightRenders.value.map { it.color })
+
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
+
+    /**
      * Test 2: recolorHighlight updates store and schedules debounce sync
      */
     @Test

--- a/core/data/src/androidTest/kotlin/com/riffle/core/data/AnnotationSyncControllerIntegrationTest.kt
+++ b/core/data/src/androidTest/kotlin/com/riffle/core/data/AnnotationSyncControllerIntegrationTest.kt
@@ -340,8 +340,9 @@ class AnnotationSyncControllerIntegrationTest {
         nullTargetController.scheduleDebounce(serverId, namespace = serverId, itemId = itemId)
         nullTargetController.syncOnClose(serverId, namespace = serverId, itemId = itemId)
 
-        // Verify AnnotationDao was never called
+        // Verify AnnotationDao was never called (either the batch or singular path)
         coVerify(exactly = 0) { annotationDao.upsertAll(any()) }
+        coVerify(exactly = 0) { annotationDao.upsert(any()) }
 
         // Verify file was not created
         val annotationSyncDir = File(filesDir, "annotation-sync")

--- a/core/data/src/androidTest/kotlin/com/riffle/core/data/AnnotationSyncControllerIntegrationTest.kt
+++ b/core/data/src/androidTest/kotlin/com/riffle/core/data/AnnotationSyncControllerIntegrationTest.kt
@@ -135,9 +135,10 @@ class AnnotationSyncControllerIntegrationTest {
         // Call syncOnOpen
         controller.syncOnOpen(serverId, namespace = serverId, itemId = itemId)
 
-        // Verify that AnnotationDao.upsert was called (at least once for each annotation)
-        // We expect 2 calls: one for ann-001, one for ann-002
-        coVerify(atLeast = 2) { annotationDao.upsert(any()) }
+        // Verify that AnnotationDao.upsertAll was called with both annotations in one batch
+        val upsertSlot1 = slot<List<AnnotationEntity>>()
+        coVerify { annotationDao.upsertAll(capture(upsertSlot1)) }
+        assertEquals(2, upsertSlot1.captured.size)
     }
 
     /**
@@ -340,7 +341,7 @@ class AnnotationSyncControllerIntegrationTest {
         nullTargetController.syncOnClose(serverId, namespace = serverId, itemId = itemId)
 
         // Verify AnnotationDao was never called
-        coVerify(exactly = 0) { annotationDao.upsert(any()) }
+        coVerify(exactly = 0) { annotationDao.upsertAll(any()) }
 
         // Verify file was not created
         val annotationSyncDir = File(filesDir, "annotation-sync")
@@ -389,13 +390,11 @@ class AnnotationSyncControllerIntegrationTest {
         // Call syncOnOpen
         controller.syncOnOpen(serverId, namespace = serverId, itemId = itemId)
 
-        // Verify only one annotation was upserted (from device-a, skipping device-b)
-        coVerify(exactly = 1) { annotationDao.upsert(any()) }
-
-        // Verify that the upserted annotation has the correct ID
-        val upsertSlot = slot<AnnotationEntity>()
-        coVerify { annotationDao.upsert(capture(upsertSlot)) }
-        assertEquals("ann-valid-001", upsertSlot.captured.id)
+        // Verify only one annotation was upserted in a single batch (from device-a, skipping device-b)
+        val upsertSlot = slot<List<AnnotationEntity>>()
+        coVerify { annotationDao.upsertAll(capture(upsertSlot)) }
+        assertEquals(1, upsertSlot.captured.size)
+        assertEquals("ann-valid-001", upsertSlot.captured.first().id)
     }
 
     /**

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationMergeOrchestrator.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationMergeOrchestrator.kt
@@ -172,9 +172,7 @@ internal class AnnotationMergeOrchestrator(
                 )
             }
 
-            for (entity in entities) {
-                annotationDao.upsert(entity)
-            }
+            annotationDao.upsertAll(entities)
             statusStore.report(CycleOutcome.Success(clock()))
             sentinelWriter.writeQuietly(target, namespace, sourceId)
         } catch (e: Exception) {

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/EpubCfiTranslator.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/EpubCfiTranslator.kt
@@ -21,11 +21,14 @@ fun extractCfiDocPath(fullCfi: String): String? {
 fun cfiDocPathToProgression(docPath: String, html: String): Double? =
     cfiDocPathToProgression(docPath, Jsoup.parse(html))
 
-fun cfiDocPathToProgression(docPath: String, doc: org.jsoup.nodes.Document): Double? {
+fun cfiDocPathToProgression(docPath: String, doc: org.jsoup.nodes.Document): Double? =
+    cfiDocPathToProgression(docPath, doc, countBodyChars(doc.body()))
+
+/** Pre-computed [totalChars] overload — avoids re-counting body chars when many CFIs share a chapter. */
+fun cfiDocPathToProgression(docPath: String, doc: org.jsoup.nodes.Document, totalChars: Long): Double? {
     val htmlEl = doc.child(0)
     val body = doc.body()
 
-    val totalChars = countBodyChars(body)
     if (totalChars == 0L) return null
 
     // ID-anchored first (image-resistant); falls back to pure numeric step walk

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/EpubCfiTranslator.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/EpubCfiTranslator.kt
@@ -18,8 +18,10 @@ fun extractCfiDocPath(fullCfi: String): String? {
     return inner.substring(bang + 1).takeIf { it.isNotEmpty() }
 }
 
-fun cfiDocPathToProgression(docPath: String, html: String): Double? {
-    val doc = Jsoup.parse(html)
+fun cfiDocPathToProgression(docPath: String, html: String): Double? =
+    cfiDocPathToProgression(docPath, Jsoup.parse(html))
+
+fun cfiDocPathToProgression(docPath: String, doc: org.jsoup.nodes.Document): Double? {
     val htmlEl = doc.child(0)
     val body = doc.body()
 

--- a/core/domain/src/test/kotlin/com/riffle/core/domain/EpubCfiTranslatorTest.kt
+++ b/core/domain/src/test/kotlin/com/riffle/core/domain/EpubCfiTranslatorTest.kt
@@ -811,4 +811,25 @@ class EpubCfiTranslatorTest {
         val prog = cfiDocPathToProgression(outboundPath, html)!!
         assertEquals(0.5, prog, 1.0 / 22.0)
     }
+
+    // ── cfiDocPathToProgression with pre-computed totalChars ──────────────────
+
+    @Test
+    fun `cfiDocPathToProgression with pre-computed totalChars matches the auto-count overload`() {
+        val html = "<html><body><p>Hello world</p><p>Second paragraph</p></body></html>"
+        val doc = Jsoup.parse(html)
+        val totalChars = countBodyChars(doc.body())
+        // The two overloads must agree on every path in this document.
+        listOf("/4/2/1:0", "/4/2/1:5", "/4/4/1:0", "/4/4/1:15").forEach { path ->
+            val expected = cfiDocPathToProgression(path, doc)
+            val actual   = cfiDocPathToProgression(path, doc, totalChars)
+            assertEquals("mismatch for path $path", expected, actual)
+        }
+    }
+
+    @Test
+    fun `cfiDocPathToProgression with pre-computed totalChars returns null when totalChars is zero`() {
+        val doc = Jsoup.parse("<html><body></body></html>")
+        assertNull(cfiDocPathToProgression("/4/2/1:0", doc, 0L))
+    }
 }


### PR DESCRIPTION
## What

Opening an EPUB with many annotations was taking 10+ seconds. Three compounding root causes:

### Root cause 1 — O(N²) Room emissions (`AnnotationMergeOrchestrator`)

`syncOnOpen` and `mergeFromListing` looped over annotations and called `annotationDao.upsert(entity)` one at a time. Each individual upsert invalidates Room's observed query and triggers a Flow emission. `AnnotationSession.highlightObserveJob`'s `flatMap` re-runs `annotationToRender` for *all current annotations* on every emission, so syncing N annotations produced N(N+1)/2 render calls — O(N²) total.

**Fix:** replace the per-entity loop with `annotationDao.upsertAll(entities)` — one transaction, one emission.

### Root cause 2 — O(DOM) `countBodyChars` called per annotation

`cfiDocPathToProgression` called `countBodyChars(body)` (full tree walk) for every annotation even when dozens shared the same chapter.

**Fix:** `chapterTotalCharsCache` keyed on `spineIndex`; new `cfiDocPathToProgression(docPath, doc, totalChars)` overload threads the pre-counted value through.

### Root cause 3 — No render result caching

Live-sync ticks every 30s caused `annotationToRender` to recompute full Locator/progression for all N annotations even when nothing changed.

**Fix:** `annotationRenderCache` keyed on annotation id, storing `Pair<AnnotationRenderKey, List<HighlightRender>>`. Cache hit (key match on cfi + text fields + color + note + emphasisStyles) returns immediately with zero DOM traversal.

Also added `chapterDocCache` so Jsoup parsing is shared across the render cycle.

## Review fixes applied

- **Stale caches after `reloadHighlightsView`**: all four caches are now cleared at the start of `openBook()` so a spine rebuild doesn't serve Documents or HighlightRenders from the previous publication layout.
- **Render cache leak on delete**: `annotationRenderCache.remove(id)` called immediately in `deleteAnnotation()`.
- **Test gap**: null-target integration test now guards both `upsertAll` and `upsert` are not called, pinning the regression against re-introducing a per-entity loop.

## Dismissed review items

- *emphasisStyles computed before cache check*: emphasisStyles is part of the cache key — it must be computed before the key is built. Splitting it into a two-level cache would add complexity without fixing a correctness bug; emphasisPool is small in practice.
- *createHighlight / mergeAdjacentIntoHighlight bypass readChapterDoc*: these are per-create operations (O(1) each), not the O(N) render hot path. Not worth caching.
- *Atomicity change in upsertAll*: all-or-nothing transaction is strictly better than partial commit on a per-entity failure.