### PR TITLE
fix(reader): elided-view publisher formatting lost when selection is inside a formatting ancestor

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -541,6 +541,33 @@ internal val SELECTION_SPAN_TRACKER_JS = """
                 return inner;
               };
               snippetHtml = walkInline(frag);
+              // walkInline only finds formatting that is a DESCENDANT of the selection range.
+              // When the selected text sits entirely inside a formatting ancestor (e.g. the user
+              // highlights "italic" from <em>italic</em>), cloneContents() returns a bare text
+              // node — <em> is an ancestor of the range, not part of its contents — so walkInline
+              // finds nothing. Walk up from commonAncestorContainer to body and collect any
+              // allowlist-tag ancestors; if any are found, wrap the plain text in them so the
+              // formatting survives into the elided view.
+              if (snippetHtml === escInline(text)) {
+                try {
+                  var anc = rng.commonAncestorContainer;
+                  var el = anc.nodeType === 3 ? anc.parentElement : anc;
+                  var wrapTags = [];
+                  while (el && el.tagName && el.tagName.toLowerCase() !== 'body') {
+                    var wt = el.tagName.toLowerCase();
+                    if (INLINE_ALLOW[wt]) wrapTags.push(wt);
+                    el = el.parentElement;
+                  }
+                  if (wrapTags.length > 0) {
+                    // wrapTags[0] is the innermost ancestor; wrap from innermost outward.
+                    var wrapped = escInline(text);
+                    for (var wi = 0; wi < wrapTags.length; wi++) {
+                      wrapped = '<' + wrapTags[wi] + '>' + wrapped + '</' + wrapTags[wi] + '>';
+                    }
+                    snippetHtml = wrapped;
+                  }
+                } catch (e) {}
+              }
               // Only report HTML that actually adds formatting on top of the plaintext — an
               // empty string tells the store to leave textSnippetHtml null and use the plain
               // render path (saves a DB write and keeps rows without formatting undecorated).

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -456,4 +456,86 @@ class ReaderWebViewScriptsTest {
             shortDelayIdx > defaultDelayIdx,
         )
     }
+
+    // Regression for the "elided view drops publisher formatting when selection is entirely inside a
+    // formatting ancestor" bug. walkInline walks Range.cloneContents() descendants, but when the
+    // user selects text that sits entirely inside <em>italic text</em>, cloneContents() returns a
+    // bare text node — the <em> is an ANCESTOR of the range, not a descendant. The fix walks up
+    // from commonAncestorContainer to <body> collecting any INLINE_ALLOW tag ancestors and wraps
+    // the plain text in them. The following pins ensure this path is present and correct.
+    @Test
+    fun `SELECTION_SPAN_TRACKER_JS adds ancestor-checking block after walkInline for formatting ancestors`() {
+        val js = SELECTION_SPAN_TRACKER_JS
+        val walkInlineIdx = js.indexOf("snippetHtml = walkInline(frag)")
+        assertTrue("walkInline call present", walkInlineIdx >= 0)
+        // Ancestor check is gated on snippetHtml equalling the raw escaped text — meaning
+        // walkInline found no formatting descendants.
+        val condIdx = js.indexOf("if (snippetHtml === escInline(text))", walkInlineIdx)
+        assertTrue("ancestor check gate is present after walkInline", condIdx > walkInlineIdx)
+        // The walk goes up via commonAncestorContainer (the canonical range ancestor API).
+        assertTrue(
+            "ancestor walk starts from commonAncestorContainer",
+            js.indexOf("rng.commonAncestorContainer", condIdx) > condIdx,
+        )
+        // Ascends to (but not including) the body element.
+        assertTrue(
+            "ancestor walk stops at body",
+            js.indexOf("el.tagName.toLowerCase() !== 'body'", condIdx) > condIdx,
+        )
+        // Uses the same INLINE_ALLOW allowlist as walkInline so descendants and ancestors are
+        // treated symmetrically — no separate ANCESTOR_ALLOW filter.
+        val inlineAllowInAncestorBlock = js.indexOf("if (INLINE_ALLOW[wt])", condIdx)
+        assertTrue(
+            "ancestor walk filters by INLINE_ALLOW (same allowlist as descendant walk)",
+            inlineAllowInAncestorBlock > condIdx,
+        )
+    }
+
+    @Test
+    fun `SELECTION_SPAN_TRACKER_JS wraps plain text in ancestors innermost-first`() {
+        val js = SELECTION_SPAN_TRACKER_JS
+        val condIdx = js.indexOf("if (snippetHtml === escInline(text))")
+        assertTrue("ancestor check gate present", condIdx >= 0)
+        // wrapTags[0] is the innermost ancestor; the loop wraps from innermost to outermost so the
+        // output nesting matches the original DOM order.
+        assertTrue(
+            "wrapping starts with escInline(text) as the innermost content",
+            js.indexOf("var wrapped = escInline(text)", condIdx) > condIdx,
+        )
+        assertTrue(
+            "loop builds up from wrapTags by index (innermost first)",
+            js.indexOf("'<' + wrapTags[wi] + '>' + wrapped + '</' + wrapTags[wi] + '>'", condIdx) > condIdx,
+        )
+    }
+
+    @Test
+    fun `SELECTION_SPAN_TRACKER_JS suppresses plain-text-only snippetHtml before bridging`() {
+        val js = SELECTION_SPAN_TRACKER_JS
+        // After the ancestor walk, if no formatting ancestor was found the snippet would still
+        // equal escInline(text). The script must clear it to '' so the bridge sends nothing and
+        // textSnippetHtml stays null (triggering the plain render path, not a no-op formatted one).
+        val condIdx = js.indexOf("if (snippetHtml === escInline(text))")
+        val clearIdx = js.indexOf("if (snippetHtml === escInline(text)) snippetHtml = '';")
+        assertTrue("ancestor check gate is present", condIdx >= 0)
+        assertTrue("clearing sentinel is present", clearIdx >= 0)
+        assertTrue("clearing comes AFTER the ancestor check", clearIdx > condIdx)
+    }
+
+    @Test
+    fun `SELECTION_SPAN_TRACKER_JS stashes snippetHtml in __riffleSelData and bridges it via onSnippetHtml`() {
+        val js = SELECTION_SPAN_TRACKER_JS
+        // The html field in __riffleSelData feeds the continuous-mode read path.
+        assertTrue("html field written to __riffleSelData stash", js.contains("html: snippetHtml"))
+        // onSnippetHtml bridges the value to paginated mode (Readium never reads __riffleSelData).
+        assertTrue(
+            "onSnippetHtml bridge call is present",
+            js.contains("RiffleSelBridge.onSnippetHtml(snippetHtml)"),
+        )
+        // Bridge is guarded by a presence check (bridge not registered in continuous ChapterWebView).
+        val bridgeIdx = js.indexOf("RiffleSelBridge.onSnippetHtml(snippetHtml)")
+        assertTrue(
+            "bridge call is guarded by RiffleSelBridge.onSnippetHtml existence check",
+            js.substring(maxOf(0, bridgeIdx - 200), bridgeIdx).contains("RiffleSelBridge.onSnippetHtml"),
+        )
+    }
 }


### PR DESCRIPTION
## What

`walkInline(frag)` walks `Range.cloneContents()` descendants to collect publisher inline formatting (`<em>`, `<i>`, `<strong>`, `<b>`, `<sup>`, `<sub>`, `<u>`, `<s>`) for the elided view. When the user's selection sits **entirely inside** a formatting element — e.g. they highlight "italic" from `<em>italic</em>` — `cloneContents()` returns a bare text node because the `<em>` is an ancestor of the range, not a descendant. `walkInline` finds nothing and `textSnippetHtml` is left null, so the elided view renders the excerpt as plain text.

## Fix

After `walkInline`, if the result equals the raw escaped text (no descendant formatting found), walk up from `rng.commonAncestorContainer` to `<body>` collecting `INLINE_ALLOW`-tagged ancestors. If any are found, wrap the escaped text in them (innermost first) so the formatting survives into the DB and renders correctly in the elided view. The same `INLINE_ALLOW` allowlist is used for both the descendant and ancestor walks — treating them symmetrically.

## Tests

`ReaderWebViewScriptsTest` — four new regression pins:
- ancestor check gate fires only when `walkInline` found no descendants
- walk ascends via `commonAncestorContainer`, stops at `<body>`, filters by `INLINE_ALLOW`
- wrapping is innermost-first
- plain-text-only result is suppressed (cleared to `''`) so `textSnippetHtml` stays null for unformatted selections
- `snippetHtml` is emitted in `__riffleSelData.html` (continuous path) and bridged via `RiffleSelBridge.onSnippetHtml` (paginated path)