### PR TITLE
fix(build): fix R8 — force okhttp-sse to 5.x instead of excluding it

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,12 +12,15 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
 }
 
-// okhttp-sse:4.x is a stale transitive dep pulled in by ktor-client-okhttp:3.1.3.
-// It references okhttp3.internal.Util which was removed in OkHttp 5.x, breaking R8.
-// OkHttp 5 ships SSE in its main artifact, so this jar is redundant everywhere.
+// ktor-client-okhttp:3.1.3 pulls in okhttp-sse:4.12.0 as a transitive dep.
+// That jar references okhttp3.internal.Util, removed in OkHttp 5.x, breaking R8.
+// Force okhttp-sse to the same 5.x version used for the main OkHttp artifact so
+// the SSE classes exist but the internal reference is gone.
 subprojects {
     configurations.all {
-        exclude(group = "com.squareup.okhttp3", module = "okhttp-sse")
+        resolutionStrategy {
+            force("com.squareup.okhttp3:okhttp-sse:${libs.versions.okhttp.get()}")
+        }
     }
 }
 

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -55,13 +55,19 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.okhttp)
-    implementation(libs.ktor.client.okhttp)
+    implementation(libs.ktor.client.okhttp) {
+        // okhttp-sse:4.x is a stale transitive dep — OkHttp 5 bundles SSE in its main artifact.
+        // The 4.x jar references okhttp3.internal.Util which was removed in 5.x, breaking R8.
+        exclude(group = "com.squareup.okhttp3", module = "okhttp-sse")
+    }
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.okhttp.mockwebserver)
     testImplementation(libs.mockk)
-    testImplementation(libs.ktor.client.okhttp)
+    testImplementation(libs.ktor.client.okhttp) {
+        exclude(group = "com.squareup.okhttp3", module = "okhttp-sse")
+    }
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.runner)

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -55,19 +55,13 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.okhttp)
-    implementation(libs.ktor.client.okhttp) {
-        // okhttp-sse:4.x is a stale transitive dep — OkHttp 5 bundles SSE in its main artifact.
-        // The 4.x jar references okhttp3.internal.Util which was removed in 5.x, breaking R8.
-        exclude(group = "com.squareup.okhttp3", module = "okhttp-sse")
-    }
+    implementation(libs.ktor.client.okhttp)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.okhttp.mockwebserver)
     testImplementation(libs.mockk)
-    testImplementation(libs.ktor.client.okhttp) {
-        exclude(group = "com.squareup.okhttp3", module = "okhttp-sse")
-    }
+    testImplementation(libs.ktor.client.okhttp)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.runner)


### PR DESCRIPTION
## Follow-up to #623

PR #623 tried to fix the R8 release build by globally excluding `okhttp-sse`. That removed `okhttp3.sse.EventSource$Factory`, which `ktor-client-okhttp:3.1.3`'s `OkHttpSSESession` actually imports — causing a different R8 error:

```
ERROR: R8: Missing class okhttp3.sse.EventSource$Factory
  (referenced from: void io.ktor.client.engine.okhttp.OkHttpSSESession.<init>(...))
```

## Root cause

`ktor-client-okhttp:3.1.3` transitively pulls `okhttp-sse:4.12.0`. That jar references `okhttp3.internal.Util`, removed in OkHttp 5.x. We can't simply exclude `okhttp-sse` because Ktor uses the SSE API from it.

## Fix

Force `okhttp-sse` to the same version as the project's main OkHttp dep (5.4.0) in the `subprojects` resolution strategy already added by #623. OkHttp 5's `okhttp-sse` artifact provides the SSE public API (`EventSource$Factory`) without the removed `internal.Util` reference.

Verified: `./gradlew :app:dependencies --configuration releaseRuntimeClasspath | grep okhttp-sse` shows `4.12.0 -> 5.4.0`.