### PR TITLE
fix(reader): fix erratic paged text selection and missing toolbar on Chrome 120+

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -461,7 +461,14 @@ internal object ColumnSnap {
           }
           window.addEventListener('scroll', function(){
             if(t) clearTimeout(t);
-            t=setTimeout(settle, 120);
+            // During an active text selection the user may be dragging a handle across a column
+            // boundary, which scrolls the WebView to a fractional column position. Use a very
+            // short debounce (~2 frames) so the snap fires quickly and the off-grid layout is
+            // imperceptible, rather than the normal 120ms which produces a visible jump after
+            // the user releases the handle.
+            var delay = 120;
+            try { var s=window.getSelection(); if(s&&!s.isCollapsed) delay=32; } catch(e3) {}
+            t=setTimeout(settle, delay);
           }, true);
           // Install-time fallback for programmatic landings that fire no scroll event (Readium's resume
           // go() on book open). Skip if a navigation snap has run/started since install — its rAF tracker

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapScript.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FigureTapScript.kt
@@ -151,15 +151,21 @@ internal object FigureTapScript {
             var longPressStartX = 0;
             var longPressStartY = 0;
             var LONG_PRESS_MOVE_THRESHOLD = 12; // CSS px — matches Android's default touchSlop
-            // Named so it can be added/removed by reference. Registered only while a figure
-            // long-press is in flight — a permanent capture listener on document interferes with
-            // Chrome's text-selection gesture handoff on newer WebView builds: the browser sees
-            // the listener run during touchcancel and suppresses the subsequent startActionMode
-            // call that would show the selection toolbar (#601).
+            // Named so they can be added/removed by reference. Both are registered only while a
+            // figure long-press is in flight — permanent capture-phase listeners on document
+            // interfere with Chrome's text-selection gesture handoff on newer WebView builds: the
+            // browser sees a listener run during the touchcancel (or contextmenu) that signals the
+            // handoff from long-press recognition to text-selection mode, and suppresses the
+            // subsequent startActionMode call that would show the selection toolbar.
+            function preventFigureContextMenu(e) {
+                document.removeEventListener('contextmenu', preventFigureContextMenu, true);
+                if (longPressTarget) e.preventDefault();
+            }
             function cancelFigureLongPress() {
                 if (longPressTimer) { clearTimeout(longPressTimer); longPressTimer = null; }
                 longPressTarget = null;
                 document.removeEventListener('touchcancel', cancelFigureLongPress, true);
+                document.removeEventListener('contextmenu', preventFigureContextMenu, true);
             }
             document.addEventListener('touchstart', function(e) {
                 var t = e.touches && e.touches[0];
@@ -169,10 +175,12 @@ internal object FigureTapScript {
                 longPressTarget = el;
                 longPressStartX = t.clientX;
                 longPressStartY = t.clientY;
-                // Arm the touchcancel guard only now that we know a figure is being pressed.
-                // Text long-presses never reach this point, so the listener never exists during
-                // the browser's text-selection gesture — preventing the toolbar suppression above.
+                // Arm the touchcancel and contextmenu guards only now that we know a figure is
+                // being pressed. Text long-presses never reach this point, so neither listener
+                // exists during the browser's text-selection gesture — preventing the toolbar
+                // suppression described above.
                 document.addEventListener('touchcancel', cancelFigureLongPress, true);
+                document.addEventListener('contextmenu', preventFigureContextMenu, true);
                 longPressTimer = setTimeout(function() {
                     if (!longPressTarget) return;
                     // Immediate visual signal that the long-press was detected — before any Kotlin
@@ -232,6 +240,7 @@ internal object FigureTapScript {
                     longPressTimer = null;
                     longPressTarget = null;
                     document.removeEventListener('touchcancel', cancelFigureLongPress, true);
+                    document.removeEventListener('contextmenu', preventFigureContextMenu, true);
                 }, 500);
             }, true);
             document.addEventListener('touchmove', function(e) {
@@ -246,11 +255,6 @@ internal object FigureTapScript {
             }, true);
             document.addEventListener('touchend', function() {
                 cancelFigureLongPress();
-            }, true);
-            // Cancel the native long-press callout on figures — belt to the CSS's braces above,
-            // for WebView builds where the CSS property alone is respected too late.
-            document.addEventListener('contextmenu', function(e) {
-                if (findFigure(e.target)) e.preventDefault();
             }, true);
         })();
         window.riffleFiguresInsideRange = window.riffleFiguresInsideRange || function(cfiRange) {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FigureTapScriptTest.kt
@@ -69,7 +69,7 @@ class FigureTapScriptTest {
     /**
      * Scrolling must take precedence over long-press: when the parent scroll container claims the
      * touch stream the WebView receives ACTION_CANCEL (JS: touchcancel). The [cancelFigureLongPress]
-     * helper is the single point that clears the timer, the target, and removes the listener.
+     * helper is the single point that clears the timer, the target, and removes both dynamic listeners.
      * This assertion flips red if the helper is removed or the clearTimeout is dropped.
      */
     @Test
@@ -88,19 +88,20 @@ class FigureTapScriptTest {
         assertTrue("cancelFigureLongPress must clearTimeout(longPressTimer)", fnBody.contains("clearTimeout(longPressTimer)"))
         assertTrue("cancelFigureLongPress must null out longPressTarget", fnBody.contains("longPressTarget = null"))
         assertTrue("cancelFigureLongPress must remove the touchcancel listener", fnBody.contains("removeEventListener('touchcancel', cancelFigureLongPress, true)"))
+        assertTrue("cancelFigureLongPress must remove the contextmenu listener", fnBody.contains("removeEventListener('contextmenu', preventFigureContextMenu, true)"))
     }
 
     /**
      * Regression test for the selection toolbar disappearing in paginated mode on newer WebView
-     * builds (Chrome 120+): a permanent capture-phase touchcancel listener on document fires
-     * during Chrome's gesture handoff from long-press recognition to text-selection mode and
-     * suppresses the subsequent startActionMode call that shows the toolbar.
+     * builds (Chrome 120+): permanent capture-phase `touchcancel` and `contextmenu` listeners on
+     * document fire during Chrome's gesture handoff from long-press recognition to text-selection
+     * mode and suppress the subsequent startActionMode call that shows the toolbar.
      *
-     * The fix is to register the touchcancel guard ONLY inside the touchstart handler and only
-     * when a figure was detected — text-selection long-presses return early before that point,
-     * so no touchcancel listener exists during their gesture lifecycle.
+     * The fix is to register both guards ONLY inside the touchstart handler and only when a figure
+     * was detected — text-selection long-presses return early before that point, so neither listener
+     * exists during their gesture lifecycle.
      *
-     * This assertion flips red if someone restores the permanent global listener.
+     * These assertions flip red if someone restores either permanent global listener.
      */
     @Test
     fun `touchcancel listener is registered dynamically inside touchstart not as a permanent global listener`() {
@@ -121,6 +122,48 @@ class FigureTapScriptTest {
             "permanent anonymous touchcancel listener must not exist (PR #601 regression guard)",
             script.contains("addEventListener('touchcancel', function()") ||
                 script.contains("addEventListener('touchcancel', function("),
+        )
+    }
+
+    /**
+     * Regression test for the companion contextmenu suppression: Chrome 120+ also suppresses
+     * the floating selection toolbar when a capture-phase `contextmenu` listener is present on
+     * document at the moment of the long-press→text-selection gesture handoff. The fix is the
+     * same as for `touchcancel` — arm [preventFigureContextMenu] only inside touchstart, disarm
+     * it as soon as the gesture resolves (timer fires, move slop exceeded, touchend, touchcancel).
+     *
+     * This assertion flips red if someone restores the permanent anonymous listener.
+     */
+    @Test
+    fun `contextmenu listener is registered dynamically inside touchstart not as a permanent global listener`() {
+        val earlyReturnIdx = script.indexOf("if (!el) return;")
+        assertTrue("early-return guard (if !el return) must exist in touchstart", earlyReturnIdx >= 0)
+        // preventFigureContextMenu must be declared before cancelFigureLongPress so the latter
+        // can reference it by name.
+        val preventFnIdx = script.indexOf("function preventFigureContextMenu(")
+        assertTrue("preventFigureContextMenu helper function must be declared", preventFnIdx >= 0)
+        val cancelFnIdx = script.indexOf("function cancelFigureLongPress()")
+        assertTrue("cancelFigureLongPress must come after preventFigureContextMenu in the script", preventFnIdx < cancelFnIdx)
+        val dynamicRegIdx = script.indexOf("document.addEventListener('contextmenu', preventFigureContextMenu, true)")
+        assertTrue("contextmenu must be registered via the named preventFigureContextMenu reference", dynamicRegIdx >= 0)
+        assertTrue(
+            "contextmenu registration must come AFTER the figure-detection early-return, " +
+                "so it is never registered during a text-selection long-press",
+            dynamicRegIdx > earlyReturnIdx,
+        )
+        // The body of preventFigureContextMenu must: remove itself, then conditionally prevent
+        // the default (only while the figure LP is still the active target).
+        val fnBodyStart = script.indexOf("{", preventFnIdx)
+        val fnBodyEnd = script.indexOf("\n            }", fnBodyStart)
+        val fnBody = script.substring(fnBodyStart, fnBodyEnd + 1)
+        assertTrue("preventFigureContextMenu must remove itself", fnBody.contains("removeEventListener('contextmenu', preventFigureContextMenu, true)"))
+        assertTrue("preventFigureContextMenu must call e.preventDefault()", fnBody.contains("e.preventDefault()"))
+        // There must be NO anonymous contextmenu listener — that was the permanent-listener shape
+        // that caused the regression and must never come back.
+        assertFalse(
+            "permanent anonymous contextmenu listener must not exist",
+            script.contains("addEventListener('contextmenu', function()") ||
+                script.contains("addEventListener('contextmenu', function("),
         )
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -417,4 +417,43 @@ class ReaderWebViewScriptsTest {
         assertTrue("walker present", walkerIdx >= 0)
         assertTrue("guard sits BEFORE the walker call", guardIdx < walkerIdx)
     }
+
+    /**
+     * Regression test for the erratic text-selection handle drag in paginated mode: the scroll
+     * listener in SETTLE_SNAP_INSTALL_JS used a fixed 120ms debounce, which produced a visible
+     * page snap while the user was still dragging a selection handle across a column boundary.
+     *
+     * Fix: when window.getSelection() is non-collapsed (active text selection), use 32ms (~2
+     * frames) so the snap fires fast enough to be imperceptible. The 120ms delay is kept for all
+     * other scroll events (page turns, column nav) where a visible settle is expected behaviour.
+     *
+     * This assertion flips red if someone removes the selection check or raises the delay back to
+     * 120ms unconditionally.
+     */
+    @Test
+    fun `SETTLE_SNAP_INSTALL_JS uses short debounce during active text selection to prevent visible handle-drag jump`() {
+        val js = ColumnSnap.SETTLE_SNAP_INSTALL_JS
+        // The selection-aware branch must be present.
+        assertTrue(
+            "SETTLE_SNAP_INSTALL_JS must check window.getSelection().isCollapsed",
+            js.contains("getSelection") && js.contains("isCollapsed"),
+        )
+        // 32ms short-path must appear in the JS.
+        assertTrue(
+            "SETTLE_SNAP_INSTALL_JS must set delay=32 during non-collapsed selection",
+            js.contains("delay=32"),
+        )
+        // The default 120ms path must still exist for non-selection scrolls.
+        assertTrue(
+            "SETTLE_SNAP_INSTALL_JS must keep delay=120 for normal scroll events",
+            js.contains("delay = 120") || js.contains("delay=120"),
+        )
+        // The short delay must appear AFTER the default so it only overrides during selection.
+        val defaultDelayIdx = js.indexOf("delay = 120").let { if (it < 0) js.indexOf("delay=120") else it }
+        val shortDelayIdx = js.indexOf("delay=32")
+        assertTrue(
+            "delay=32 override must appear AFTER the default delay=120 assignment",
+            shortDelayIdx > defaultDelayIdx,
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Two related regressions in paginated mode on newer WebView builds (Chrome 120+, Android 13+), both confirmed from a real-device recording:

**Bug 1 — Erratic selection / handles jump while dragging**

`SETTLE_SNAP_INSTALL_JS` fires its column-snap debounce on every scroll event — including those triggered by a selection handle crossing a column boundary. The 120ms delay was long enough to produce a visible page snap (the column jumping to a fractional position) while the user was still dragging. Fix: check `window.getSelection().isCollapsed` in the scroll handler and use 32ms (~2 frames) when an active selection exists, keeping 120ms for all other scroll events.

**Bug 2 — Selection toolbar never appears**

PR #610 made the `touchcancel` listener dynamic to fix the toolbar suppression on Chrome 120+. The `contextmenu` listener in `FigureTapScript` was still a permanent capture-phase listener on `document`, which is enough for Chrome to suppress `startActionMode` during the long-press→text-selection gesture handoff. Fix: apply the same dynamic pattern — arm `preventFigureContextMenu` only inside `touchstart` after figure detection, disarm it when the gesture resolves (timer fires, move slop exceeded, touchend, touchcancel). Text-selection long-presses return before the figure-detection point and never see either listener.

## Tests

- `FigureTapScriptTest`: added `contextmenu listener is registered dynamically inside touchstart not as a permanent global listener` — flips red if the permanent anonymous listener is restored; updated `cancelFigureLongPress` assertion to also verify contextmenu removal.
- `ReaderWebViewScriptsTest`: added `SETTLE_SNAP_INSTALL_JS uses short debounce during active text selection to prevent visible handle-drag jump` — flips red if the `isCollapsed` check is removed or the 32ms override is raised back to 120ms unconditionally.

Both bugs are reproducible on Android 13 AVD (Chrome 112+ WebView). Device verification on the real device is recommended for the handle-drag feel (AVD synthetic touch events cannot reliably automate the selection handle gesture).