### PR TITLE
fix(build): fix R8 release build — exclude stale okhttp-sse globally

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,15 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
 }
 
+// okhttp-sse:4.x is a stale transitive dep pulled in by ktor-client-okhttp:3.1.3.
+// It references okhttp3.internal.Util which was removed in OkHttp 5.x, breaking R8.
+// OkHttp 5 ships SSE in its main artifact, so this jar is redundant everywhere.
+subprojects {
+    configurations.all {
+        exclude(group = "com.squareup.okhttp3", module = "okhttp-sse")
+    }
+}
+
 // Enforces that `Log.[dweiv]("RIFFLE_…"` literals only live in core/logging.
 // Anything else: route the call through `Logger` + `LogChannel`. See #337.
 // Excludes RIFFLE_TEST (androidTest tag). Detection logic lives in

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -55,13 +55,19 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.okhttp)
-    implementation(libs.ktor.client.okhttp)
+    implementation(libs.ktor.client.okhttp) {
+        // okhttp-sse:4.x is a stale transitive dep — OkHttp 5 bundles SSE in its main artifact.
+        // The 4.x jar references okhttp3.internal.Util which was removed in 5.x, breaking R8.
+        exclude(group = "com.squareup.okhttp3", module = "okhttp-sse")
+    }
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.okhttp.mockwebserver)
     testImplementation(libs.mockk)
-    testImplementation(libs.ktor.client.okhttp)
+    testImplementation(libs.ktor.client.okhttp) {
+        exclude(group = "com.squareup.okhttp3", module = "okhttp-sse")
+    }
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.runner)

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -55,19 +55,13 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.okhttp)
-    implementation(libs.ktor.client.okhttp) {
-        // okhttp-sse:4.x is a stale transitive dep — OkHttp 5 bundles SSE in its main artifact.
-        // The 4.x jar references okhttp3.internal.Util which was removed in 5.x, breaking R8.
-        exclude(group = "com.squareup.okhttp3", module = "okhttp-sse")
-    }
+    implementation(libs.ktor.client.okhttp)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.okhttp.mockwebserver)
     testImplementation(libs.mockk)
-    testImplementation(libs.ktor.client.okhttp) {
-        exclude(group = "com.squareup.okhttp3", module = "okhttp-sse")
-    }
+    testImplementation(libs.ktor.client.okhttp)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.runner)

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -6,11 +6,7 @@ plugins {
 dependencies {
     implementation(project(":core:domain"))
     api(libs.ktor.client.core)
-    implementation(libs.ktor.client.okhttp) {
-        // okhttp-sse:4.x is a stale transitive dep — OkHttp 5 bundles SSE in its main artifact.
-        // The 4.x jar references okhttp3.internal.Util which was removed in 5.x, breaking R8.
-        exclude(group = "com.squareup.okhttp3", module = "okhttp-sse")
-    }
+    implementation(libs.ktor.client.okhttp)
     implementation(libs.ktor.client.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.okhttp)


### PR DESCRIPTION
## What

The release workflow (`v2.33.0`) was failing at the R8 minification step:

```
ERROR: R8: Missing class okhttp3.internal.Util
  (referenced from: void okhttp3.internal.sse.RealEventSource.processResponse(...))
```

`ktor-client-okhttp:3.1.3` transitively pulls in `okhttp-sse:4.12.0`, which references `okhttp3.internal.Util` — a class removed in OkHttp 5.x. OkHttp 5 ships SSE in its main artifact, so the 4.x jar is both redundant and broken.

PR #621 added a per-site `exclude` in `core:network`, but `core:data` also declares `implementation(libs.ktor.client.okhttp)` independently and was still pulling in the stale jar.

## Fix

Instead of duplicating the exclusion at every call site (fragile — future modules would silently re-break R8):

- Adds a single `subprojects { configurations.all { exclude(...) } }` block in the root `build.gradle.kts`.
- Removes the now-redundant per-site blocks from `core:network` and `core:data`.

Verified: `./gradlew :app:dependencies --configuration releaseRuntimeClasspath | grep okhttp-sse` returns nothing.