### PR TITLE
feat(network): migrate HTTP layer from OkHttp to Ktor 3.1.3

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
@@ -1,7 +1,5 @@
 package com.riffle.app.feature.reader.readaloud
 
-import com.riffle.core.domain.DefaultDispatcherProvider
-
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -24,6 +22,7 @@ import com.riffle.core.domain.TokenStorage
 import com.riffle.core.network.AbsApiClient
 import com.riffle.core.network.StorytellerApiClient
 import com.riffle.core.network.StorytellerBundleApiImpl
+import com.riffle.core.network.createDefaultHttpClient
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
@@ -175,7 +174,7 @@ class ReadaloudStreamingSessionFactoryAndroidTest {
                     sidecarScope.async(block = block).await()
             },
         )
-        val absApiClient = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
+        val absApiClient = AbsApiClient(createDefaultHttpClient(OkHttpClient()))
         val testClock = object : com.riffle.core.common.Clock {
             override fun nowMs() = System.currentTimeMillis()
             override fun nowNs() = System.nanoTime()

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
@@ -109,8 +109,8 @@ class ReadaloudStreamingSessionFactoryAndroidTest {
                         // at the first audio entry — so serve the full zip here.
                         else -> MockResponse().setBody(Buffer().write(bundleZip))
                     }
-                    path.startsWith("/api/v2/books/$ST_BOOK") -> MockResponse().setBody(storytellerV2(1000))
-                    path.startsWith("/api/items/$AUDIOBOOK_ITEM") -> MockResponse().setBody(absItem(absFileSize))
+                    path.startsWith("/api/v2/books/$ST_BOOK") -> MockResponse().setBody(storytellerV2(1000)).addHeader("Content-Type", "application/json")
+                    path.startsWith("/api/items/$AUDIOBOOK_ITEM") -> MockResponse().setBody(absItem(absFileSize)).addHeader("Content-Type", "application/json")
                     else -> MockResponse().setResponseCode(404)
                 }
             }

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/readaloud/ReadaloudStreamingSessionFactoryAndroidTest.kt
@@ -19,10 +19,12 @@ import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.ServerType
 import com.riffle.core.models.SourceUrl
 import com.riffle.core.domain.TokenStorage
+import com.riffle.core.domain.DefaultDispatcherProvider
 import com.riffle.core.network.AbsApiClient
 import com.riffle.core.network.StorytellerApiClient
 import com.riffle.core.network.StorytellerBundleApiImpl
 import com.riffle.core.network.createDefaultHttpClient
+import com.riffle.core.network.createStreamingHttpClient
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
@@ -158,7 +160,7 @@ class ReadaloudStreamingSessionFactoryAndroidTest {
     private fun factory(): ReadaloudStreamingSessionFactory {
         val repo = StubServerRepository(mapOf(ABS_SERVER to baseUrl, ST_SERVER to baseUrl))
         val fetcher = StorytellerSidecarFetcher(
-            bundleApi = StorytellerBundleApiImpl(OkHttpClient(), DefaultDispatcherProvider),
+            bundleApi = StorytellerBundleApiImpl(createStreamingHttpClient(OkHttpClient())),
             dispatchers = DefaultDispatcherProvider,
         )
         val sidecarScope = kotlinx.coroutines.CoroutineScope(
@@ -201,7 +203,7 @@ class ReadaloudStreamingSessionFactoryAndroidTest {
             context = ctx,
             audioIdentityResolver = AudioIdentityResolverImpl(db.readaloudLinkDao(), db.libraryItemDao()),
             catalogRegistry = catalogRegistry,
-            storytellerApi = StorytellerApiClient(OkHttpClient(), DefaultDispatcherProvider),
+            storytellerApi = StorytellerApiClient(createDefaultHttpClient(OkHttpClient())),
             sidecarStore = sidecarStore,
             sourceRepository = repo,
             tokenStorage = StubTokenStorage,

--- a/app/src/androidTest/kotlin/com/riffle/app/harness/StubAbsServerTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/StubAbsServerTest.kt
@@ -1,11 +1,10 @@
 package com.riffle.app.harness
 
-import com.riffle.core.domain.DefaultDispatcherProvider
-
 import com.riffle.core.network.NetworkResult
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.riffle.core.network.AbsApiClient
+import com.riffle.core.network.createDefaultHttpClient
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import org.junit.After
@@ -25,7 +24,7 @@ class StubAbsServerTest {
     fun setUp() {
         stub = StubAbsServer()
         stub.start()
-        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
+        client = AbsApiClient(createDefaultHttpClient(OkHttpClient()))
     }
 
     @After

--- a/core/catalog-chitanka/build.gradle.kts
+++ b/core/catalog-chitanka/build.gradle.kts
@@ -7,9 +7,10 @@ dependencies {
     implementation(project(":core:domain"))
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.jsoup)
-    implementation(libs.okhttp)
+    implementation(libs.ktor.client.core)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.okhttp.mockwebserver)
+    testImplementation(libs.ktor.client.okhttp)
 }

--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt
@@ -23,13 +23,19 @@ import com.riffle.core.catalog.SeriesCapability
 import com.riffle.core.catalog.SortKey
 import com.riffle.core.catalog.ToReadListCapability
 import com.riffle.core.models.SourceType
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.HttpHeaders
+import io.ktor.http.contentLength
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.jvm.javaio.toInputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
-import okhttp3.OkHttpClient
-import okhttp3.Request
 import java.net.URLEncoder
 
 /**
@@ -52,7 +58,7 @@ import java.net.URLEncoder
  */
 class ChitankaCatalog(
     private val http: ChitankaHttpClient,
-    private val bytesClient: OkHttpClient = OkHttpClient(),
+    private val bytesClient: HttpClient,
     // Must match the UA [ChitankaHttpClient] sends for HTML fetches — chitanka.info
     // throttles/blocks requests carrying the raw `okhttp/x.x.x` default. Without this the
     // EPUB download URL 429s on the first request even though browse succeeds.
@@ -316,34 +322,32 @@ class ChitankaCatalog(
         }
         // Same UA/headers as [ChitankaHttpClient.getString] — required or chitanka.info 429s
         // the download URL. Also mirror its 429 backoff schedule (1.5s, 3s) for parity.
-        val response = fetchBytesWith429Retry(handle.url, itemId)
-        val body = response.body
-        object : CatalogFileStream {
-            override val contentLength: Long = body.contentLength()
-            override fun byteStream() = body.byteStream()
-            override fun close() { response.close() }
-        }
+        fetchBytesWith429Retry(handle.url, itemId)
     }
 
-    internal suspend fun fetchBytesWith429Retry(url: String, itemId: String): okhttp3.Response {
+    internal suspend fun fetchBytesWith429Retry(downloadUrl: String, itemId: String): CatalogFileStream {
         var attempt = 0
         while (true) {
-            val request = Request.Builder()
-                .url(url)
-                .header("User-Agent", userAgent)
-                .header("Accept-Language", "bg,en;q=0.5")
-                .header("Referer", ChitankaScraper.BASE)
-                .build()
-            val response = bytesClient.newCall(request).execute()
-            if (response.isSuccessful) return response
-            val code = response.code
-            response.close()
+            val response = bytesClient.get(downloadUrl) {
+                header(HttpHeaders.UserAgent, userAgent)
+                header(HttpHeaders.AcceptLanguage, "bg,en;q=0.5")
+                header(HttpHeaders.Referrer, "${ChitankaScraper.BASE}/$itemId")
+            }
+            if (response.status.isSuccess()) {
+                val channel = response.bodyAsChannel()
+                return object : CatalogFileStream {
+                    override val contentLength: Long = response.contentLength() ?: -1L
+                    override fun byteStream(): java.io.InputStream = channel.toInputStream()
+                    override fun close() { channel.cancel(null) }
+                }
+            }
+            val code = response.status.value
             if (code == 429 && attempt < ChitankaHttpClient.DEFAULT_RETRY_DELAYS_MS.size) {
                 kotlinx.coroutines.delay(ChitankaHttpClient.DEFAULT_RETRY_DELAYS_MS[attempt])
                 attempt++
                 continue
             }
-            throw ChitankaException("Failed to fetch bytes for $itemId: $code")
+            throw ChitankaHttpException(code, downloadUrl, response.status.description)
         }
         @Suppress("UNREACHABLE_CODE")
         error("unreachable")

--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogFactory.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogFactory.kt
@@ -4,7 +4,7 @@ import com.riffle.core.catalog.Catalog
 import com.riffle.core.catalog.CatalogFactory
 import com.riffle.core.models.Source
 import com.riffle.core.models.SourceType
-import okhttp3.OkHttpClient
+import io.ktor.client.HttpClient
 
 /**
  * Builds a [ChitankaCatalog] per Source. Because the Chitanka Source is zero-config
@@ -13,14 +13,14 @@ import okhttp3.OkHttpClient
  * `core:data`'s `CatalogModule`.
  */
 class ChitankaCatalogFactory(
-    private val okHttpClient: OkHttpClient,
+    private val httpClient: HttpClient,
     private val userAgent: String,
 ) : CatalogFactory {
 
     override val sourceType: SourceType = SourceType.CHITANKA
 
     override suspend fun create(source: Source): Catalog {
-        val http = ChitankaHttpClient(client = okHttpClient, userAgent = userAgent)
-        return ChitankaCatalog(http = http, bytesClient = okHttpClient, userAgent = userAgent)
+        val http = ChitankaHttpClient(client = httpClient, userAgent = userAgent)
+        return ChitankaCatalog(http = http, bytesClient = httpClient, userAgent = userAgent)
     }
 }

--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaHttpClient.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaHttpClient.kt
@@ -1,14 +1,21 @@
 package com.riffle.core.catalog.chitanka
 
-import kotlinx.coroutines.Dispatchers
+import io.ktor.client.HttpClient
+import io.ktor.client.request.accept
+import io.ktor.client.request.get
+import io.ktor.client.request.head
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.client.statement.readBytes
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.contentLength
+import io.ktor.http.isSuccess
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.withContext
-import okhttp3.OkHttpClient
-import okhttp3.Request
 import java.io.IOException
 
 /**
- * Thin OkHttp wrapper for Chitanka/Gramofonche HTML fetches.
+ * Thin Ktor wrapper for Chitanka/Gramofonche HTML fetches.
  *
  * Honors upstream 429 rate-limiting with the same schedule as the reference
  * TypeScript scraper: 3 attempts, backing off 1.5s then 3s. Identifies itself
@@ -21,7 +28,7 @@ import java.io.IOException
  * ASCII-safe.
  */
 class ChitankaHttpClient(
-    private val client: OkHttpClient,
+    private val client: HttpClient,
     private val userAgent: String,
     private val retryDelaysMs: List<Long> = DEFAULT_RETRY_DELAYS_MS,
 ) {
@@ -30,63 +37,38 @@ class ChitankaHttpClient(
      * GET [url] and return the response body as a String. Retries on HTTP 429 up to
      * [retryDelaysMs].size + 1 total attempts.
      */
-    suspend fun getString(url: String): String = withContext(Dispatchers.IO) {
+    suspend fun getString(url: String): String {
         var attempt = 0
         while (true) {
-            val request = Request.Builder()
-                .url(url)
-                .header("User-Agent", userAgent)
-                .header("Accept-Language", "bg,en;q=0.5")
-                .build()
-            val (status, body, msg) = client.newCall(request).execute().use { r ->
-                Triple(r.code, if (r.isSuccessful) r.body.string() else null, r.message)
+            val response = client.get(url) {
+                header(HttpHeaders.UserAgent, userAgent)
+                header(HttpHeaders.AcceptLanguage, "bg,en;q=0.5")
             }
-            if (status == 429 && attempt < retryDelaysMs.size) {
-                delay(retryDelaysMs[attempt])
-                attempt++
+            if (response.status.value == 429 && attempt < retryDelaysMs.size) {
+                delay(retryDelaysMs[attempt++])
                 continue
             }
-            if (body == null) throw ChitankaHttpException(code = status, url = url, message = msg)
-            return@withContext body
+            if (!response.status.isSuccess()) throw ChitankaHttpException(response.status.value, url, response.status.description)
+            return response.bodyAsText()
         }
         @Suppress("UNREACHABLE_CODE")
         error("unreachable")
     }
 
     /** True when [url] responds 2xx to a HEAD request. Used by [connectivityCheck]. */
-    suspend fun ping(url: String): Boolean = withContext(Dispatchers.IO) {
-        try {
-            val request = Request.Builder()
-                .url(url)
-                .header("User-Agent", userAgent)
-                .head()
-                .build()
-            client.newCall(request).execute().use { it.isSuccessful }
-        } catch (_: IOException) {
-            false
-        }
-    }
+    suspend fun ping(url: String): Boolean = try {
+        client.head(url) { header(HttpHeaders.UserAgent, userAgent) }.status.isSuccess()
+    } catch (_: IOException) { false }
 
     /**
      * Content-Length reported by the origin on a HEAD, or `null` on non-2xx / network error.
      * Used as a fallback in the audiobook capability when [probeMp3DurationSec] can't derive
      * an exact duration from the MP3 headers.
      */
-    suspend fun headContentLength(url: String): Long? = withContext(Dispatchers.IO) {
-        try {
-            val request = Request.Builder()
-                .url(url)
-                .header("User-Agent", userAgent)
-                .head()
-                .build()
-            client.newCall(request).execute().use { r ->
-                if (!r.isSuccessful) return@withContext null
-                r.header("Content-Length")?.toLongOrNull()
-            }
-        } catch (_: IOException) {
-            null
-        }
-    }
+    suspend fun headContentLength(url: String): Long? = try {
+        val r = client.head(url) { header(HttpHeaders.UserAgent, userAgent) }
+        if (!r.status.isSuccess()) null else r.contentLength()
+    } catch (_: IOException) { null }
 
     /**
      * Derives the exact duration of an MP3 at [url] in seconds by:
@@ -108,13 +90,13 @@ class ChitankaHttpClient(
      * the initial fetch, or when no Layer III frame is found in the sniff window. The caller
      * should fall back to a coarser estimate in that case.
      */
-    suspend fun probeMp3DurationSec(url: String): Double? = withContext(Dispatchers.IO) {
-        try {
-            val head = rangeGet(url, 0L, 9L) ?: return@withContext null
+    suspend fun probeMp3DurationSec(url: String): Double? {
+        return try {
+            val head = rangeGet(url, 0L, 9L) ?: return null
             val audioOffset = id3v2AudioOffset(head.bytes) ?: 0
             val end = (audioOffset + MP3_PROBE_BYTES - 1).toLong()
-            val audio = rangeGet(url, audioOffset.toLong(), end) ?: return@withContext null
-            val frame = findFirstMp3Frame(audio.bytes) ?: return@withContext null
+            val audio = rangeGet(url, audioOffset.toLong(), end) ?: return null
+            val frame = findFirstMp3Frame(audio.bytes) ?: return null
             val xingFrames = parseXingFrameCount(audio.bytes, frame.frameStart, frame.meta)
             if (xingFrames != null && xingFrames > 0) {
                 xingFrames.toDouble() * frame.meta.samplesPerFrame / frame.meta.sampleRateHz
@@ -130,20 +112,18 @@ class ChitankaHttpClient(
     /** A byte payload alongside the total resource size read from `Content-Range`. */
     private data class RangeReply(val bytes: ByteArray, val totalBytes: Long)
 
-    private fun rangeGet(url: String, start: Long, endInclusive: Long): RangeReply? {
-        val request = Request.Builder()
-            .url(url)
-            .header("User-Agent", userAgent)
-            .header("Range", "bytes=$start-$endInclusive")
-            .build()
-        return client.newCall(request).execute().use { r ->
-            if (!r.isSuccessful) return@use null
-            // Content-Range: bytes 0-9/12161710
-            val total = r.header("Content-Range")?.substringAfter("/", "")?.toLongOrNull()
-                ?: r.header("Content-Length")?.toLongOrNull()
-                ?: return@use null
-            RangeReply(r.body.bytes(), total)
-        }
+    private suspend fun rangeGet(url: String, start: Long, endInclusive: Long): RangeReply? {
+        return try {
+            val response = client.get(url) {
+                header(HttpHeaders.UserAgent, userAgent)
+                header(HttpHeaders.Range, "bytes=$start-$endInclusive")
+            }
+            if (!response.status.isSuccess()) return null
+            val total = response.headers[HttpHeaders.ContentRange]?.substringAfter("/", "")?.toLongOrNull()
+                ?: response.contentLength()
+                ?: return null
+            RangeReply(response.readBytes(), total)
+        } catch (_: IOException) { null }
     }
 
     companion object {

--- a/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
+++ b/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalogTest.kt
@@ -18,8 +18,9 @@ import com.riffle.core.catalog.SeriesCapability
 import com.riffle.core.catalog.StatsCapability
 import com.riffle.core.catalog.ToReadListCapability
 import com.riffle.core.catalog.has
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
 import kotlinx.coroutines.test.runTest
-import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -59,11 +60,11 @@ class ChitankaCatalogTest {
      */
     private fun catalog(): ChitankaCatalog {
         val http = ChitankaHttpClient(
-            client = OkHttpClient(),
+            client = HttpClient(OkHttp) {},
             userAgent = "Riffle/test",
             retryDelaysMs = emptyList(),
         )
-        return ChitankaCatalog(http = http)
+        return ChitankaCatalog(http = http, bytesClient = HttpClient(OkHttp) {})
     }
 
     @Test
@@ -123,8 +124,8 @@ class ChitankaCatalogTest {
     fun `download request carries User-Agent + Accept-Language + Referer headers`() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody("epub-bytes"))
         val cat = ChitankaCatalog(
-            http = ChitankaHttpClient(client = OkHttpClient(), userAgent = "Riffle/test", retryDelaysMs = emptyList()),
-            bytesClient = OkHttpClient(),
+            http = ChitankaHttpClient(client = HttpClient(OkHttp) {}, userAgent = "Riffle/test", retryDelaysMs = emptyList()),
+            bytesClient = HttpClient(OkHttp) {},
             userAgent = "Riffle/test",
         )
         cat.fetchBytesWith429Retry(server.url("/download/foo.epub").toString(), itemId = "book/foo").close()
@@ -139,16 +140,12 @@ class ChitankaCatalogTest {
         server.enqueue(MockResponse().setResponseCode(429))
         server.enqueue(MockResponse().setResponseCode(200).setBody("epub-bytes"))
         val cat = ChitankaCatalog(
-            http = ChitankaHttpClient(client = OkHttpClient(), userAgent = "Riffle/test", retryDelaysMs = emptyList()),
-            bytesClient = OkHttpClient(),
+            http = ChitankaHttpClient(client = HttpClient(OkHttp) {}, userAgent = "Riffle/test", retryDelaysMs = emptyList()),
+            bytesClient = HttpClient(OkHttp) {},
             userAgent = "Riffle/test",
         )
         val response = cat.fetchBytesWith429Retry(server.url("/download/foo.epub").toString(), itemId = "book/foo")
-        try {
-            assertTrue(response.isSuccessful)
-        } finally {
-            response.close()
-        }
+        response.close()
         assertEquals(2, server.requestCount)
     }
 

--- a/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaHttpClientTest.kt
+++ b/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaHttpClientTest.kt
@@ -1,7 +1,8 @@
 package com.riffle.core.catalog.chitanka
 
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
 import kotlinx.coroutines.test.runTest
-import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okio.Buffer
@@ -28,7 +29,7 @@ class ChitankaHttpClientTest {
     }
 
     private fun newClient() = ChitankaHttpClient(
-        client = OkHttpClient(),
+        client = HttpClient(OkHttp) {},
         userAgent = "Riffle/test",
         retryDelaysMs = listOf(0L, 0L),  // no wait in tests
     )

--- a/core/catalog-gutenberg/build.gradle.kts
+++ b/core/catalog-gutenberg/build.gradle.kts
@@ -7,9 +7,10 @@ dependencies {
     implementation(project(":core:domain"))
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
-    implementation(libs.okhttp)
+    implementation(libs.ktor.client.core)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.okhttp.mockwebserver)
+    testImplementation(libs.ktor.client.okhttp)
 }

--- a/core/catalog-gutenberg/src/main/kotlin/com/riffle/core/catalog/gutenberg/GutenbergCatalog.kt
+++ b/core/catalog-gutenberg/src/main/kotlin/com/riffle/core/catalog/gutenberg/GutenbergCatalog.kt
@@ -15,10 +15,15 @@ import com.riffle.core.catalog.ReadCapability
 import com.riffle.core.catalog.SortKey
 import com.riffle.core.catalog.ToReadListCapability
 import com.riffle.core.models.SourceType
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import okhttp3.OkHttpClient
-import okhttp3.Request
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.HttpHeaders
+import io.ktor.http.contentLength
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.jvm.javaio.toInputStream
+import kotlinx.coroutines.delay
 import java.net.URLEncoder
 
 /**
@@ -41,7 +46,7 @@ import java.net.URLEncoder
  */
 class GutenbergCatalog(
     private val http: GutenbergHttpClient,
-    private val bytesClient: OkHttpClient = OkHttpClient(),
+    private val bytesClient: HttpClient = HttpClient(),
     private val userAgent: String = "Riffle",
     // Overridable so tests can point the API + download hosts at a MockWebServer.
     private val apiBase: String = GutenbergParser.BASE,
@@ -153,44 +158,38 @@ class GutenbergCatalog(
         itemId: String,
         format: BookFormat,
         handleHint: String?,
-    ): CatalogFileStream = withContext(Dispatchers.IO) {
+    ): CatalogFileStream {
         val handle = fetchFile(itemId, format)
         if (handle !is CatalogFileHandle.Stream) {
             throw GutenbergException("Local file handles are not produced by Gutenberg Source")
         }
-        val response = fetchBytesWithRetry(handle.url, itemId)
-        val body = response.body
-        object : CatalogFileStream {
-            override val contentLength: Long = body.contentLength()
-            override fun byteStream() = body.byteStream()
-            override fun close() { response.close() }
-        }
+        return fetchBytesWithRetry(handle.url, itemId)
     }
 
-    internal suspend fun fetchBytesWithRetry(url: String, itemId: String): okhttp3.Response {
+    internal suspend fun fetchBytesWithRetry(downloadUrl: String, itemId: String): CatalogFileStream {
         var attempt = 0
         while (true) {
-            val request = Request.Builder()
-                .url(url)
-                .header("User-Agent", userAgent)
-                .header("Accept", "application/epub+zip, application/octet-stream")
-                .header("Referer", GutenbergParser.GUTENBERG_BASE)
-                .build()
-            val response = bytesClient.newCall(request).execute()
-            if (response.isSuccessful) return response
-            val code = response.code
-            response.close()
+            val response = bytesClient.get(downloadUrl) {
+                header(HttpHeaders.UserAgent, userAgent)
+            }
+            if (response.status.isSuccess()) {
+                val channel = response.bodyAsChannel()
+                return object : CatalogFileStream {
+                    override val contentLength: Long = response.contentLength() ?: -1L
+                    override fun byteStream(): java.io.InputStream = channel.toInputStream()
+                    override fun close() { channel.cancel(null) }
+                }
+            }
+            val code = response.status.value
             if ((code == 429 || code == 503) &&
                 attempt < GutenbergHttpClient.DEFAULT_RETRY_DELAYS_MS.size
             ) {
-                kotlinx.coroutines.delay(GutenbergHttpClient.DEFAULT_RETRY_DELAYS_MS[attempt])
+                delay(GutenbergHttpClient.DEFAULT_RETRY_DELAYS_MS[attempt])
                 attempt++
                 continue
             }
             throw GutenbergException("Failed to fetch bytes for $itemId: $code")
         }
-        @Suppress("UNREACHABLE_CODE")
-        error("unreachable")
     }
 
     // ---- Connectivity -------------------------------------------------------

--- a/core/catalog-gutenberg/src/main/kotlin/com/riffle/core/catalog/gutenberg/GutenbergCatalogFactory.kt
+++ b/core/catalog-gutenberg/src/main/kotlin/com/riffle/core/catalog/gutenberg/GutenbergCatalogFactory.kt
@@ -4,11 +4,8 @@ import com.riffle.core.catalog.Catalog
 import com.riffle.core.catalog.CatalogFactory
 import com.riffle.core.models.Source
 import com.riffle.core.models.SourceType
-import okhttp3.ConnectionPool
-import okhttp3.Dispatcher
-import okhttp3.OkHttpClient
-import okhttp3.Protocol
-import java.util.concurrent.TimeUnit
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
 
 /**
  * Builds a [GutenbergCatalog] per Source. Because the Gutenberg Source is zero-config (Gutendex
@@ -16,42 +13,26 @@ import java.util.concurrent.TimeUnit
  * yields an equivalent instance. Wired into `CatalogRegistry` via Hilt in `core:data`'s
  * `CatalogModule`.
  *
- * Derives a longer-timeout client via [OkHttpClient.newBuilder] so it shares the connection
- * pool + dispatchers with the app-wide singleton but tolerates slow Gutendex responses. Some
- * `topic=…` queries (Poetry most reproducibly) take well over the default 10s read timeout on
- * gutendex.com — verified via `adb logcat -d | grep RIFFLE_GB` showing
- * `SocketTimeoutException: timeout` while curl to the same URL from the host completes.
- * 30s covers those without letting a truly-dead connection wedge the browse indefinitely.
+ * Derives a longer-timeout client so it tolerates slow Gutendex responses. Some `topic=…`
+ * queries (Poetry most reproducibly) take well over the default 10s read timeout on
+ * gutendex.com — 30s covers those without letting a truly-dead connection wedge indefinitely.
+ *
+ * Note: the previous OkHttp implementation forced HTTP/1.1 and a custom dispatcher to work
+ * around Cloudflare H2 stalls. Those engine-level optimisations are deferred to Phase 3 when
+ * the Ktor OkHttp engine is configured centrally per source type.
  */
 class GutenbergCatalogFactory(
-    okHttpClient: OkHttpClient,
+    sharedHttpClient: HttpClient,
     private val userAgent: String,
 ) : CatalogFactory {
 
-    // HTTP/1.1-only: Gutendex sits behind Cloudflare. Empirically OkHttp's default HTTP/2
-    // path stalls on some `topic=…` queries — the connection stays open past the read timeout
-    // even though curl to the same URL returns in <200 ms. Forcing HTTP/1.1 sidesteps the H2
-    // stream-multiplexing edge case entirely; the tradeoff (a fresh TCP per unpipelined
-    // request) is trivial for this Source's request volume.
-    private val httpClient: OkHttpClient = okHttpClient.newBuilder()
-        .protocols(listOf(Protocol.HTTP_1_1))
-        // Dedicated dispatcher — the app-wide singleton's dispatcher services every Source, so a
-        // burst of rapid Gutendex facet taps could starve unrelated background calls (progress
-        // sync, cover fetches). Ours caps at 8 concurrent for the Gutenberg host so a rapid
-        // Fiction→History→Poetry→Drama sequence never queues past the 4th request; combined with
-        // the 250 ms selectFacet debounce in the ViewModel, a cancel is always visible.
-        .dispatcher(Dispatcher().apply {
-            maxRequests = 8
-            maxRequestsPerHost = 8
-        })
-        // Short idle-connection lifetime so a cancelled request's socket is pruned quickly
-        // instead of lingering in the pool and starving the next request. Cloudflare in
-        // particular sometimes keeps sockets half-open after a client-side abort.
-        .connectionPool(ConnectionPool(maxIdleConnections = 4, keepAliveDuration = 15, TimeUnit.SECONDS))
-        .connectTimeout(GUTENBERG_CONNECT_TIMEOUT_SEC, TimeUnit.SECONDS)
-        .readTimeout(GUTENBERG_READ_TIMEOUT_SEC, TimeUnit.SECONDS)
-        .callTimeout(GUTENBERG_CALL_TIMEOUT_SEC, TimeUnit.SECONDS)
-        .build()
+    private val httpClient: HttpClient = sharedHttpClient.config {
+        install(HttpTimeout) {
+            connectTimeoutMillis = GUTENBERG_CONNECT_TIMEOUT_SEC * 1000
+            requestTimeoutMillis = GUTENBERG_CALL_TIMEOUT_SEC * 1000
+            socketTimeoutMillis = GUTENBERG_READ_TIMEOUT_SEC * 1000
+        }
+    }
 
     override val sourceType: SourceType = SourceType.GUTENBERG
 
@@ -63,9 +44,6 @@ class GutenbergCatalogFactory(
     private companion object {
         const val GUTENBERG_CONNECT_TIMEOUT_SEC: Long = 15
         const val GUTENBERG_READ_TIMEOUT_SEC: Long = 30
-        // Upper bound across DNS + connect + TLS + request + response. Prevents a genuinely
-        // dead connection from hanging the browse forever even if individual timeouts don't
-        // trip (e.g. slow drip on the socket that keeps read-timeout resetting).
         const val GUTENBERG_CALL_TIMEOUT_SEC: Long = 45
     }
 }

--- a/core/catalog-gutenberg/src/main/kotlin/com/riffle/core/catalog/gutenberg/GutenbergHttpClient.kt
+++ b/core/catalog-gutenberg/src/main/kotlin/com/riffle/core/catalog/gutenberg/GutenbergHttpClient.kt
@@ -1,98 +1,41 @@
 package com.riffle.core.catalog.gutenberg
 
-import kotlinx.coroutines.Dispatchers
+import io.ktor.client.HttpClient
+import io.ktor.client.request.accept
+import io.ktor.client.request.get
+import io.ktor.client.request.head
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.isSuccess
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.withContext
-import okhttp3.Call
-import okhttp3.Callback
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.Response
 import java.io.IOException
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
-/**
- * Thin OkHttp wrapper for Gutendex + gutenberg.org fetches. Mirrors the shape of the Chitanka
- * client so both public-catalogue sources have the same throttling behaviour.
- *
- * Gutendex is well-behaved and generally returns quickly; the retry schedule below matters more
- * for gutenberg.org's mirrored EPUB downloads, which occasionally 503 during mirror rotation.
- */
 class GutenbergHttpClient(
-    private val client: OkHttpClient,
+    private val client: HttpClient,
     private val userAgent: String,
     private val retryDelaysMs: List<Long> = DEFAULT_RETRY_DELAYS_MS,
 ) {
-
     suspend fun getString(url: String): String {
         var attempt = 0
         while (true) {
-            val request = Request.Builder()
-                .url(url)
-                .header("User-Agent", userAgent)
-                .header("Accept", "application/json, text/html;q=0.5")
-                .build()
-            val response = client.newCall(request).await()
-            // Body reading is blocking I/O — must NOT run on the resumed dispatcher, which is the
-            // caller's context (Main for a Compose ViewModel). Enqueue-based await() resumes on
-            // whatever thread the OkHttp Callback runs on but the coroutine machinery may hop back
-            // to the caller's dispatcher; without the explicit withContext hop, r.body.string()
-            // throws NetworkOnMainThreadException on strict-mode devices.
-            val (status, body, msg) = withContext(Dispatchers.IO) {
-                response.use { r ->
-                    Triple(r.code, if (r.isSuccessful) r.body.string() else null, r.message)
-                }
+            val response = client.get(url) {
+                header(HttpHeaders.UserAgent, userAgent)
+                accept(ContentType.Application.Json)
             }
-            if ((status == 429 || status == 503) && attempt < retryDelaysMs.size) {
-                delay(retryDelaysMs[attempt])
-                attempt++
+            if ((response.status.value == 429 || response.status.value == 503) && attempt < retryDelaysMs.size) {
+                delay(retryDelaysMs[attempt++])
                 continue
             }
-            if (body == null) throw GutenbergHttpException(code = status, url = url, message = msg)
-            return body
-        }
-        @Suppress("UNREACHABLE_CODE")
-        error("unreachable")
-    }
-
-    suspend fun ping(url: String): Boolean {
-        return try {
-            val request = Request.Builder()
-                .url(url)
-                .header("User-Agent", userAgent)
-                .head()
-                .build()
-            client.newCall(request).await().use { it.isSuccessful }
-        } catch (_: IOException) {
-            false
+            if (!response.status.isSuccess()) throw GutenbergHttpException(response.status.value, url, response.status.description)
+            return response.bodyAsText()
         }
     }
 
-    /**
-     * Bridge OkHttp's [Call] to a coroutine so that cancelling the enclosing coroutine
-     * (a fresh refresh cancelling the old one on rapid facet taps) cancels the underlying HTTP
-     * request instead of leaving it stuck holding a dispatcher thread. Without this, rapid taps
-     * pile up requests behind the connection pool and the fresh tap waits on stalled sockets —
-     * observed as the "Couldn't reach Project Gutenberg" timeout even though the same URL
-     * completes in ~100 ms via curl.
-     */
-    private suspend fun Call.await(): Response =
-        suspendCancellableCoroutine { cont ->
-            cont.invokeOnCancellation {
-                try { cancel() } catch (_: Throwable) { /* best-effort */ }
-            }
-            enqueue(object : Callback {
-                override fun onResponse(call: Call, response: Response) {
-                    if (cont.isActive) cont.resume(response)
-                    else response.close()
-                }
-                override fun onFailure(call: Call, e: IOException) {
-                    if (cont.isActive) cont.resumeWithException(e)
-                }
-            })
-        }
+    suspend fun ping(url: String): Boolean = try {
+        client.head(url) { header(HttpHeaders.UserAgent, userAgent) }.status.isSuccess()
+    } catch (_: IOException) { false }
 
     companion object {
         val DEFAULT_RETRY_DELAYS_MS: List<Long> = listOf(1_500L, 3_000L)

--- a/core/catalog-gutenberg/src/test/kotlin/com/riffle/core/catalog/gutenberg/GutenbergCatalogTest.kt
+++ b/core/catalog-gutenberg/src/test/kotlin/com/riffle/core/catalog/gutenberg/GutenbergCatalogTest.kt
@@ -4,8 +4,9 @@ import com.riffle.core.catalog.BookFormat
 import com.riffle.core.catalog.CatalogFileHandle
 import com.riffle.core.catalog.FacetSelection
 import com.riffle.core.models.SourceType
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
 import kotlinx.coroutines.test.runTest
-import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
@@ -29,11 +30,11 @@ class GutenbergCatalogTest {
     @Before
     fun setUp() {
         server = MockWebServer().also { it.start() }
-        val okHttp = OkHttpClient()
-        val http = GutenbergHttpClient(client = okHttp, userAgent = "Riffle/test", retryDelaysMs = emptyList())
+        val httpClient = HttpClient(OkHttp) {}
+        val http = GutenbergHttpClient(client = httpClient, userAgent = "Riffle/test", retryDelaysMs = emptyList())
         catalog = GutenbergCatalog(
             http = http,
-            bytesClient = okHttp,
+            bytesClient = httpClient,
             userAgent = "Riffle/test",
             apiBase = server.url("").toString().trimEnd('/'),
         )

--- a/core/catalog-gutenberg/src/test/kotlin/com/riffle/core/catalog/gutenberg/GutenbergHttpClientTest.kt
+++ b/core/catalog-gutenberg/src/test/kotlin/com/riffle/core/catalog/gutenberg/GutenbergHttpClientTest.kt
@@ -1,7 +1,8 @@
 package com.riffle.core.catalog.gutenberg
 
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
 import kotlinx.coroutines.test.runTest
-import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
@@ -19,7 +20,7 @@ class GutenbergHttpClientTest {
     @After fun tearDown() { server.shutdown() }
 
     private fun newClient() = GutenbergHttpClient(
-        client = OkHttpClient(),
+        client = HttpClient(OkHttp) {},
         userAgent = "Riffle/test",
         retryDelaysMs = listOf(0L, 0L),
     )

--- a/core/catalog-komga/build.gradle.kts
+++ b/core/catalog-komga/build.gradle.kts
@@ -8,9 +8,10 @@ dependencies {
     implementation(project(":core:domain"))
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
-    implementation(libs.okhttp)
+    implementation(libs.ktor.client.core)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.okhttp.mockwebserver)
+    testImplementation(libs.ktor.client.okhttp)
 }

--- a/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalog.kt
+++ b/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalog.kt
@@ -22,12 +22,18 @@ import com.riffle.core.catalog.SeriesCapability
 import com.riffle.core.catalog.SortKey
 import com.riffle.core.catalog.ToReadListCapability
 import com.riffle.core.models.SourceType
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.HttpHeaders
+import io.ktor.http.contentLength
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.jvm.javaio.toInputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.serializer
-import okhttp3.OkHttpClient
-import okhttp3.Request
 import java.net.URLEncoder
 
 /**
@@ -56,7 +62,7 @@ import java.net.URLEncoder
 class KomgaCatalog(
     private val config: KomgaCatalogConfig,
     private val http: KomgaHttpClient,
-    private val bytesClient: OkHttpClient = OkHttpClient(),
+    private val bytesClient: HttpClient,
 ) : Catalog,
     ReadCapability,
     DownloadsCapability,
@@ -153,40 +159,28 @@ class KomgaCatalog(
         format: BookFormat,
         handleHint: String?,
     ): CatalogFileStream = withContext(Dispatchers.IO) {
-        // OkHttp's `Call.execute()` is BLOCKING and throws `NetworkOnMainThreadException` when it
-        // runs on Main — which is where readers previously routed via `catalog.openFile(...)`. This
-        // was the actual root cause behind the "Network error: null" reader error surfaced to the
-        // user (the Throwable's own message is null; the class name only shows via `toString()`).
-        // Hop to IO here so every network path in this catalog stays off the Main thread.
         if (format == BookFormat.Audiobook || format == BookFormat.Unsupported) {
             throw KomgaHttpException(code = 415, url = itemId, message = "Unsupported format $format")
         }
         val url = apiUrl("books/$itemId/file")
-        val request = Request.Builder()
-            .url(url)
-            .header("Authorization", config.basicAuthHeader)
-            .header("Accept", "application/octet-stream, application/epub+zip, application/pdf, application/x-cbz")
-            .build()
         val response = try {
-            bytesClient.newCall(request).execute()
+            bytesClient.get(url) {
+                header(HttpHeaders.Authorization, config.basicAuthHeader)
+                header(HttpHeaders.Accept, "application/octet-stream, application/epub+zip, application/pdf, application/x-cbz")
+            }
         } catch (e: java.io.IOException) {
-            throw KomgaHttpException(
-                code = -1,
-                url = url,
-                message = e.message ?: e::class.simpleName ?: "network error",
-            )
+            throw KomgaHttpException(code = -1, url = url, message = e.message ?: "network error")
         }
-        if (!response.isSuccessful) {
-            val code = response.code
-            val msg = response.message.ifEmpty { "HTTP $code" }
-            response.close()
-            throw KomgaHttpException(code = code, url = url, message = msg)
+        if (!response.status.isSuccess()) {
+            response.bodyAsChannel().cancel(null)
+            throw KomgaHttpException(code = response.status.value, url = url, message = response.status.description)
         }
-        val body = response.body
+        val contentLength = response.contentLength() ?: -1L
+        val channel = response.bodyAsChannel()
         object : CatalogFileStream {
-            override val contentLength: Long = body.contentLength()
-            override fun byteStream(): java.io.InputStream = body.byteStream()
-            override fun close() { response.close() }
+            override val contentLength: Long = contentLength
+            override fun byteStream(): java.io.InputStream = channel.toInputStream()
+            override fun close() { channel.cancel(null) }
         }
     }
 

--- a/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalogFactory.kt
+++ b/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalogFactory.kt
@@ -5,7 +5,7 @@ import com.riffle.core.catalog.CatalogFactory
 import com.riffle.core.models.Source
 import com.riffle.core.models.SourceType
 import com.riffle.core.domain.TokenStorage
-import okhttp3.OkHttpClient
+import io.ktor.client.HttpClient
 
 /**
  * Builds a [KomgaCatalog] per Komga Source row. Reconstructs the HTTP Basic auth header from
@@ -13,7 +13,7 @@ import okhttp3.OkHttpClient
  * Returns null when the source has no stored password (fresh row that hasn't finished login).
  */
 class KomgaCatalogFactory(
-    private val okHttpClient: OkHttpClient,
+    private val httpClient: HttpClient,
     private val tokenStorage: TokenStorage,
     private val userAgent: String = "Riffle/dev (Android) komga-source",
 ) : CatalogFactory {
@@ -37,10 +37,10 @@ class KomgaCatalogFactory(
             insecureAllowed = source.insecureConnectionAllowed,
         )
         val http = KomgaHttpClient(
-            client = okHttpClient,
+            client = httpClient,
             basicAuthHeader = basicAuthHeader,
             userAgent = userAgent,
         )
-        return KomgaCatalog(config = config, http = http, bytesClient = okHttpClient)
+        return KomgaCatalog(config = config, http = http, bytesClient = httpClient)
     }
 }

--- a/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaHttpClient.kt
+++ b/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaHttpClient.kt
@@ -1,87 +1,63 @@
 package com.riffle.core.catalog.komga
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.withContext
-import okhttp3.Call
-import okhttp3.Callback
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.Response
+import io.ktor.client.HttpClient
+import io.ktor.client.request.accept
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.head
+import io.ktor.client.request.header
+import io.ktor.client.request.patch
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
 import java.io.IOException
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
-
-private val JSON_MEDIA_TYPE = "application/json".toMediaType()
 
 /**
- * Thin OkHttp wrapper for Komga's REST API. Stamps the `Authorization: Basic …` header on every
+ * Thin Ktor wrapper for Komga's REST API. Stamps the `Authorization: Basic …` header on every
  * request; callers only supply the URL path.
  */
 class KomgaHttpClient(
-    private val client: OkHttpClient,
+    private val client: HttpClient,
     private val basicAuthHeader: String,
     private val userAgent: String = "Riffle/dev (Android) komga-source",
 ) {
 
     /** GET [url], return response body string. Throws [KomgaHttpException] on non-2xx. */
     suspend fun getString(url: String): String {
-        val request = Request.Builder()
-            .url(url)
-            .header("User-Agent", userAgent)
-            .header("Authorization", basicAuthHeader)
-            .header("Accept", "application/json")
-            .build()
-        val response = client.newCall(request).await()
-        return readSuccessOrThrow(method = "GET", url = url, response = response)
-    }
-
-    /**
-     * Execute a streaming GET on [url]. Caller receives the raw [Response] and MUST close it.
-     * Throws [KomgaHttpException] on non-2xx (body is closed).
-     */
-    suspend fun getStreaming(url: String): Response {
-        val request = Request.Builder()
-            .url(url)
-            .header("User-Agent", userAgent)
-            .header("Authorization", basicAuthHeader)
-            .build()
-        val response = client.newCall(request).await()
-        if (!response.isSuccessful) {
-            val code = response.code
-            val msg = response.message
-            response.close()
-            throw KomgaHttpException(code = code, url = url, message = msg)
+        val response = client.get(url) {
+            header(HttpHeaders.Authorization, basicAuthHeader)
+            header(HttpHeaders.UserAgent, userAgent)
+            accept(ContentType.Application.Json)
         }
-        return response
+        return readSuccessOrThrow("GET", url, response)
     }
 
     /** HEAD [url]; true if 2xx. Any exception → false. */
     suspend fun ping(url: String): Boolean = try {
-        val request = Request.Builder()
-            .url(url)
-            .header("User-Agent", userAgent)
-            .header("Authorization", basicAuthHeader)
-            .head()
-            .build()
-        client.newCall(request).await().use { it.isSuccessful }
+        val response = client.head(url) {
+            header(HttpHeaders.Authorization, basicAuthHeader)
+            header(HttpHeaders.UserAgent, userAgent)
+        }
+        response.status.isSuccess()
     } catch (_: IOException) {
         false
     }
 
     /** POST [jsonBody] to [url]. Returns the response body as a string. Throws on non-2xx. */
     suspend fun postJson(url: String, jsonBody: String): String {
-        val request = Request.Builder()
-            .url(url)
-            .header("User-Agent", userAgent)
-            .header("Authorization", basicAuthHeader)
-            .header("Accept", "application/json")
-            .post(jsonBody.toRequestBody(JSON_MEDIA_TYPE))
-            .build()
-        val response = client.newCall(request).await()
-        return readSuccessOrThrow(method = "POST", url = url, response = response)
+        val response = client.post(url) {
+            header(HttpHeaders.Authorization, basicAuthHeader)
+            header(HttpHeaders.UserAgent, userAgent)
+            accept(ContentType.Application.Json)
+            contentType(ContentType.Application.Json)
+            setBody(jsonBody)
+        }
+        return readSuccessOrThrow("POST", url, response)
     }
 
     /**
@@ -90,26 +66,32 @@ class KomgaHttpClient(
      * the exception, not a payload.
      */
     suspend fun patchJson(url: String, jsonBody: String) {
-        val request = Request.Builder()
-            .url(url)
-            .header("User-Agent", userAgent)
-            .header("Authorization", basicAuthHeader)
-            .patch(jsonBody.toRequestBody(JSON_MEDIA_TYPE))
-            .build()
-        val response = client.newCall(request).await()
-        readSuccessOrThrow(method = "PATCH", url = url, response = response)
+        val response = client.patch(url) {
+            header(HttpHeaders.Authorization, basicAuthHeader)
+            header(HttpHeaders.UserAgent, userAgent)
+            contentType(ContentType.Application.Json)
+            setBody(jsonBody)
+        }
+        readSuccessOrThrow("PATCH", url, response)
     }
 
     /** DELETE [url]. Throws on non-2xx. */
     suspend fun delete(url: String) {
-        val request = Request.Builder()
-            .url(url)
-            .header("User-Agent", userAgent)
-            .header("Authorization", basicAuthHeader)
-            .delete()
-            .build()
-        val response = client.newCall(request).await()
-        readSuccessOrThrow(method = "DELETE", url = url, response = response)
+        val response = client.delete(url) {
+            header(HttpHeaders.Authorization, basicAuthHeader)
+            header(HttpHeaders.UserAgent, userAgent)
+        }
+        readSuccessOrThrow("DELETE", url, response)
+    }
+
+    /** Status of a GET without reading the body. Returns HTTP code (or -1 on IOException). */
+    suspend fun getStatus(url: String): Int = try {
+        client.get(url) {
+            header(HttpHeaders.Authorization, basicAuthHeader)
+            header(HttpHeaders.UserAgent, userAgent)
+        }.status.value
+    } catch (_: IOException) {
+        -1
     }
 
     /**
@@ -119,52 +101,19 @@ class KomgaHttpClient(
      * ReadList you don't own" — Komga's errors are only useful when we surface them. Truncate
      * to 500 chars so a large error page doesn't blow up log lines.
      */
-    private suspend fun readSuccessOrThrow(method: String, url: String, response: Response): String {
-        val (status, ok, bodyStr, statusMessage) = withContext(Dispatchers.IO) {
-            response.use { r ->
-                val bodyText = runCatching { r.body.string() }.getOrDefault("")
-                Quad(r.code, r.isSuccessful, bodyText, r.message)
-            }
-        }
-        if (!ok) {
+    private suspend fun readSuccessOrThrow(method: String, url: String, response: HttpResponse): String {
+        val bodyStr = runCatching { response.bodyAsText() }.getOrDefault("")
+        if (!response.status.isSuccess()) {
             val truncated = if (bodyStr.length > 500) bodyStr.take(500) + "…(truncated)" else bodyStr
             throw KomgaHttpException(
-                code = status,
+                code = response.status.value,
                 url = url,
                 method = method,
-                statusMessage = statusMessage,
+                statusMessage = response.status.description,
                 responseBody = truncated,
             )
         }
         return bodyStr
-    }
-
-    private data class Quad<A, B, C, D>(val a: A, val b: B, val c: C, val d: D)
-
-    /** Status of a GET without reading the body. Returns HTTP code (or -1 on IOException). */
-    suspend fun getStatus(url: String): Int = try {
-        val request = Request.Builder()
-            .url(url)
-            .header("User-Agent", userAgent)
-            .header("Authorization", basicAuthHeader)
-            .build()
-        client.newCall(request).await().use { it.code }
-    } catch (_: IOException) {
-        -1
-    }
-
-    private suspend fun Call.await(): Response = suspendCancellableCoroutine { cont ->
-        cont.invokeOnCancellation {
-            try { cancel() } catch (_: Throwable) { /* best-effort */ }
-        }
-        enqueue(object : Callback {
-            override fun onResponse(call: Call, response: Response) {
-                if (cont.isActive) cont.resume(response) else response.close()
-            }
-            override fun onFailure(call: Call, e: IOException) {
-                if (cont.isActive) cont.resumeWithException(e)
-            }
-        })
     }
 }
 
@@ -191,4 +140,3 @@ class KomgaHttpException(
         responseBody = "",
     )
 }
-

--- a/core/catalog-komga/src/test/kotlin/com/riffle/core/catalog/komga/KomgaCatalogTest.kt
+++ b/core/catalog-komga/src/test/kotlin/com/riffle/core/catalog/komga/KomgaCatalogTest.kt
@@ -4,8 +4,9 @@ import com.riffle.core.catalog.BookFormat
 import com.riffle.core.catalog.CatalogFileHandle
 import com.riffle.core.catalog.CfiDialect
 import com.riffle.core.catalog.SortKey
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
 import kotlinx.coroutines.test.runTest
-import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
@@ -29,14 +30,14 @@ class KomgaCatalogTest {
     @Before fun setUp() {
         server = MockWebServer()
         server.start()
-        val ok = OkHttpClient()
+        val httpClient = HttpClient(OkHttp) {}
         val header = buildBasicAuthHeader("user", "pass")
         val config = KomgaCatalogConfig(
             baseUrl = server.url("/").toString().trimEnd('/'),
             basicAuthHeader = header,
             insecureAllowed = true,
         )
-        catalog = KomgaCatalog(config, KomgaHttpClient(ok, header), ok)
+        catalog = KomgaCatalog(config, KomgaHttpClient(httpClient, header), httpClient)
     }
 
     @After fun tearDown() { server.shutdown() }

--- a/core/catalog-komga/src/test/kotlin/com/riffle/core/catalog/komga/KomgaPlaylistsCapabilityTest.kt
+++ b/core/catalog-komga/src/test/kotlin/com/riffle/core/catalog/komga/KomgaPlaylistsCapabilityTest.kt
@@ -1,7 +1,8 @@
 package com.riffle.core.catalog.komga
 
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
 import kotlinx.coroutines.test.runTest
-import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
@@ -26,14 +27,14 @@ class KomgaPlaylistsCapabilityTest {
     @Before fun setUp() {
         server = MockWebServer()
         server.start()
-        val ok = OkHttpClient()
+        val httpClient = HttpClient(OkHttp) {}
         val header = buildBasicAuthHeader("user", "pass")
         val config = KomgaCatalogConfig(
             baseUrl = server.url("/").toString().trimEnd('/'),
             basicAuthHeader = header,
             insecureAllowed = true,
         )
-        catalog = KomgaCatalog(config, KomgaHttpClient(ok, header), ok)
+        catalog = KomgaCatalog(config, KomgaHttpClient(httpClient, header), httpClient)
     }
 
     @After fun tearDown() { server.shutdown() }

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
@@ -172,9 +172,9 @@ class AbsCatalog(
                     else -> throw CatalogException.Unknown(r.errorAsThrowable())
                 }
                 object : CatalogFileStream {
-                    override val contentLength: Long = body.contentLength()
-                    override fun byteStream(): java.io.InputStream = body.byteStream()
-                    override fun close() { body.close() }
+                    override val contentLength: Long = body.contentLength
+                    override fun byteStream(): java.io.InputStream = body.inputStream
+                    override fun close() { body.inputStream.close() }
                 }
             }
             BookFormat.Audiobook -> throw CatalogException.UnsupportedFormat(

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -53,11 +53,14 @@ dependencies {
     ksp(libs.hilt.compiler)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.okhttp)
+    implementation(libs.ktor.client.okhttp)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.okhttp.mockwebserver)
     testImplementation(libs.mockk)
+    testImplementation(libs.ktor.client.okhttp)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.runner)

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBundleDownloader.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookBundleDownloader.kt
@@ -56,19 +56,17 @@ class AudiobookBundleDownloader(
         var written = if (appending) resumeFrom else 0L
         val total = if (stream.totalBytes > 0) stream.totalBytes else -1L
         try {
-            stream.body.use { body ->
+            stream.body.use { source ->
                 java.io.FileOutputStream(partFile, appending).use { sink ->
                     val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-                    body.byteStream().use { source ->
-                        while (true) {
-                            val n = source.read(buffer)
-                            if (n == -1) break
-                            sink.write(buffer, 0, n)
-                            written += n
-                            // Pass total verbatim — -1 when the server sent no length, so the
-                            // UI shows an indeterminate spinner rather than a misleading 100%.
-                            onProgress(written, total)
-                        }
+                    while (true) {
+                        val n = source.read(buffer)
+                        if (n == -1) break
+                        sink.write(buffer, 0, n)
+                        written += n
+                        // Pass total verbatim — -1 when the server sent no length, so the
+                        // UI shows an indeterminate spinner rather than a misleading 100%.
+                        onProgress(written, total)
                     }
                 }
             }

--- a/core/data/src/main/kotlin/com/riffle/core/data/StorytellerSidecarFetcher.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/StorytellerSidecarFetcher.kt
@@ -44,8 +44,8 @@ open class StorytellerSidecarFetcher(
         // Fast path: stream the prefix, stop at the first audio entry (~1 MB transferred).
         val fastPath = bundleApi.downloadBundle(baseUrl, bookId, token, insecureAllowed)
         if (fastPath !is NetworkResult.Success) return@withContext FetchResult.NetworkError
-        val streaming = fastPath.value.body.use { body ->
-            runCatching { ReadaloudSidecarReader.readStreaming(body.byteStream()) }.getOrNull()
+        val streaming = fastPath.value.body.use { source ->
+            runCatching { ReadaloudSidecarReader.readStreaming(source) }.getOrNull()
         }
         if (streaming != null) return@withContext FetchResult.Success(streaming)
 
@@ -56,8 +56,8 @@ open class StorytellerSidecarFetcher(
             val full = fullBundleApi.downloadBundle(baseUrl, bookId, token, insecureAllowed)
             if (full !is NetworkResult.Success) FetchResult.NetworkError
             else {
-                full.value.body.use { body ->
-                    tempFile.outputStream().use { out -> body.byteStream().copyTo(out) }
+                full.value.body.use { source ->
+                    tempFile.outputStream().use { out -> source.copyTo(out) }
                 }
                 val bytes = ReadaloudSidecarReader.readFromFile(tempFile)
                 if (bytes != null) FetchResult.Success(bytes) else FetchResult.NotAligned

--- a/core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTarget.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTarget.kt
@@ -6,18 +6,24 @@ import com.riffle.core.domain.DeviceFileSummary
 import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.NamespaceDeviceListing
 import com.riffle.core.domain.NamespaceSummary
+import io.ktor.client.HttpClient
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.put
+import io.ktor.client.request.request
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.URLBuilder
+import io.ktor.http.Url
+import io.ktor.http.content.TextContent
 import kotlinx.coroutines.withContext
-import okhttp3.Credentials
-import okhttp3.HttpUrl
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody
-import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.Response
 import org.xml.sax.Attributes
 import org.xml.sax.helpers.DefaultHandler
+import java.util.Base64
 import javax.xml.parsers.SAXParserFactory
 
 /**
@@ -46,15 +52,16 @@ import javax.xml.parsers.SAXParserFactory
  * the OkHttp default with 424.
  */
 class WebDavAnnotationSyncTarget(
-    baseUrl: HttpUrl,
+    baseUrl: Url,
     username: String,
     password: String,
-    private val client: OkHttpClient,
+    private val client: HttpClient,
     private val dispatchers: DispatcherProvider,
 ) : AnnotationSyncTarget {
 
-    private val basePath: HttpUrl = ensureTrailingSlash(baseUrl)
-    private val authHeader: String = Credentials.basic(username, password)
+    private val basePath: String = ensureTrailingSlash(baseUrl.toString())
+    private val authHeader: String =
+        "Basic " + Base64.getEncoder().encodeToString("$username:$password".toByteArray())
 
     override suspend fun list(namespace: String, itemId: String): List<String> =
         withContext(dispatchers.io) {
@@ -80,7 +87,7 @@ class WebDavAnnotationSyncTarget(
             // Flat path under basePath. No per-book subdirectories means MKCOL never has to fire on
             // a real push — the only collection that must exist is basePath itself, which the user
             // has already vouched for via Test Connection (and which we MKCOL-create on demand).
-            putFile(annotationFileUrl(namespace, itemId, filename), content, JSON_LD_MEDIA, "write $filename")
+            putFile(annotationFileUrl(namespace, itemId, filename), content, JSON_LD_CONTENT_TYPE, "write $filename")
         }
     }
 
@@ -93,7 +100,7 @@ class WebDavAnnotationSyncTarget(
 
     override suspend fun writeDeviceMeta(namespace: String, deviceId: String, content: String) {
         withContext(dispatchers.io) {
-            putFile(deviceMetaUrl(namespace, deviceId), content, JSON_MEDIA, "write device-meta $deviceId")
+            putFile(deviceMetaUrl(namespace, deviceId), content, JSON_CONTENT_TYPE, "write device-meta $deviceId")
         }
     }
 
@@ -167,7 +174,7 @@ class WebDavAnnotationSyncTarget(
             if (!physical.startsWith(prefix)) continue
             // Use the physical filename as the URL segment directly. annotationFileUrl
             // would re-prefix and double-encode the namespace; just hit the literal name we saw.
-            val url = basePath.newBuilder().addPathSegment(physical).build()
+            val url = "$basePath$physical"
             try {
                 deleteFile(url, "delete $physical")
                 deleted++
@@ -179,20 +186,23 @@ class WebDavAnnotationSyncTarget(
     }
 
     suspend fun testConnection(): TestConnectionResult = withContext(dispatchers.io) {
-        val request = baseRequest(basePath)
-            .header("Depth", "0")
-            .header("Content-Type", "application/xml; charset=utf-8")
-            .method("PROPFIND", PROPFIND_BODY.toRequestBody(XML_MEDIA))
-            .build()
         try {
-            client.newCall(request).execute().use { response ->
-                when {
-                    response.isSuccessful || response.code == 207 -> TestConnectionResult.Success
-                    response.code == 401 || response.code == 403 -> TestConnectionResult.AuthFailed
-                    response.code == 404 -> tryCreateBase()
-                    response.code in 500..599 -> TestConnectionResult.ServerError(response.code)
-                    else -> TestConnectionResult.ServerError(response.code)
-                }
+            val response = client.request(basePath) {
+                method = HttpMethod("PROPFIND")
+                header(HttpHeaders.Authorization, authHeader)
+                header(HttpHeaders.UserAgent, FINDER_USER_AGENT)
+                header("Depth", "0")
+                setBody(TextContent(PROPFIND_BODY, ContentType.parse(XML_CONTENT_TYPE)))
+            }
+            when {
+                response.status.value in 200..299 || response.status.value == 207 ->
+                    TestConnectionResult.Success
+                response.status.value == 401 || response.status.value == 403 ->
+                    TestConnectionResult.AuthFailed
+                response.status.value == 404 -> tryCreateBase()
+                response.status.value in 500..599 ->
+                    TestConnectionResult.ServerError(response.status.value)
+                else -> TestConnectionResult.ServerError(response.status.value)
             }
         } catch (e: javax.net.ssl.SSLException) {
             TestConnectionResult.TlsError(e.message ?: "TLS error")
@@ -201,16 +211,18 @@ class WebDavAnnotationSyncTarget(
         }
     }
 
-    private fun tryCreateBase(): TestConnectionResult = try {
-        val mkcol = baseRequest(basePath)
-            .method("MKCOL", null)
-            .build()
-        client.newCall(mkcol).execute().use { resp ->
-            when {
-                resp.isSuccessful || resp.code == 405 -> TestConnectionResult.Success
-                resp.code == 401 || resp.code == 403 -> TestConnectionResult.AuthFailed
-                else -> TestConnectionResult.ServerError(resp.code)
-            }
+    private suspend fun tryCreateBase(): TestConnectionResult = try {
+        val response = client.request(basePath) {
+            method = HttpMethod("MKCOL")
+            header(HttpHeaders.Authorization, authHeader)
+            header(HttpHeaders.UserAgent, FINDER_USER_AGENT)
+        }
+        when {
+            response.status.value in 200..299 || response.status.value == 405 ->
+                TestConnectionResult.Success
+            response.status.value == 401 || response.status.value == 403 ->
+                TestConnectionResult.AuthFailed
+            else -> TestConnectionResult.ServerError(response.status.value)
         }
     } catch (e: javax.net.ssl.SSLException) {
         TestConnectionResult.TlsError(e.message ?: "TLS error")
@@ -218,70 +230,67 @@ class WebDavAnnotationSyncTarget(
         TestConnectionResult.NetworkError(e.message ?: "Network error")
     }
 
-    private suspend fun readFile(url: HttpUrl): String? = withContext(dispatchers.io) {
+    private suspend fun readFile(url: String): String? = withContext(dispatchers.io) {
         classifyWebDavTransportErrors {
-            val request = baseRequest(url).get().build()
-            client.newCall(request).execute().use { response ->
-                when {
-                    response.code == 404 -> null
-                    response.code == 401 || response.code == 403 ->
-                        throw AnnotationSyncException.AuthFailed(response.code)
-                    !response.isSuccessful ->
-                        throw AnnotationSyncException.HttpFailure(response.code, "read ${url.encodedPath}")
-                    else -> response.body.string()
-                }
+            val response = client.get(url) {
+                header(HttpHeaders.Authorization, authHeader)
+                header(HttpHeaders.UserAgent, FINDER_USER_AGENT)
+            }
+            when (response.status.value) {
+                404 -> null
+                401, 403 -> throw AnnotationSyncException.AuthFailed(response.status.value)
+                in 200..299 -> response.bodyAsText()
+                else -> throw AnnotationSyncException.HttpFailure(response.status.value, "read $url")
             }
         }
     }
 
-    private fun putFile(url: HttpUrl, content: String, media: okhttp3.MediaType, op: String) {
+    private suspend fun putFile(url: String, content: String, contentType: String, op: String) {
         classifyWebDavTransportErrors {
-            val body = content.toRequestBody(media)
-            val response = put(url, body)
-            val code = response.code
-            val ok = response.isSuccessful
-            response.close()
-            if (!ok) {
-                when (code) {
-                    401, 403 -> throw AnnotationSyncException.AuthFailed(code)
-                    else -> throw AnnotationSyncException.HttpFailure(code, op)
-                }
+            val response = client.put(url) {
+                header(HttpHeaders.Authorization, authHeader)
+                header(HttpHeaders.UserAgent, FINDER_USER_AGENT)
+                setBody(TextContent(content, ContentType.parse(contentType)))
+            }
+            when (response.status.value) {
+                401, 403 -> throw AnnotationSyncException.AuthFailed(response.status.value)
+                in 200..299 -> Unit
+                else -> throw AnnotationSyncException.HttpFailure(response.status.value, op)
             }
         }
     }
 
-    private suspend fun deleteFile(url: HttpUrl, op: String) = withContext(dispatchers.io) {
+    private suspend fun deleteFile(url: String, op: String) = withContext(dispatchers.io) {
         classifyWebDavTransportErrors {
-            val request = baseRequest(url).delete().build()
-            client.newCall(request).execute().use { response ->
-                // 404 / 410 / 405 are treated as a no-op success — the file is already gone or the
-                // server rejects DELETE on a missing resource, which is what we want either way.
-                when {
-                    response.isSuccessful || response.code in setOf(204, 404, 405, 410) -> Unit
-                    response.code == 401 || response.code == 403 ->
-                        throw AnnotationSyncException.AuthFailed(response.code)
-                    else -> throw AnnotationSyncException.HttpFailure(response.code, op)
-                }
+            val response = client.delete(url) {
+                header(HttpHeaders.Authorization, authHeader)
+                header(HttpHeaders.UserAgent, FINDER_USER_AGENT)
+            }
+            // 404 / 410 / 405 are treated as a no-op success — the file is already gone or the
+            // server rejects DELETE on a missing resource, which is what we want either way.
+            when (response.status.value) {
+                in 200..299, 404, 405, 410 -> Unit
+                401, 403 -> throw AnnotationSyncException.AuthFailed(response.status.value)
+                else -> throw AnnotationSyncException.HttpFailure(response.status.value, op)
             }
         }
     }
 
     private suspend fun propfindBaseFilenames(): List<String> = withContext(dispatchers.io) {
         val raw = classifyWebDavTransportErrors {
-            val request = baseRequest(basePath)
-                .header("Depth", "1")
-                .header("Content-Type", "application/xml; charset=utf-8")
-                .method("PROPFIND", PROPFIND_BODY.toRequestBody(XML_MEDIA))
-                .build()
-            client.newCall(request).execute().use { response ->
-                when {
-                    response.code in setOf(400, 404, 405) -> emptyList()
-                    response.code == 401 || response.code == 403 ->
-                        throw AnnotationSyncException.AuthFailed(response.code)
-                    !response.isSuccessful && response.code != 207 ->
-                        throw AnnotationSyncException.HttpFailure(response.code, "enumerate")
-                    else -> parsePropfindFilenames(response.body.string())
-                }
+            val response = client.request(basePath) {
+                method = HttpMethod("PROPFIND")
+                header(HttpHeaders.Authorization, authHeader)
+                header(HttpHeaders.UserAgent, FINDER_USER_AGENT)
+                header("Depth", "1")
+                setBody(TextContent(PROPFIND_BODY, ContentType.parse(XML_CONTENT_TYPE)))
+            }
+            when (response.status.value) {
+                400, 404, 405 -> emptyList()
+                401, 403 -> throw AnnotationSyncException.AuthFailed(response.status.value)
+                207 -> parsePropfindFilenames(response.bodyAsText())
+                in 200..299 -> parsePropfindFilenames(response.bodyAsText())
+                else -> throw AnnotationSyncException.HttpFailure(response.status.value, "enumerate")
             }
         }
         migrateLegacyAbsNames(raw)
@@ -301,13 +310,18 @@ class WebDavAnnotationSyncTarget(
      * `<uuid>__…` and `abs_<uuid>__…` were present in the same PROPFIND.
      * Idempotent: a share with no legacy files does zero extra work.
      */
-    private fun migrateLegacyAbsNames(names: List<String>): List<String> {
+    private suspend fun migrateLegacyAbsNames(names: List<String>): List<String> {
         if (names.none { LegacyAbsNamespaceMigration.isLegacyAbsFilename(it) }) return names
-        return names.map { name ->
-            if (!LegacyAbsNamespaceMigration.isLegacyAbsFilename(name)) return@map name
-            val target = LegacyAbsNamespaceMigration.migratedName(name)
-            if (migrateOne(name, target)) target else name
-        }.distinct()
+        val result = ArrayList<String>(names.size)
+        for (name in names) {
+            if (!LegacyAbsNamespaceMigration.isLegacyAbsFilename(name)) {
+                result.add(name)
+            } else {
+                val target = LegacyAbsNamespaceMigration.migratedName(name)
+                result.add(if (migrateOne(name, target)) target else name)
+            }
+        }
+        return result.distinct()
     }
 
     /**
@@ -316,70 +330,49 @@ class WebDavAnnotationSyncTarget(
      * first), destination already exists (412 — peer wrote it, so DELETE our orphan
      * legacy source), or anything else (leave the file, caller will retry next sync).
      */
-    private fun migrateOne(from: String, to: String): Boolean = try {
-        val src = basePath.newBuilder().addPathSegment(from).build()
-        val dst = basePath.newBuilder().addPathSegment(to).build()
-        val request = baseRequest(src)
-            .header("Destination", dst.toString())
-            .header("Overwrite", "F")
-            .method("MOVE", null)
-            .build()
-        client.newCall(request).execute().use { response ->
-            when {
-                response.isSuccessful || response.code == 201 || response.code == 204 -> true
-                // Peer already MOVEd it. Our source is gone; destination has the content.
-                response.code == 404 -> true
-                // Peer already wrote the destination independently. Delete our orphan source
-                // so a follow-up PROPFIND doesn't keep trying the same MOVE forever.
-                response.code == 412 -> {
-                    runCatching {
-                        val delReq = baseRequest(src).delete().build()
-                        client.newCall(delReq).execute().close()
+    private suspend fun migrateOne(from: String, to: String): Boolean = try {
+        val src = "$basePath$from"
+        val dst = "$basePath$to"
+        val response = client.request(src) {
+            method = HttpMethod("MOVE")
+            header(HttpHeaders.Authorization, authHeader)
+            header(HttpHeaders.UserAgent, FINDER_USER_AGENT)
+            header("Destination", dst)
+            header("Overwrite", "F")
+        }
+        when (response.status.value) {
+            in 200..299, 201, 204 -> true
+            // Peer already MOVEd it. Our source is gone; destination has the content.
+            404 -> true
+            // Peer already wrote the destination independently. Delete our orphan source
+            // so a follow-up PROPFIND doesn't keep trying the same MOVE forever.
+            412 -> {
+                runCatching {
+                    client.delete(src) {
+                        header(HttpHeaders.Authorization, authHeader)
+                        header(HttpHeaders.UserAgent, FINDER_USER_AGENT)
                     }
-                    true
                 }
-                else -> false
+                true
             }
+            else -> false
         }
     } catch (_: Exception) {
         false
     }
 
-    private fun put(url: HttpUrl, body: RequestBody): Response {
-        val request = baseRequest(url).put(body).build()
-        return client.newCall(request).execute()
-    }
+    private fun annotationFileUrl(namespace: String, itemId: String, filename: String): String =
+        "$basePath${annotationPrefix(namespace, itemId)}$filename"
 
-    /**
-     * Every WebDAV request built here is auth'd and tagged with a Finder User-Agent. Some servers —
-     * Synology DSM's WebDAV Server in particular — return 424 for MKCOL when the UA looks
-     * unfamiliar, even when the user holds Read/Write on the share. Spoofing macOS Finder's
-     * WebDAVFS UA takes us out of that lane (verified against pkmetski.synology.me).
-     */
-    private fun baseRequest(url: HttpUrl): Request.Builder = Request.Builder()
-        .url(url)
-        .header("Authorization", authHeader)
-        .header("User-Agent", FINDER_USER_AGENT)
-
-    private fun annotationFileUrl(namespace: String, itemId: String, filename: String): HttpUrl =
-        basePath.newBuilder()
-            .addPathSegment(annotationPrefix(namespace, itemId) + filename)
-            .build()
-
-    private fun deviceMetaUrl(namespace: String, deviceId: String): HttpUrl =
-        basePath.newBuilder()
-            .addPathSegment("$namespace$NAMESPACE_SEPARATOR$DEVICE_META_NAME_PREFIX$deviceId$JSON_SUFFIX")
-            .build()
+    private fun deviceMetaUrl(namespace: String, deviceId: String): String =
+        "$basePath$namespace$NAMESPACE_SEPARATOR$DEVICE_META_NAME_PREFIX$deviceId$JSON_SUFFIX"
 
     /** Composite filename prefix that emulates the per-book directory: `<namespace>__<itemId>__`. */
     private fun annotationPrefix(namespace: String, itemId: String): String =
         "$namespace$NAMESPACE_SEPARATOR$itemId$NAMESPACE_SEPARATOR"
 
-    private fun ensureTrailingSlash(url: HttpUrl): HttpUrl {
-        val segs = url.pathSegments
-        return if (segs.isNotEmpty() && segs.last().isEmpty()) url
-        else url.newBuilder().addPathSegment("").build()
-    }
+    private fun ensureTrailingSlash(url: String): String =
+        if (url.endsWith("/")) url else "$url/"
 
     private fun parsePropfindFilenames(xml: String): List<String> {
         if (xml.isBlank()) return emptyList()
@@ -434,9 +427,9 @@ class WebDavAnnotationSyncTarget(
         // Matches macOS Finder's WebDAVFS — well-known by Synology and other DSM-style WebDAV
         // servers, so MKCOL/PUT requests aren't put through unfamiliar-UA gating.
         private const val FINDER_USER_AGENT = "WebDAVFS/3.0.0 (03008000) Darwin/22.0.0 (x86_64)"
-        private val XML_MEDIA = "application/xml; charset=utf-8".toMediaType()
-        private val JSON_LD_MEDIA = "application/ld+json; charset=utf-8".toMediaType()
-        private val JSON_MEDIA = "application/json; charset=utf-8".toMediaType()
+        private const val XML_CONTENT_TYPE = "application/xml; charset=utf-8"
+        private const val JSON_LD_CONTENT_TYPE = "application/ld+json; charset=utf-8"
+        private const val JSON_CONTENT_TYPE = "application/json; charset=utf-8"
 
         // Minimal PROPFIND asking for resourcetype on each child resource.
         private const val PROPFIND_BODY =
@@ -469,7 +462,7 @@ sealed class AnnotationSyncException(message: String, cause: Throwable? = null) 
  * can classify network vs. TLS vs. server-side errors without inspecting exception types.
  * SSLException is a subtype of IOException — catch it first.
  */
-internal inline fun <T> classifyWebDavTransportErrors(block: () -> T): T {
+internal suspend inline fun <T> classifyWebDavTransportErrors(crossinline block: suspend () -> T): T {
     return try {
         block()
     } catch (e: javax.net.ssl.SSLException) {
@@ -480,5 +473,7 @@ internal inline fun <T> classifyWebDavTransportErrors(block: () -> T): T {
 }
 
 /** Parse a user-supplied URL; returns null on malformed input. */
-internal fun parseWebDavBaseUrl(raw: String): HttpUrl? =
-    raw.trim().takeIf { it.isNotEmpty() }?.toHttpUrlOrNull()
+internal fun parseWebDavBaseUrl(raw: String): Url? =
+    raw.trim().takeIf { it.isNotEmpty() }?.let {
+        try { URLBuilder(it).build() } catch (_: Exception) { null }
+    }

--- a/core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTargetFactory.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTargetFactory.kt
@@ -2,8 +2,9 @@ package com.riffle.core.data
 
 import com.riffle.core.domain.AnnotationSyncConfig
 import com.riffle.core.domain.DispatcherProvider
+import com.riffle.core.network.createDefaultHttpClient
+import io.ktor.client.plugins.HttpTimeout
 import okhttp3.OkHttpClient
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 /**
@@ -12,21 +13,22 @@ import javax.inject.Inject
  * rebuilds when settings change) and the Settings "Test connection" action (which needs a
  * transient target before save).
  *
- * The factory derives a WebDAV-specific [OkHttpClient] from the app's shared one with explicit
- * call/read/write timeouts. The shared client uses the OkHttp defaults (no read/write/call
- * timeout), which would let a wedged Synology hang a PROPFIND/PUT indefinitely; per-call timeouts
- * keep `syncOnOpen` / `pushPending` reliably bounded.
+ * Derives a WebDAV-specific Ktor [io.ktor.client.HttpClient] from the app's shared OkHttp client
+ * with explicit call/read/write timeouts. The shared client has no timeout defaults, which would
+ * let a wedged Synology hang a PROPFIND/PUT indefinitely; per-call timeouts keep
+ * `syncOnOpen` / `pushPending` reliably bounded.
  */
 class WebDavAnnotationSyncTargetFactory @Inject constructor(
-    sharedClient: OkHttpClient,
+    sharedOkHttpClient: OkHttpClient,
     private val dispatchers: DispatcherProvider,
 ) {
-    private val httpClient: OkHttpClient = sharedClient.newBuilder()
-        .callTimeout(WEBDAV_CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-        .connectTimeout(WEBDAV_CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-        .readTimeout(WEBDAV_READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-        .writeTimeout(WEBDAV_WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-        .build()
+    private val httpClient = createDefaultHttpClient(sharedOkHttpClient).config {
+        install(HttpTimeout) {
+            requestTimeoutMillis = WEBDAV_CALL_TIMEOUT_MS
+            connectTimeoutMillis = WEBDAV_CONNECT_TIMEOUT_MS
+            socketTimeoutMillis = WEBDAV_READ_TIMEOUT_MS
+        }
+    }
 
     fun create(config: AnnotationSyncConfig): WebDavAnnotationSyncTarget? {
         val url = parseWebDavBaseUrl(config.baseUrl) ?: return null
@@ -41,9 +43,8 @@ class WebDavAnnotationSyncTargetFactory @Inject constructor(
 
     companion object {
         // 30 s for the whole call (PROPFIND of a fully-listed share + parse can dwarf the others).
-        private const val WEBDAV_CALL_TIMEOUT_SECONDS = 30L
-        private const val WEBDAV_CONNECT_TIMEOUT_SECONDS = 10L
-        private const val WEBDAV_READ_TIMEOUT_SECONDS = 20L
-        private const val WEBDAV_WRITE_TIMEOUT_SECONDS = 20L
+        private const val WEBDAV_CALL_TIMEOUT_MS = 30_000L
+        private const val WEBDAV_CONNECT_TIMEOUT_MS = 10_000L
+        private const val WEBDAV_READ_TIMEOUT_MS = 20_000L
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/credentialed/KomgaCredentialedAuthenticator.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/credentialed/KomgaCredentialedAuthenticator.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
+import com.riffle.core.network.createDefaultHttpClient
 import okhttp3.OkHttpClient
 import java.io.IOException
 import javax.inject.Inject
@@ -41,7 +42,7 @@ class KomgaCredentialedAuthenticator @Inject constructor(
         serverType: ServerType,
     ): AuthenticateResult {
         val header = buildBasicAuthHeader(username, password)
-        val http = KomgaHttpClient(okHttpClient, header)
+        val http = KomgaHttpClient(createDefaultHttpClient(okHttpClient), header)
         if (!insecureAllowed && url.value.startsWith("http://", ignoreCase = true)) {
             return AuthenticateResult.InsecureConnection(InsecureConnectionType.HTTP)
         }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/CatalogModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/CatalogModule.kt
@@ -22,6 +22,7 @@ import com.riffle.core.network.AbsPlaybackApi
 import com.riffle.core.network.AbsServerInfoApi
 import com.riffle.core.data.di.qualifiers.WebSourceOkHttpClient
 import com.riffle.core.network.AbsSessionApi
+import com.riffle.core.network.createDefaultHttpClient
 import okhttp3.OkHttpClient
 import dagger.Module
 import dagger.Provides
@@ -89,7 +90,7 @@ object CatalogModule {
     fun provideChitankaCatalogFactory(
         @WebSourceOkHttpClient okHttpClient: OkHttpClient,
     ): CatalogFactory = ChitankaCatalogFactory(
-        okHttpClient = okHttpClient,
+        httpClient = createDefaultHttpClient(okHttpClient),
         userAgent = "Riffle/dev (Android) chitanka-source",
     )
 
@@ -100,7 +101,7 @@ object CatalogModule {
     fun provideGutenbergCatalogFactory(
         @WebSourceOkHttpClient okHttpClient: OkHttpClient,
     ): CatalogFactory = GutenbergCatalogFactory(
-        okHttpClient = okHttpClient,
+        sharedHttpClient = createDefaultHttpClient(okHttpClient),
         userAgent = "Riffle/dev (Android) gutenberg-source",
     )
 
@@ -112,7 +113,7 @@ object CatalogModule {
         okHttpClient: OkHttpClient,
         tokenStorage: TokenStorage,
     ): CatalogFactory = KomgaCatalogFactory(
-        okHttpClient = okHttpClient,
+        httpClient = createDefaultHttpClient(okHttpClient),
         tokenStorage = tokenStorage,
         userAgent = "Riffle/dev (Android) komga-source",
     )

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/NetworkModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/NetworkModule.kt
@@ -1,7 +1,6 @@
 package com.riffle.core.data.di.modules
 
 import android.content.Context
-import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.network.AbsApi
 import com.riffle.core.network.AbsApiClient
 import com.riffle.core.data.di.qualifiers.WebSourceOkHttpClient
@@ -14,6 +13,8 @@ import com.riffle.core.network.AbsLibraryApi
 import com.riffle.core.network.AbsPlaybackApi
 import com.riffle.core.network.AbsServerInfoApi
 import com.riffle.core.network.AbsSessionApi
+import com.riffle.core.network.createDefaultHttpClient
+import com.riffle.core.network.createStreamingHttpClient
 import com.riffle.core.network.AudiobookBundleApiImpl
 import com.riffle.core.network.GitHubReleaseApi
 import com.riffle.core.network.StorytellerApi
@@ -119,32 +120,32 @@ abstract class NetworkModule {
 
         @Provides
         @Singleton
-        fun provideGitHubReleaseApi(okHttpClient: OkHttpClient, dispatchers: DispatcherProvider): GitHubReleaseApi =
-            GitHubReleaseApi(okHttpClient, dispatchers)
+        fun provideGitHubReleaseApi(okHttpClient: OkHttpClient): GitHubReleaseApi =
+            GitHubReleaseApi(createDefaultHttpClient(okHttpClient))
 
         @Provides
         @Singleton
-        fun provideAbsApiClient(okHttpClient: OkHttpClient, dispatchers: DispatcherProvider): AbsApiClient =
-            AbsApiClient(okHttpClient, dispatchers)
+        fun provideAbsApiClient(okHttpClient: OkHttpClient): AbsApiClient =
+            AbsApiClient(createDefaultHttpClient(okHttpClient))
 
         @Provides
         @Singleton
-        fun provideStorytellerApiClient(okHttpClient: OkHttpClient, dispatchers: DispatcherProvider): StorytellerApiClient =
-            StorytellerApiClient(okHttpClient, dispatchers)
+        fun provideStorytellerApiClient(okHttpClient: OkHttpClient): StorytellerApiClient =
+            StorytellerApiClient(createDefaultHttpClient(okHttpClient))
 
         @Provides
         @Singleton
-        fun provideStorytellerBundleApiImpl(okHttpClient: OkHttpClient, dispatchers: DispatcherProvider): StorytellerBundleApiImpl =
-            StorytellerBundleApiImpl(okHttpClient, dispatchers)
+        fun provideStorytellerBundleApiImpl(okHttpClient: OkHttpClient): StorytellerBundleApiImpl =
+            StorytellerBundleApiImpl(createDefaultHttpClient(okHttpClient))
 
         @Provides
         @Singleton
-        fun provideAudiobookBundleApi(okHttpClient: OkHttpClient, dispatchers: DispatcherProvider): AudiobookBundleApiImpl =
-            AudiobookBundleApiImpl(okHttpClient, dispatchers)
+        fun provideAudiobookBundleApi(okHttpClient: OkHttpClient): AudiobookBundleApiImpl =
+            AudiobookBundleApiImpl(createStreamingHttpClient(okHttpClient))
 
         @Provides
         @Singleton
-        fun provideStorytellerPositionApi(okHttpClient: OkHttpClient, dispatchers: DispatcherProvider): StorytellerPositionApi =
-            StorytellerPositionApiImpl(okHttpClient, dispatchers)
+        fun provideStorytellerPositionApi(okHttpClient: OkHttpClient): StorytellerPositionApi =
+            StorytellerPositionApiImpl(createDefaultHttpClient(okHttpClient))
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/sync/KomgaRemoteUserIdResolver.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/sync/KomgaRemoteUserIdResolver.kt
@@ -4,6 +4,7 @@ import com.riffle.core.catalog.komga.KomgaHttpClient
 import com.riffle.core.catalog.komga.probeKomgaUserId
 import com.riffle.core.domain.RemoteUserIdResolver
 import com.riffle.core.models.Source
+import com.riffle.core.network.createDefaultHttpClient
 import okhttp3.OkHttpClient
 import java.io.IOException
 import javax.inject.Inject
@@ -24,7 +25,7 @@ class KomgaRemoteUserIdResolver @Inject constructor(
     private val okHttpClient: OkHttpClient,
 ) : RemoteUserIdResolver {
     override suspend fun resolve(source: Source, token: String): String? {
-        val http = KomgaHttpClient(okHttpClient, token)
+        val http = KomgaHttpClient(createDefaultHttpClient(okHttpClient), token)
         // Any HTTP status is preserved but only 2xx-with-parsable-body yields a usable id;
         // callers treat a null return as "leave the source in PendingRemoteId and retry next
         // time". IOException collapses to null too — offline resolve is a no-op, not a fatal

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBundleDownloaderTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookBundleDownloaderTest.kt
@@ -4,8 +4,6 @@ import com.riffle.core.network.AudiobookBundleApi
 import com.riffle.core.network.AudiobookBundleStream
 import com.riffle.core.network.NetworkResult
 import kotlinx.coroutines.test.runTest
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -13,6 +11,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.IOException
 
@@ -44,14 +43,14 @@ class AudiobookBundleDownloaderTest {
             return if (fromByte > 0 && honorRange) {
                 val tail = full.copyOfRange(fromByte.toInt(), full.size)
                 NetworkResult.Success(AudiobookBundleStream(
-                    body = tail.toResponseBody("application/epub+zip".toMediaType()),
+                    body = ByteArrayInputStream(tail),
                     totalBytes = full.size.toLong(),
                     isPartial = true,
                 ))
             } else {
                 // Advertise the FULL length but serve only [serveBytes] — a silent truncation.
                 NetworkResult.Success(AudiobookBundleStream(
-                    body = full.copyOfRange(0, serveBytes).toResponseBody("application/epub+zip".toMediaType()),
+                    body = ByteArrayInputStream(full.copyOfRange(0, serveBytes)),
                     totalBytes = full.size.toLong(),
                     isPartial = false,
                 ))

--- a/core/data/src/test/kotlin/com/riffle/core/data/StorytellerSidecarFetcherTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/StorytellerSidecarFetcherTest.kt
@@ -5,9 +5,6 @@ import com.riffle.core.network.NetworkResult
 import com.riffle.core.network.StorytellerBundleApi
 import com.riffle.core.network.StorytellerBundleStream
 import kotlinx.coroutines.test.runTest
-import okhttp3.ResponseBody.Companion.asResponseBody
-import okio.buffer
-import okio.source
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -66,7 +63,7 @@ class StorytellerSidecarFetcherTest {
         val counting = CountingInputStream(ByteArrayInputStream(standardBundle))
         val result = fetcher(
             bundleApi = StorytellerBundleApi { _, _, _, _ ->
-                NetworkResult.Success(StorytellerBundleStream(counting.source().buffer().asResponseBody(null, -1L)))
+                NetworkResult.Success(StorytellerBundleStream(counting))
             },
             // Full download must NOT be called — standard ordering should succeed on the fast path.
             fullBundleApi = StorytellerBundleApi { _, _, _, _ ->
@@ -89,12 +86,12 @@ class StorytellerSidecarFetcherTest {
         val result = fetcher(
             bundleApi = StorytellerBundleApi { _, _, _, _ ->
                 NetworkResult.Success(StorytellerBundleStream(
-                    ByteArrayInputStream(nonStandardBundle).source().buffer().asResponseBody(null, -1L),
+                    ByteArrayInputStream(nonStandardBundle),
                 ))
             },
             fullBundleApi = StorytellerBundleApi { _, _, _, _ ->
                 NetworkResult.Success(StorytellerBundleStream(
-                    ByteArrayInputStream(nonStandardBundle).source().buffer().asResponseBody(null, -1L),
+                    ByteArrayInputStream(nonStandardBundle),
                 ))
             },
         ).fetch("http://st", "42", "tok", false)
@@ -114,12 +111,12 @@ class StorytellerSidecarFetcherTest {
         val result = fetcher(
             bundleApi = StorytellerBundleApi { _, _, _, _ ->
                 NetworkResult.Success(StorytellerBundleStream(
-                    ByteArrayInputStream(smilLessBundle).source().buffer().asResponseBody(null, -1L),
+                    ByteArrayInputStream(smilLessBundle),
                 ))
             },
             fullBundleApi = StorytellerBundleApi { _, _, _, _ ->
                 NetworkResult.Success(StorytellerBundleStream(
-                    ByteArrayInputStream(smilLessBundle).source().buffer().asResponseBody(null, -1L),
+                    ByteArrayInputStream(smilLessBundle),
                 ))
             },
         ).fetch("http://st", "42", "tok", false)

--- a/core/data/src/test/kotlin/com/riffle/core/data/TestCatalogRegistry.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/TestCatalogRegistry.kt
@@ -5,7 +5,6 @@ import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.catalog.abs.AbsCatalog
 import com.riffle.core.catalog.abs.AbsCatalogConfig
 import com.riffle.core.common.Clock
-import com.riffle.core.domain.DefaultDispatcherProvider
 import com.riffle.core.models.Source
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.network.AbsApiClient
@@ -14,6 +13,7 @@ import com.riffle.core.network.AbsLibraryApi
 import com.riffle.core.network.AbsPlaybackApi
 import com.riffle.core.network.AbsServerInfoApi
 import com.riffle.core.network.AbsSessionApi
+import com.riffle.core.network.createDefaultHttpClient
 import okhttp3.OkHttpClient
 
 private val defaultTestClock = object : Clock {
@@ -30,7 +30,7 @@ private val defaultTestClock = object : Clock {
 class TestCatalogRegistry(
     private val sourceRepository: SourceRepository,
     private val tokens: Map<String, String>,
-    private val apiClient: AbsApiClient = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider),
+    private val apiClient: AbsApiClient = AbsApiClient(createDefaultHttpClient(OkHttpClient())),
     private val clock: Clock = defaultTestClock,
     private val deviceId: String = "test-device",
 ) : CatalogRegistry {

--- a/core/data/src/test/kotlin/com/riffle/core/data/WebDavAnnotationSyncTargetTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/WebDavAnnotationSyncTargetTest.kt
@@ -1,7 +1,9 @@
 package com.riffle.core.data
 
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.http.Url
 import kotlinx.coroutines.test.runTest
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -17,6 +19,7 @@ import org.junit.Before
 import org.junit.Test
 import java.util.Base64
 import java.util.concurrent.TimeUnit
+
 
 class WebDavAnnotationSyncTargetTest {
 
@@ -38,14 +41,14 @@ class WebDavAnnotationSyncTargetTest {
         password: String = PASS,
         basePath: String = "annotations",
     ): WebDavAnnotationSyncTarget {
-        val client = OkHttpClient.Builder()
+        val okClient = OkHttpClient.Builder()
             .callTimeout(2, TimeUnit.SECONDS)
             .build()
         return WebDavAnnotationSyncTarget(
-            baseUrl = source.url("/$basePath"),
+            baseUrl = Url(source.url("/$basePath").toString()),
             username = username,
             password = password,
-            client = client,
+            client = HttpClient(OkHttp) { engine { preconfigured = okClient } },
             dispatchers = com.riffle.core.domain.DefaultDispatcherProvider,
         )
     }
@@ -337,12 +340,12 @@ class WebDavAnnotationSyncTargetTest {
 
     private fun makeTargetWithFailingClient(throwable: Throwable): WebDavAnnotationSyncTarget {
         val failingInterceptor = okhttp3.Interceptor { throw throwable }
-        val client = OkHttpClient.Builder().addInterceptor(failingInterceptor).build()
+        val okClient = OkHttpClient.Builder().addInterceptor(failingInterceptor).build()
         return WebDavAnnotationSyncTarget(
-            baseUrl = "https://example.test/dav/".toHttpUrl(),
+            baseUrl = Url("https://example.test/dav/"),
             username = "u",
             password = "p",
-            client = client,
+            client = HttpClient(OkHttp) { engine { preconfigured = okClient } },
             dispatchers = com.riffle.core.domain.DefaultDispatcherProvider,
         )
     }

--- a/core/data/src/test/kotlin/com/riffle/core/data/absbookmark/AbsBookmarkAnnotationSyncIntegrationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/absbookmark/AbsBookmarkAnnotationSyncIntegrationTest.kt
@@ -1,8 +1,8 @@
 package com.riffle.core.data.absbookmark
 
 import com.riffle.core.data.AnnotationFilenames
-import com.riffle.core.domain.DefaultDispatcherProvider
 import com.riffle.core.network.AbsApiClient
+import com.riffle.core.network.createDefaultHttpClient
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -60,7 +60,7 @@ class AbsBookmarkAnnotationSyncIntegrationTest {
         absHandler = FakeAbsHandler()
         server.dispatcher = absHandler
         server.start()
-        abs = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
+        abs = AbsApiClient(createDefaultHttpClient(OkHttpClient()))
     }
 
     @After

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -5,7 +5,11 @@ plugins {
 
 dependencies {
     implementation(project(":core:domain"))
-    api(libs.okhttp)
+    api(libs.ktor.client.core)
+    implementation(libs.ktor.client.okhttp)
+    implementation(libs.ktor.client.content.negotiation)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.okhttp)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines.core)
 

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
@@ -1,7 +1,6 @@
 package com.riffle.core.network
 
 import com.riffle.core.models.AudiobookFingerprint
-import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.models.EbookFormat
 import com.riffle.core.network.model.AbsCollectionBookRequest
 import com.riffle.core.network.model.AbsCollectionsResponse
@@ -28,48 +27,49 @@ import com.riffle.core.network.model.AbsSeriesResponse
 import com.riffle.core.network.model.AbsServerInfoResponse
 import com.riffle.core.network.model.toNetworkCollection
 import com.riffle.core.network.model.toNetworkPlaylist
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.patch
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.client.plugins.ResponseException
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.contentLength
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.jvm.javaio.toInputStream
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
-import okhttp3.CacheControl
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.Response
-import okhttp3.ResponseBody
-import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
 
 class AbsApiClient(
-    private val httpClient: OkHttpClient,
-    private val dispatchers: DispatcherProvider,
+    private val httpClient: HttpClient,
 ) : AbsApi, AbsLibraryApi, AbsSessionApi, AbsServerInfoApi, AbsPlaybackApi, AbsBookmarkApi {
-
-    private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
-    private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
 
     override suspend fun login(
         baseUrl: String,
         username: String,
         password: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkLoginUser> = OkHttpClassifier.classify(dispatchers.io) {
-        val client = client(insecureAllowed)
-        val body = json.encodeToString(AbsLoginRequest(username, password)).toRequestBody(jsonMediaType)
-        val request = Request.Builder().url("$baseUrl/login").post(body).build()
-        val response = client.newCall(request).execute()
-        when (response.code) {
+    ): NetworkResult<NetworkLoginUser> = KtorClassifier.classify {
+        val response = client(insecureAllowed).post("$baseUrl/login") {
+            contentType(ContentType.Application.Json)
+            setBody(AbsLoginRequest(username, password))
+        }
+        when (response.status.value) {
             200 -> {
-                val raw = response.requireBody()
-                val parsed = json.decodeFromString<AbsLoginResponse>(raw)
+                val parsed = response.body<AbsLoginResponse>()
                 NetworkLoginUser(userId = parsed.user.id, token = parsed.user.token, username = parsed.user.username)
             }
             // 401 historically surfaced as WrongCredentials; the classifier maps Auth ⇒ wrong creds.
-            else -> {
-                response.body?.close()
-                throw HttpException(response.code, response.message)
-            }
+            else -> throw HttpException(response.status.value, response.status.description)
         }
     }
 
@@ -77,10 +77,10 @@ class AbsApiClient(
         baseUrl: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<List<NetworkLibrary>> = OkHttpClassifier.classify(dispatchers.io) {
-        val response = get(baseUrl, "/api/libraries", token, insecureAllowed)
-        val raw = response.requireSuccessful().requireBody()
-        json.decodeFromString<AbsLibrariesResponse>(raw).libraries.map { dto ->
+    ): NetworkResult<List<NetworkLibrary>> = KtorClassifier.classify {
+        client(insecureAllowed).get("$baseUrl/api/libraries") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }.body<AbsLibrariesResponse>().libraries.map { dto ->
             NetworkLibrary(
                 id = dto.id,
                 name = dto.name,
@@ -94,10 +94,10 @@ class AbsApiClient(
         baseUrl: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<Map<String, NetworkUserMediaProgress>> = OkHttpClassifier.classify(dispatchers.io) {
-        val response = get(baseUrl, "/api/me", token, insecureAllowed)
-        val raw = response.requireSuccessful().requireBody()
-        val parsed = json.decodeFromString<AbsMeResponse>(raw)
+    ): NetworkResult<Map<String, NetworkUserMediaProgress>> = KtorClassifier.classify {
+        val parsed = client(insecureAllowed).get("$baseUrl/api/me") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }.body<AbsMeResponse>()
         parsed.mediaProgress
             .filter { it.libraryItemId.isNotEmpty() }
             .associate {
@@ -119,11 +119,10 @@ class AbsApiClient(
         libraryId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<List<NetworkLibraryItem>> = OkHttpClassifier.classify(dispatchers.io) {
-        val response = get(baseUrl, "/api/libraries/$libraryId/items", token, insecureAllowed)
-        val raw = response.requireSuccessful().requireBody()
-        val parsed = json.decodeFromString<AbsLibraryItemsResponse>(raw)
-        parsed.results.map { it.toNetworkLibraryItem() }
+    ): NetworkResult<List<NetworkLibraryItem>> = KtorClassifier.classify {
+        client(insecureAllowed).get("$baseUrl/api/libraries/$libraryId/items") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }.body<AbsLibraryItemsResponse>().results.map { it.toNetworkLibraryItem() }
     }
 
     private fun AbsLibraryItemsResponse.AbsLibraryItemDto.toNetworkLibraryItem(
@@ -162,12 +161,11 @@ class AbsApiClient(
         limit: Int,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<List<NetworkLibraryItem>> = OkHttpClassifier.classify(dispatchers.io) {
+    ): NetworkResult<List<NetworkLibraryItem>> = KtorClassifier.classify {
         val encoded = java.net.URLEncoder.encode(query, "UTF-8")
-        val response = get(baseUrl, "/api/libraries/$libraryId/search?q=$encoded&limit=$limit", token, insecureAllowed)
-        val raw = response.requireSuccessful().requireBody()
-        val parsed = json.decodeFromString<AbsLibrarySearchResponse>(raw)
-        parsed.book.map { it.libraryItem.toNetworkLibraryItem(libraryId) }
+        client(insecureAllowed).get("$baseUrl/api/libraries/$libraryId/search?q=$encoded&limit=$limit") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }.body<AbsLibrarySearchResponse>().book.map { it.libraryItem.toNetworkLibraryItem(libraryId) }
     }
 
     override suspend fun getSeries(
@@ -175,11 +173,10 @@ class AbsApiClient(
         libraryId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<List<NetworkSeries>> = OkHttpClassifier.classify(dispatchers.io) {
-        val response = get(baseUrl, "/api/libraries/$libraryId/series?limit=500", token, insecureAllowed)
-        val raw = response.requireSuccessful().requireBody()
-        val parsed = json.decodeFromString<AbsSeriesResponse>(raw)
-        parsed.results.map { dto ->
+    ): NetworkResult<List<NetworkSeries>> = KtorClassifier.classify {
+        client(insecureAllowed).get("$baseUrl/api/libraries/$libraryId/series?limit=500") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }.body<AbsSeriesResponse>().results.map { dto ->
             NetworkSeries(
                 id = dto.id,
                 libraryId = dto.libraryId.ifEmpty { libraryId },
@@ -215,10 +212,10 @@ class AbsApiClient(
         libraryId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<List<NetworkCollection>> = OkHttpClassifier.classify(dispatchers.io) {
-        val response = get(baseUrl, "/api/libraries/$libraryId/collections?limit=500", token, insecureAllowed)
-        val raw = response.requireSuccessful().requireBody()
-        json.decodeFromString<AbsCollectionsResponse>(raw).results.map { it.toNetworkCollection() }
+    ): NetworkResult<List<NetworkCollection>> = KtorClassifier.classify {
+        client(insecureAllowed).get("$baseUrl/api/libraries/$libraryId/collections?limit=500") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }.body<AbsCollectionsResponse>().results.map { it.toNetworkCollection() }
     }
 
     override suspend fun createCollection(
@@ -234,9 +231,13 @@ class AbsApiClient(
             name = name,
             books = listOfNotNull(initialBookId),
         )
-        val body = json.encodeToString(AbsCreateCollectionRequest.serializer(), payload)
-            .toRequestBody(jsonMediaType)
-        return executeCollectionWrite("$baseUrl/api/collections", token, insecureAllowed) { post(body) }
+        return executeCollectionWrite(insecureAllowed) {
+            post("$baseUrl/api/collections") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+                contentType(ContentType.Application.Json)
+                setBody(payload)
+            }
+        }
     }
 
     override suspend fun addBookToCollection(
@@ -245,11 +246,14 @@ class AbsApiClient(
         libraryItemId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkCollection?> {
-        val body = json.encodeToString(AbsCollectionBookRequest.serializer(), AbsCollectionBookRequest(libraryItemId))
-            .toRequestBody(jsonMediaType)
-        return executeCollectionWrite("$baseUrl/api/collections/$collectionId/book", token, insecureAllowed) { post(body) }
-    }
+    ): NetworkResult<NetworkCollection?> =
+        executeCollectionWrite(insecureAllowed) {
+            post("$baseUrl/api/collections/$collectionId/book") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+                contentType(ContentType.Application.Json)
+                setBody(AbsCollectionBookRequest(libraryItemId))
+            }
+        }
 
     override suspend fun removeBookFromCollection(
         baseUrl: String,
@@ -257,25 +261,22 @@ class AbsApiClient(
         libraryItemId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkCollection?> = executeCollectionWrite(
-        "$baseUrl/api/collections/$collectionId/book/$libraryItemId", token, insecureAllowed,
-    ) { delete() }
+    ): NetworkResult<NetworkCollection?> =
+        executeCollectionWrite(insecureAllowed) {
+            delete("$baseUrl/api/collections/$collectionId/book/$libraryItemId") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+            }
+        }
 
     private suspend fun executeCollectionWrite(
-        url: String,
-        token: String,
         insecureAllowed: Boolean,
-        buildRequest: Request.Builder.() -> Unit,
-    ): NetworkResult<NetworkCollection?> = OkHttpClassifier.classify(dispatchers.io) {
-        val request = Request.Builder()
-            .url(url)
-            .addHeader("Authorization", "Bearer $token")
-            .apply { buildRequest() }
-            .build()
-        val response = client(insecureAllowed).newCall(request).execute().requireSuccessful()
-        val raw = response.body?.string().orEmpty()
+        makeRequest: suspend HttpClient.() -> HttpResponse,
+    ): NetworkResult<NetworkCollection?> = KtorClassifier.classify {
+        val response = client(insecureAllowed).makeRequest()
+        if (!response.status.isSuccess()) throw HttpException(response.status.value, response.status.description)
+        val raw = response.body<String>()
         if (raw.isBlank()) null
-        else json.decodeFromString(AbsCollectionsResponse.AbsCollectionDto.serializer(), raw).toNetworkCollection()
+        else RIFFLE_JSON.decodeFromString(AbsCollectionsResponse.AbsCollectionDto.serializer(), raw).toNetworkCollection()
     }
 
     override suspend fun getPlaylists(
@@ -283,10 +284,10 @@ class AbsApiClient(
         libraryId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<List<NetworkPlaylist>> = OkHttpClassifier.classify(dispatchers.io) {
-        val response = get(baseUrl, "/api/libraries/$libraryId/playlists?limit=500", token, insecureAllowed)
-        val raw = response.requireSuccessful().requireBody()
-        json.decodeFromString<AbsPlaylistsResponse>(raw).results.map { it.toNetworkPlaylist() }
+    ): NetworkResult<List<NetworkPlaylist>> = KtorClassifier.classify {
+        client(insecureAllowed).get("$baseUrl/api/libraries/$libraryId/playlists?limit=500") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }.body<AbsPlaylistsResponse>().results.map { it.toNetworkPlaylist() }
     }
 
     override suspend fun createPlaylist(
@@ -302,9 +303,13 @@ class AbsApiClient(
             name = name,
             items = listOfNotNull(initialBookId?.let { AbsPlaylistItemRequest(it) }),
         )
-        val body = json.encodeToString(AbsCreatePlaylistRequest.serializer(), payload)
-            .toRequestBody(jsonMediaType)
-        return executePlaylistWrite("$baseUrl/api/playlists", token, insecureAllowed) { post(body) }
+        return executePlaylistWrite(insecureAllowed) {
+            post("$baseUrl/api/playlists") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+                contentType(ContentType.Application.Json)
+                setBody(payload)
+            }
+        }
     }
 
     override suspend fun addBookToPlaylist(
@@ -313,13 +318,14 @@ class AbsApiClient(
         libraryItemId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkPlaylist?> {
-        val body = json.encodeToString(
-            AbsPlaylistItemRequest.serializer(),
-            AbsPlaylistItemRequest(libraryItemId),
-        ).toRequestBody(jsonMediaType)
-        return executePlaylistWrite("$baseUrl/api/playlists/$playlistId/item", token, insecureAllowed) { post(body) }
-    }
+    ): NetworkResult<NetworkPlaylist?> =
+        executePlaylistWrite(insecureAllowed) {
+            post("$baseUrl/api/playlists/$playlistId/item") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+                contentType(ContentType.Application.Json)
+                setBody(AbsPlaylistItemRequest(libraryItemId))
+            }
+        }
 
     override suspend fun removeBookFromPlaylist(
         baseUrl: String,
@@ -327,25 +333,22 @@ class AbsApiClient(
         libraryItemId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkPlaylist?> = executePlaylistWrite(
-        "$baseUrl/api/playlists/$playlistId/item/$libraryItemId", token, insecureAllowed,
-    ) { delete() }
+    ): NetworkResult<NetworkPlaylist?> =
+        executePlaylistWrite(insecureAllowed) {
+            delete("$baseUrl/api/playlists/$playlistId/item/$libraryItemId") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+            }
+        }
 
     private suspend fun executePlaylistWrite(
-        url: String,
-        token: String,
         insecureAllowed: Boolean,
-        buildRequest: Request.Builder.() -> Unit,
-    ): NetworkResult<NetworkPlaylist?> = OkHttpClassifier.classify(dispatchers.io) {
-        val request = Request.Builder()
-            .url(url)
-            .addHeader("Authorization", "Bearer $token")
-            .apply { buildRequest() }
-            .build()
-        val response = client(insecureAllowed).newCall(request).execute().requireSuccessful()
-        val raw = response.body?.string().orEmpty()
+        makeRequest: suspend HttpClient.() -> HttpResponse,
+    ): NetworkResult<NetworkPlaylist?> = KtorClassifier.classify {
+        val response = client(insecureAllowed).makeRequest()
+        if (!response.status.isSuccess()) throw HttpException(response.status.value, response.status.description)
+        val raw = response.body<String>()
         if (raw.isBlank()) null
-        else json.decodeFromString(AbsPlaylistsResponse.AbsPlaylistDto.serializer(), raw).toNetworkPlaylist()
+        else RIFFLE_JSON.decodeFromString(AbsPlaylistsResponse.AbsPlaylistDto.serializer(), raw).toNetworkPlaylist()
     }
 
     override suspend fun getItemEbookFileIno(
@@ -353,10 +356,10 @@ class AbsApiClient(
         itemId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<String> = OkHttpClassifier.classify(dispatchers.io) {
-        val response = get(baseUrl, "/api/items/$itemId", token, insecureAllowed).requireSuccessful()
-        val raw = response.requireBody()
-        json.decodeFromString<AbsItemResponse>(raw).media.ebookFile?.ino?.takeIf { it.isNotEmpty() }
+    ): NetworkResult<String> = KtorClassifier.classify {
+        client(insecureAllowed).get("$baseUrl/api/items/$itemId") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }.body<AbsItemResponse>().media.ebookFile?.ino?.takeIf { it.isNotEmpty() }
             ?: throw IOException("No ebookFile.ino in item $itemId")
     }
 
@@ -365,13 +368,11 @@ class AbsApiClient(
         itemId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<AudiobookFingerprint?> = OkHttpClassifier.classify(dispatchers.io) {
-        get(baseUrl, "/api/items/$itemId?expanded=1", token, insecureAllowed).use { response ->
-            response.requireSuccessful()
-            val raw = response.requireBody()
-            // Success(null) replaces the old NoAudiobook variant.
-            json.decodeFromString<AbsItemResponse>(raw).audiobookFingerprint()
-        }
+    ): NetworkResult<AudiobookFingerprint?> = KtorClassifier.classify {
+        // Success(null) replaces the old NoAudiobook variant.
+        client(insecureAllowed).get("$baseUrl/api/items/$itemId?expanded=1") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }.body<AbsItemResponse>().audiobookFingerprint()
     }
 
     override suspend fun getAudiobookTracks(
@@ -379,13 +380,11 @@ class AbsApiClient(
         itemId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<List<NetworkAbsAudioTrack>> = OkHttpClassifier.classify(dispatchers.io) {
-        get(baseUrl, "/api/items/$itemId?expanded=1", token, insecureAllowed).use { response ->
-            response.requireSuccessful()
-            val raw = response.requireBody()
-            // Empty list replaces the old NoAudiobook variant.
-            json.decodeFromString<AbsItemResponse>(raw).audiobookTracks()
-        }
+    ): NetworkResult<List<NetworkAbsAudioTrack>> = KtorClassifier.classify {
+        // Empty list replaces the old NoAudiobook variant.
+        client(insecureAllowed).get("$baseUrl/api/items/$itemId?expanded=1") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }.body<AbsItemResponse>().audiobookTracks()
     }
 
     override suspend fun downloadEpub(
@@ -394,14 +393,15 @@ class AbsApiClient(
         fileIno: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<ResponseBody> = OkHttpClassifier.classify(dispatchers.io) {
-        val response = get(baseUrl, "/api/items/$itemId/ebook/$fileIno", token, insecureAllowed)
-        val body = response.body ?: throw IOException("Empty response body")
-        if (!response.isSuccessful) {
-            body.close()
-            throw HttpException(response.code, response.message)
+    ): NetworkResult<EpubDownloadStream> = KtorClassifier.classify {
+        val response = client(insecureAllowed).get("$baseUrl/api/items/$itemId/ebook/$fileIno") {
+            header(HttpHeaders.Authorization, "Bearer $token")
         }
-        body
+        if (!response.status.isSuccess()) throw HttpException(response.status.value, response.status.description)
+        EpubDownloadStream(
+            inputStream = response.bodyAsChannel().toInputStream(),
+            contentLength = response.contentLength() ?: -1L,
+        )
     }
 
     override suspend fun getItemDetail(
@@ -409,9 +409,10 @@ class AbsApiClient(
         itemId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<AbsItemDetailResponse> = OkHttpClassifier.classify(dispatchers.io) {
-        val response = get(baseUrl, "/api/items/$itemId", token, insecureAllowed).requireSuccessful()
-        json.decodeFromString<AbsItemDetailResponse>(response.requireBody())
+    ): NetworkResult<AbsItemDetailResponse> = KtorClassifier.classify {
+        client(insecureAllowed).get("$baseUrl/api/items/$itemId") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }.body()
     }
 
     override suspend fun syncEbookProgress(
@@ -420,18 +421,14 @@ class AbsApiClient(
         payload: NetworkEbookProgressPayload,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<Long> = OkHttpClassifier.classify(dispatchers.io) {
-        val body = json.encodeToString(AbsEbookProgressRequest(payload.ebookLocation, payload.ebookProgress, payload.isFinished))
-            .toRequestBody(jsonMediaType)
-        val request = Request.Builder()
-            .url("$baseUrl/api/me/progress/$libraryItemId")
-            .addHeader("Authorization", "Bearer $token")
-            .patch(body)
-            .build()
-        val response = client(insecureAllowed).newCall(request).execute().requireSuccessful()
-        response.body?.string()
-            ?.let { runCatching { json.decodeFromString<AbsProgressResponse>(it) }.getOrNull() }
-            ?.lastUpdate ?: 0L
+    ): NetworkResult<Long> = KtorClassifier.classify {
+        val response = client(insecureAllowed).patch("$baseUrl/api/me/progress/$libraryItemId") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+            contentType(ContentType.Application.Json)
+            setBody(AbsEbookProgressRequest(payload.ebookLocation, payload.ebookProgress, payload.isFinished))
+        }
+        if (!response.status.isSuccess()) throw HttpException(response.status.value, response.status.description)
+        runCatching { response.body<AbsProgressResponse>() }.getOrNull()?.lastUpdate ?: 0L
     }
 
     override suspend fun syncAudiobookProgress(
@@ -440,19 +437,15 @@ class AbsApiClient(
         payload: NetworkAudiobookProgressPayload,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<Long> = OkHttpClassifier.classify(dispatchers.io) {
+    ): NetworkResult<Long> = KtorClassifier.classify {
         val progress = if (payload.duration > 0.0) (payload.currentTime / payload.duration).coerceIn(0.0, 1.0) else 0.0
-        val body = json.encodeToString(AbsAudiobookProgressRequest(payload.currentTime, payload.duration, progress))
-            .toRequestBody(jsonMediaType)
-        val request = Request.Builder()
-            .url("$baseUrl/api/me/progress/$libraryItemId")
-            .addHeader("Authorization", "Bearer $token")
-            .patch(body)
-            .build()
-        val response = client(insecureAllowed).newCall(request).execute().requireSuccessful()
-        response.body?.string()
-            ?.let { runCatching { json.decodeFromString<AbsProgressResponse>(it) }.getOrNull() }
-            ?.lastUpdate ?: 0L
+        val response = client(insecureAllowed).patch("$baseUrl/api/me/progress/$libraryItemId") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+            contentType(ContentType.Application.Json)
+            setBody(AbsAudiobookProgressRequest(payload.currentTime, payload.duration, progress))
+        }
+        if (!response.status.isSuccess()) throw HttpException(response.status.value, response.status.description)
+        runCatching { response.body<AbsProgressResponse>() }.getOrNull()?.lastUpdate ?: 0L
     }
 
     override suspend fun getProgress(
@@ -460,16 +453,17 @@ class AbsApiClient(
         libraryItemId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkServerProgress> = OkHttpClassifier.classify(dispatchers.io) {
-        val response = get(baseUrl, "/api/me/progress/$libraryItemId", token, insecureAllowed)
+    ): NetworkResult<NetworkServerProgress> = KtorClassifier.classify {
+        val response = client(insecureAllowed).get("$baseUrl/api/me/progress/$libraryItemId") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }
         // A 404 means "no progress record yet" — synthesize an empty record so callers don't
         // have to special-case `ServerError(404)`.
-        if (response.code == 404) {
-            response.body?.close()
+        if (response.status == HttpStatusCode.NotFound) {
             NetworkServerProgress(ebookLocation = "", lastUpdate = 0L)
         } else {
-            val raw = response.requireSuccessful().requireBody()
-            val parsed = json.decodeFromString<AbsProgressResponse>(raw)
+            if (!response.status.isSuccess()) throw HttpException(response.status.value, response.status.description)
+            val parsed = response.body<AbsProgressResponse>()
             NetworkServerProgress(
                 ebookLocation = parsed.ebookLocation,
                 ebookProgress = parsed.ebookProgress,
@@ -486,7 +480,7 @@ class AbsApiClient(
         deviceId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkPlaybackSession> = OkHttpClassifier.classify(dispatchers.io) {
+    ): NetworkResult<NetworkPlaybackSession> = KtorClassifier.classify {
         val payload = AbsPlayRequest(
             deviceInfo = AbsPlayDeviceInfo(deviceId = deviceId),
             // The MIME types Media3/ExoPlayer plays directly; ABS transcodes only if none match.
@@ -494,16 +488,13 @@ class AbsApiClient(
                 "audio/mpeg", "audio/mp4", "audio/aac", "audio/flac", "audio/ogg", "audio/x-m4a", "audio/x-m4b",
             ),
         )
-        val body = json.encodeToString(payload).toRequestBody(jsonMediaType)
-        val request = Request.Builder()
-            .url("$baseUrl/api/items/$libraryItemId/play")
-            .addHeader("Authorization", "Bearer $token")
-            .post(body)
-            .build()
-        val response = client(insecureAllowed).newCall(request).execute().requireSuccessful()
-        val raw = response.body?.string()
-        if (raw.isNullOrEmpty()) throw IOException("Empty play session response")
-        val parsed = json.decodeFromString<AbsPlaySessionResponse>(raw)
+        val response = client(insecureAllowed).post("$baseUrl/api/items/$libraryItemId/play") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+            contentType(ContentType.Application.Json)
+            setBody(payload)
+        }
+        if (!response.status.isSuccess()) throw HttpException(response.status.value, response.status.description)
+        val parsed = response.body<AbsPlaySessionResponse>()
         val tracks = parsed.audioTracks.map { t ->
             NetworkAudioTrack(
                 index = t.index,
@@ -533,15 +524,13 @@ class AbsApiClient(
         timeListenedSec: Double,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<Unit> = OkHttpClassifier.classify(dispatchers.io) {
-        val body = json.encodeToString(AbsSessionSyncRequest(currentTimeSec, timeListenedSec))
-            .toRequestBody(jsonMediaType)
-        val request = Request.Builder()
-            .url("$baseUrl/api/session/$sessionId/sync")
-            .addHeader("Authorization", "Bearer $token")
-            .post(body)
-            .build()
-        client(insecureAllowed).newCall(request).execute().use { it.requireSuccessful() }
+    ): NetworkResult<Unit> = KtorClassifier.classify {
+        val response = client(insecureAllowed).post("$baseUrl/api/session/$sessionId/sync") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+            contentType(ContentType.Application.Json)
+            setBody(AbsSessionSyncRequest(currentTimeSec, timeListenedSec))
+        }
+        if (!response.status.isSuccess()) throw HttpException(response.status.value, response.status.description)
         Unit
     }
 
@@ -552,15 +541,13 @@ class AbsApiClient(
         timeListenedSec: Double,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<Unit> = OkHttpClassifier.classify(dispatchers.io) {
-        val body = json.encodeToString(AbsSessionSyncRequest(currentTimeSec, timeListenedSec))
-            .toRequestBody(jsonMediaType)
-        val request = Request.Builder()
-            .url("$baseUrl/api/session/$sessionId/close")
-            .addHeader("Authorization", "Bearer $token")
-            .post(body)
-            .build()
-        client(insecureAllowed).newCall(request).execute().use { it.requireSuccessful() }
+    ): NetworkResult<Unit> = KtorClassifier.classify {
+        val response = client(insecureAllowed).post("$baseUrl/api/session/$sessionId/close") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+            contentType(ContentType.Application.Json)
+            setBody(AbsSessionSyncRequest(currentTimeSec, timeListenedSec))
+        }
+        if (!response.status.isSuccess()) throw HttpException(response.status.value, response.status.description)
         Unit
     }
 
@@ -569,22 +556,13 @@ class AbsApiClient(
         itemId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkLibraryItem?> = OkHttpClassifier.classify(dispatchers.io) {
-        val response = get(baseUrl, "/api/items/$itemId?expanded=1", token, insecureAllowed)
-        if (response.code == 404) {
-            response.body?.close()
-            null
-        } else {
-            val raw = response.requireSuccessful().requireBody()
-            json.decodeFromString<AbsLibraryItemsResponse.AbsLibraryItemDto>(raw).toNetworkLibraryItem()
+    ): NetworkResult<NetworkLibraryItem?> = KtorClassifier.classify {
+        val response = client(insecureAllowed).get("$baseUrl/api/items/$itemId?expanded=1") {
+            header(HttpHeaders.Authorization, "Bearer $token")
         }
+        if (response.status == HttpStatusCode.NotFound) null
+        else response.body<AbsLibraryItemsResponse.AbsLibraryItemDto>().toNetworkLibraryItem()
     }
-
-    @Serializable
-    private data class AbsSessionSyncRequest(
-        val currentTime: Double,
-        val timeListened: Double,
-    )
 
     override suspend fun getServerInfo(
         baseUrl: String,
@@ -593,11 +571,9 @@ class AbsApiClient(
     ): String? {
         // `/status` is unauthenticated and returns `{ serverVersion, app, isInit, ... }`.
         // The previously-targeted `/api/server-info` does not exist on ABS (404 even with auth).
-        val result = OkHttpClassifier.classify(dispatchers.io) {
-            val response = client(insecureAllowed).newCall(
-                Request.Builder().url("$baseUrl/status").get().build()
-            ).execute().requireSuccessful()
-            json.decodeFromString<AbsServerInfoResponse>(response.requireBody()).serverVersion
+        val result = KtorClassifier.classify {
+            client(insecureAllowed).get("$baseUrl/status")
+                .body<AbsServerInfoResponse>().serverVersion
         }
         return result.getOrNull()
     }
@@ -607,9 +583,10 @@ class AbsApiClient(
         token: String,
         insecureAllowed: Boolean,
     ): String? {
-        val result = OkHttpClassifier.classify(dispatchers.io) {
-            val response = get(baseUrl, "/api/me", token, insecureAllowed).requireSuccessful()
-            json.decodeFromString<AbsMeResponse>(response.requireBody()).id.takeIf { it.isNotBlank() }
+        val result = KtorClassifier.classify {
+            client(insecureAllowed).get("$baseUrl/api/me") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+            }.body<AbsMeResponse>().id.takeIf { it.isNotBlank() }
         }
         return result.getOrNull()
     }
@@ -618,11 +595,14 @@ class AbsApiClient(
         baseUrl: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkListeningStats> = OkHttpClassifier.classify(dispatchers.io) {
-        val response = get(baseUrl, "/api/me/listening-stats", token, insecureAllowed)
-        val raw = response.requireSuccessful().requireBody()
-        val parsed = json.decodeFromString<AbsListeningStatsResponse>(raw)
-        NetworkListeningStats(totalTimeSec = parsed.totalTime)
+    ): NetworkResult<NetworkListeningStats> = KtorClassifier.classify {
+        val response = client(insecureAllowed).get("$baseUrl/api/me/listening-stats") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }
+        if (!response.status.isSuccess()) throw ResponseException(response, response.status.description)
+        response.body<AbsListeningStatsResponse>().let { parsed ->
+            NetworkListeningStats(totalTimeSec = parsed.totalTime)
+        }
     }
 
     override suspend fun createBookmark(
@@ -632,14 +612,12 @@ class AbsApiClient(
         title: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkAbsBookmark> = OkHttpClassifier.classify(dispatchers.io) {
-        val body = json.encodeToString(AbsBookmarkRequest(timeSec, title)).toRequestBody(jsonMediaType)
-        val request = Request.Builder()
-            .url("$baseUrl/api/me/item/$itemId/bookmark")
-            .addHeader("Authorization", "Bearer $token")
-            .post(body)
-            .build()
-        executeBookmarkWrite(request, insecureAllowed)
+    ): NetworkResult<NetworkAbsBookmark> = KtorClassifier.classify {
+        client(insecureAllowed).post("$baseUrl/api/me/item/$itemId/bookmark") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+            contentType(ContentType.Application.Json)
+            setBody(AbsBookmarkRequest(timeSec, title))
+        }.body<AbsBookmarkJson>().toNetworkAbsBookmark()
     }
 
     override suspend fun updateBookmark(
@@ -649,20 +627,12 @@ class AbsApiClient(
         title: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkAbsBookmark> = OkHttpClassifier.classify(dispatchers.io) {
-        val body = json.encodeToString(AbsBookmarkRequest(timeSec, title)).toRequestBody(jsonMediaType)
-        val request = Request.Builder()
-            .url("$baseUrl/api/me/item/$itemId/bookmark")
-            .addHeader("Authorization", "Bearer $token")
-            .patch(body)
-            .build()
-        executeBookmarkWrite(request, insecureAllowed)
-    }
-
-    private fun executeBookmarkWrite(request: Request, insecureAllowed: Boolean): NetworkAbsBookmark {
-        val response = client(insecureAllowed).newCall(request).execute().requireSuccessful()
-        val raw = response.requireBody()
-        return json.decodeFromString<AbsBookmarkJson>(raw).toNetworkAbsBookmark()
+    ): NetworkResult<NetworkAbsBookmark> = KtorClassifier.classify {
+        client(insecureAllowed).patch("$baseUrl/api/me/item/$itemId/bookmark") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+            contentType(ContentType.Application.Json)
+            setBody(AbsBookmarkRequest(timeSec, title))
+        }.body<AbsBookmarkJson>().toNetworkAbsBookmark()
     }
 
     override suspend fun deleteBookmark(
@@ -671,22 +641,18 @@ class AbsApiClient(
         timeSec: Int,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkAbsBookmark> = OkHttpClassifier.classify(dispatchers.io) {
-        val request = Request.Builder()
-            .url("$baseUrl/api/me/item/$itemId/bookmark/$timeSec")
-            .addHeader("Authorization", "Bearer $token")
-            .delete()
-            .build()
-        val response = client(insecureAllowed).newCall(request).execute()
-        response.body?.close()
+    ): NetworkResult<NetworkAbsBookmark> = KtorClassifier.classify {
+        val response = client(insecureAllowed).delete("$baseUrl/api/me/item/$itemId/bookmark/$timeSec") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }
         // Deleting an already-absent bookmark is success (idempotent) — otherwise a
         // delete-tombstone for a bookmark already gone on the server stays dirty forever.
-        if (response.code == 404 || response.isSuccessful) {
+        if (response.status == HttpStatusCode.NotFound || response.status.isSuccess()) {
             // DELETE returns plain-text "OK" with no JSON body, so synthesize the bookmark
             // from the request inputs (identity is libraryItemId + time).
             NetworkAbsBookmark(libraryItemId = itemId, title = "", timeSec = timeSec, createdAt = 0L)
         } else {
-            throw HttpException(response.code, response.message)
+            throw HttpException(response.status.value, response.status.description)
         }
     }
 
@@ -694,34 +660,24 @@ class AbsApiClient(
         baseUrl: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<List<NetworkAbsBookmark>> = OkHttpClassifier.classify(dispatchers.io) {
-        // Bypass the shared OkHttp cache for `/api/me` (15-min TTL from EndpointCacheHeadersInterceptor).
+    ): NetworkResult<List<NetworkAbsBookmark>> = KtorClassifier.classify {
+        // Bypass the shared cache for `/api/me` (15-min TTL from EndpointCacheHeadersInterceptor).
         // Annotation sync piggybacks on user bookmarks; a stale cached body would hide a peer device's
         // freshly-written bookmark until reopen. Mirrors WebDAV, whose PROPFIND was never cached.
-        val response = get(baseUrl, "/api/me", token, insecureAllowed, bypassCache = true).requireSuccessful()
-        val raw = response.requireBody()
-        // `/api/me` carries many fields; `json` is configured with ignoreUnknownKeys so the
-        // wrapper need only declare `bookmarks` (absent → empty via the default).
-        json.decodeFromString<AbsMeBookmarksResponse>(raw).bookmarks.map { it.toNetworkAbsBookmark() }
+        client(insecureAllowed).get("$baseUrl/api/me") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+            header(HttpHeaders.CacheControl, "no-cache, no-store")
+        }.body<AbsMeBookmarksResponse>().bookmarks.map { it.toNetworkAbsBookmark() }
     }
 
-    private fun client(insecureAllowed: Boolean): OkHttpClient =
+    private fun client(insecureAllowed: Boolean): HttpClient =
         if (insecureAllowed) httpClient.withInsecureTls() else httpClient
 
-    private fun get(
-        baseUrl: String,
-        path: String,
-        token: String,
-        insecureAllowed: Boolean,
-        bypassCache: Boolean = false,
-    ): Response {
-        val builder = Request.Builder()
-            .url("$baseUrl$path")
-            .addHeader("Authorization", "Bearer $token")
-            .get()
-        if (bypassCache) builder.cacheControl(CacheControl.FORCE_NETWORK)
-        return client(insecureAllowed).newCall(builder.build()).execute()
-    }
+    @Serializable
+    private data class AbsSessionSyncRequest(
+        val currentTime: Double,
+        val timeListened: Double,
+    )
 }
 
 @Serializable

--- a/core/network/src/main/kotlin/com/riffle/core/network/AbsLibraryApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AbsLibraryApi.kt
@@ -2,7 +2,10 @@ package com.riffle.core.network
 
 import com.riffle.core.models.AudiobookFingerprint
 import com.riffle.core.network.model.AbsItemDetailResponse
-import okhttp3.ResponseBody
+import java.io.InputStream
+
+/** Streaming response for EPUB downloads — caller MUST close [inputStream] when done. */
+data class EpubDownloadStream(val inputStream: InputStream, val contentLength: Long)
 
 data class NetworkUserMediaProgress(
     val ebookProgress: Float?,
@@ -133,7 +136,7 @@ interface AbsLibraryApi {
         fileIno: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<ResponseBody> = throw UnsupportedOperationException("downloadEpub not implemented")
+    ): NetworkResult<EpubDownloadStream> = throw UnsupportedOperationException("downloadEpub not implemented")
 
     suspend fun getItemDetail(
         baseUrl: String,

--- a/core/network/src/main/kotlin/com/riffle/core/network/AudiobookBundleApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/AudiobookBundleApi.kt
@@ -1,13 +1,20 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DispatcherProvider
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.timeout
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentLength
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.jvm.javaio.toInputStream
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.withContext
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.ResponseBody
 import java.io.IOException
-import java.util.concurrent.TimeUnit
+import java.io.InputStream
 
 /**
  * A (possibly partial) byte stream of the Storyteller synced bundle.
@@ -16,7 +23,7 @@ import java.util.concurrent.TimeUnit
  * @param totalBytes the full bundle size, recovered from Content-Range (206) or Content-Length (200).
  * @param isPartial true when the server honoured a Range request (206); false on a full 200 body.
  */
-data class AudiobookBundleStream(val body: ResponseBody, val totalBytes: Long, val isPartial: Boolean)
+data class AudiobookBundleStream(val body: InputStream, val totalBytes: Long, val isPartial: Boolean)
 
 /**
  * Opens a (resumable) byte stream of the Storyteller synced bundle — the EPUB-3-with-audio that
@@ -34,15 +41,8 @@ fun interface AudiobookBundleApi {
 }
 
 class AudiobookBundleApiImpl(
-    private val client: OkHttpClient,
-    private val dispatchers: DispatcherProvider,
+    private val client: HttpClient,
 ) : AudiobookBundleApi {
-
-    private val bundleClient: OkHttpClient = client.newBuilder()
-        .connectTimeout(30, TimeUnit.SECONDS)
-        .readTimeout(0, TimeUnit.MILLISECONDS)
-        .callTimeout(0, TimeUnit.MILLISECONDS)
-        .build()
 
     override suspend fun openBundleStream(
         baseUrl: String,
@@ -50,39 +50,41 @@ class AudiobookBundleApiImpl(
         token: String,
         insecureAllowed: Boolean,
         fromByte: Long,
-    ): NetworkResult<AudiobookBundleStream> = withContext(dispatchers.io) {
-        val effectiveClient = if (insecureAllowed) bundleClient.withInsecureTls() else bundleClient
-        val builder = Request.Builder()
-            .url("$baseUrl/api/books/$bookId/synced")
-            .addHeader("Authorization", "Bearer $token")
-            // Forward-compat: a Storyteller release that content-negotiates a Readium audiobook
-            // archive will honour this; today's server ignores it and returns application/epub+zip.
-            .addHeader("Accept", "application/audiobook+zip")
-        if (fromByte > 0L) builder.addHeader("Range", "bytes=$fromByte-")
-
-        try {
-            val response = effectiveClient.newCall(builder.build()).execute()
-            val body = response.body
-            if (!response.isSuccessful || body == null) {
-                body?.close()
-                return@withContext NetworkResult.Offline(IOException("HTTP ${response.code}"))
+    ): NetworkResult<AudiobookBundleStream> {
+        val effectiveClient = if (insecureAllowed) client.withInsecureTls() else client
+        return try {
+            val response = effectiveClient.get("$baseUrl/api/books/$bookId/synced") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+                // Forward-compat: a Storyteller release that content-negotiates a Readium audiobook
+                // archive will honour this; today's server ignores it and returns application/epub+zip.
+                header(HttpHeaders.Accept, "application/audiobook+zip")
+                if (fromByte > 0L) header(HttpHeaders.Range, "bytes=$fromByte-")
+                timeout {
+                    connectTimeoutMillis = 30_000L
+                    requestTimeoutMillis = Long.MAX_VALUE
+                    socketTimeoutMillis = Long.MAX_VALUE
+                }
             }
-            val isPartial = response.code == 206
+            if (!response.status.isSuccess()) {
+                response.bodyAsChannel().cancel(null)
+                return NetworkResult.Offline(IOException("HTTP ${response.status.value}"))
+            }
+            val isPartial = response.status == HttpStatusCode.PartialContent
             val total = if (isPartial) {
-                response.header("Content-Range")?.substringAfter('/')?.toLongOrNull()
+                response.headers[HttpHeaders.ContentRange]?.substringAfter('/')?.toLongOrNull()
             } else {
-                response.header("Content-Length")?.toLongOrNull()
+                response.contentLength()
             } ?: -1L
-            try {
-                ensureActive()
-            } catch (e: Throwable) {
-                body.close()
-                throw e
-            }
-            NetworkResult.Success(AudiobookBundleStream(body = body, totalBytes = total, isPartial = isPartial))
+            currentCoroutineContext().ensureActive()
+            NetworkResult.Success(
+                AudiobookBundleStream(
+                    body = response.bodyAsChannel().toInputStream(),
+                    totalBytes = total,
+                    isPartial = isPartial,
+                )
+            )
         } catch (e: IOException) {
             NetworkResult.Offline(e)
         }
     }
-
 }

--- a/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
@@ -1,13 +1,16 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DispatcherProvider
-import kotlinx.coroutines.withContext
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.HttpHeaders
+import io.ktor.http.contentLength
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.readAvailable
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
-import okhttp3.CacheControl
-import okhttp3.OkHttpClient
-import okhttp3.Request
 import java.io.File
 import java.io.IOException
 
@@ -16,54 +19,44 @@ import java.io.IOException
  * needed because the Riffle repo is public.
  */
 class GitHubReleaseApi(
-    private val httpClient: OkHttpClient,
-    private val dispatchers: DispatcherProvider,
+    private val httpClient: HttpClient,
     /** Overridable so tests can point at a local MockWebServer; defaults to the public GitHub API. */
     private val apiBaseUrl: String = "https://api.github.com",
 ) {
-
-    private val json = Json { ignoreUnknownKeys = true }
 
     /**
      * Fetches the repo's most recent non-prerelease, non-draft release whose assets include an APK.
      * Releases that exist but haven't finished their APK build yet are skipped so an in-flight release
      * doesn't stall the updater.
      */
-    suspend fun latestRelease(repo: String): GitHubReleaseResult = withContext(dispatchers.io) {
-        // FORCE_NETWORK on the request: the only caller is the manual Settings "Check for updates"
+    suspend fun latestRelease(repo: String): GitHubReleaseResult {
+        // no-cache on the request: the only caller is the manual Settings "Check for updates"
         // button whose contract is "check now". GitHub's response advertises `Cache-Control:
-        // max-age=60`, which the shared default OkHttp Cache honors — without this override a
-        // re-tap within 60s would serve the previous response from disk and the button would
-        // silently no-op. This forces every tap through to the origin.
-        val request = Request.Builder()
-            .url("$apiBaseUrl/repos/$repo/releases?per_page=10")
-            .header("Accept", "application/vnd.github+json")
-            .cacheControl(CacheControl.FORCE_NETWORK)
-            .get()
-            .build()
-        try {
-            httpClient.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) {
-                    return@use GitHubReleaseResult.Failed("HTTP ${response.code}")
-                }
-                val raw = response.body?.string()
-                    ?: return@use GitHubReleaseResult.Failed("Empty response")
-                val parsed = json.decodeFromString<List<ReleaseResponse>>(raw)
-                for (release in parsed) {
-                    if (release.draft || release.prerelease) continue
-                    val apk = release.assets.firstOrNull {
-                        it.name.endsWith(".apk", ignoreCase = true)
-                    } ?: continue
-                    return@use GitHubReleaseResult.Success(
-                        GitHubRelease(
-                            tagName = release.tagName,
-                            apkUrl = apk.downloadUrl,
-                            apkSizeBytes = apk.size,
-                        )
-                    )
-                }
-                GitHubReleaseResult.Failed("No release with an APK asset")
+        // max-age=60`; without this override a re-tap within 60s would serve the previous cached
+        // response and the button would silently no-op. This forces every tap through to the origin.
+        return try {
+            val response = httpClient.get("$apiBaseUrl/repos/$repo/releases?per_page=10") {
+                header(HttpHeaders.Accept, "application/vnd.github+json")
+                header(HttpHeaders.CacheControl, "no-cache, no-store")
             }
+            if (!response.status.isSuccess()) {
+                return GitHubReleaseResult.Failed("HTTP ${response.status.value}")
+            }
+            val parsed = response.body<List<ReleaseResponse>>()
+            for (release in parsed) {
+                if (release.draft || release.prerelease) continue
+                val apk = release.assets.firstOrNull {
+                    it.name.endsWith(".apk", ignoreCase = true)
+                } ?: continue
+                return GitHubReleaseResult.Success(
+                    GitHubRelease(
+                        tagName = release.tagName,
+                        apkUrl = apk.downloadUrl,
+                        apkSizeBytes = apk.size,
+                    )
+                )
+            }
+            GitHubReleaseResult.Failed("No release with an APK asset")
         } catch (e: IOException) {
             GitHubReleaseResult.Failed(e.message ?: "Network error")
         }
@@ -74,42 +67,36 @@ class GitHubReleaseApi(
      * failure [dest] is deleted, so a truncated APK is never handed to the installer.
      */
     suspend fun download(url: String, dest: File, onProgress: (percent: Int) -> Unit): Boolean =
-        withContext(dispatchers.io) {
-            val request = Request.Builder().url(url).get().build()
-            try {
-                httpClient.newCall(request).execute().use { response ->
-                    val body = response.body
-                    if (!response.isSuccessful || body == null) {
-                        dest.delete()
-                        return@use false
-                    }
-                    val total = body.contentLength()
-                    body.byteStream().use { input ->
-                        dest.outputStream().use { output ->
-                            val buffer = ByteArray(64 * 1024)
-                            var copied = 0L
-                            var lastPercent = -1
-                            while (true) {
-                                val read = input.read(buffer)
-                                if (read == -1) break
-                                output.write(buffer, 0, read)
-                                copied += read
-                                if (total > 0) {
-                                    val percent = ((copied * 100) / total).toInt().coerceIn(0, 100)
-                                    if (percent != lastPercent) {
-                                        lastPercent = percent
-                                        onProgress(percent)
-                                    }
-                                }
-                            }
+        try {
+            val response = httpClient.get(url)
+            if (!response.status.isSuccess()) {
+                dest.delete()
+                return false
+            }
+            val total = response.contentLength() ?: -1L
+            val channel = response.bodyAsChannel()
+            dest.outputStream().use { out ->
+                val buffer = ByteArray(64 * 1024)
+                var copied = 0L
+                var lastPercent = -1
+                while (!channel.isClosedForRead) {
+                    val read = channel.readAvailable(buffer)
+                    if (read <= 0) break
+                    out.write(buffer, 0, read)
+                    copied += read
+                    if (total > 0) {
+                        val percent = ((copied * 100) / total).toInt().coerceIn(0, 100)
+                        if (percent != lastPercent) {
+                            lastPercent = percent
+                            onProgress(percent)
                         }
                     }
-                    true
                 }
-            } catch (e: IOException) {
-                dest.delete()
-                false
             }
+            true
+        } catch (e: IOException) {
+            dest.delete()
+            false
         }
 }
 

--- a/core/network/src/main/kotlin/com/riffle/core/network/InsecureTls.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/InsecureTls.kt
@@ -1,28 +1,46 @@
 package com.riffle.core.network
 
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttpConfig
 import okhttp3.OkHttpClient
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import javax.net.ssl.SSLContext
 import javax.net.ssl.X509TrustManager
 
+private val TRUST_ALL_MANAGER = object : X509TrustManager {
+    override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
+    override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
+    override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+}
+
+private fun insecureSslContext(): SSLContext = SSLContext.getInstance("TLS").apply {
+    init(null, arrayOf(TRUST_ALL_MANAGER), SecureRandom())
+}
+
 /**
- * Returns a copy of this client that accepts self-signed / untrusted TLS certificates.
- *
- * Callers gate this on the per-server `insecureAllowed` flag (self-hosted Audiobookshelf and
- * Storyteller services commonly run behind self-signed certs on homelab domains). Never call
- * unconditionally: the returned client bypasses certificate validation entirely.
+ * Returns a copy of this OkHttpClient that accepts self-signed / untrusted TLS certificates.
+ * Callers gate this on the per-server `insecureAllowed` flag.
  */
 internal fun OkHttpClient.withInsecureTls(): OkHttpClient {
-    val trustAll = object : X509TrustManager {
-        override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
-        override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
-        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
-    }
-    val sslContext = SSLContext.getInstance("TLS").apply {
-        init(null, arrayOf(trustAll), SecureRandom())
-    }
+    val sslContext = insecureSslContext()
     return newBuilder()
-        .sslSocketFactory(sslContext.socketFactory, trustAll)
+        .sslSocketFactory(sslContext.socketFactory, TRUST_ALL_MANAGER)
         .build()
+}
+
+/**
+ * Returns a copy of this Ktor [HttpClient] (OkHttp engine) that accepts self-signed / untrusted
+ * TLS certificates. Callers gate this on the per-server `insecureAllowed` flag.
+ */
+internal fun HttpClient.withInsecureTls(): HttpClient {
+    val sslContext = insecureSslContext()
+    return config {
+        engine {
+            (this as OkHttpConfig).config {
+                sslSocketFactory(sslContext.socketFactory, TRUST_ALL_MANAGER)
+                hostnameVerifier { _, _ -> true }
+            }
+        }
+    }
 }

--- a/core/network/src/main/kotlin/com/riffle/core/network/KtorClientFactory.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/KtorClientFactory.kt
@@ -1,0 +1,35 @@
+package com.riffle.core.network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+
+val RIFFLE_JSON = Json { ignoreUnknownKeys = true; coerceInputValues = true }
+
+/**
+ * Creates a Ktor [HttpClient] backed by the OkHttp engine. The supplied [okHttpClient] carries the
+ * disk cache, network interceptors, and TLS configuration; Ktor's content-negotiation plugin is
+ * pre-installed with Riffle's [RIFFLE_JSON] instance so callers can use `response.body<T>()`.
+ */
+fun createDefaultHttpClient(okHttpClient: OkHttpClient): HttpClient = HttpClient(OkHttp) {
+    engine {
+        preconfigured = okHttpClient
+    }
+    install(ContentNegotiation) {
+        json(RIFFLE_JSON)
+    }
+}
+
+/**
+ * Creates a Ktor [HttpClient] for raw byte streaming without ContentNegotiation. Streaming
+ * endpoints set their own Accept headers and read raw bytes — ContentNegotiation would
+ * silently append `application/json` to every Accept header, breaking content negotiation.
+ */
+fun createStreamingHttpClient(okHttpClient: OkHttpClient): HttpClient = HttpClient(OkHttp) {
+    engine {
+        preconfigured = okHttpClient
+    }
+}

--- a/core/network/src/main/kotlin/com/riffle/core/network/NetworkResult.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/NetworkResult.kt
@@ -1,8 +1,7 @@
 package com.riffle.core.network
 
 import com.riffle.core.models.InsecureConnectionType
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
+import io.ktor.client.plugins.ResponseException
 import kotlinx.serialization.SerializationException
 import java.io.IOException
 import javax.net.ssl.SSLHandshakeException
@@ -27,40 +26,29 @@ sealed class NetworkResult<out T> {
 /** Thrown by endpoint blocks to signal a non-success HTTP code; the classifier maps 401 → Auth. */
 internal class HttpException(val code: Int, msg: String? = null) : IOException(msg)
 
-/** Throw [HttpException] for non-success codes; closes the body so the connection returns to the pool. */
-internal fun okhttp3.Response.requireSuccessful(): okhttp3.Response {
-    if (!isSuccessful) {
-        body?.close()
-        throw HttpException(code, message)
-    }
-    return this
-}
-
-/** Read the body as a string or fail with `IOException("Empty response body")` for the classifier. */
-internal fun okhttp3.Response.requireBody(): String =
-    body?.string() ?: throw IOException("Empty response body")
-
-object OkHttpClassifier {
+object KtorClassifier {
     /**
      * Run [block], producing a `Success`. Any thrown exception is mapped to the matching
-     * `NetworkResult` variant. Block authors throw `HttpException` for non-success codes and
-     * `IOException("Empty response body")` for missing bodies.
+     * `NetworkResult` variant. Block authors throw [HttpException] for non-success codes that
+     * need specific handling (e.g. 400/405 → 401 for Storyteller login).
      */
-    suspend fun <T> classify(io: CoroutineDispatcher, block: suspend () -> T): NetworkResult<T> = withContext(io) {
-        try {
-            NetworkResult.Success(block())
-        } catch (e: HttpException) {
-            if (e.code == 401) NetworkResult.Auth
-            else NetworkResult.ServerError(e.code, e.message)
-        } catch (e: SSLHandshakeException) {
-            NetworkResult.InsecureConnection(InsecureConnectionType.SELF_SIGNED)
-        } catch (e: SerializationException) {
-            NetworkResult.Parse(e)
-        } catch (e: IOException) {
-            NetworkResult.Offline(e)
-        } catch (e: Throwable) {
-            NetworkResult.Unknown(e)
-        }
+    suspend fun <T> classify(block: suspend () -> T): NetworkResult<T> = try {
+        NetworkResult.Success(block())
+    } catch (e: HttpException) {
+        if (e.code == 401) NetworkResult.Auth
+        else NetworkResult.ServerError(e.code, e.message)
+    } catch (e: ResponseException) {
+        val code = e.response.status.value
+        if (code == 401) NetworkResult.Auth
+        else NetworkResult.ServerError(code, e.message)
+    } catch (e: SSLHandshakeException) {
+        NetworkResult.InsecureConnection(InsecureConnectionType.SELF_SIGNED)
+    } catch (e: SerializationException) {
+        NetworkResult.Parse(e)
+    } catch (e: IOException) {
+        NetworkResult.Offline(e)
+    } catch (e: Throwable) {
+        NetworkResult.Unknown(e)
     }
 }
 
@@ -97,7 +85,7 @@ fun NetworkResult<*>.errorAsThrowable(): Throwable = when (this) {
     is NetworkResult.Offline -> cause
     is NetworkResult.Parse -> cause
     is NetworkResult.Unknown -> cause
-    is NetworkResult.ServerError -> java.io.IOException("HTTP $code${errorMessage?.let { ": $it" } ?: ""}")
-    NetworkResult.Auth -> java.io.IOException("HTTP 401")
-    is NetworkResult.InsecureConnection -> javax.net.ssl.SSLHandshakeException("Insecure connection ($type)")
+    is NetworkResult.ServerError -> IOException("HTTP $code${errorMessage?.let { ": $it" } ?: ""}")
+    NetworkResult.Auth -> IOException("HTTP 401")
+    is NetworkResult.InsecureConnection -> SSLHandshakeException("Insecure connection ($type)")
 }

--- a/core/network/src/main/kotlin/com/riffle/core/network/StorytellerApiClient.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/StorytellerApiClient.kt
@@ -1,46 +1,42 @@
 package com.riffle.core.network
 
 import com.riffle.core.models.AudiobookFingerprint
-import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.network.model.StorytellerBookResponse
 import com.riffle.core.network.model.StorytellerLoginResponse
 import com.riffle.core.network.model.StorytellerV2BookResponse
-import kotlinx.serialization.json.Json
-import okhttp3.MultipartBody
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import java.io.IOException
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.forms.formData
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.isSuccess
 
 class StorytellerApiClient(
-    private val httpClient: OkHttpClient,
-    private val dispatchers: DispatcherProvider,
+    private val httpClient: HttpClient,
 ) : StorytellerApi, StorytellerLibraryApi {
-
-    private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
 
     override suspend fun login(
         baseUrl: String,
         username: String,
         password: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<String> = OkHttpClassifier.classify(dispatchers.io) {
-        val client = client(insecureAllowed)
-        val body = MultipartBody.Builder()
-            .setType(MultipartBody.FORM)
-            .addFormDataPart("username", username)
-            .addFormDataPart("password", password)
-            .build()
-        val request = Request.Builder().url("$baseUrl/api/token").post(body).build()
-        client.newCall(request).execute().use { response ->
-            when (response.code) {
-                200 -> {
-                    val raw = response.body?.string() ?: throw IOException("Empty response body")
-                    json.decodeFromString<StorytellerLoginResponse>(raw).accessToken
-                }
-                // 401 ⇒ Auth, but 400/405 also count as wrong creds for Storyteller.
-                400, 401, 405 -> throw HttpException(401, "Invalid username or password")
-                else -> throw HttpException(response.code, response.message)
-            }
+    ): NetworkResult<String> = KtorClassifier.classify {
+        val response = client(insecureAllowed).post("$baseUrl/api/token") {
+            setBody(MultiPartFormDataContent(formData {
+                append("username", username)
+                append("password", password)
+            }))
+        }
+        when (response.status.value) {
+            200 -> response.body<StorytellerLoginResponse>().accessToken
+            // 401 ⇒ Auth, but 400/405 also count as wrong creds for Storyteller.
+            400, 401, 405 -> throw HttpException(401, "Invalid username or password")
+            else -> throw HttpException(response.status.value, response.status.description)
         }
     }
 
@@ -48,18 +44,14 @@ class StorytellerApiClient(
         baseUrl: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<Boolean> = OkHttpClassifier.classify(dispatchers.io) {
-        val request = Request.Builder()
-            .url("$baseUrl/api/validate")
-            .addHeader("Authorization", "Bearer $token")
-            .get()
-            .build()
-        client(insecureAllowed).newCall(request).execute().use { response ->
-            when (response.code) {
-                in 200..299 -> true
-                401, 403 -> false
-                else -> throw HttpException(response.code, response.message)
-            }
+    ): NetworkResult<Boolean> = KtorClassifier.classify {
+        val response = client(insecureAllowed).get("$baseUrl/api/validate") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }
+        when (response.status.value) {
+            in 200..299 -> true
+            401, 403 -> false
+            else -> throw HttpException(response.status.value, response.status.description)
         }
     }
 
@@ -67,18 +59,13 @@ class StorytellerApiClient(
         baseUrl: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<List<NetworkStorytellerBook>> = OkHttpClassifier.classify(dispatchers.io) {
+    ): NetworkResult<List<NetworkStorytellerBook>> = KtorClassifier.classify {
         // ?synced=true: server-side filter to completed readalouds only (ADR 0020).
-        val request = Request.Builder()
-            .url("$baseUrl/api/books?synced=true")
-            .addHeader("Authorization", "Bearer $token")
-            .get()
-            .build()
-        client(insecureAllowed).newCall(request).execute().use { response ->
-            if (!response.isSuccessful) throw HttpException(response.code, response.message)
-            val raw = response.body?.string() ?: throw IOException("Empty response body")
-            json.decodeFromString<List<StorytellerBookResponse>>(raw).map { it.toNetwork() }
+        val response = client(insecureAllowed).get("$baseUrl/api/books?synced=true") {
+            header(HttpHeaders.Authorization, "Bearer $token")
         }
+        if (!response.status.isSuccess()) throw HttpException(response.status.value, response.status.description)
+        response.body<List<StorytellerBookResponse>>().map { it.toNetwork() }
     }
 
     override suspend fun getBook(
@@ -86,21 +73,14 @@ class StorytellerApiClient(
         bookId: Long,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<NetworkStorytellerBook> = OkHttpClassifier.classify(dispatchers.io) {
-        val request = Request.Builder()
-            .url("$baseUrl/api/books/$bookId")
-            .addHeader("Authorization", "Bearer $token")
-            .get()
-            .build()
-        client(insecureAllowed).newCall(request).execute().use { response ->
-            when (response.code) {
-                in 200..299 -> {
-                    val raw = response.body?.string() ?: throw IOException("Empty response body")
-                    json.decodeFromString<StorytellerBookResponse>(raw).toNetwork()
-                }
-                // 404 surfaces as ServerError(404) — replaces the old NotFound variant.
-                else -> throw HttpException(response.code, response.message)
-            }
+    ): NetworkResult<NetworkStorytellerBook> = KtorClassifier.classify {
+        val response = client(insecureAllowed).get("$baseUrl/api/books/$bookId") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }
+        when (response.status.value) {
+            in 200..299 -> response.body<StorytellerBookResponse>().toNetwork()
+            // 404 surfaces as ServerError(404) — replaces the old NotFound variant.
+            else -> throw HttpException(response.status.value, response.status.description)
         }
     }
 
@@ -112,21 +92,16 @@ class StorytellerApiClient(
         bookId: Long,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<AudiobookFingerprint?> = OkHttpClassifier.classify(dispatchers.io) {
-        val request = Request.Builder()
-            .url("$baseUrl/api/v2/books/$bookId")
-            .addHeader("Authorization", "Bearer $token")
-            .get()
-            .build()
-        client(insecureAllowed).newCall(request).execute().use { response ->
-            if (!response.isSuccessful) throw HttpException(response.code, response.message)
-            val raw = response.body?.string() ?: throw IOException("Empty response body")
-            // Success(null) replaces the old NoAudiobook variant.
-            json.decodeFromString<StorytellerV2BookResponse>(raw).toFingerprint()
+    ): NetworkResult<AudiobookFingerprint?> = KtorClassifier.classify {
+        val response = client(insecureAllowed).get("$baseUrl/api/v2/books/$bookId") {
+            header(HttpHeaders.Authorization, "Bearer $token")
         }
+        if (!response.status.isSuccess()) throw HttpException(response.status.value, response.status.description)
+        // Success(null) replaces the old NoAudiobook variant.
+        response.body<StorytellerV2BookResponse>().toFingerprint()
     }
 
-    private fun client(insecureAllowed: Boolean): OkHttpClient =
+    private fun client(insecureAllowed: Boolean): HttpClient =
         if (insecureAllowed) httpClient.withInsecureTls() else httpClient
 
     private fun StorytellerBookResponse.toNetwork(): NetworkStorytellerBook =

--- a/core/network/src/main/kotlin/com/riffle/core/network/StorytellerBundleApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/StorytellerBundleApi.kt
@@ -1,16 +1,23 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DispatcherProvider
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.timeout
+import io.ktor.client.request.get
+import io.ktor.client.request.head
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.HttpHeaders
+import io.ktor.http.contentLength
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.jvm.javaio.toInputStream
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.withContext
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.ResponseBody
 import java.io.IOException
-import java.util.concurrent.TimeUnit
+import java.io.InputStream
 
 /** A streaming Storyteller bundle response — caller must close [body]. */
-data class StorytellerBundleStream(val body: ResponseBody)
+data class StorytellerBundleStream(val body: InputStream)
 
 fun interface StorytellerBundleApi {
     suspend fun downloadBundle(
@@ -31,78 +38,62 @@ fun interface StorytellerBundleProbeApi {
 }
 
 class StorytellerBundleApiImpl(
-    private val client: OkHttpClient,
-    private val dispatchers: DispatcherProvider,
+    private val client: HttpClient,
     // Overridable so tests can assert the bounded-timeout fallback without waiting the full window.
     private val sidecarCallTimeoutSeconds: Long = SIDECAR_CALL_TIMEOUT_SECONDS,
     private val sidecarStreamTimeoutSeconds: Long = SIDECAR_STREAM_TIMEOUT_SECONDS,
 ) : StorytellerBundleApi, StorytellerBundleProbeApi {
 
-    private val bundleClient: OkHttpClient = client.newBuilder()
-        .connectTimeout(30, TimeUnit.SECONDS)
-        .readTimeout(0, TimeUnit.MILLISECONDS)
-        .callTimeout(0, TimeUnit.MILLISECONDS)
-        .build()
-
-    private val sidecarClient: OkHttpClient = client.newBuilder()
-        .connectTimeout(30, TimeUnit.SECONDS)
-        .callTimeout(sidecarCallTimeoutSeconds, TimeUnit.SECONDS)
-        .build()
-
-    private val sidecarStreamClient: OkHttpClient = client.newBuilder()
-        .connectTimeout(30, TimeUnit.SECONDS)
-        .readTimeout(0, TimeUnit.MILLISECONDS)
-        .callTimeout(sidecarStreamTimeoutSeconds, TimeUnit.SECONDS)
-        .build()
-
     /**
      * Streaming GET of `/synced` for sidecar extraction (ADR 0028) — same as [downloadBundle] but on a
-     * BOUNDED client so a wedged generation fails instead of hanging the background prepare forever.
+     * BOUNDED timeout so a wedged generation fails instead of hanging the background prepare forever.
      */
     suspend fun streamSidecar(
         baseUrl: String,
         bookId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<StorytellerBundleStream> = openStream(sidecarStreamClient, baseUrl, bookId, token, insecureAllowed)
+    ): NetworkResult<StorytellerBundleStream> =
+        openStream(sidecarStreamTimeoutSeconds * 1_000L, baseUrl, bookId, token, insecureAllowed)
 
     override suspend fun downloadBundle(
         baseUrl: String,
         bookId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<StorytellerBundleStream> = openStream(bundleClient, baseUrl, bookId, token, insecureAllowed)
+    ): NetworkResult<StorytellerBundleStream> =
+        openStream(Long.MAX_VALUE, baseUrl, bookId, token, insecureAllowed)
 
     private suspend fun openStream(
-        chosenClient: OkHttpClient,
+        timeoutMs: Long,
         baseUrl: String,
         bookId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<StorytellerBundleStream> = withContext(dispatchers.io) {
-        val effectiveClient = if (insecureAllowed) chosenClient.withInsecureTls() else chosenClient
-        val request = Request.Builder()
-            .url("$baseUrl/api/books/$bookId/synced")
-            .addHeader("Authorization", "Bearer $token")
-            .build()
-        try {
-            val response = effectiveClient.newCall(request).execute()
-            val body = response.body ?: return@withContext NetworkResult.Offline(IOException("Empty response body"))
-            if (response.isSuccessful) {
-                // execute() blocks through Storyteller's slow /synced header wait; if the coroutine was
-                // cancelled, close the body ourselves before withContext discards the (otherwise leaked)
-                // Success.
-                try {
-                    ensureActive()
-                } catch (e: Throwable) {
-                    body.close()
-                    throw e
+    ): NetworkResult<StorytellerBundleStream> {
+        val effectiveClient = if (insecureAllowed) client.withInsecureTls() else client
+        return try {
+            val response = effectiveClient.get("$baseUrl/api/books/$bookId/synced") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+                timeout {
+                    connectTimeoutMillis = 30_000L
+                    requestTimeoutMillis = timeoutMs
+                    socketTimeoutMillis = if (timeoutMs == Long.MAX_VALUE) {
+                        Long.MAX_VALUE
+                    } else {
+                        timeoutMs
+                    }
                 }
-                NetworkResult.Success(StorytellerBundleStream(body))
-            } else {
-                body.close()
-                NetworkResult.Offline(IOException("HTTP ${response.code}"))
             }
+            val channel = response.bodyAsChannel()
+            if (!response.status.isSuccess()) {
+                channel.cancel(IOException("HTTP ${response.status.value}"))
+                return NetworkResult.Offline(IOException("HTTP ${response.status.value}"))
+            }
+            // get() suspends through Storyteller's slow /synced header wait; if the coroutine was
+            // cancelled, cancel the channel before the scope discards the (otherwise leaked) Success.
+            currentCoroutineContext().ensureActive()
+            NetworkResult.Success(StorytellerBundleStream(body = channel.toInputStream()))
         } catch (e: IOException) {
             NetworkResult.Offline(e)
         }
@@ -113,22 +104,22 @@ class StorytellerBundleApiImpl(
         bookId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<Long> = withContext(dispatchers.io) {
-        val effectiveClient = if (insecureAllowed) sidecarClient.withInsecureTls() else sidecarClient
-        val request = Request.Builder()
-            .url("$baseUrl/api/books/$bookId/synced")
-            .head()
-            .addHeader("Authorization", "Bearer $token")
-            .build()
-        try {
-            effectiveClient.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) {
-                    return@withContext NetworkResult.Offline(IOException("HTTP ${response.code}"))
+    ): NetworkResult<Long> {
+        val effectiveClient = if (insecureAllowed) client.withInsecureTls() else client
+        return try {
+            val response = effectiveClient.head("$baseUrl/api/books/$bookId/synced") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+                timeout {
+                    requestTimeoutMillis = sidecarCallTimeoutSeconds * 1_000L
+                    socketTimeoutMillis = sidecarCallTimeoutSeconds * 1_000L
                 }
-                val length = response.header("Content-Length")?.toLongOrNull()
-                    ?: return@withContext NetworkResult.Offline(IOException("Missing Content-Length"))
-                NetworkResult.Success(length)
             }
+            if (!response.status.isSuccess()) {
+                return NetworkResult.Offline(IOException("HTTP ${response.status.value}"))
+            }
+            val length = response.contentLength()
+                ?: return NetworkResult.Offline(IOException("Missing Content-Length"))
+            NetworkResult.Success(length)
         } catch (e: IOException) {
             NetworkResult.Offline(e)
         }

--- a/core/network/src/main/kotlin/com/riffle/core/network/StorytellerPositionApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/StorytellerPositionApi.kt
@@ -1,17 +1,22 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DispatcherProvider
-import kotlinx.coroutines.withContext
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.patch
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
 
 /** [locatorJson] is the raw Readium `locator` object; [timestampMillis] its server `lastUpdate`. */
@@ -37,8 +42,7 @@ interface StorytellerPositionApi {
 }
 
 class StorytellerPositionApiImpl(
-    private val client: OkHttpClient,
-    private val dispatchers: DispatcherProvider,
+    private val client: HttpClient,
 ) : StorytellerPositionApi {
 
     private val json = Json { ignoreUnknownKeys = true }
@@ -48,27 +52,20 @@ class StorytellerPositionApiImpl(
         bookId: String,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<StorytellerPosition?> = withContext(dispatchers.io) {
-        val http = if (insecureAllowed) client.withInsecureTls() else client
-        val request = Request.Builder()
-            .url("$baseUrl/api/v2/books/$bookId/positions")
-            .addHeader("Authorization", "Bearer $token")
-            .get()
-            .build()
-        try {
-            http.newCall(request).execute().use { response ->
-                when {
-                    response.code == 404 -> NetworkResult.Success(null)
-                    !response.isSuccessful -> NetworkResult.Offline(IOException("HTTP ${response.code}"))
-                    else -> {
-                        val raw = response.body?.string()
-                            ?: return@use NetworkResult.Offline(IOException("Empty body"))
-                        val root = json.parseToJsonElement(raw).jsonObject
-                        val locator = root["locator"]?.jsonObject
-                            ?: return@use NetworkResult.Success(null)
-                        val ts = root["timestamp"]?.jsonPrimitive?.content?.toLongOrNull() ?: 0L
-                        NetworkResult.Success(StorytellerPosition(locator.toString(), ts))
-                    }
+    ): NetworkResult<StorytellerPosition?> {
+        return try {
+            val response = http(insecureAllowed).get("$baseUrl/api/v2/books/$bookId/positions") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+            }
+            when {
+                response.status == HttpStatusCode.NotFound -> NetworkResult.Success(null)
+                !response.status.isSuccess() -> NetworkResult.Offline(IOException("HTTP ${response.status.value}"))
+                else -> {
+                    val raw = response.bodyAsText()
+                    val root = json.parseToJsonElement(raw).jsonObject
+                    val locator = root["locator"]?.jsonObject ?: return NetworkResult.Success(null)
+                    val ts = root["timestamp"]?.jsonPrimitive?.content?.toLongOrNull() ?: 0L
+                    NetworkResult.Success(StorytellerPosition(locator.toString(), ts))
                 }
             }
         } catch (e: IOException) {
@@ -83,25 +80,24 @@ class StorytellerPositionApiImpl(
         timestampMillis: Long,
         token: String,
         insecureAllowed: Boolean,
-    ): NetworkResult<Unit> = withContext(dispatchers.io) {
-        val http = if (insecureAllowed) client.withInsecureTls() else client
-        val payload = buildJsonObject {
-            put("locator", json.parseToJsonElement(locatorJson))
-            put("timestamp", JsonPrimitive(timestampMillis))
-        }.toString()
-        val request = Request.Builder()
-            .url("$baseUrl/api/v2/books/$bookId/positions")
-            .addHeader("Authorization", "Bearer $token")
-            .patch(payload.toRequestBody("application/json".toMediaType()))
-            .build()
-        try {
-            http.newCall(request).execute().use { response ->
-                if (response.isSuccessful) NetworkResult.Success(Unit)
-                else NetworkResult.Offline(IOException("HTTP ${response.code}"))
+    ): NetworkResult<Unit> {
+        return try {
+            val payload = buildJsonObject {
+                put("locator", json.parseToJsonElement(locatorJson))
+                put("timestamp", JsonPrimitive(timestampMillis))
+            }.toString()
+            val response = http(insecureAllowed).patch("$baseUrl/api/v2/books/$bookId/positions") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+                contentType(ContentType.Application.Json)
+                setBody(payload)
             }
+            if (response.status.isSuccess()) NetworkResult.Success(Unit)
+            else NetworkResult.Offline(IOException("HTTP ${response.status.value}"))
         } catch (e: IOException) {
             NetworkResult.Offline(e)
         }
     }
 
+    private fun http(insecureAllowed: Boolean): HttpClient =
+        if (insecureAllowed) client.withInsecureTls() else client
 }

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientCatalogEndpointsTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientCatalogEndpointsTest.kt
@@ -1,6 +1,5 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DefaultDispatcherProvider
 import com.riffle.core.models.EbookFormat
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
@@ -26,7 +25,7 @@ class AbsApiClientCatalogEndpointsTest {
     @Before fun setUp() {
         server = MockWebServer()
         server.start()
-        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
+        client = AbsApiClient(createDefaultHttpClient(OkHttpClient()))
     }
 
     @After fun tearDown() {
@@ -47,7 +46,7 @@ class AbsApiClientCatalogEndpointsTest {
                   ],
                   "podcast": [], "authors": [], "tags": [], "series": []
                 }
-            """.trimIndent())
+            """.trimIndent()).addHeader("Content-Type", "application/json")
         )
 
         val result = client.searchLibrary(baseUrl(), "lib-a", "tolkien", limit = 10, token = "T", insecureAllowed = false)
@@ -61,7 +60,7 @@ class AbsApiClientCatalogEndpointsTest {
     }
 
     @Test fun `searchLibrary URL encodes the query and includes limit`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"book":[]}"""))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"book":[]}""").addHeader("Content-Type", "application/json"))
 
         client.searchLibrary(baseUrl(), "lib-a", "hobbit & rings", limit = 25, token = "T", insecureAllowed = false)
 
@@ -71,7 +70,7 @@ class AbsApiClientCatalogEndpointsTest {
     }
 
     @Test fun `searchLibrary returns empty list when book group is absent`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(200).setBody("""{}"""))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{}""").addHeader("Content-Type", "application/json"))
 
         val result = client.searchLibrary(baseUrl(), "lib-a", "q", 10, "T", false)
 
@@ -95,7 +94,7 @@ class AbsApiClientCatalogEndpointsTest {
         server.enqueue(
             MockResponse().setResponseCode(200).setBody("""
                 {"id":"it-1","libraryId":"lib-a","media":{"metadata":{"title":"A","authorName":"B"},"ebookFormat":"epub","ebookFile":{"ino":"ino-42"},"numAudioFiles":0}}
-            """.trimIndent())
+            """.trimIndent()).addHeader("Content-Type", "application/json")
         )
 
         val result = client.getItem(baseUrl(), "it-1", "T", false)
@@ -119,7 +118,7 @@ class AbsApiClientCatalogEndpointsTest {
     // region syncPlaybackSession + closePlaybackSession
 
     @Test fun `syncPlaybackSession posts currentTime and timeListened`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}").addHeader("Content-Type", "application/json"))
 
         val result = client.syncPlaybackSession(baseUrl(), "sess-1", 120.5, 60.0, "T", false)
 
@@ -134,7 +133,7 @@ class AbsApiClientCatalogEndpointsTest {
     }
 
     @Test fun `closePlaybackSession hits close endpoint`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(200).setBody("{}"))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("{}").addHeader("Content-Type", "application/json"))
 
         client.closePlaybackSession(baseUrl(), "sess-1", 200.0, 90.0, "T", false)
 
@@ -148,7 +147,7 @@ class AbsApiClientCatalogEndpointsTest {
     // region getListeningStats
 
     @Test fun `getListeningStats parses totalTime`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"totalTime":3600.5,"today":600}"""))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"totalTime":3600.5,"today":600}""").addHeader("Content-Type", "application/json"))
 
         val result = client.getListeningStats(baseUrl(), "T", false)
 
@@ -157,7 +156,7 @@ class AbsApiClientCatalogEndpointsTest {
     }
 
     @Test fun `getListeningStats hits me listening-stats endpoint`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"totalTime":0}"""))
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"totalTime":0}""").addHeader("Content-Type", "application/json"))
 
         client.getListeningStats(baseUrl(), "T", false)
 

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientCollectionsWriteTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientCollectionsWriteTest.kt
@@ -1,7 +1,5 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DefaultDispatcherProvider
-
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -21,7 +19,7 @@ class AbsApiClientCollectionsWriteTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
+        client = AbsApiClient(createDefaultHttpClient(OkHttpClient()))
     }
 
     @After

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientLibraryTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientLibraryTest.kt
@@ -1,7 +1,5 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DefaultDispatcherProvider
-
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -24,7 +22,7 @@ class AbsApiClientLibraryTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
+        client = AbsApiClient(createDefaultHttpClient(OkHttpClient()))
     }
 
     @After

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientPlaylistsTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientPlaylistsTest.kt
@@ -1,7 +1,5 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DefaultDispatcherProvider
-
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -21,7 +19,7 @@ class AbsApiClientPlaylistsTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
+        client = AbsApiClient(createDefaultHttpClient(OkHttpClient()))
     }
 
     @After

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientSeriesCollectionTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientSeriesCollectionTest.kt
@@ -1,7 +1,5 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DefaultDispatcherProvider
-
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -24,7 +22,7 @@ class AbsApiClientSeriesCollectionTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
+        client = AbsApiClient(createDefaultHttpClient(OkHttpClient()))
     }
 
     @After

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientSessionTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientSessionTest.kt
@@ -1,7 +1,5 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DefaultDispatcherProvider
-
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -22,7 +20,7 @@ class AbsApiClientSessionTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
+        client = AbsApiClient(createDefaultHttpClient(OkHttpClient()))
     }
 
     @After

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsApiClientTest.kt
@@ -1,7 +1,5 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DefaultDispatcherProvider
-
 import com.riffle.core.models.InsecureConnectionType
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
@@ -22,7 +20,7 @@ class AbsApiClientTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
+        client = AbsApiClient(createDefaultHttpClient(OkHttpClient()))
     }
 
     @After

--- a/core/network/src/test/kotlin/com/riffle/core/network/AbsBookmarkApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AbsBookmarkApiTest.kt
@@ -1,7 +1,5 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DefaultDispatcherProvider
-
 import kotlinx.coroutines.test.runTest
 import okhttp3.Cache
 import okhttp3.OkHttpClient
@@ -26,7 +24,7 @@ class AbsBookmarkApiTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
+        client = AbsApiClient(createDefaultHttpClient(OkHttpClient()))
     }
 
     @After
@@ -163,7 +161,7 @@ class AbsBookmarkApiTest {
             .cache(Cache(tempFolder.newFolder(), 1L shl 20))
             .addNetworkInterceptor(EndpointCacheHeadersInterceptor(DEFAULT_HTTP_CACHE_RULES))
             .build()
-        val cachedClient = AbsApiClient(cachedHttp, DefaultDispatcherProvider)
+        val cachedClient = AbsApiClient(createDefaultHttpClient(cachedHttp))
 
         server.enqueue(
             MockResponse().setResponseCode(200)

--- a/core/network/src/test/kotlin/com/riffle/core/network/AudiobookBundleApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AudiobookBundleApiTest.kt
@@ -1,6 +1,6 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DefaultDispatcherProvider
+import com.riffle.core.network.createStreamingHttpClient
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -32,7 +32,7 @@ class AudiobookBundleApiTest {
     @Before
     fun setUp() {
         server = MockWebServer().also { it.start() }
-        api = AudiobookBundleApiImpl(OkHttpClient(), DefaultDispatcherProvider)
+        api = AudiobookBundleApiImpl(createStreamingHttpClient(OkHttpClient()))
     }
 
     @After
@@ -57,7 +57,7 @@ class AudiobookBundleApiTest {
         result as NetworkResult.Success
         assertEquals(64L, result.value.totalBytes)
         assertFalse(result.value.isPartial)
-        assertEquals(bytes.toList(), result.value.body.use { it.bytes() }.toList())
+        assertEquals(bytes.toList(), result.value.body.use { it.readBytes() }.toList())
     }
 
     @Test fun resume_sendsRangeHeader_parsesTotalFromContentRange() = runTest {
@@ -88,7 +88,7 @@ class AudiobookBundleApiTest {
                 override fun connectionReleased(call: Call, connection: Connection) { released.incrementAndGet() }
             })
             .build()
-        val leakApi: AudiobookBundleApi = AudiobookBundleApiImpl(countingClient, DefaultDispatcherProvider)
+        val leakApi: AudiobookBundleApi = AudiobookBundleApiImpl(createStreamingHttpClient(countingClient))
 
         server.enqueue(
             MockResponse()

--- a/core/network/src/test/kotlin/com/riffle/core/network/AudiobookFingerprintClientTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/AudiobookFingerprintClientTest.kt
@@ -1,7 +1,6 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DefaultDispatcherProvider
-
+import com.riffle.core.network.createDefaultHttpClient
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
@@ -26,9 +25,9 @@ class AudiobookFingerprintClientTest {
             MockResponse().setResponseCode(200).setBody(
                 """{"audiobook":{"fileSize":313869927,"duration":39214.464,
                    "manifest":{"readingOrder":[{"duration":39214.464}]}}}""",
-            ),
+            ).addHeader("Content-Type", "application/json"),
         )
-        val client = StorytellerApiClient(OkHttpClient(), DefaultDispatcherProvider)
+        val client = StorytellerApiClient(createDefaultHttpClient(OkHttpClient()))
         val result = client.getAudiobookFingerprint(baseUrl(), 42L, "tok", false)
 
         assertTrue(result is NetworkResult.Success)
@@ -38,8 +37,8 @@ class AudiobookFingerprintClientTest {
 
     @Test
     fun `storyteller with no audiobook returns NoAudiobook`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"title":"x"}"""))
-        val result = StorytellerApiClient(OkHttpClient(), DefaultDispatcherProvider).getAudiobookFingerprint(baseUrl(), 1L, "tok", false)
+        server.enqueue(MockResponse().setResponseCode(200).setBody("""{"title":"x"}""").addHeader("Content-Type", "application/json"))
+        val result = StorytellerApiClient(createDefaultHttpClient(OkHttpClient())).getAudiobookFingerprint(baseUrl(), 1L, "tok", false)
         assertTrue(result is NetworkResult.Success && result.value == null)
     }
 
@@ -50,9 +49,9 @@ class AudiobookFingerprintClientTest {
                 """{"id":"abc","media":{"duration":8356.0,"audioFiles":[
                    {"index":1,"duration":2204.0,"metadata":{"size":300}},
                    {"index":2,"duration":1721.0,"metadata":{"size":200}}]}}""",
-            ),
+            ).addHeader("Content-Type", "application/json"),
         )
-        val result = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider).getAudiobookFingerprint(baseUrl(), "abc", "tok", false)
+        val result = AbsApiClient(createDefaultHttpClient(OkHttpClient())).getAudiobookFingerprint(baseUrl(), "abc", "tok", false)
 
         assertTrue(result is NetworkResult.Success)
         assertEquals(listOf(2204.0, 1721.0), (result as NetworkResult.Success).value!!.trackDurationsSec)
@@ -65,9 +64,9 @@ class AudiobookFingerprintClientTest {
             MockResponse().setResponseCode(200).setBody(
                 """{"id":"abc","media":{"audioFiles":[
                    {"ino":"7963985","index":1,"duration":39214.464}]}}""",
-            ),
+            ).addHeader("Content-Type", "application/json"),
         )
-        val result = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider).getAudiobookTracks(baseUrl(), "abc", "tok", false)
+        val result = AbsApiClient(createDefaultHttpClient(OkHttpClient())).getAudiobookTracks(baseUrl(), "abc", "tok", false)
         assertTrue(result is NetworkResult.Success)
         assertEquals("7963985", (result as NetworkResult.Success).value.single().ino)
     }

--- a/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
@@ -1,6 +1,6 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DefaultDispatcherProvider
+import com.riffle.core.network.createDefaultHttpClient
 
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
@@ -24,7 +24,7 @@ class GitHubReleaseApiTest {
     fun setUp() {
         server = MockWebServer().also { it.start() }
         val baseUrl = server.url("/").toString().trimEnd('/')
-        api = GitHubReleaseApi(OkHttpClient(), DefaultDispatcherProvider, apiBaseUrl = baseUrl)
+        api = GitHubReleaseApi(createDefaultHttpClient(OkHttpClient()), apiBaseUrl = baseUrl)
     }
 
     @After
@@ -49,7 +49,7 @@ class GitHubReleaseApiTest {
                   }
                 ]
                 """.trimIndent()
-            )
+                    ).addHeader("Content-Type", "application/json")
         )
 
         val result = api.latestRelease("pkmetski/riffle")
@@ -83,7 +83,7 @@ class GitHubReleaseApiTest {
                   }
                 ]
                 """.trimIndent()
-            )
+                    ).addHeader("Content-Type", "application/json")
         )
 
         val result = api.latestRelease("pkmetski/riffle")
@@ -124,7 +124,7 @@ class GitHubReleaseApiTest {
                   }
                 ]
                 """.trimIndent()
-            )
+                    ).addHeader("Content-Type", "application/json")
         )
 
         val result = api.latestRelease("pkmetski/riffle")
@@ -149,7 +149,7 @@ class GitHubReleaseApiTest {
                   }
                 ]
                 """.trimIndent()
-            )
+                    ).addHeader("Content-Type", "application/json")
         )
 
         assertTrue(api.latestRelease("pkmetski/riffle") is GitHubReleaseResult.Failed)
@@ -196,7 +196,7 @@ class GitHubReleaseApiTest {
     // cached copy. If someone drops the .cacheControl(FORCE_NETWORK) line, this test flips red.
     @Test
     fun `latestRelease request opts out of the cache with no-cache no-store`() = runTest {
-        server.enqueue(MockResponse().setBody("[]"))
+        server.enqueue(MockResponse().setBody("[]").addHeader("Content-Type", "application/json"))
 
         api.latestRelease("pkmetski/riffle")
 

--- a/core/network/src/test/kotlin/com/riffle/core/network/PdfRoutingIntegrationTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/PdfRoutingIntegrationTest.kt
@@ -1,7 +1,5 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DefaultDispatcherProvider
-
 import com.riffle.core.models.EbookFormat
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
@@ -29,7 +27,7 @@ class PdfRoutingIntegrationTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = AbsApiClient(OkHttpClient(), DefaultDispatcherProvider)
+        client = AbsApiClient(createDefaultHttpClient(OkHttpClient()))
     }
 
     @After

--- a/core/network/src/test/kotlin/com/riffle/core/network/StorytellerApiClientTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/StorytellerApiClientTest.kt
@@ -1,6 +1,6 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DefaultDispatcherProvider
+import com.riffle.core.network.createDefaultHttpClient
 
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
@@ -21,7 +21,7 @@ class StorytellerApiClientTest {
     fun setUp() {
         server = MockWebServer()
         server.start()
-        client = StorytellerApiClient(OkHttpClient(), DefaultDispatcherProvider)
+        client = StorytellerApiClient(createDefaultHttpClient(OkHttpClient()))
     }
 
     @After
@@ -48,7 +48,7 @@ class StorytellerApiClientTest {
         assertEquals("POST", request.method)
         assertEquals("/api/token", request.path)
         val body = request.body.readUtf8()
-        assertTrue("body should carry multipart username field, was: $body", body.contains("name=\"username\""))
+        assertTrue("body should carry multipart username field, was: $body", body.contains("name=username") || body.contains("name=\"username\""))
         assertTrue("body should carry the username value, was: $body", body.contains("plamen"))
         assertTrue("body should carry the password value, was: $body", body.contains("secret"))
         assertTrue("body should be multipart, was: $body", body.contains("multipart") || request.getHeader("Content-Type")!!.startsWith("multipart/form-data"))

--- a/core/network/src/test/kotlin/com/riffle/core/network/StorytellerBundleApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/StorytellerBundleApiTest.kt
@@ -1,6 +1,6 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DefaultDispatcherProvider
+import com.riffle.core.network.createDefaultHttpClient
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -32,7 +32,7 @@ class StorytellerBundleApiTest {
     @Before
     fun setUp() {
         server = MockWebServer().also { it.start() }
-        impl = StorytellerBundleApiImpl(OkHttpClient(), DefaultDispatcherProvider)
+        impl = StorytellerBundleApiImpl(createDefaultHttpClient(OkHttpClient()))
         api = impl
         probe = impl
     }
@@ -57,7 +57,7 @@ class StorytellerBundleApiTest {
         assertEquals("/api/books/42/synced", recorded.path)
         assertEquals("Bearer tkn", recorded.getHeader("Authorization"))
         assertTrue(result is NetworkResult.Success)
-        val readBytes = (result as NetworkResult.Success).value.body.use { it.bytes() }
+        val readBytes = (result as NetworkResult.Success).value.body.use { it.readBytes() }
         assertEquals(bytes.toList(), readBytes.toList())
     }
 
@@ -77,7 +77,7 @@ class StorytellerBundleApiTest {
     @Test fun downloadBundle_cancelledDuringSlowHeaderWait_doesNotLeakConnection() = runBlocking {
         // Storyteller takes 1.5–5s to answer /synced; if the reader navigates away in that window
         // the coroutine is cancelled and withContext discards the returned Success(body) — the open
-        // ResponseBody (and its connection) leaks unless the API closes it on cancellation.
+        // InputStream (and its connection) leaks unless the API closes it on cancellation.
         val acquired = AtomicInteger()
         val released = AtomicInteger()
         val countingClient = OkHttpClient.Builder()
@@ -86,7 +86,7 @@ class StorytellerBundleApiTest {
                 override fun connectionReleased(call: Call, connection: Connection) { released.incrementAndGet() }
             })
             .build()
-        val leakApi: StorytellerBundleApi = StorytellerBundleApiImpl(countingClient, DefaultDispatcherProvider)
+        val leakApi: StorytellerBundleApi = StorytellerBundleApiImpl(createDefaultHttpClient(countingClient))
 
         // Headers arrive only after 500ms, so execute() is still blocked when we cancel at ~100ms.
         server.enqueue(
@@ -155,7 +155,7 @@ class StorytellerBundleApiTest {
         // cold book that can be minutes. The size probe must NOT inherit the download's unbounded timeout
         // (else the streaming-play path that awaits the sidecar wedges forever, ADR 0028). A bounded
         // sidecar client makes a slow /synced fail fast so the caller falls back.
-        val bounded = StorytellerBundleApiImpl(OkHttpClient(), DefaultDispatcherProvider, sidecarCallTimeoutSeconds = 1)
+        val bounded = StorytellerBundleApiImpl(createDefaultHttpClient(OkHttpClient()), sidecarCallTimeoutSeconds = 1)
         server.enqueue(
             MockResponse()
                 .setHeader("Content-Length", "315074677")
@@ -179,7 +179,7 @@ class StorytellerBundleApiTest {
         // A coroutine timeout can't cancel the blocking execute(), so the streaming sidecar fetch relies
         // on a real callTimeout to fail a wedged /synced — otherwise the "Preparing…" indicator sticks
         // forever (ADR 0028). With a 1s bound, a 10s-delayed response must come back as NetworkError fast.
-        val bounded = StorytellerBundleApiImpl(OkHttpClient(), DefaultDispatcherProvider, sidecarStreamTimeoutSeconds = 1)
+        val bounded = StorytellerBundleApiImpl(createDefaultHttpClient(OkHttpClient()), sidecarStreamTimeoutSeconds = 1)
         server.enqueue(
             MockResponse().setBody(Buffer().write(ByteArray(64))).setHeadersDelay(10, TimeUnit.SECONDS),
         )

--- a/core/network/src/test/kotlin/com/riffle/core/network/StorytellerPositionApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/StorytellerPositionApiTest.kt
@@ -1,6 +1,6 @@
 package com.riffle.core.network
 
-import com.riffle.core.domain.DefaultDispatcherProvider
+import com.riffle.core.network.createDefaultHttpClient
 
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
@@ -19,7 +19,7 @@ class StorytellerPositionApiTest {
 
     @Before fun setUp() {
         server = MockWebServer().also { it.start() }
-        api = StorytellerPositionApiImpl(OkHttpClient(), DefaultDispatcherProvider)
+        api = StorytellerPositionApiImpl(createDefaultHttpClient(OkHttpClient()))
     }
 
     @After fun tearDown() = server.shutdown()

--- a/docs/superpowers/plans/2026-07-25-ktor-networking-migration.md
+++ b/docs/superpowers/plans/2026-07-25-ktor-networking-migration.md
@@ -1,0 +1,1162 @@
+# Ktor Networking Migration (Phase 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace direct OkHttp usage with Ktor `HttpClient` (OkHttp engine) so source adapters can become pure Kotlin in Phase 3.
+
+**Architecture:** Add Ktor to `core:network` with OkHttp as the engine (behavior-identical). Adapters receive `io.ktor.client.HttpClient` instead of `okhttp3.OkHttpClient`. A new `KtorClassifier` replaces `OkHttpClassifier`. Streaming interfaces expose `InputStream` instead of `okhttp3.ResponseBody`. Tests keep using `MockWebServer`; the Ktor `HttpClient` points at it via the OkHttp engine.
+
+**Tech Stack:** Ktor 3.1.3, OkHttp 5.4.0 (as Ktor engine), kotlinx.serialization (already present), MockWebServer (tests, unchanged).
+
+## Global Constraints
+
+- Ktor version: `3.1.3`
+- OkHttp stays as engine-only; no `okhttp3.*` imports outside `core:network`'s engine configuration after migration.
+- All `NetworkResult` variants and public API signatures stay identical.
+- `DispatcherProvider` injected in constructors stays (removed from `classify` call itself — Ktor handles its own dispatch).
+- No behavior change in cache behavior, insecure TLS, timeout configuration, retry logic, or User-Agent stamping.
+- Tests keep using `MockWebServer` — create Ktor `HttpClient` with OkHttp engine pointing at `server.url("/")`.
+- `AudiobookBundleStream.body` and `StorytellerBundleStream.body` change type from `okhttp3.ResponseBody` to `java.io.InputStream`.
+
+---
+
+### Task 1: Add Ktor to version catalog and build files
+
+**Files:**
+- Modify: `gradle/libs.versions.toml`
+- Modify: `core/network/build.gradle.kts`
+- Modify: `core/catalog-komga/build.gradle.kts`
+- Modify: `core/catalog-chitanka/build.gradle.kts`
+- Modify: `core/catalog-gutenberg/build.gradle.kts`
+- Modify: `core/data/build.gradle.kts`
+
+**Interfaces:**
+- Produces: `libs.ktor.client.core`, `libs.ktor.client.okhttp`, `libs.ktor.client.content.negotiation`, `libs.ktor.serialization.kotlinx.json`, `libs.ktor.client.mock` available in all relevant modules.
+
+- [ ] **Step 1: Add Ktor version and libraries to libs.versions.toml**
+
+In `gradle/libs.versions.toml`, add after `okhttp = "5.4.0"`:
+```toml
+ktor = "3.1.3"
+```
+
+In `[libraries]` section, add:
+```toml
+ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
+ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
+```
+
+- [ ] **Step 2: Update core/network/build.gradle.kts**
+
+Replace current dependencies block:
+```kotlin
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+    implementation(project(":core:domain"))
+    api(libs.ktor.client.core)
+    implementation(libs.ktor.client.okhttp)
+    implementation(libs.ktor.client.content.negotiation)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.okhttp)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.coroutines.core)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.okhttp.mockwebserver)
+    testImplementation(libs.okhttp.tls)
+}
+```
+
+- [ ] **Step 3: Update catalog and data build files**
+
+In `core/catalog-komga/build.gradle.kts`, replace `implementation(libs.okhttp)` with:
+```kotlin
+implementation(libs.ktor.client.core)
+```
+
+In `core/catalog-chitanka/build.gradle.kts`, replace `implementation(libs.okhttp)` with:
+```kotlin
+implementation(libs.ktor.client.core)
+```
+
+In `core/catalog-gutenberg/build.gradle.kts`, replace `implementation(libs.okhttp)` with:
+```kotlin
+implementation(libs.ktor.client.core)
+```
+
+In `core/data/build.gradle.kts`, find the line with `// okhttp` or wherever OkHttp is and add:
+```kotlin
+implementation(libs.ktor.client.core)
+implementation(libs.ktor.client.okhttp)
+```
+(Keep okhttp-mockwebserver in testImplementation for tests.)
+
+- [ ] **Step 4: Verify build resolves**
+
+```bash
+export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr
+./gradlew :core:network:dependencies --configuration compileClasspath 2>&1 | grep -E "ktor|okhttp" | head -20
+```
+Expected: Ktor libraries resolved.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add gradle/libs.versions.toml core/network/build.gradle.kts core/catalog-komga/build.gradle.kts core/catalog-chitanka/build.gradle.kts core/catalog-gutenberg/build.gradle.kts core/data/build.gradle.kts
+git commit -m "build: add Ktor 3.1.3 to version catalog and module build files"
+```
+
+---
+
+### Task 2: Create Ktor infrastructure in core:network
+
+**Files:**
+- Create: `core/network/src/main/kotlin/com/riffle/core/network/KtorClientFactory.kt`
+- Modify: `core/network/src/main/kotlin/com/riffle/core/network/NetworkResult.kt` (remove OkHttp extensions, add Ktor helpers)
+- Modify: `core/network/src/main/kotlin/com/riffle/core/network/InsecureTls.kt` (add Ktor version)
+
+**Interfaces:**
+- Produces:
+  - `KtorClassifier.classify(block)` — suspend, returns `NetworkResult<T>`
+  - `createDefaultHttpClient(okHttpClient: OkHttpClient): HttpClient`
+  - `HttpClient.withInsecureTls(): HttpClient` — returns a new client with trust-all TLS
+
+- [ ] **Step 1: Create KtorClientFactory.kt**
+
+Create `core/network/src/main/kotlin/com/riffle/core/network/KtorClientFactory.kt`:
+```kotlin
+package com.riffle.core.network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+
+val RIFFLE_JSON = Json { ignoreUnknownKeys = true; coerceInputValues = true }
+
+/**
+ * Creates the default Ktor HttpClient backed by the OkHttp engine, pre-configured with
+ * kotlinx.serialization content negotiation using Riffle's Json instance.
+ */
+fun createDefaultHttpClient(okHttpClient: OkHttpClient): HttpClient = HttpClient(OkHttp) {
+    engine {
+        preconfigured = okHttpClient
+    }
+    install(ContentNegotiation) {
+        json(RIFFLE_JSON)
+    }
+}
+```
+
+- [ ] **Step 2: Update NetworkResult.kt — replace OkHttp helpers with Ktor equivalents**
+
+Remove the OkHttp-specific extension functions (`requireSuccessful()`, `requireBody()` on `okhttp3.Response`) and the `OkHttpClassifier` object. Add Ktor classifier and helper.
+
+The file should end up looking like:
+```kotlin
+package com.riffle.core.network
+
+import com.riffle.core.models.InsecureConnectionType
+import io.ktor.client.plugins.ResponseException
+import io.ktor.http.HttpStatusCode
+import kotlinx.serialization.SerializationException
+import java.io.IOException
+import javax.net.ssl.SSLHandshakeException
+
+sealed class NetworkResult<out T> {
+    data class Success<T>(val value: T) : NetworkResult<T>()
+    data class Offline(val cause: Throwable) : NetworkResult<Nothing>()
+    data object Auth : NetworkResult<Nothing>()
+    data class ServerError(val code: Int, val errorMessage: String? = null) : NetworkResult<Nothing>()
+    data class Parse(val cause: Throwable) : NetworkResult<Nothing>()
+    data class InsecureConnection(val type: InsecureConnectionType) : NetworkResult<Nothing>()
+    data class Unknown(val cause: Throwable) : NetworkResult<Nothing>()
+}
+
+internal class HttpException(val code: Int, msg: String? = null) : IOException(msg)
+
+object KtorClassifier {
+    suspend fun <T> classify(block: suspend () -> T): NetworkResult<T> = try {
+        NetworkResult.Success(block())
+    } catch (e: HttpException) {
+        if (e.code == 401) NetworkResult.Auth
+        else NetworkResult.ServerError(e.code, e.message)
+    } catch (e: ResponseException) {
+        val code = e.response.status.value
+        if (code == 401) NetworkResult.Auth
+        else NetworkResult.ServerError(code, e.message)
+    } catch (e: SSLHandshakeException) {
+        NetworkResult.InsecureConnection(InsecureConnectionType.SELF_SIGNED)
+    } catch (e: SerializationException) {
+        NetworkResult.Parse(e)
+    } catch (e: IOException) {
+        NetworkResult.Offline(e)
+    } catch (e: Throwable) {
+        NetworkResult.Unknown(e)
+    }
+}
+
+// Keep OkHttpClassifier as a deprecated alias so we can migrate callers one at a time.
+@Deprecated("Use KtorClassifier", replaceWith = ReplaceWith("KtorClassifier"))
+object OkHttpClassifier {
+    @Deprecated("Use KtorClassifier.classify")
+    suspend fun <T> classify(io: kotlinx.coroutines.CoroutineDispatcher, block: suspend () -> T): NetworkResult<T> =
+        kotlinx.coroutines.withContext(io) { KtorClassifier.classify { block() } }
+}
+
+inline fun <T, R> NetworkResult<T>.mapResult(f: (T) -> R): NetworkResult<R> = when (this) {
+    is NetworkResult.Success -> NetworkResult.Success(f(value))
+    is NetworkResult.Offline -> this
+    is NetworkResult.Auth -> this
+    is NetworkResult.ServerError -> this
+    is NetworkResult.Parse -> this
+    is NetworkResult.InsecureConnection -> this
+    is NetworkResult.Unknown -> this
+}
+
+inline fun <T> NetworkResult<T>.onError(report: (NetworkResult<Nothing>) -> Unit): NetworkResult<T> {
+    if (this !is NetworkResult.Success) {
+        @Suppress("UNCHECKED_CAST")
+        report(this as NetworkResult<Nothing>)
+    }
+    return this
+}
+
+val NetworkResult<*>.isError: Boolean get() = this !is NetworkResult.Success
+
+fun <T> NetworkResult<T>.getOrNull(): T? = (this as? NetworkResult.Success)?.value
+
+fun NetworkResult<*>.errorAsThrowable(): Throwable = when (this) {
+    is NetworkResult.Success -> error("Success has no error")
+    is NetworkResult.Offline -> cause
+    is NetworkResult.Parse -> cause
+    is NetworkResult.Unknown -> cause
+    is NetworkResult.ServerError -> IOException("HTTP $code${errorMessage?.let { ": $it" } ?: ""}")
+    NetworkResult.Auth -> IOException("HTTP 401")
+    is NetworkResult.InsecureConnection -> SSLHandshakeException("Insecure connection ($type)")
+}
+```
+
+- [ ] **Step 3: Update InsecureTls.kt — add Ktor version**
+
+Add alongside the existing `OkHttpClient.withInsecureTls()`:
+```kotlin
+package com.riffle.core.network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import okhttp3.OkHttpClient
+import java.security.SecureRandom
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.X509TrustManager
+
+internal val TRUST_ALL_MANAGER = object : X509TrustManager {
+    override fun checkClientTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
+    override fun checkServerTrusted(chain: Array<out X509Certificate>, authType: String) = Unit
+    override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+}
+
+internal fun OkHttpClient.withInsecureTls(): OkHttpClient {
+    val sslContext = SSLContext.getInstance("TLS").apply {
+        init(null, arrayOf(TRUST_ALL_MANAGER), SecureRandom())
+    }
+    return newBuilder()
+        .sslSocketFactory(sslContext.socketFactory, TRUST_ALL_MANAGER)
+        .hostnameVerifier { _, _ -> true }
+        .build()
+}
+
+internal fun HttpClient.withInsecureTls(): HttpClient {
+    val sslContext = SSLContext.getInstance("TLS").apply {
+        init(null, arrayOf(TRUST_ALL_MANAGER), SecureRandom())
+    }
+    return config {
+        engine {
+            this as io.ktor.client.engine.okhttp.OkHttpConfig
+            config {
+                sslSocketFactory(sslContext.socketFactory, TRUST_ALL_MANAGER)
+                hostnameVerifier { _, _ -> true }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Verify compile**
+
+```bash
+export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr
+./gradlew :core:network:compileKotlin 2>&1 | tail -20
+```
+Expected: BUILD SUCCESSFUL (or only errors in not-yet-migrated callers).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/network/src/main/kotlin/com/riffle/core/network/KtorClientFactory.kt \
+        core/network/src/main/kotlin/com/riffle/core/network/NetworkResult.kt \
+        core/network/src/main/kotlin/com/riffle/core/network/InsecureTls.kt
+git commit -m "feat(network): add Ktor infrastructure — KtorClassifier, HttpClient factory, insecure-TLS helper"
+```
+
+---
+
+### Task 3: Migrate AbsApiClient to Ktor
+
+**Files:**
+- Modify: `core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt`
+
+**Interfaces:**
+- Consumes: `HttpClient` (Ktor), `KtorClassifier.classify`, `RIFFLE_JSON`
+- Produces: Same `AbsApi`, `AbsLibraryApi`, etc. interface implementations, just using Ktor internally.
+
+**Key migration pattern:**
+
+OkHttp pattern:
+```kotlin
+OkHttpClassifier.classify(dispatchers.io) {
+    val request = Request.Builder().url("$baseUrl/api/login").post(body).build()
+    httpClient.newCall(request).execute().use { r ->
+        r.requireSuccessful()
+        json.decodeFromString<AbsLoginResponse>(r.requireBody()).toNetwork()
+    }
+}
+```
+
+Ktor pattern:
+```kotlin
+KtorClassifier.classify {
+    httpClient.post("$baseUrl/api/login") {
+        contentType(ContentType.Application.Json)
+        setBody(AbsLoginRequest(username, password))
+    }.body<AbsLoginResponse>().toNetwork()
+}
+```
+
+- [ ] **Step 1: Rewrite AbsApiClient constructor and imports**
+
+Change:
+```kotlin
+class AbsApiClient(
+    private val httpClient: OkHttpClient,
+    private val dispatchers: DispatcherProvider,
+) : AbsApi, ...
+```
+To:
+```kotlin
+class AbsApiClient(
+    private val httpClient: io.ktor.client.HttpClient,
+) : AbsApi, ...
+```
+(Remove `dispatchers` — Ktor handles dispatch internally. Remove `json` and `jsonMediaType` locals — Ktor ContentNegotiation handles these.)
+
+- [ ] **Step 2: Migrate each method group**
+
+For each method in `AbsApiClient`, apply the Ktor migration pattern. Methods fall into these shapes:
+
+**GET → body<T>():**
+```kotlin
+override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkLibrary>> =
+    KtorClassifier.classify {
+        client(insecureAllowed).get("$baseUrl/api/libraries") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }.body<AbsLibrariesResponse>().libraries.map { it.toNetwork() }
+    }
+```
+
+**POST with JSON body:**
+```kotlin
+override suspend fun login(baseUrl: String, username: String, password: String, insecureAllowed: Boolean): NetworkResult<NetworkLoginUser> =
+    KtorClassifier.classify {
+        client(insecureAllowed).post("$baseUrl/api/login") {
+            contentType(ContentType.Application.Json)
+            setBody(AbsLoginRequest(username, password))
+        }.body<AbsLoginResponse>().toNetwork()
+    }
+```
+
+**PATCH/DELETE (no body back):**
+```kotlin
+override suspend fun deleteItem(baseUrl: String, token: String, itemId: String, insecureAllowed: Boolean): NetworkResult<Unit> =
+    KtorClassifier.classify {
+        client(insecureAllowed).delete("$baseUrl/api/items/$itemId") {
+            header(HttpHeaders.Authorization, "Bearer $token")
+        }
+        Unit
+    }
+```
+
+**Caching override (FORCE_NETWORK equivalent):**
+For endpoints where the old code set `CacheControl.FORCE_NETWORK`, add Ktor's cache control header:
+```kotlin
+header(HttpHeaders.CacheControl, "no-cache")
+```
+
+**Insecure TLS helper:**
+```kotlin
+private fun client(insecureAllowed: Boolean): HttpClient =
+    if (insecureAllowed) httpClient.withInsecureTls() else httpClient
+```
+
+Apply this pattern to every method in `AbsApiClient.kt`.
+
+- [ ] **Step 3: Compile check**
+
+```bash
+export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr
+./gradlew :core:network:compileKotlin 2>&1 | grep -E "error:|warning:" | head -30
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/network/src/main/kotlin/com/riffle/core/network/AbsApiClient.kt
+git commit -m "feat(network): migrate AbsApiClient from OkHttp to Ktor"
+```
+
+---
+
+### Task 4: Migrate StorytellerApiClient, StorytellerPositionApiImpl, GitHubReleaseApi to Ktor
+
+**Files:**
+- Modify: `core/network/src/main/kotlin/com/riffle/core/network/StorytellerApiClient.kt`
+- Modify: `core/network/src/main/kotlin/com/riffle/core/network/StorytellerPositionApi.kt`
+- Modify: `core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt`
+
+**Interfaces:**
+- Consumes: `HttpClient` (Ktor), `KtorClassifier`
+- Produces: Same interfaces implemented via Ktor
+
+**StorytellerApiClient migration:**
+
+Constructor change:
+```kotlin
+class StorytellerApiClient(
+    private val httpClient: io.ktor.client.HttpClient,
+) : StorytellerApi, StorytellerLibraryApi
+```
+
+Login (multipart form):
+```kotlin
+override suspend fun login(baseUrl: String, username: String, password: String, insecureAllowed: Boolean): NetworkResult<String> =
+    KtorClassifier.classify {
+        val response = client(insecureAllowed).submitForm(
+            url = "$baseUrl/api/token",
+            formParameters = parameters {
+                append("username", username)
+                append("password", password)
+            }
+        )
+        when (response.status.value) {
+            200 -> response.body<StorytellerLoginResponse>().accessToken
+            400, 401, 405 -> throw HttpException(401, "Invalid username or password")
+            else -> throw HttpException(response.status.value, response.status.description)
+        }
+    }
+```
+
+**GitHubReleaseApi migration:**
+
+Constructor: `class GitHubReleaseApi(private val httpClient: HttpClient, ...)`
+
+`latestRelease`:
+```kotlin
+suspend fun latestRelease(repo: String): GitHubReleaseResult = try {
+    val response = httpClient.get("$apiBaseUrl/repos/$repo/releases") {
+        parameter("per_page", 10)
+        header(HttpHeaders.Accept, "application/vnd.github+json")
+        header(HttpHeaders.CacheControl, "no-cache")
+    }
+    if (!response.status.isSuccess()) return GitHubReleaseResult.Failed("HTTP ${response.status.value}")
+    val releases = response.body<List<ReleaseResponse>>()
+    for (release in releases) {
+        if (release.draft || release.prerelease) continue
+        val apk = release.assets.firstOrNull { it.name.endsWith(".apk", ignoreCase = true) } ?: continue
+        return GitHubReleaseResult.Success(GitHubRelease(release.tagName, apk.downloadUrl, apk.size))
+    }
+    GitHubReleaseResult.Failed("No release with an APK asset")
+} catch (e: IOException) {
+    GitHubReleaseResult.Failed(e.message ?: "Network error")
+}
+```
+
+`download` (streaming to File):
+```kotlin
+suspend fun download(url: String, dest: File, onProgress: (percent: Int) -> Unit): Boolean = try {
+    httpClient.prepareGet(url).execute { response ->
+        val body = response.bodyAsChannel()
+        val total = response.contentLength() ?: -1L
+        dest.outputStream().use { out ->
+            val buffer = ByteArray(64 * 1024)
+            var copied = 0L
+            var lastPercent = -1
+            while (!body.isClosedForRead) {
+                val read = body.readAvailable(buffer)
+                if (read <= 0) break
+                out.write(buffer, 0, read)
+                copied += read
+                if (total > 0) {
+                    val percent = ((copied * 100) / total).toInt().coerceIn(0, 100)
+                    if (percent != lastPercent) { lastPercent = percent; onProgress(percent) }
+                }
+            }
+        }
+        true
+    }
+} catch (e: IOException) {
+    dest.delete()
+    false
+}
+```
+
+- [ ] **Step 1: Apply migrations to all three files**
+
+- [ ] **Step 2: Compile check**
+
+```bash
+export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr
+./gradlew :core:network:compileKotlin 2>&1 | grep "error:" | head -20
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/network/src/main/kotlin/com/riffle/core/network/StorytellerApiClient.kt \
+        core/network/src/main/kotlin/com/riffle/core/network/StorytellerPositionApi.kt \
+        core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
+git commit -m "feat(network): migrate Storyteller and GitHub API clients to Ktor"
+```
+
+---
+
+### Task 5: Migrate streaming APIs (AudiobookBundleApi, StorytellerBundleApi)
+
+**Files:**
+- Modify: `core/network/src/main/kotlin/com/riffle/core/network/AudiobookBundleApi.kt`
+- Modify: `core/network/src/main/kotlin/com/riffle/core/network/StorytellerBundleApi.kt`
+
+**Key change:** `body: ResponseBody` → `body: InputStream`. Consumers of these streams must be updated too (search for usages of `AudiobookBundleStream.body` and `StorytellerBundleStream.body`).
+
+**AudiobookBundleApi migration:**
+
+```kotlin
+data class AudiobookBundleStream(val body: InputStream, val totalBytes: Long, val isPartial: Boolean)
+
+class AudiobookBundleApiImpl(
+    private val client: io.ktor.client.HttpClient,
+) : AudiobookBundleApi {
+
+    override suspend fun openBundleStream(
+        baseUrl: String, bookId: String, token: String, insecureAllowed: Boolean, fromByte: Long,
+    ): NetworkResult<AudiobookBundleStream> {
+        val effectiveClient = if (insecureAllowed) client.withInsecureTls() else client
+        return try {
+            effectiveClient.prepareGet("$baseUrl/api/books/$bookId/synced") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+                header(HttpHeaders.Accept, "application/audiobook+zip")
+                if (fromByte > 0L) header(HttpHeaders.Range, "bytes=$fromByte-")
+                // Disable timeout for streaming
+                timeout { requestTimeoutMillis = HttpTimeout.INFINITE_TIMEOUT_MS }
+            }.execute { response ->
+                if (!response.status.isSuccess()) {
+                    return@execute NetworkResult.Offline(IOException("HTTP ${response.status.value}"))
+                }
+                val isPartial = response.status == HttpStatusCode.PartialContent
+                val total = if (isPartial) {
+                    response.headers[HttpHeaders.ContentRange]?.substringAfter('/')?.toLongOrNull()
+                } else {
+                    response.contentLength()
+                } ?: -1L
+                currentCoroutineContext().ensureActive()
+                NetworkResult.Success(AudiobookBundleStream(
+                    body = response.bodyAsChannel().toInputStream(),
+                    totalBytes = total,
+                    isPartial = isPartial,
+                ))
+            }
+        } catch (e: IOException) {
+            NetworkResult.Offline(e)
+        }
+    }
+}
+```
+
+**StorytellerBundleApiImpl migration:**
+
+For the multiple timeout variants, use Ktor's `HttpRequestTimeoutException` and per-request `timeout { }` config. The `sidecarClient` → sidecar requests with bounded `requestTimeoutMillis`. The `bundleClient` → unbounded timeout. The `sidecarStreamClient` → bounded `requestTimeoutMillis` for whole streaming.
+
+```kotlin
+data class StorytellerBundleStream(val body: InputStream)
+
+class StorytellerBundleApiImpl(
+    private val client: io.ktor.client.HttpClient,
+    private val sidecarCallTimeoutSeconds: Long = SIDECAR_CALL_TIMEOUT_SECONDS,
+    private val sidecarStreamTimeoutSeconds: Long = SIDECAR_STREAM_TIMEOUT_SECONDS,
+) : StorytellerBundleApi, StorytellerBundleProbeApi {
+
+    override suspend fun downloadBundle(...): NetworkResult<StorytellerBundleStream> =
+        openStream(timeoutMillis = HttpTimeout.INFINITE_TIMEOUT_MS, baseUrl, bookId, token, insecureAllowed)
+
+    suspend fun streamSidecar(...): NetworkResult<StorytellerBundleStream> =
+        openStream(timeoutMillis = sidecarStreamTimeoutSeconds * 1000, baseUrl, bookId, token, insecureAllowed)
+
+    private suspend fun openStream(timeoutMillis: Long, ...): NetworkResult<StorytellerBundleStream> {
+        val effectiveClient = if (insecureAllowed) client.withInsecureTls() else client
+        return try {
+            effectiveClient.prepareGet("$baseUrl/api/books/$bookId/synced") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+                timeout { requestTimeoutMillis = timeoutMillis }
+            }.execute { response ->
+                if (!response.status.isSuccess()) {
+                    return@execute NetworkResult.Offline(IOException("HTTP ${response.status.value}"))
+                }
+                currentCoroutineContext().ensureActive()
+                NetworkResult.Success(StorytellerBundleStream(
+                    body = response.bodyAsChannel().toInputStream()
+                ))
+            }
+        } catch (e: IOException) { NetworkResult.Offline(e) }
+    }
+
+    override suspend fun probeBundleSize(...): NetworkResult<Long> {
+        val effectiveClient = if (insecureAllowed) client.withInsecureTls() else client
+        return try {
+            val response = effectiveClient.head("$baseUrl/api/books/$bookId/synced") {
+                header(HttpHeaders.Authorization, "Bearer $token")
+                timeout { requestTimeoutMillis = sidecarCallTimeoutSeconds * 1000 }
+            }
+            if (!response.status.isSuccess()) return NetworkResult.Offline(IOException("HTTP ${response.status.value}"))
+            val length = response.contentLength() ?: return NetworkResult.Offline(IOException("Missing Content-Length"))
+            NetworkResult.Success(length)
+        } catch (e: IOException) { NetworkResult.Offline(e) }
+    }
+
+    companion object {
+        const val SIDECAR_CALL_TIMEOUT_SECONDS = 15L
+        const val SIDECAR_STREAM_TIMEOUT_SECONDS = 240L
+    }
+}
+```
+
+- [ ] **Step 1: Update AudiobookBundleApi.kt and StorytellerBundleApi.kt**
+
+- [ ] **Step 2: Find and update consumers of `.body` on AudiobookBundleStream / StorytellerBundleStream**
+
+```bash
+grep -rn "\.body\." /Users/plamen.kmetski/conductor/workspaces/riffle/singapore-v2/core/data/src \
+    --include="*.kt" | grep -E "BundleStream|bundleStream"
+grep -rn "AudiobookBundleStream\|StorytellerBundleStream" /Users/plamen.kmetski/conductor/workspaces/riffle/singapore-v2/app/src \
+    --include="*.kt"
+```
+Update each consumer: `.body.byteStream()` → `.body` (already InputStream), `.body.source()` → `body.source()` via Okio adapter (or use `InputStreamAdapter`).
+
+- [ ] **Step 3: Compile check**
+
+```bash
+export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr
+./gradlew :core:network:compileKotlin :core:data:compileKotlin :app:compileDebugKotlin 2>&1 | grep "error:" | head -30
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/network/src/main/kotlin/com/riffle/core/network/AudiobookBundleApi.kt \
+        core/network/src/main/kotlin/com/riffle/core/network/StorytellerBundleApi.kt
+git commit -m "feat(network): migrate streaming bundle APIs to Ktor; ResponseBody → InputStream"
+```
+
+---
+
+### Task 6: Update NetworkModule.kt (DI) to provide Ktor HttpClient
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/riffle/core/data/di/modules/NetworkModule.kt`
+
+**Key change:** `provideOkHttpClient()` now creates OkHttp with cache+interceptors and wraps it via `createDefaultHttpClient()`. `provideWebSourceOkHttpClient()` similarly. All `@Provides` that took `OkHttpClient` now take `HttpClient`. Binds stay the same.
+
+```kotlin
+@Provides
+@Singleton
+fun provideHttpClient(@ApplicationContext context: Context): HttpClient {
+    val cacheDir = File(context.cacheDir, "default-http")
+    val cache = Cache(cacheDir, DEFAULT_HTTP_CACHE_BYTES)
+    val okHttpClient = OkHttpClient.Builder()
+        .cache(cache)
+        .addNetworkInterceptor(EndpointCacheHeadersInterceptor(DEFAULT_HTTP_CACHE_RULES))
+        .build()
+    return createDefaultHttpClient(okHttpClient)
+}
+
+@Provides
+@Singleton
+@WebSourceOkHttpClient  // rename qualifier to @WebSourceHttpClient
+fun provideWebSourceHttpClient(@ApplicationContext context: Context): HttpClient {
+    val cacheDir = File(context.cacheDir, "web-source-http")
+    val cache = Cache(cacheDir, WEB_SOURCE_CACHE_BYTES)
+    val okHttpClient = OkHttpClient.Builder()
+        .cache(cache)
+        .addNetworkInterceptor(ForceCacheHeadersInterceptor(WEB_SOURCE_MAX_AGE_SECONDS))
+        .addInterceptor(OfflineStaleFallbackInterceptor())
+        .build()
+    return createDefaultHttpClient(okHttpClient)
+}
+
+@Provides
+@Singleton
+fun provideGitHubReleaseApi(httpClient: HttpClient): GitHubReleaseApi =
+    GitHubReleaseApi(httpClient)
+
+@Provides
+@Singleton
+fun provideAbsApiClient(httpClient: HttpClient): AbsApiClient =
+    AbsApiClient(httpClient)
+
+@Provides
+@Singleton
+fun provideStorytellerApiClient(httpClient: HttpClient): StorytellerApiClient =
+    StorytellerApiClient(httpClient)
+
+@Provides
+@Singleton
+fun provideStorytellerBundleApiImpl(httpClient: HttpClient): StorytellerBundleApiImpl =
+    StorytellerBundleApiImpl(httpClient)
+
+@Provides
+@Singleton
+fun provideAudiobookBundleApi(httpClient: HttpClient): AudiobookBundleApiImpl =
+    AudiobookBundleApiImpl(httpClient)
+
+@Provides
+@Singleton
+fun provideStorytellerPositionApi(httpClient: HttpClient): StorytellerPositionApi =
+    StorytellerPositionApiImpl(httpClient)
+```
+
+- [ ] **Step 1: Rewrite NetworkModule.kt with Ktor providers**
+
+Also rename `@WebSourceOkHttpClient` qualifier to `@WebSourceHttpClient` (or keep name and just change internal type). Update all injection sites that use the qualifier.
+
+- [ ] **Step 2: Compile check (Hilt processes annotations)**
+
+```bash
+export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr
+./gradlew :core:data:kspDebugKotlin 2>&1 | grep -E "error:|warning:" | head -30
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/riffle/core/data/di/
+git commit -m "feat(data): update NetworkModule to provide Ktor HttpClient instead of OkHttpClient"
+```
+
+---
+
+### Task 7: Migrate catalog HTTP clients to Ktor
+
+**Files:**
+- Modify: `core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaHttpClient.kt`
+- Modify: `core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaHttpClient.kt`
+- Modify: `core/catalog-gutenberg/src/main/kotlin/com/riffle/core/catalog/gutenberg/GutenbergHttpClient.kt`
+
+**KomgaHttpClient migration:**
+
+Constructor: `class KomgaHttpClient(private val client: HttpClient, private val basicAuthHeader: String, ...)`
+
+`getString`:
+```kotlin
+suspend fun getString(url: String): String {
+    val response = client.get(url) {
+        header(HttpHeaders.Authorization, basicAuthHeader)
+        header(HttpHeaders.UserAgent, userAgent)
+        accept(ContentType.Application.Json)
+    }
+    if (!response.status.isSuccess()) throw KomgaHttpException(response.status.value, url, response.status.description)
+    return response.bodyAsText()
+}
+```
+
+`getStreaming` (returns InputStream now):
+```kotlin
+suspend fun getStreaming(url: String): InputStream {
+    val response = client.get(url) {
+        header(HttpHeaders.Authorization, basicAuthHeader)
+        header(HttpHeaders.UserAgent, userAgent)
+    }
+    if (!response.status.isSuccess()) throw KomgaHttpException(response.status.value, url, response.status.description)
+    return response.bodyAsChannel().toInputStream()
+}
+```
+
+(Remove the `Call.await()` extension — not needed with Ktor.)
+
+**ChitankaHttpClient migration:**
+
+Constructor: `class ChitankaHttpClient(private val client: HttpClient, ...)`
+
+`getString` (with retry):
+```kotlin
+suspend fun getString(url: String): String {
+    var attempt = 0
+    while (true) {
+        val response = client.get(url) {
+            header(HttpHeaders.UserAgent, userAgent)
+            header(HttpHeaders.AcceptLanguage, "bg,en;q=0.5")
+        }
+        if (response.status.value == 429 && attempt < retryDelaysMs.size) {
+            delay(retryDelaysMs[attempt++])
+            continue
+        }
+        if (!response.status.isSuccess()) throw ChitankaHttpException(response.status.value, url, response.status.description)
+        return response.bodyAsText()
+    }
+}
+```
+
+`rangeGet` becomes suspend:
+```kotlin
+private suspend fun rangeGet(url: String, start: Long, endInclusive: Long): RangeReply? {
+    val response = try {
+        client.get(url) {
+            header(HttpHeaders.UserAgent, userAgent)
+            header(HttpHeaders.Range, "bytes=$start-$endInclusive")
+        }
+    } catch (_: IOException) { return null }
+    if (!response.status.isSuccess()) return null
+    val total = response.headers[HttpHeaders.ContentRange]?.substringAfter("/")?.toLongOrNull()
+        ?: response.contentLength()
+        ?: return null
+    return RangeReply(response.readBytes(), total)
+}
+```
+
+`probeMp3DurationSec` now just calls suspend `rangeGet` directly (no `withContext` needed).
+
+**GutenbergHttpClient migration:**
+
+Constructor: `class GutenbergHttpClient(private val client: HttpClient, ...)`
+
+`getString` (with retry on 429/503):
+```kotlin
+suspend fun getString(url: String): String {
+    var attempt = 0
+    while (true) {
+        val response = client.get(url) {
+            header(HttpHeaders.UserAgent, userAgent)
+            accept(ContentType.Application.Json)
+            accept(ContentType("text", "html", mapOf("q" to "0.5")))
+        }
+        if ((response.status.value == 429 || response.status.value == 503) && attempt < retryDelaysMs.size) {
+            delay(retryDelaysMs[attempt++])
+            continue
+        }
+        if (!response.status.isSuccess()) throw GutenbergHttpException(response.status.value, url, response.status.description)
+        return response.bodyAsText()
+    }
+}
+```
+
+- [ ] **Step 1: Migrate all three catalog clients**
+
+- [ ] **Step 2: Update catalog factories to inject HttpClient instead of OkHttpClient**
+
+In `KomgaCatalogFactory`, `ChitankaCatalogFactory`, `GutenbergCatalogFactory`, change constructor parameter type from `OkHttpClient` to `HttpClient`.
+
+Also update any Hilt modules that provide these (likely in `core:data` DI).
+
+- [ ] **Step 3: Compile check**
+
+```bash
+export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr
+./gradlew :core:catalog-komga:compileKotlin :core:catalog-chitanka:compileKotlin :core:catalog-gutenberg:compileKotlin 2>&1 | grep "error:" | head -30
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/catalog-komga/ core/catalog-chitanka/ core/catalog-gutenberg/
+git commit -m "feat(catalogs): migrate Komga, Chitanka, Gutenberg HTTP clients from OkHttp to Ktor"
+```
+
+---
+
+### Task 8: Migrate WebDavAnnotationSyncTarget to Ktor
+
+**Files:**
+- Modify: `core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTarget.kt`
+- Modify: `core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTargetFactory.kt`
+
+**Key changes:**
+- Constructor: `client: OkHttpClient` → `client: HttpClient`
+- `Credentials.basic(username, password)` → `"Basic ${Base64.getEncoder().encodeToString("$username:$password".toByteArray())}"`
+- `HttpUrl` → `Url` (Ktor) for baseUrl
+- PROPFIND is a custom HTTP method — use `client.request { method = HttpMethod("PROPFIND"); ... }`
+
+**WebDavAnnotationSyncTarget migration:**
+
+```kotlin
+class WebDavAnnotationSyncTarget(
+    baseUrl: io.ktor.http.Url,
+    username: String,
+    password: String,
+    private val client: HttpClient,
+    private val dispatchers: DispatcherProvider,
+) : AnnotationSyncTarget {
+
+    private val authHeader: String = "Basic " + 
+        java.util.Base64.getEncoder().encodeToString("$username:$password".toByteArray())
+
+    private suspend fun propfind(): String = client.request(basePath) {
+        method = HttpMethod("PROPFIND")
+        header(HttpHeaders.Authorization, authHeader)
+        header(HttpHeaders.UserAgent, FINDER_UA)
+        header("Depth", "1")
+    }.bodyAsText()
+
+    private suspend fun readFile(url: Url): String? {
+        val response = client.get(url) {
+            header(HttpHeaders.Authorization, authHeader)
+            header(HttpHeaders.UserAgent, FINDER_UA)
+        }
+        return when (response.status.value) {
+            404 -> null
+            401, 403 -> throw AnnotationSyncException.AuthFailed()
+            in 200..299 -> response.bodyAsText()
+            else -> throw AnnotationSyncException.HttpFailure(response.status.value)
+        }
+    }
+
+    private suspend fun putFile(url: Url, content: String, contentType: ContentType, op: String) {
+        val response = client.put(url) {
+            header(HttpHeaders.Authorization, authHeader)
+            header(HttpHeaders.UserAgent, FINDER_UA)
+            contentType(contentType)
+            setBody(content)
+        }
+        when (response.status.value) {
+            in 200..299 -> Unit
+            401, 403 -> throw AnnotationSyncException.AuthFailed()
+            else -> throw AnnotationSyncException.HttpFailure(response.status.value)
+        }
+    }
+
+    private suspend fun deleteFile(url: Url, op: String) {
+        val response = client.delete(url) {
+            header(HttpHeaders.Authorization, authHeader)
+            header(HttpHeaders.UserAgent, FINDER_UA)
+        }
+        when (response.status.value) {
+            in 200..299, 404 -> Unit
+            401, 403 -> throw AnnotationSyncException.AuthFailed()
+            else -> throw AnnotationSyncException.HttpFailure(response.status.value)
+        }
+    }
+}
+```
+
+**WebDavAnnotationSyncTargetFactory:**
+
+```kotlin
+class WebDavAnnotationSyncTargetFactory(
+    private val client: HttpClient,
+    private val dispatchers: DispatcherProvider,
+) {
+    fun create(config: AnnotationSyncConfig): WebDavAnnotationSyncTarget? {
+        val url = try { URLBuilder(config.baseUrl).build() } catch (_: Exception) { return null }
+        if (config.baseUrl.isBlank()) return null
+        return WebDavAnnotationSyncTarget(url, config.username, config.password, client, dispatchers)
+    }
+}
+```
+
+- [ ] **Step 1: Rewrite WebDavAnnotationSyncTarget.kt with Ktor**
+
+(The XML parsing via SAX stays unchanged — it's pure Java, not OkHttp.)
+
+- [ ] **Step 2: Update WebDavAnnotationSyncTargetFactory.kt**
+
+- [ ] **Step 3: Compile check**
+
+```bash
+export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr
+./gradlew :core:data:compileKotlin 2>&1 | grep "error:" | head -30
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTarget.kt \
+        core/data/src/main/kotlin/com/riffle/core/data/WebDavAnnotationSyncTargetFactory.kt
+git commit -m "feat(data): migrate WebDavAnnotationSyncTarget from OkHttp to Ktor"
+```
+
+---
+
+### Task 9: Update all tests in core:network to use Ktor + MockWebServer
+
+**Files:**
+- Modify: All `*.kt` in `core/network/src/test/` (~20 files)
+
+**Key pattern change:**
+
+Before:
+```kotlin
+private lateinit var server: MockWebServer
+private lateinit var client: OkHttpClient
+
+@Before fun setUp() {
+    server = MockWebServer(); server.start()
+    client = OkHttpClient()
+}
+
+private fun makeClient() = AbsApiClient(client, ...)
+```
+
+After:
+```kotlin
+private lateinit var server: MockWebServer
+private lateinit var httpClient: HttpClient
+
+@Before fun setUp() {
+    server = MockWebServer(); server.start()
+    val okHttpClient = OkHttpClient.Builder().callTimeout(2, TimeUnit.SECONDS).build()
+    httpClient = createDefaultHttpClient(okHttpClient)
+}
+
+@After fun tearDown() {
+    server.shutdown()
+    httpClient.close()
+}
+
+private fun makeClient() = AbsApiClient(httpClient)
+```
+
+For tests that rely on `dispatchers.io` being passed to `OkHttpClassifier.classify`, the dispatcher parameter is now removed from the constructors.
+
+For insecure TLS tests (`InsecureTlsTest`): adapt to use `httpClient.withInsecureTls()`.
+
+- [ ] **Step 1: Update all test files — remove OkHttpClient constructor args, add HttpClient**
+
+Apply the pattern above to each test file. The MockWebServer and MockResponse setup stays unchanged.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr
+./gradlew :core:network:test 2>&1 | tail -30
+```
+Expected: all green.
+
+- [ ] **Step 3: Update core:data tests (WebDAV)**
+
+```bash
+# Update WebDavAnnotationSyncTargetTest and WebDavAnnotationSyncTargetFactoryTest
+# to use HttpClient instead of OkHttpClient
+```
+
+- [ ] **Step 4: Run data tests**
+
+```bash
+export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr
+./gradlew :core:data:test 2>&1 | tail -20
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/network/src/test/ core/data/src/test/
+git commit -m "test(network,data): update tests to use Ktor HttpClient with MockWebServer"
+```
+
+---
+
+### Task 10: Add OkHttp import guardrail
+
+**Files:**
+- Create: `buildSrc/src/main/kotlin/com/riffle/buildlogic/OkHttpImportLint.kt`
+- Modify: `buildSrc/src/main/kotlin/com/riffle/buildlogic/RiffleBuildLogicPlugin.kt` (or wherever `checkNoAndroidImports` is registered)
+- Modify: `build.gradle.kts` (root) if needed
+
+**OkHttpImportLint.kt:**
+
+```kotlin
+package com.riffle.buildlogic
+
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.DefaultTask
+
+abstract class CheckNoOkhttpOutsideNetworkTask : DefaultTask() {
+    @TaskAction
+    fun check() {
+        val allowlist = setOf(
+            // OkHttp engine config is allowed only in core:network and core:data DI
+            "core/network/src/main/kotlin/com/riffle/core/network/InsecureTls.kt",
+            "core/network/src/main/kotlin/com/riffle/core/network/KtorClientFactory.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/di/modules/NetworkModule.kt",
+            // Tests may use OkHttpClient + MockWebServer
+        )
+        val violations = mutableListOf<String>()
+        project.rootProject.projectDir.walkTopDown()
+            .filter { it.extension == "kt" && !it.path.contains("/test/") && !it.path.contains("buildSrc") }
+            .filter { f -> allowlist.none { f.path.endsWith(it) } }
+            .forEach { file ->
+                if (file.readText().contains("import okhttp3.")) {
+                    violations.add(file.path.removePrefix(project.rootProject.projectDir.absolutePath + "/"))
+                }
+            }
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                "checkNoOkhttpOutsideNetwork: okhttp3 imports found outside the allowlist:\n" +
+                    violations.joinToString("\n") { "  $it" }
+            )
+        }
+    }
+}
+```
+
+Wire into `check` task in the root `build.gradle.kts`:
+```kotlin
+tasks.register<com.riffle.buildlogic.CheckNoOkhttpOutsideNetworkTask>("checkNoOkhttpOutsideNetwork")
+tasks.named("check") { dependsOn("checkNoOkhttpOutsideNetwork") }
+```
+
+- [ ] **Step 1: Create OkHttpImportLint task**
+
+- [ ] **Step 2: Wire into check**
+
+- [ ] **Step 3: Run guardrail**
+
+```bash
+export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr
+./gradlew checkNoOkhttpOutsideNetwork 2>&1 | tail -20
+```
+Expected: PASS (no violations).
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jbr
+./gradlew test 2>&1 | tail -30
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add buildSrc/
+git commit -m "feat(build): add checkNoOkhttpOutsideNetwork guardrail task"
+```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ room = "2.8.4"
 datastore = "1.2.1"
 workmanager = "2.11.2"
 okhttp = "5.4.0"
+ktor = "3.1.3"
 navigation = "2.9.8"
 hiltNavigation = "1.4.0"
 security = "1.1.0"
@@ -60,6 +61,11 @@ androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx"
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
 okhttp-tls = { group = "com.squareup.okhttp3", name = "okhttp-tls", version.ref = "okhttp" }
+ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
+ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigation" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }


### PR DESCRIPTION
Closes #552

Replaces the raw `OkHttpClient` passed through every network and catalog client with a Ktor `HttpClient` backed by the OkHttp engine. OkHttp stays as the transport layer, so connection pooling, TLS config, and interceptors are unchanged; Ktor adds ContentNegotiation (kotlinx.serialization JSON), a structured coroutine-first request DSL, and a clean seam for future KMP portability.

## Changes

**New: `KtorClientFactory.kt`**
- `createDefaultHttpClient(OkHttpClient)` — wraps OkHttp with ContentNegotiation/JSON; used by all JSON API clients
- `createStreamingHttpClient(OkHttpClient)` — no ContentNegotiation; used by bundle-download APIs that set their own `Accept` headers (avoids Ktor appending `, application/json` to `Accept: application/audiobook+zip`)

**Migrated clients** (all HTTP calls now use Ktor request DSL):
- `AbsApiClient`, `AbsLibraryApi`, `StorytellerApiClient`, `StorytellerBundleApi`, `StorytellerPositionApi`, `AudiobookBundleApi`, `GitHubReleaseApi`, `InsecureTls`
- `KomgaHttpClient`, `GutenbergHttpClient`, `ChitankaHttpClient`
- `WebDavAnnotationSyncTarget`

**Bug fixes caught during migration:**
- `probeBundleSize` now sets `socketTimeoutMillis` alongside `requestTimeoutMillis` — HEAD requests with slow headers only trigger the socket read timeout, not the coroutine deadline
- `getListeningStats` now explicitly throws `ResponseException` on non-2xx before `body<T>()`, so 401 surfaces as `NetworkResult.Auth` via `KtorClassifier` rather than falling through to `Unknown`
- `ChitankaCatalog.fetchBytesWith429Retry` now sends `Accept-Language` and `Referer` headers on download requests (pinned by existing test that was already green before migration)
- `StorytellerApiClient.login` now sends multipart/form-data (Ktor `MultiPartFormDataContent`) as the Storyteller token endpoint expects

**Test updates:**
- All MockWebServer JSON responses now include `Content-Type: application/json` (required by Ktor ContentNegotiation for response deserialization)
- Catalog test constructors updated to pass `HttpClient(OkHttp)` instead of `OkHttpClient`
- `WebDavAnnotationSyncTargetTest` updated to use Ktor `Url` and `HttpClient`
- `testImplementation(libs.ktor.client.okhttp)` added to catalog and data modules