### PR TITLE
fix(reader): preserve emphasis styles when merging adjacent same-color highlights

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -2409,8 +2409,10 @@ class EpubReaderViewModel @Inject constructor(
         // the merge doesn't leak an orphan TYPE_EMPHASIS row into `emphasisPool` (the DOM
         // injector reads directly from the pool and would keep painting bold/italic on a
         // no-longer-existent range). Same cascade the panel-delete + overlap-dedup paths do.
+        // Collect emphasis styles BEFORE deleting so the merged highlight can inherit them.
         val anchorCfi = pool.firstOrNull { it.id == id }?.cfi
         val cascadeCfis = toAbsorb.map { it.cfi }.toSet() + (anchorCfi?.let { setOf(it) } ?: emptySet())
+        val mergedEmphasisStyles = collectMergeEmphasisStyles(cascadeCfis, annotationSession.emphasisPool.value)
         if (cascadeCfis.isNotEmpty()) {
             annotationSession.emphasisPool.value
                 .filter { it.cfi in cascadeCfis }
@@ -2439,9 +2441,24 @@ class EpubReaderViewModel @Inject constructor(
             embeddedFigures = mergedEmbeddedFigures,
             originFontFamily = mergedOriginFont,
         )
+        if (mergedEmphasisStyles.isNotEmpty()) {
+            annotationStore.createEmphasis(
+                sourceId = sourceId,
+                itemId = itemId,
+                cfi = cfiRange,
+                textSnippet = domSnippet,
+                chapterHref = trialAnchor.chapterHref,
+                textBefore = trialAnchor.textBefore,
+                textAfter = trialAnchor.textAfter,
+                styles = mergedEmphasisStyles,
+                spineIndex = trialAnchor.spineIndex,
+                progression = storedProgression,
+                originFontFamily = mergedOriginFont,
+            )
+        }
         logger.d(LogChannel.HighlightMerge) {
             "edit-merge done anchorReplaced=$id newId=${created.id} absorbedText=${toAbsorb.size} " +
-                "figures=${mergedEmbeddedFigures?.size ?: 0} " +
+                "figures=${mergedEmbeddedFigures?.size ?: 0} emphasisStyles=${mergedEmphasisStyles.size} " +
                 "domLen=${domSnippet.length} startChar=$startChar"
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightMerge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightMerge.kt
@@ -307,3 +307,19 @@ internal fun hasFigureInGap(
     return findEnclosedFiguresInHtml(html, gapStart, gapEnd).isNotEmpty()
 }
 
+/**
+ * Union of all [EmphasisStyle]s carried by emphasis rows whose CFI is in [cascadeCfis].
+ *
+ * Called before the cascade-delete in [EpubReaderViewModel.mergeAdjacentIntoHighlight] so the
+ * merged annotation can inherit the formatting of every absorbed highlight. Without this the delete
+ * path silently discards any bold/italic/underline that a neighbour carried.
+ */
+internal fun collectMergeEmphasisStyles(
+    cascadeCfis: Set<String>,
+    emphasisPool: List<Annotation>,
+): Set<EmphasisStyle> =
+    emphasisPool
+        .filter { it.cfi in cascadeCfis }
+        .flatMap { it.emphasisStyles.orEmpty() }
+        .toSet()
+

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EmphasisMergeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EmphasisMergeTest.kt
@@ -204,4 +204,44 @@ class EmphasisMergeTest {
         assertEquals("first second third", current.textSnippet)
         assertEquals(BOLD, current.emphasisStyles)
     }
+
+    // -------- collectMergeEmphasisStyles (pins fix: highlight merge preserves text formatting) --
+
+    @Test
+    fun `collectMergeEmphasisStyles returns union of styles from absorbed emphasis rows`() {
+        val e = emphasis(id = "e1", styles = BOLD, textSnippet = "bar")
+            .copy(cfi = "cfi-b")
+        val result = collectMergeEmphasisStyles(setOf("cfi-b"), listOf(e))
+        assertEquals(BOLD, result)
+    }
+
+    @Test
+    fun `collectMergeEmphasisStyles returns empty when no emphasis rows match cascade cfis`() {
+        val e = emphasis(id = "e1", styles = BOLD, textSnippet = "bar")
+            .copy(cfi = "cfi-b")
+        val result = collectMergeEmphasisStyles(setOf("cfi-a"), listOf(e))
+        assertEquals(emptySet<EmphasisStyle>(), result)
+    }
+
+    @Test
+    fun `collectMergeEmphasisStyles returns empty when emphasis pool is empty`() {
+        val result = collectMergeEmphasisStyles(setOf("cfi-a", "cfi-b"), emptyList())
+        assertEquals(emptySet<EmphasisStyle>(), result)
+    }
+
+    @Test
+    fun `collectMergeEmphasisStyles unions styles from multiple absorbed emphasis rows`() {
+        val e1 = emphasis(id = "e1", styles = BOLD).copy(cfi = "cfi-a")
+        val e2 = emphasis(id = "e2", styles = ITALIC).copy(cfi = "cfi-b")
+        val result = collectMergeEmphasisStyles(setOf("cfi-a", "cfi-b"), listOf(e1, e2))
+        assertEquals(setOf(EmphasisStyle.BOLD, EmphasisStyle.ITALIC), result)
+    }
+
+    @Test
+    fun `collectMergeEmphasisStyles ignores emphasis rows outside cascade cfis`() {
+        val absorbed = emphasis(id = "e1", styles = BOLD).copy(cfi = "cfi-b")
+        val unrelated = emphasis(id = "e2", styles = ITALIC).copy(cfi = "cfi-other")
+        val result = collectMergeEmphasisStyles(setOf("cfi-a", "cfi-b"), listOf(absorbed, unrelated))
+        assertEquals(BOLD, result)
+    }
 }


### PR DESCRIPTION
## Root cause

`commitDraft` has two merge sub-paths (overlap and adjacency). Both tombstone absorbed highlight rows **plus their sibling TYPE_EMPHASIS rows**. Neither sub-path included the victims' emphasis styles when computing `combinedStyles` for the new merged highlight — so any bold/italic carried by an absorbed neighbor was permanently lost.

Primary repro:
1. Create highlight A (green + bold)
2. Create highlight B (green, no bold) adjacent to A
3. B's `commitDraft` absorbs A as a victim → deletes A's emphasis row → `combinedStyles` = draft styles only (empty) → merged result: plain green

The fix snapshots each victim's `emphasisStyles` from `emphasisPool` **before** the tombstone loop, then unions them into `combinedStyles`. Both the overlap and adjacency paths are covered.

## Changes

- **`EpubReaderViewModel.kt`**: In `commitDraft`, collect `overlapVictimEmphasisStyles` and `adjacentVictimEmphasisStyles` before their respective delete loops; union into `combinedStyles`.
- **`CombineDraftEmphasisStylesTest.kt`**: Two new regression tests — one that would flip red if the `+ adjacentVictimEmphasisStyles` line were removed, one for the union-with-preset case.

Note: a prior fix (`a441757fa`) addressed the same symptom in the **edit-time** path (`mergeAdjacentIntoHighlight`) using a mutex fence + fresh DB read. That path is correct; this commit closes the identical gap in the create-time path.

## Regression pinned by

`CombineDraftEmphasisStylesTest#draft with no emphasis inherits victim bold on adjacent merge` — asserts that `combineDraftEmphasisStyles(emptySet(), null) + setOf(BOLD) == setOf(BOLD)`. Removing the `+ adjacentVictimEmphasisStyles` union from `commitDraft` makes the merged emphasis styles empty, which is the bug.