### PR TITLE
fix(reader): elided-view shows raw spine IDs (part0010) when TOC cache is cold

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1501,6 +1501,18 @@ class EpubReaderViewModel @Inject constructor(
             initialFocusAnnotationId = o.initialFocusAnnotationId,
         )
 
+        // Cache the publication's TOC from the already-open publication so the elided view
+        // shows real chapter names even when the detail screen was never visited on this device
+        // (root cause of "part0010"-style headings in the Highlights reader).
+        val tocFromPub = pub.tableOfContents.toTocEntries()
+        val readerServerId = o.resolvedReaderServerId
+        if (tocFromPub.isNotEmpty() && readerServerId != null) {
+            viewModelScope.launch {
+                val inode = libraryItemDao.getById(readerServerId, itemId)?.ebookFileIno ?: "unknown"
+                tocRepository.saveToc(readerServerId, itemId, inode, tocFromPub)
+            }
+        }
+
         // Navigate to the requested TOC entry using the same path as an in-reader TOC tap.
         // formattingPrefsProvider in the nav event handler ensures the correct continuous vs paged
         // path is taken even when Compose state hasn't caught up yet.
@@ -3834,8 +3846,14 @@ internal fun elidedChapterTitle(href: String, derived: String, toc: List<TocEntr
 private val UUID_TITLE_REGEX =
     Regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 
+// Matches auto-generated EPUB spine filenames: letters/underscores/hyphens followed by 3+
+// digits (e.g. "part0010", "item003", "text00001"). Human-readable titles never end in
+// zero-padded digit runs of this length, so these are safe to treat as unhelpful.
+private val SPINE_FILENAME_REGEX = Regex("^[a-zA-Z][a-zA-Z0-9_-]*\\d{3,}$")
+
 internal fun looksUnhelpfulTitle(title: String): Boolean =
-    title.isBlank() || title.equals("Chapter", ignoreCase = true) || UUID_TITLE_REGEX.matches(title)
+    title.isBlank() || title.equals("Chapter", ignoreCase = true) ||
+    UUID_TITLE_REGEX.matches(title) || SPINE_FILENAME_REGEX.matches(title)
 
 /**
  * Resolves a highlight's chapter title from the cached TOC (Fix B, ADR 0041 follow-up) — without

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -3870,7 +3870,7 @@ internal fun resolveChapterTitle(href: String, toc: List<TocEntry>): String? {
         for (entry in entries) {
             val entryHref = entry.href.substringBefore('#')
             if (entryHref == normalized || entryHref.endsWith("/$normalized") || normalized.endsWith("/$entryHref")) {
-                return entry.title
+                return entry.title.ifBlank { null }
             }
             search(entry.children)?.let { return it }
         }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelHighlightsSourceTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelHighlightsSourceTest.kt
@@ -211,6 +211,17 @@ class EpubReaderViewModelHighlightsSourceTest {
     }
 
     @Test
+    fun `resolveChapterTitle returns null for blank TOC title so Chapter N fallback applies`() {
+        // Regression: EPUBs with missing navLabel text produce TocEntry(title=""). Without the
+        // ifBlank guard, resolveChapterTitle returned "" (non-null) and elidedChapterTitle
+        // short-circuited to a blank heading, bypassing the "Chapter N" fallback.
+        val toc = listOf(TocEntry(title = "", href = "OEBPS/part0010.xhtml"))
+        assertNull(resolveChapterTitle("OEBPS/part0010.xhtml", toc))
+        // Confirm elidedChapterTitle falls through to "Chapter N" for blank-titled TOC entries.
+        assertEquals("Chapter 1", elidedChapterTitle("OEBPS/part0010.xhtml", "part0010", toc, 0))
+    }
+
+    @Test
     fun `resolveChapterTitle matches nested TOC entries`() {
         val toc = listOf(
             TocEntry(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelHighlightsSourceTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelHighlightsSourceTest.kt
@@ -149,6 +149,46 @@ class EpubReaderViewModelHighlightsSourceTest {
         assertEquals("Chapter", deriveChapterTitle(""))
     }
 
+    // ---- looksUnhelpfulTitle / elidedChapterTitle -----------------------------------------
+
+    @Test
+    fun `looksUnhelpfulTitle rejects blank, bare Chapter, UUID, and spine filenames`() {
+        // Should be flagged as unhelpful → fall through to "Chapter N"
+        assertTrue(looksUnhelpfulTitle(""))
+        assertTrue(looksUnhelpfulTitle("   "))
+        assertTrue(looksUnhelpfulTitle("Chapter"))
+        assertTrue(looksUnhelpfulTitle("chapter"))
+        assertTrue(looksUnhelpfulTitle("6ba7b810-9dad-11d1-80b4-00c04fd430c8")) // UUID
+        assertTrue(looksUnhelpfulTitle("part0010"))   // EPUB spine filename — the bug
+        assertTrue(looksUnhelpfulTitle("item003"))
+        assertTrue(looksUnhelpfulTitle("text00001"))
+        assertTrue(looksUnhelpfulTitle("SECTION_012"))
+    }
+
+    @Test
+    fun `looksUnhelpfulTitle accepts real chapter titles`() {
+        assertFalse(looksUnhelpfulTitle("The Nature of Complexity"))
+        assertFalse(looksUnhelpfulTitle("Introduction"))
+        assertFalse(looksUnhelpfulTitle("Epilogue"))
+        assertFalse(looksUnhelpfulTitle("ch03"))       // short but no 3-digit run
+        assertFalse(looksUnhelpfulTitle("Act2"))       // only one trailing digit
+        assertFalse(looksUnhelpfulTitle("Part3"))
+    }
+
+    @Test
+    fun `elidedChapterTitle falls back to Chapter N when TOC is empty and derived is a spine filename`() {
+        // Regression: before SPINE_FILENAME_REGEX, "part0010" slipped past looksUnhelpfulTitle
+        // and was displayed verbatim as the chapter heading.
+        assertEquals("Chapter 1", elidedChapterTitle("OEBPS/part0010.xhtml", "part0010", emptyList(), 0))
+        assertEquals("Chapter 3", elidedChapterTitle("OEBPS/item003.xhtml", "item003", emptyList(), 2))
+    }
+
+    @Test
+    fun `elidedChapterTitle uses TOC title when available regardless of spine filename`() {
+        val toc = listOf(TocEntry(title = "Complexity", href = "OEBPS/part0010.xhtml"))
+        assertEquals("Complexity", elidedChapterTitle("OEBPS/part0010.xhtml", "part0010", toc, 0))
+    }
+
     // ---- Fix B (ADR 0041 follow-up): chapter titles resolved from the cached TOC -----------
 
     // The regression this pins: without TOC resolution, Highlights-mode chapter headings show the


### PR DESCRIPTION
## Root cause

The TOC cache (`toc_cache` table) was only written by `ExtractEpubTocUseCase`, called exclusively from `LibraryItemDetailViewModel` (the detail screen). If a user opened the reader directly — via Continue Reading, a deep link, or after annotation sync from another device — without ever visiting the detail screen on that device, `getCachedToc` returned null permanently. With no TOC entries to match against, `elidedChapterTitle` fell back to `deriveChapterTitle`'s href-basename output (e.g. `"part0010"`), which `looksUnhelpfulTitle` did not recognise as unhelpful, so raw EPUB spine IDs were displayed verbatim as chapter headings in the Highlights reader.

The condition was permanent per-device because there was no other write path to the TOC cache.

## Fixes

**1. Save TOC on full-book open** (`onOpenReady`): When the full-book reader opens a publication, it now caches the TOC from the already-parsed `pub.tableOfContents`. Fire-and-forget background coroutine — zero latency impact. The first time a user reads a book on any device the TOC is available for all future elided-view opens on that device.

**2. Extend `looksUnhelpfulTitle` with `SPINE_FILENAME_REGEX`**: Spine-filename-style IDs (`^[a-zA-Z][a-zA-Z0-9_-]*\d{3,}$`, e.g. `part0010`, `item003`) are now treated as unhelpful, falling through to `"Chapter N"`. Belt-and-suspenders for devices where the EPUB was never opened in full-reader mode.

**3. Fix blank TOC title pass-through in `resolveChapterTitle`** (review finding): EPUBs with missing `<navLabel>` text produce `TocEntry(title="")`. `resolveChapterTitle` was returning `""` (non-null), causing `elidedChapterTitle` to short-circuit to a blank heading and bypass `"Chapter N"`. Fixed with `ifBlank { null }`.

## Tests

- `looksUnhelpfulTitle rejects blank, bare Chapter, UUID, and spine filenames`
- `looksUnhelpfulTitle accepts real chapter titles`
- `elidedChapterTitle falls back to Chapter N when TOC is empty and derived is a spine filename`
- `elidedChapterTitle uses TOC title when available regardless of spine filename`
- `resolveChapterTitle returns null for blank TOC title so Chapter N fallback applies`