### PR TITLE
fix(reader): make touchcancel guard dynamic so text-selection toolbar appears on newer WebView

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapScript.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapScript.kt
@@ -151,6 +151,16 @@ internal object FigureTapScript {
             var longPressStartX = 0;
             var longPressStartY = 0;
             var LONG_PRESS_MOVE_THRESHOLD = 12; // CSS px — matches Android's default touchSlop
+            // Named so it can be added/removed by reference. Registered only while a figure
+            // long-press is in flight — a permanent capture listener on document interferes with
+            // Chrome's text-selection gesture handoff on newer WebView builds: the browser sees
+            // the listener run during touchcancel and suppresses the subsequent startActionMode
+            // call that would show the selection toolbar (#601).
+            function cancelFigureLongPress() {
+                if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
+                longPressTarget = null;
+                document.removeEventListener('touchcancel', cancelFigureLongPress, true);
+            }
             document.addEventListener('touchstart', function(e) {
                 var t = e.touches && e.touches[0];
                 if (!t) return;
@@ -159,6 +169,10 @@ internal object FigureTapScript {
                 longPressTarget = el;
                 longPressStartX = t.clientX;
                 longPressStartY = t.clientY;
+                // Arm the touchcancel guard only now that we know a figure is being pressed.
+                // Text long-presses never reach this point, so the listener never exists during
+                // the browser's text-selection gesture — preventing the toolbar suppression above.
+                document.addEventListener('touchcancel', cancelFigureLongPress, true);
                 longPressTimer = setTimeout(function() {
                     if (!longPressTarget) return;
                     // Immediate visual signal that the long-press was detected — before any Kotlin
@@ -216,6 +230,7 @@ internal object FigureTapScript {
                         window.$bridgeName.onFigureLongPress(JSON.stringify(payload));
                     } catch (err) {}
                     longPressTarget = null;
+                    document.removeEventListener('touchcancel', cancelFigureLongPress, true);
                 }, 500);
             }, true);
             document.addEventListener('touchmove', function(e) {
@@ -225,23 +240,11 @@ internal object FigureTapScript {
                 var dx = t.clientX - longPressStartX;
                 var dy = t.clientY - longPressStartY;
                 if (dx * dx + dy * dy > LONG_PRESS_MOVE_THRESHOLD * LONG_PRESS_MOVE_THRESHOLD) {
-                    clearTimeout(longPressTimer);
-                    longPressTimer = null;
-                    longPressTarget = null;
+                    cancelFigureLongPress();
                 }
             }, true);
             document.addEventListener('touchend', function() {
-                if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
-                longPressTarget = null;
-            }, true);
-            // Scrolling must take precedence over long-press. When the parent NestedScrollView
-            // (continuous mode) or Readium's pager (paginated/vertical) intercepts the touch
-            // stream past its slop threshold, the WebView receives ACTION_CANCEL — which surfaces
-            // in JS as touchcancel, not touchmove or touchend. Without this handler the 500ms
-            // timer keeps running and the annotations menu pops even though the user is scrolling.
-            document.addEventListener('touchcancel', function() {
-                if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
-                longPressTarget = null;
+                cancelFigureLongPress();
             }, true);
             // Cancel the native long-press callout on figures — belt to the CSS's braces above,
             // for WebView builds where the CSS property alone is respected too late.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapScript.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapScript.kt
@@ -229,6 +229,7 @@ internal object FigureTapScript {
                     try {
                         window.$bridgeName.onFigureLongPress(JSON.stringify(payload));
                     } catch (err) {}
+                    longPressTimer = null;
                     longPressTarget = null;
                     document.removeEventListener('touchcancel', cancelFigureLongPress, true);
                 }, 500);

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.reader
 
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -49,38 +50,71 @@ class FigureTapScriptTest {
     }
 
     @Test
-    fun `touchmove and touchend clear the pending long-press timer`() {
+    fun `touchmove and touchend cancel the pending long-press via the shared cancelFigureLongPress helper`() {
         assertTrue(script.contains("addEventListener('touchmove'"))
         assertTrue(script.contains("addEventListener('touchend'"))
-        // Both handlers must clear the same timer variable to cancel a pending long-press.
-        assertTrue(script.contains("clearTimeout(longPressTimer)"))
+        // Both handlers delegate to cancelFigureLongPress() so the timer clear, target clear, and
+        // dynamic touchcancel removal all happen through a single code path.
+        val moveIdx = script.indexOf("addEventListener('touchmove'")
+        val moveEnd = script.indexOf("}, true);", moveIdx).let { it + "}, true);".length }
+        val moveBlock = script.substring(moveIdx, moveEnd)
+        assertTrue("touchmove must call cancelFigureLongPress()", moveBlock.contains("cancelFigureLongPress()"))
+
+        val endIdx = script.indexOf("addEventListener('touchend'")
+        val endEnd = script.indexOf("}, true);", endIdx).let { it + "}, true);".length }
+        val endBlock = script.substring(endIdx, endEnd)
+        assertTrue("touchend must call cancelFigureLongPress()", endBlock.contains("cancelFigureLongPress()"))
     }
 
     /**
-     * Scrolling must take precedence over long-press: when the parent scroll container
-     * (continuous mode's NestedScrollView, or Readium's pager in paginated/vertical) claims the
-     * touch stream, the WebView receives ACTION_CANCEL, which surfaces in JS as touchcancel —
-     * NOT touchmove or touchend. Without a touchcancel handler the 500ms long-press timer keeps
-     * running and the annotations menu pops even though the user is scrolling. This assertion
-     * flips red if that handler is removed.
+     * Scrolling must take precedence over long-press: when the parent scroll container claims the
+     * touch stream the WebView receives ACTION_CANCEL (JS: touchcancel). The [cancelFigureLongPress]
+     * helper is the single point that clears the timer, the target, and removes the listener.
+     * This assertion flips red if the helper is removed or the clearTimeout is dropped.
      */
     @Test
-    fun `touchcancel clears the pending long-press timer so scrolling suppresses the annotations menu`() {
+    fun `cancelFigureLongPress function clears timer and target so scroll cancels the annotations menu`() {
+        val fnIdx = script.indexOf("function cancelFigureLongPress()")
+        assertTrue("cancelFigureLongPress helper function must be declared", fnIdx >= 0)
+        // Locate the function body — ends at the first `}` at the same nesting level.
+        val bodyStart = script.indexOf("{", fnIdx)
+        val bodyEnd = script.indexOf("\n            }", bodyStart)
+        val fnBody = script.substring(bodyStart, bodyEnd + 1)
+        assertTrue("cancelFigureLongPress must clearTimeout(longPressTimer)", fnBody.contains("clearTimeout(longPressTimer)"))
+        assertTrue("cancelFigureLongPress must null out longPressTarget", fnBody.contains("longPressTarget = null"))
+        assertTrue("cancelFigureLongPress must remove the touchcancel listener", fnBody.contains("removeEventListener('touchcancel', cancelFigureLongPress, true)"))
+    }
+
+    /**
+     * Regression test for the selection toolbar disappearing in paginated mode on newer WebView
+     * builds (Chrome 120+): a permanent capture-phase touchcancel listener on document fires
+     * during Chrome's gesture handoff from long-press recognition to text-selection mode and
+     * suppresses the subsequent startActionMode call that shows the toolbar.
+     *
+     * The fix is to register the touchcancel guard ONLY inside the touchstart handler and only
+     * when a figure was detected — text-selection long-presses return early before that point,
+     * so no touchcancel listener exists during their gesture lifecycle.
+     *
+     * This assertion flips red if someone restores the permanent global listener.
+     */
+    @Test
+    fun `touchcancel listener is registered dynamically inside touchstart not as a permanent global listener`() {
+        // The registration must appear INSIDE the touchstart handler, not outside it.
+        // Check: touchcancel registration comes AFTER the figure-detection early-return guard.
+        val earlyReturnIdx = script.indexOf("if (!el) return;")
+        assertTrue("early-return guard (if !el return) must exist in touchstart", earlyReturnIdx >= 0)
+        val dynamicRegIdx = script.indexOf("document.addEventListener('touchcancel', cancelFigureLongPress, true)")
+        assertTrue("touchcancel must be registered via the named cancelFigureLongPress reference", dynamicRegIdx >= 0)
         assertTrue(
-            "touchcancel handler must exist so parent-intercepted scrolls cancel the long-press",
-            script.contains("addEventListener('touchcancel'"),
+            "touchcancel registration must come AFTER the figure-detection early-return, " +
+                "so it is never registered during a text-selection long-press",
+            dynamicRegIdx > earlyReturnIdx,
         )
-        // Locate only the touchcancel handler block — from the listener registration up to its
-        // closing `}, true);` — to avoid the assertion passing because a clearTimeout appears in
-        // a later handler (e.g. the contextmenu block that follows immediately in the script).
-        val cancelIdx = script.indexOf("addEventListener('touchcancel'")
-        check(cancelIdx >= 0) // already asserted by assertTrue above; keeps the compiler happy
-        val handlerEnd = script.indexOf("}, true);", cancelIdx).takeIf { it >= 0 }
-            ?: error("touchcancel handler closing delimiter not found")
-        val cancelBlock = script.substring(cancelIdx, handlerEnd + "}, true);".length)
-        assertTrue(
-            "touchcancel handler must clearTimeout(longPressTimer)",
-            cancelBlock.contains("clearTimeout(longPressTimer)"),
+        // There must be NO anonymous-function touchcancel listener — that was the PR #599 shape
+        // that caused the regression and must never come back.
+        assertFalse(
+            "permanent anonymous touchcancel listener must not exist (PR #601 regression guard)",
+            script.contains("addEventListener('touchcancel', function()"),
         )
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
@@ -76,7 +76,12 @@ class FigureTapScriptTest {
     fun `cancelFigureLongPress function clears timer and target so scroll cancels the annotations menu`() {
         val fnIdx = script.indexOf("function cancelFigureLongPress()")
         assertTrue("cancelFigureLongPress helper function must be declared", fnIdx >= 0)
-        // Locate the function body — ends at the first `}` at the same nesting level.
+        // Locate the function body. trimIndent() on installScript's raw string strips 0 spaces
+        // (the interpolated JS constants have 0-indent lines which floor the minimum). The raw
+        // 12-space indent of the function's closing `}` is therefore preserved verbatim in the
+        // output, so "\n            }" (12 spaces) correctly identifies it. The function body has
+        // no nested standalone-`}` on its own line (the one `if` is a single-line statement),
+        // so the first 12-space `}` after the declaration IS the closing brace.
         val bodyStart = script.indexOf("{", fnIdx)
         val bodyEnd = script.indexOf("\n            }", bodyStart)
         val fnBody = script.substring(bodyStart, bodyEnd + 1)
@@ -111,10 +116,11 @@ class FigureTapScriptTest {
             dynamicRegIdx > earlyReturnIdx,
         )
         // There must be NO anonymous-function touchcancel listener — that was the PR #599 shape
-        // that caused the regression and must never come back.
+        // that caused the regression and must never come back. Check both no-arg and e-arg forms.
         assertFalse(
             "permanent anonymous touchcancel listener must not exist (PR #601 regression guard)",
-            script.contains("addEventListener('touchcancel', function()"),
+            script.contains("addEventListener('touchcancel', function()") ||
+                script.contains("addEventListener('touchcancel', function("),
         )
     }
 


### PR DESCRIPTION
## Root cause

PR #599 added a permanent capture-phase `touchcancel` listener on `document` to cancel figure long-presses when the parent scroll container intercepts the touch stream (Android `ACTION_CANCEL` surfaces in JS as `touchcancel`). On Chrome 109 (API-33 emulator WebView) this is benign. On Chrome 120+ (physical devices with newer WebView) the browser fires `touchcancel` at the exact moment it hands the gesture from long-press recognition to text-selection mode. Having any active capture listener at that point causes Chrome to suppress the subsequent `startActionMode` call that would show the floating Annotate/Copy/Search/Share toolbar — the toolbar simply never appears.

## Fix

Convert the global permanent listener into a dynamic one:

- The `cancelFigureLongPress()` helper (which clears the timer, nulls the target, and removes itself) is now a named function so it can be passed by reference to `addEventListener`/`removeEventListener`.
- The `touchcancel` listener is added to `document` **only inside `touchstart`**, after `detectFigureAt` confirms a figure element was pressed.
- It is removed as soon as the gesture resolves: when the 500 ms timer fires, when `touchmove` slop is exceeded, when `touchend` fires, or when `touchcancel` itself fires.
- Text-selection long-presses return early from `touchstart` (no figure detected), so the `touchcancel` listener **never exists** during their gesture lifecycle. Chrome never sees it during the gesture handoff, and the toolbar appears normally.

The scroll-suppression fix from #599 is fully preserved: figure long-presses on scroll-intercepted touches still cancel correctly via the same `cancelFigureLongPress` path.

## Tests

Updated `FigureTapScriptTest` (JVM, string-shape assertions against the emitted JS):

- `cancelFigureLongPress function clears timer and target so scroll cancels the annotations menu` — asserts the helper clears `longPressTimer`, nulls `longPressTarget`, and calls `removeEventListener('touchcancel', cancelFigureLongPress, true)`.
- `touchcancel listener is registered dynamically inside touchstart not as a permanent global listener` — asserts the `addEventListener('touchcancel'` registration appears **after** the `if (!el) return` figure-detection guard, and that no anonymous-function `touchcancel` listener exists (the PR #599 shape that must not come back).
- Updated `touchmove and touchend cancel the pending long-press via the shared cancelFigureLongPress helper` — both handlers now delegate to `cancelFigureLongPress()` rather than duplicating the inline clear.

Regression assertion: reverting the fix (restoring the permanent anonymous listener) makes `touchcancel listener is registered dynamically inside touchstart not as a permanent global listener` go red immediately.