### PR TITLE
fix(reader): extend highlight top coverage by 1px for physical-device font metrics

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
@@ -71,7 +71,7 @@ fun highlightTintTemplate(): HtmlDecorationTemplate =
         },
         stylesheet = """
             .$HIGHLIGHT_TINT_CLASS {
-                margin: 0px -1px 0 0;
+                margin: -1px -1px 0 0;
                 padding: 0 2px 0 0;
                 border-radius: 3px;
                 box-sizing: border-box;


### PR DESCRIPTION
Physical devices render glyph ascenders slightly above the bounding box reported
by Readium's `getClientRects()`. The AVD's font metrics happen to fit within that
rect, so the issue is invisible there. Shifting `margin-top` from `0` to `-1px`
lifts each per-line decoration box 1px, covering ascenders that otherwise clip on
physical devices.

## Change
`HighlightDecoration.kt` — `highlightTintTemplate()` stylesheet:
```
-  margin: 0px -1px 0 0;
+  margin: -1px -1px 0 0;
```

Applies to both readaloud "now speaking" and persisted annotation highlights in
paginated/vertical mode. Continuous mode uses inline `<mark>` elements whose
background follows the em box natively and is unaffected.