### PR TITLE
fix(reader): abort OverScroller on smooth-tail window shift to prevent blank screen on far annotation jump

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -964,22 +964,22 @@ internal class ContinuousWindowController(
                 topIndex--
                 prependChapter(topIndex)
                 // prependChapter calls scrollBy(+placeholder) to keep visible content in place.
-                // If an OverScroller animation (smoothScrollTo / fling) is running, its next
-                // computeScroll frame will overwrite that scrollBy, making the chapter appear to
-                // jump. Aborting here lets the scrollBy stick. Safe when idle (abortAnimation on
-                // an already-finished scroller is a no-op).
-                port.abortFling()
+                // During smooth-tail annotation nav the OverScroller targets the annotation Y; its
+                // next computeScroll frame would overwrite the scrollBy, making content jump.
+                // Guard on smoothTailInProgress so normal user flings are not interrupted at
+                // chapter boundaries.
+                if (smoothTailInProgress) port.abortFling()
                 shiftInProgress = false
             }
             ChapterWindowManager.Decision.ShiftForward -> {
                 shiftInProgress = true
                 removeTop()
-                // removeTop calls scrollBy(-h) to keep visible content in place, but an active
-                // OverScroller (from smoothScrollTo or a fling) overwrites that on its next
-                // computeScroll frame — it keeps chasing the original target in the now-shifted
-                // layout. For smooth-tail annotation nav this lands well past the annotation into
-                // placeholder chapters → blank screen. Aborting here lets the scrollBy stick.
-                port.abortFling()
+                // removeTop calls scrollBy(-h) to keep visible content in place. During smooth-tail
+                // annotation nav the OverScroller keeps chasing the original target in the
+                // now-shifted layout, landing past the annotation into placeholder chapters →
+                // blank screen. Guard on smoothTailInProgress so normal user flings are not
+                // interrupted at chapter boundaries.
+                if (smoothTailInProgress) port.abortFling()
                 val nextIndex = topIndex + webViews.size
                 if (nextIndex < allChapters.size) appendChapter(nextIndex)
                 shiftInProgress = false

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -963,11 +963,23 @@ internal class ContinuousWindowController(
                 removeBottom()
                 topIndex--
                 prependChapter(topIndex)
+                // prependChapter calls scrollBy(+placeholder) to keep visible content in place.
+                // If an OverScroller animation (smoothScrollTo / fling) is running, its next
+                // computeScroll frame will overwrite that scrollBy, making the chapter appear to
+                // jump. Aborting here lets the scrollBy stick. Safe when idle (abortAnimation on
+                // an already-finished scroller is a no-op).
+                port.abortFling()
                 shiftInProgress = false
             }
             ChapterWindowManager.Decision.ShiftForward -> {
                 shiftInProgress = true
                 removeTop()
+                // removeTop calls scrollBy(-h) to keep visible content in place, but an active
+                // OverScroller (from smoothScrollTo or a fling) overwrites that on its next
+                // computeScroll frame — it keeps chasing the original target in the now-shifted
+                // layout. For smooth-tail annotation nav this lands well past the annotation into
+                // placeholder chapters → blank screen. Aborting here lets the scrollBy stick.
+                port.abortFling()
                 val nextIndex = topIndex + webViews.size
                 if (nextIndex < allChapters.size) appendChapter(nextIndex)
                 shiftInProgress = false

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWindowManagerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWindowManagerTest.kt
@@ -405,9 +405,11 @@ class ChapterWindowManagerTest {
     // was overwritten by the OverScroller on the next computeScroll frame, making the scroll land
     // viewport/2 + h past the annotation → placeholder blank territory.
     //
-    // Fix: ContinuousWindowController.maybeShift calls port.abortFling() after removeTop/prependChapter
-    // so the OverScroller stops chasing the stale target. This test pins the trigger: ShiftForward
-    // MUST fire when the smooth-tail endpoint places the viewport midpoint in the following chapter.
+    // Fix: ContinuousWindowController.maybeShift calls port.abortFling() when smoothTailInProgress
+    // after removeTop/prependChapter, so the OverScroller stops chasing the stale target. The abort
+    // is guarded by smoothTailInProgress to avoid killing normal user flings at chapter boundaries.
+    // This test pins the trigger: ShiftForward MUST fire when the smooth-tail endpoint places the
+    // viewport midpoint in the following chapter.
 
     @Test
     fun `shift forward fires when smooth-tail endpoint puts viewport midpoint past the chapter boundary`() {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWindowManagerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWindowManagerTest.kt
@@ -396,6 +396,80 @@ class ChapterWindowManagerTest {
         assertEquals(ChapterWindowManager.Decision.Hold, d)
     }
 
+    // ── smooth-tail far-jump blank-screen regression ─────────────────────────
+    //
+    // Root cause: during a smooth-tail annotation navigation the OverScroller targets y (annotation
+    // absolute scroll position). At scrollY=y the viewport midpoint is y + viewport/2. When the
+    // annotation is in the last ~(viewport/2) px of a chapter, y + viewport/2 is inside the next
+    // chapter, so ShiftForward fires at the animation's end. ShiftForward's removeTop scrollBy(-h)
+    // was overwritten by the OverScroller on the next computeScroll frame, making the scroll land
+    // viewport/2 + h past the annotation → placeholder blank territory.
+    //
+    // Fix: ContinuousWindowController.maybeShift calls port.abortFling() after removeTop/prependChapter
+    // so the OverScroller stops chasing the stale target. This test pins the trigger: ShiftForward
+    // MUST fire when the smooth-tail endpoint places the viewport midpoint in the following chapter.
+
+    @Test
+    fun `shift forward fires when smooth-tail endpoint puts viewport midpoint past the chapter boundary`() {
+        // Window [ch20, ch21(target), ch22], chaptersBehind=1. Annotation at 90 % of ch21.
+        // y = slot.top(ch21) + 0.9 * ch21.height = 5000 + 7200 = 12200.
+        // At scrollY=y the midpoint = y + viewport/2 = 12200 + 1200 = 13400 → inside ch22
+        // (which spans 13000..18000). Gap = ch22.globalIndex - topIndex = 21-19 = 2 > 1 → ShiftForward.
+        // Without port.abortFling() in ContinuousWindowController.maybeShift the OverScroller
+        // rewrites the removeTop scrollBy(-5000) correction on the next frame, landing 5000px past
+        // the annotation in placeholder territory → blank screen.
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val viewport = 2400
+        val ch20Height = 5000; val ch21Height = 8000; val ch22Height = 5000
+        val window = listOf(
+            slot("ch20",  0,                          ch20Height),
+            slot("ch21",  ch20Height,                 ch21Height),
+            slot("ch22",  ch20Height + ch21Height,    ch22Height),
+        )
+        val annotationOffsetInCh21 = (ch21Height * 0.9).toInt()  // 7200 px within ch21
+        val scrollY = ch20Height + annotationOffsetInCh21         // 12200 — the smooth-tail target y
+        val midpoint = scrollY + viewport / 2                     // 13400 — in ch22
+        // ch22 starts at 13000; midpoint=13400 is inside ch22 (global index 21, topIndex=19 → gap 2)
+        val viewportMidIndex = 21  // ch22's global index in the reading order
+        val decision = mgr.decide(
+            scrollY = scrollY,
+            viewportChapterIndex = viewportMidIndex,
+            window = window,
+            topIndex = 19,
+            totalChapters = 25,
+            viewportHeight = viewport,
+        )
+        assertEquals(ChapterWindowManager.Decision.ShiftForward, decision)
+    }
+
+    @Test
+    fun `holds when annotation at 80 pct of chapter keeps midpoint inside same chapter`() {
+        // Symmetric check: with the annotation at 80 % the midpoint stays inside ch21 → Hold.
+        // This distinguishes "the trigger fires only for annotations near the chapter end" from
+        // "any mid-chapter annotation triggers a spurious shift".
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val viewport = 2400
+        val ch20Height = 5000; val ch21Height = 8000; val ch22Height = 5000
+        val window = listOf(
+            slot("ch20",  0,                          ch20Height),
+            slot("ch21",  ch20Height,                 ch21Height),
+            slot("ch22",  ch20Height + ch21Height,    ch22Height),
+        )
+        val annotationOffsetInCh21 = (ch21Height * 0.8).toInt()  // 6400 px within ch21
+        val scrollY = ch20Height + annotationOffsetInCh21         // 11400
+        val midpoint = scrollY + viewport / 2                     // 12600 — still inside ch21 (5000..13000)
+        val viewportMidIndex = 20  // ch21's global index — gap = 20-19 = 1 = chaptersBehind → not > budget
+        val decision = mgr.decide(
+            scrollY = scrollY,
+            viewportChapterIndex = viewportMidIndex,
+            window = window,
+            topIndex = 19,
+            totalChapters = 25,
+            viewportHeight = viewport,
+        )
+        assertEquals(ChapterWindowManager.Decision.Hold, decision)
+    }
+
     // ── unknown viewport chapter (-1 from indexOfFirst) ──────────────────────
 
     @Test


### PR DESCRIPTION
## Root cause

In continuous reader mode, navigating to an annotation far into the book (e.g. Chapter 21 from Chapter 1) would show a blank screen instead of the annotation.

The smooth-tail annotation navigation calls `smoothScrollTo(y)` to pan to the annotation. When the annotation is in the last ~(viewport/2)px of a chapter, the viewport midpoint at scroll position `y` is inside the _next_ chapter. `maybeShift()` fires `ShiftForward`, which calls `removeTop()` → `scrollBy(-h)` to compensate. But the still-running OverScroller's next `computeScroll` frame overwrites the `scrollBy(-h)`, landing `h` pixels past the annotation into unloaded placeholder territory — blank screen.

## Fix

After each window shift in `maybeShift()`, call `port.abortFling()` when `smoothTailInProgress` is `true`, so the OverScroller stops chasing the stale pre-shift target and the `scrollBy` compensation sticks.

The guard on `smoothTailInProgress` is important: without it, normal user flings would be killed dead at every chapter boundary (the OverScroller is shared between `smoothScrollTo` and user flings). The abort is scoped to programmatic annotation navigation only.

## Tests

Two regression tests added to `ChapterWindowManagerTest`:
- `shift forward fires when smooth-tail endpoint puts viewport midpoint past the chapter boundary` — pins the exact trigger: annotation at 90% of a chapter, viewport midpoint falls in the next chapter → `ShiftForward`.
- `holds when annotation at 80 pct of chapter keeps midpoint inside same chapter` — verifies no spurious shift for mid-chapter annotations.

These tests would pass even if the `abortFling()` calls were removed (they cover `ChapterWindowManager.decide()`, the pure decision logic). The abort itself is Android-View territory and not JVM-testable without an Android mock; the regression tests pin the _trigger condition_ that the fix guards against.

## Review items addressed

- Scoped `abortFling()` to `smoothTailInProgress` after code review confirmed the unconditional calls would kill live user flings at every chapter boundary during normal reading.