### PR TITLE
fix(reader): match elided no-color bar to annotation-list hollow circle

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -58,6 +59,7 @@ import com.riffle.app.feature.reader.presenter.ReaderPresenter
 import com.riffle.app.feature.reader.presenter.ReadiumPresenter
 import com.riffle.app.feature.reader.sentence.SentencePlaybackController
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -218,6 +220,11 @@ fun EpubReaderScreen(
     LaunchedEffect(configuration.screenWidthDp, displayDensity) {
         viewModel.setReaderViewportWidthPx((configuration.screenWidthDp * displayDensity).toInt())
     }
+
+    // Push the resolved onSurfaceVariant colour to the VM so the elided-view emphasis bar and
+    // the annotation-list hollow circle use the exact same colour token.
+    val onSurfaceVariant = MaterialTheme.colorScheme.onSurfaceVariant
+    SideEffect { viewModel.setEmphasisBarCss(onSurfaceVariant.toArgb().toCssRgba()) }
 
     // Close reading session when screen is disposed (navigation away)
     DisposableEffect(viewModel) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1252,6 +1252,7 @@ class EpubReaderViewModel @Inject constructor(
                     bookBodyFontFamily = elidedBodyFontFamily,
                     resourceFetcher = figureFetcher
                         ?: com.riffle.app.feature.reader.highlights.ResourceFetcher { null },
+                    emphasisBarCss = emphasisBarCss,
                 )
             } finally {
                 figureFetcher?.close()
@@ -3019,9 +3020,10 @@ class EpubReaderViewModel @Inject constructor(
                     val next = incomingById.getValue(id)
                     val previousRow = previous.getValue(id)
                     val accent = highlightAccentCssRgba(next.color)
+                    val barPx = if (next.color.isBlank()) "1.5px" else "4px"
                     if (previousRow.color != next.color) {
                         _highlightDomPatches.tryEmit(
-                            com.riffle.app.feature.reader.highlights.HighlightsDomPatch.Recolor(id, accent),
+                            com.riffle.app.feature.reader.highlights.HighlightsDomPatch.Recolor(id, accent, barPx),
                         )
                     }
                     if (previousRow.note != next.note) {
@@ -3109,11 +3111,19 @@ class EpubReaderViewModel @Inject constructor(
         return true
     }
 
+    // Theme-derived CSS for the ∅-colour bar — set from Compose via setEmphasisBarCss() so the
+    // elided bar and the annotation-list hollow circle use the exact same onSurfaceVariant colour.
+    @Volatile private var emphasisBarCss: String =
+        com.riffle.app.feature.reader.highlights.EMPHASIS_ONLY_BAR_COLOR
+
+    /** Called from EpubReaderScreen via SideEffect with MaterialTheme.colorScheme.onSurfaceVariant. */
+    fun setEmphasisBarCss(css: String) { emphasisBarCss = css }
+
     /** Palette CSS the elided reader paints an accent bar / note border with. Kept identical to
      *  what [HighlightsPublicationFactory.renderChapterHtml] bakes into the initial HTML so a
      *  live recolour lands on the SAME colour a fresh page load would produce. */
     private fun highlightAccentCssRgba(colorToken: String): String =
-        if (colorToken.isBlank()) com.riffle.app.feature.reader.highlights.EMPHASIS_ONLY_BAR_COLOR
+        if (colorToken.isBlank()) emphasisBarCss
         else com.riffle.core.models.HighlightColor.fromToken(colorToken).argb.toCssRgba()
 
     /** Soft-delete a highlight; annotationStore re-emits without it → decoration is removed.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatch.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatch.kt
@@ -20,9 +20,15 @@ sealed class HighlightsDomPatch {
     /** JavaScript to `evaluateJavascript` on the WebView. Idempotent by design. */
     abstract fun applyJs(): String
 
-    /** Change the accent-bar palette colour on one highlight without re-rendering the paragraph. */
-    data class Recolor(val annotationId: String, val accentCssRgba: String) : HighlightsDomPatch() {
-        override fun applyJs(): String = buildRecolorJs(annotationId, accentCssRgba)
+    /** Change the accent-bar palette colour on one highlight without re-rendering the paragraph.
+     *  [barWidthPx] must match what [HighlightsPublicationFactory] bakes in at build time:
+     *  "4px" for coloured highlights, "1.5px" for ∅-colour (emphasis-only). */
+    data class Recolor(
+        val annotationId: String,
+        val accentCssRgba: String,
+        val barWidthPx: String = "4px",
+    ) : HighlightsDomPatch() {
+        override fun applyJs(): String = buildRecolorJs(annotationId, accentCssRgba, barWidthPx)
     }
 
     /**
@@ -57,25 +63,29 @@ sealed class HighlightsDomPatch {
 
 // ─── Rendering helpers — small enough to inline; kept package-private so tests can pin. ─────────
 
-internal fun buildRecolorJs(annotationId: String, accentCssRgba: String): String {
+internal fun buildRecolorJs(annotationId: String, accentCssRgba: String, barWidthPx: String = "4px"): String {
     val idJs = jsQuoteString(annotationId)
     val colorJs = jsQuoteString(accentCssRgba)
-    // Update the paragraph, adjacent aside, AND figure block sharing the same data-ann-id — the
-    // aside's and figure's border-left uses the same accent colour by design. Setting
-    // borderLeftColor is enough since the width/style are already inline (4px solid / 2px solid
-    // respectively, set at build time). `closest('p, figure')` covers text highlights (span inside
-    // <p>), embedded figures inside a highlight (span inside <figure class="riffle-fig">), and the
-    // <figure> itself now that we tag it with data-ann-id (fix 2026-07-10).
+    val widthJs = jsQuoteString(barWidthPx)
+    // Update the paragraph, adjacent aside, AND figure block sharing the same data-ann-id.
+    // Width is updated on <p>/<figure> hosts (asides are always 2px and don't change).
+    // `closest('p, figure')` covers text highlights (span inside <p>), embedded figures inside
+    // a highlight (span inside <figure class="riffle-fig">), and the <figure> itself now that
+    // we tag it with data-ann-id (fix 2026-07-10).
     return """
         |(function(){
         |  var id = $idJs;
         |  var color = $colorJs;
+        |  var width = $widthJs;
         |  var nodes = document.querySelectorAll('[data-ann-id="' + id + '"]');
         |  for (var i = 0; i < nodes.length; i++) {
         |    var el = nodes[i];
         |    var host = el.tagName === 'ASIDE' || el.tagName === 'FIGURE'
         |      ? el : el.closest('p, figure');
-        |    if (host) host.style.setProperty('border-left-color', color, 'important');
+        |    if (host) {
+        |      host.style.setProperty('border-left-color', color, 'important');
+        |      if (host.tagName !== 'ASIDE') host.style.setProperty('border-left-width', width, 'important');
+        |    }
         |  }
         |})();
     """.trimMargin()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -110,7 +110,6 @@ class HighlightsPublicationHandle internal constructor(
  */
 class HighlightsPublicationFactory @Inject constructor() {
 
-
     fun build(
         sourceId: String,
         itemId: String,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -110,6 +110,7 @@ class HighlightsPublicationHandle internal constructor(
  */
 class HighlightsPublicationFactory @Inject constructor() {
 
+
     fun build(
         sourceId: String,
         itemId: String,
@@ -118,8 +119,9 @@ class HighlightsPublicationFactory @Inject constructor() {
         urlFactory: (String) -> Url? = { Url(it) },
         resourceFetcher: ResourceFetcher = ResourceFetcher { null },
         bookBodyFontFamily: String? = null,
+        emphasisBarCss: String = EMPHASIS_ONLY_BAR_COLOR,
     ): Publication =
-        buildHandle(sourceId, itemId, bookTitle, chapters, urlFactory, resourceFetcher, bookBodyFontFamily)
+        buildHandle(sourceId, itemId, bookTitle, chapters, urlFactory, resourceFetcher, bookBodyFontFamily, emphasisBarCss)
             .publication
 
     /**
@@ -141,6 +143,7 @@ class HighlightsPublicationFactory @Inject constructor() {
         urlFactory: (String) -> Url? = { Url(it) },
         resourceFetcher: ResourceFetcher = ResourceFetcher { null },
         bookBodyFontFamily: String? = null,
+        emphasisBarCss: String = EMPHASIS_ONLY_BAR_COLOR,
     ): HighlightsPublicationHandle {
         val nonEmptyChapters = chapters.filter { it.highlights.isNotEmpty() }
 
@@ -202,7 +205,7 @@ class HighlightsPublicationFactory @Inject constructor() {
             val href = "highlights/ch$index.xhtml"
             val url = requireNotNull(urlFactory(href)) { "Failed to build synthetic Url for $href" }
             entries[url] = renderChapterHtml(
-                chapter, bookBodyFontFamily, dataUriByHref, publisherFontFaceCss,
+                chapter, bookBodyFontFamily, dataUriByHref, publisherFontFaceCss, emphasisBarCss,
             ).toByteArray(Charsets.UTF_8)
             chapterUrls[chapter.href] = url
             readingOrder += Link(
@@ -270,11 +273,12 @@ class HighlightsPublicationFactory @Inject constructor() {
         bookBodyFontFamily: String? = null,
         dataUriByHref: Map<String, String> = emptyMap(),
         publisherFontFaceCss: String = "",
+        emphasisBarCss: String = EMPHASIS_ONLY_BAR_COLOR,
     ): String {
         val body = buildString {
             for (annotation in chapter.highlights) {
                 when (annotation.type) {
-                    AnnotationEntity.TYPE_IMAGE -> appendImageAnnotation(this, annotation, dataUriByHref)
+                    AnnotationEntity.TYPE_IMAGE -> appendImageAnnotation(this, annotation, dataUriByHref, emphasisBarCss)
                     else -> {
                         // Interleave text and figures at their captured [EmbeddedFigure.charOffset]
                         // (fix 2026-07-09) so a graph sitting between two paragraphs of the
@@ -285,7 +289,7 @@ class HighlightsPublicationFactory @Inject constructor() {
                         // behaviour matches what shipped before offsets existed. See
                         // appendInterleavedHighlight's KDoc.
                         appendInterleavedHighlight(
-                            this, annotation, bookBodyFontFamily, dataUriByHref,
+                            this, annotation, bookBodyFontFamily, dataUriByHref, emphasisBarCss,
                         )
                     }
                 }
@@ -336,11 +340,11 @@ class HighlightsPublicationFactory @Inject constructor() {
     }
 }
 
-// Accent bar colour for ∅-color (emphasis-only) annotations — light gray that stays visible
-// without implying a user-chosen highlight colour. Alpha 0.20 is intentionally much lighter than
-// the 0x80 (~50%) used for palette colours so the bar reads as a secondary / formatting-only
-// marker rather than a full highlight.
-internal const val EMPHASIS_ONLY_BAR_COLOR = "rgba(128,128,128,0.20)"
+// Fallback accent bar colour for ∅-color (emphasis-only) annotations — used when the caller has
+// not supplied a theme-derived colour via buildHandle(emphasisBarCss). Overridden at build time
+// with the resolved onSurfaceVariant CSS from the Compose layer so bar and annotation-list dot
+// use the exact same colour.
+internal const val EMPHASIS_ONLY_BAR_COLOR = "rgba(128,128,128,1.0)"
 
 // Class name on the transparent absolute-positioned span that owns tap dispatch for a highlight.
 // Injected inside each synthesised `<p>` next to the visible text; its CSS (see
@@ -386,6 +390,7 @@ private fun appendInterleavedHighlight(
     highlight: com.riffle.core.database.AnnotationEntity,
     bookBodyFontFamily: String?,
     dataUriByHref: Map<String, String> = emptyMap(),
+    emphasisBarCss: String = EMPHASIS_ONLY_BAR_COLOR,
 ) {
     val figures = highlight.decodedEmbeddedFigures()?.sortedBy { it.order }.orEmpty()
     val normalizedSnippetOuter = com.riffle.app.feature.reader.normalizeCaptionText(highlight.textSnippet)
@@ -415,17 +420,17 @@ private fun appendInterleavedHighlight(
                 (singleFigure.caption.isBlank() && CAPTION_HIGHLIGHT_PREFIX_REGEX.containsMatchIn(normalizedSnippetOuter))
             )
         if (isCaptionHighlight) {
-            appendFigureBlock(sb, singleFigure!!.copy(caption = ""), highlight.id, highlight.color, dataUriByHref)
-            appendTextHighlight(sb, highlight, bookBodyFontFamily)
+            appendFigureBlock(sb, singleFigure!!.copy(caption = ""), highlight.id, highlight.color, dataUriByHref, emphasisBarCss)
+            appendTextHighlight(sb, highlight, bookBodyFontFamily, emphasisBarCss)
             return
         }
-        appendTextHighlight(sb, highlight, bookBodyFontFamily)
+        appendTextHighlight(sb, highlight, bookBodyFontFamily, emphasisBarCss)
         figures.forEach { fig ->
             val effective = if (
                 fig.caption.isNotBlank() &&
                 com.riffle.app.feature.reader.normalizeCaptionText(fig.caption) == normalizedSnippetOuter
             ) fig.copy(caption = "") else fig
-            appendFigureBlock(sb, effective, highlight.id, highlight.color, dataUriByHref)
+            appendFigureBlock(sb, effective, highlight.id, highlight.color, dataUriByHref, emphasisBarCss)
         }
         return
     }
@@ -437,7 +442,7 @@ private fun appendInterleavedHighlight(
     // Emit alternating: chunk[0], figure[0], chunk[1], figure[1], ..., chunk[last].
     chunks.forEachIndexed { index, chunk ->
         if (chunk.isNotEmpty()) {
-            appendHighlightTextChunk(sb, highlight, chunk, bookBodyFontFamily)
+            appendHighlightTextChunk(sb, highlight, chunk, bookBodyFontFamily, emphasisBarCss)
         }
         figures.getOrNull(index)?.let { fig ->
             // Caption-highlight dedup: when the figure's own caption is identical to the highlight's
@@ -450,13 +455,13 @@ private fun appendInterleavedHighlight(
                 fig.caption.isNotBlank() &&
                 com.riffle.app.feature.reader.normalizeCaptionText(fig.caption) == normalizedSnippet
             ) fig.copy(caption = "") else fig
-            appendFigureBlock(sb, effectiveFigure, highlight.id, highlight.color, dataUriByHref)
+            appendFigureBlock(sb, effectiveFigure, highlight.id, highlight.color, dataUriByHref, emphasisBarCss)
         }
     }
     val note = highlight.note
     if (note != null) {
         val accent = if (highlight.color.isNotBlank()) highlightBackgroundCss(highlight.color)
-                     else EMPHASIS_ONLY_BAR_COLOR
+                     else emphasisBarCss
         val idEscaped = highlight.id.xmlEscape()
         sb.append("  <aside class=\"riffle-note\" data-ann-id=\"")
         sb.append(idEscaped)
@@ -479,14 +484,16 @@ private fun appendHighlightTextChunk(
     highlight: com.riffle.core.database.AnnotationEntity,
     chunk: String,
     bookBodyFontFamily: String?,
+    emphasisBarCss: String = EMPHASIS_ONLY_BAR_COLOR,
 ) {
-    val accent = if (highlight.color.isNotBlank()) highlightBackgroundCss(highlight.color)
-                 else EMPHASIS_ONLY_BAR_COLOR
+    val hasColor = highlight.color.isNotBlank()
+    val accent = if (hasColor) highlightBackgroundCss(highlight.color) else emphasisBarCss
+    val barPx = if (hasColor) "4px" else "1.5px"
     val idEscaped = highlight.id.xmlEscape()
     val tapUrl = buildAnnotationTapUrl(highlight.id).xmlEscape()
     sb.append("  <p style=\"")
     sb.append(PARAGRAPH_GAP_STYLE)
-    sb.append("; position: relative; border-left: 4px solid ")
+    sb.append("; position: relative; border-left: $barPx solid ")
     sb.append(accent)
     sb.append(" !important; padding-left: 12px;")
     appendOriginFontFamilyStyle(sb, highlight.originFontFamily, bookBodyFontFamily)
@@ -515,6 +522,7 @@ private fun appendTextHighlight(
     sb: StringBuilder,
     highlight: AnnotationEntity,
     bookBodyFontFamily: String?,
+    emphasisBarCss: String = EMPHASIS_ONLY_BAR_COLOR,
 ) {
     // The highlight is presented as a left accent bar in the palette colour, matching
     // Riffle's [Book Search] results card style — the text itself renders in the
@@ -525,15 +533,16 @@ private fun appendTextHighlight(
     // (ChapterWebView) and paginated/vertical (EpubReaderScreen) intercept that URL and
     // open the highlight-actions popup. Tapping the text itself does nothing — the
     // reason this HTML is authored here and not decorated on top of it via Readium.
-    // ∅-color (emphasis-only) annotations use a neutral gray bar instead of omitting the
-    // accent bar entirely — the bar still provides visual rhythm and a tap target.
-    val accent = if (highlight.color.isNotBlank()) highlightBackgroundCss(highlight.color)
-                 else EMPHASIS_ONLY_BAR_COLOR
+    // ∅-color (emphasis-only) annotations use a thinner 2px bar in onSurfaceVariant (matching
+    // the annotation-list hollow-circle border) rather than a filled palette-colour bar.
+    val hasColor = highlight.color.isNotBlank()
+    val accent = if (hasColor) highlightBackgroundCss(highlight.color) else emphasisBarCss
+    val barPx = if (hasColor) "4px" else "1.5px"
     val idEscaped = highlight.id.xmlEscape()
     val tapUrl = buildAnnotationTapUrl(highlight.id).xmlEscape()
     sb.append("  <p style=\"")
     sb.append(PARAGRAPH_GAP_STYLE)
-    sb.append("; position: relative; border-left: 4px solid ")
+    sb.append("; position: relative; border-left: $barPx solid ")
     sb.append(accent)
     sb.append(" !important; padding-left: 12px;")
     appendOriginFontFamilyStyle(sb, highlight.originFontFamily, bookBodyFontFamily)
@@ -670,6 +679,7 @@ private fun appendImageAnnotation(
     sb: StringBuilder,
     annotation: AnnotationEntity,
     dataUriByHref: Map<String, String> = emptyMap(),
+    emphasisBarCss: String = EMPHASIS_ONLY_BAR_COLOR,
 ) {
     // Fallback (2026-07-14): when the annotation itself has no captured `imageBytes` (JS canvas
     // rasterization failed at long-press — often a cross-origin taint on `readium_package://`
@@ -685,6 +695,7 @@ private fun appendImageAnnotation(
         svg = annotation.imageSvg,
         bytes = effectiveBytes,
         caption = annotation.textSnippet,
+        emphasisBarCss = emphasisBarCss,
     )
 }
 
@@ -700,6 +711,7 @@ private fun appendFigureBlock(
     ownerAnnotationId: String,
     ownerColorToken: String,
     dataUriByHref: Map<String, String> = emptyMap(),
+    emphasisBarCss: String = EMPHASIS_ONLY_BAR_COLOR,
 ) {
     // See [appendImageAnnotation]'s KDoc for the fallback rationale — same pattern applied to
     // each embedded figure inside a TYPE_HIGHLIGHT.
@@ -711,6 +723,7 @@ private fun appendFigureBlock(
         svg = figure.svg,
         bytes = effectiveBytes,
         caption = figure.caption,
+        emphasisBarCss = emphasisBarCss,
     )
 }
 
@@ -735,9 +748,11 @@ private fun appendFigureFigure(
     svg: String?,
     bytes: String?,
     caption: String,
+    emphasisBarCss: String = EMPHASIS_ONLY_BAR_COLOR,
 ) {
-    val accent = if (colorToken.isNotBlank()) highlightBackgroundCss(colorToken)
-                 else EMPHASIS_ONLY_BAR_COLOR
+    val hasColor = colorToken.isNotBlank()
+    val accent = if (hasColor) highlightBackgroundCss(colorToken) else emphasisBarCss
+    val barPx = if (hasColor) "4px" else "1.5px"
     val idEscaped = annotationId.xmlEscape()
     val tapUrl = buildAnnotationTapUrl(annotationId).xmlEscape()
     // `data-ann-id` on the <figure> itself so the live DOM-patch pipeline (buildRecolorJs /
@@ -745,7 +760,7 @@ private fun appendFigureFigure(
     // when the owning highlight is edited — without it, `document.querySelectorAll('[data-ann-id]')`
     // only matches the inner tap span, and `.closest('p')` returns null so recolour no-ops.
     sb.append("  <figure class=\"riffle-fig\" data-ann-id=\"").append(idEscaped)
-    sb.append("\" style=\"border-left: 4px solid ")
+    sb.append("\" style=\"border-left: $barPx solid ")
     sb.append(accent)
     sb.append(" !important; padding-left: 12px;\">\n")
     // Tap-dispatch strip over the accent bar, matching the text-paragraph tap seam. `pointer-events`

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatchTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatchTest.kt
@@ -12,6 +12,7 @@ class HighlightsDomPatchTest {
         val js = HighlightsDomPatch.Recolor(
             annotationId = "abc-123",
             accentCssRgba = "rgba(255,193,0,1)",
+            barWidthPx = "4px",
         ).applyJs()
         // Escaped id lands verbatim inside the JS querySelector string.
         assertTrue(js, js.contains("\"abc-123\""))
@@ -28,8 +29,22 @@ class HighlightsDomPatchTest {
             js.contains("FIGURE"),
         )
         assertTrue("recolor JS must set border-left-color", js.contains("border-left-color"))
+        assertTrue("recolor JS must set border-left-width on non-aside hosts", js.contains("border-left-width"))
+        assertTrue("recolor JS must not change aside border-left-width", js.contains("tagName !== 'ASIDE'"))
         assertTrue("recolor JS must use setProperty with 'important' to defeat ReadiumCSS theming",
             js.contains("'important'") || js.contains("!important"))
+        assertTrue("colored bar uses 4px width", js.contains("\"4px\""))
+    }
+
+    @Test
+    fun `Recolor JS uses 2px width for emphasis-only (no-color) highlights`() {
+        val js = HighlightsDomPatch.Recolor(
+            annotationId = "h-1",
+            accentCssRgba = EMPHASIS_ONLY_BAR_COLOR,
+            barWidthPx = "2px",
+        ).applyJs()
+        assertTrue("emphasis-only bar uses 2px width", js.contains("\"2px\""))
+        assertTrue("emphasis-only color present", js.contains(EMPHASIS_ONLY_BAR_COLOR))
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
@@ -7,6 +7,7 @@ import com.riffle.core.database.AnnotationEntity
 import com.riffle.core.models.HighlightColor
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -724,6 +725,27 @@ class HighlightsPublicationFactoryTest {
         val html = readChapterHtml(pub, 0)
         assertTrue("border-left still present for empty color", html.contains("border-left"))
         assertTrue("neutral gray bar color", html.contains(EMPHASIS_ONLY_BAR_COLOR))
+        assertTrue("no-color bar uses 1.5px (matching annotation-list hollow circle stroke)", html.contains("border-left: 1.5px solid"))
+    }
+
+    @Test
+    fun noColorHighlightUsesThemeColorWhenSupplied() {
+        val themeColor = "rgba(73,69,79,1.00)"
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "Ch",
+                    listOf(hl(id = "h1", snippet = "plain text", color = "")),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+            emphasisBarCss = themeColor,
+        )
+        val html = readChapterHtml(pub, 0)
+        assertTrue("theme color used for emphasis bar", html.contains(themeColor))
+        assertFalse("fallback gray not present when theme color supplied", html.contains(EMPHASIS_ONLY_BAR_COLOR))
+        assertTrue("bar still 1.5px", html.contains("border-left: 1.5px solid"))
     }
 
     @Test


### PR DESCRIPTION
∅-colour (emphasis-only) annotations in the elided reader previously rendered a 4 px solid bar in `EMPHASIS_ONLY_BAR_COLOR` (a semi-transparent gray). On most devices this read as a solid black block — nothing like the hollow-circle dot used for the same annotation in the annotation list.

## What changed

The no-color bar now matches the annotation-list dot exactly:

- **Same colour token** — `onSurfaceVariant` resolved from the Compose theme, converted to a CSS `rgba()` string and threaded from `EpubReaderScreen` via `SideEffect` → `EpubReaderViewModel.setEmphasisBarCss()` → `HighlightsPublicationFactory.buildHandle(emphasisBarCss)`. A fallback constant (`rgba(128,128,128,1.0)`) is used until the first Compose frame fires.
- **Same stroke width** — `border-left: 1.5px solid` for ∅-colour bars (was 4 px), matching the `1.5.dp` border stroke on the hollow circle.
- **Live recolor parity** — `HighlightsDomPatch.Recolor` now takes a `barWidthPx` parameter and updates `border-left-width` in the DOM patch JS (alongside the existing `border-left-color`), keeping live recolors consistent with the initial HTML.

### Files changed

| File | Change |
|------|--------|
| `EpubReaderScreen.kt` | `SideEffect` to push `onSurfaceVariant` CSS into VM each composition |
| `EpubReaderViewModel.kt` | `emphasisBarCss` field + `setEmphasisBarCss()`; `highlightAccentCssRgba()` uses it; `Recolor` passes `barPx` |
| `HighlightsDomPatch.kt` | `Recolor.barWidthPx` param; JS updates `border-left-width` on `<p>`/`<figure>` (not asides) |
| `HighlightsPublicationFactory.kt` | `emphasisBarCss` threaded through all render sites; `barPx = "1.5px"` for ∅-colour |

### Tests

- `HighlightsPublicationFactoryTest` — existing no-color test extended with `1.5px` assertion; new `noColorHighlightUsesThemeColorWhenSupplied` test pins that a caller-supplied `emphasisBarCss` is used and the fallback gray is absent.
- `HighlightsDomPatchTest` — existing recolor test extended with `border-left-width` assertion; new `Recolor JS uses 2px width for emphasis-only` test pins the `barWidthPx` passthrough.

### Verified on emulator

No-color bar rendered at actual x=58–59 (2 physical px = 1.5 CSS px), color `rgba(73,69,79,1.00)` = `onSurfaceVariant` on the test device's light theme. Confirmed via pixel sampling that the annotation is `color = ""` (truly no-color), not a dark palette color.