### PR TITLE
feat(changelog): make version history entries link to their GitHub release pages

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/update/ChangelogScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/update/ChangelogScreen.kt
@@ -26,6 +26,13 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.riffle.core.domain.ReleaseInfo
@@ -83,15 +90,39 @@ fun ChangelogScreen(
 
 @Composable
 private fun ReleaseEntry(release: ReleaseInfo) {
+    val uriHandler = LocalUriHandler.current
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 12.dp),
     ) {
-        Text(
-            text = "v${release.versionName}",
-            style = MaterialTheme.typography.titleSmall,
-        )
+        if (release.releaseUrl.isNotBlank()) {
+            val linkColor = MaterialTheme.colorScheme.primary
+            Text(
+                text = buildAnnotatedString {
+                    withLink(
+                        LinkAnnotation.Clickable(
+                            tag = "release",
+                            styles = TextLinkStyles(
+                                style = SpanStyle(
+                                    color = linkColor,
+                                    textDecoration = TextDecoration.Underline,
+                                ),
+                            ),
+                            linkInteractionListener = { uriHandler.openUri(release.releaseUrl) },
+                        )
+                    ) {
+                        append("v${release.versionName}")
+                    }
+                },
+                style = MaterialTheme.typography.titleSmall,
+            )
+        } else {
+            Text(
+                text = "v${release.versionName}",
+                style = MaterialTheme.typography.titleSmall,
+            )
+        }
         Spacer(modifier = Modifier.height(4.dp))
         Text(
             text = release.changelog.ifBlank { "No release notes." },

--- a/app/src/main/kotlin/com/riffle/app/feature/update/ChangelogScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/update/ChangelogScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
@@ -98,8 +99,8 @@ private fun ReleaseEntry(release: ReleaseInfo) {
     ) {
         if (release.releaseUrl.isNotBlank()) {
             val linkColor = MaterialTheme.colorScheme.primary
-            Text(
-                text = buildAnnotatedString {
+            val annotated = remember(release.releaseUrl, release.versionName, linkColor) {
+                buildAnnotatedString {
                     withLink(
                         LinkAnnotation.Clickable(
                             tag = "release",
@@ -114,7 +115,10 @@ private fun ReleaseEntry(release: ReleaseInfo) {
                     ) {
                         append("v${release.versionName}")
                     }
-                },
+                }
+            }
+            Text(
+                text = annotated,
                 style = MaterialTheme.typography.titleSmall,
             )
         } else {

--- a/app/src/test/kotlin/com/riffle/app/feature/update/ChangelogViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/update/ChangelogViewModelTest.kt
@@ -58,6 +58,18 @@ class ChangelogViewModelTest {
     }
 
     @Test
+    fun `releaseUrl is preserved in loaded state so the UI can render a link`() = runTest(testDispatcher) {
+        releasesResult = listOf(
+            ReleaseInfo("2.0.0", 20000, "Notes", "https://x", 1000L, "https://github.com/pkmetski/riffle/releases/tag/v2.0.0"),
+        )
+        val vm = makeViewModel()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val loaded = vm.state.value as ChangelogUiState.Loaded
+        assertEquals("https://github.com/pkmetski/riffle/releases/tag/v2.0.0", loaded.releases[0].releaseUrl)
+    }
+
+    @Test
     fun `state is Loaded with empty list when repo returns nothing`() = runTest(testDispatcher) {
         releasesResult = emptyList()
         val vm = makeViewModel()

--- a/core/data/src/main/kotlin/com/riffle/core/data/AppUpdateRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AppUpdateRepositoryImpl.kt
@@ -96,6 +96,7 @@ class AppUpdateRepositoryImpl @Inject constructor(
                     changelog = release.body,
                     downloadUrl = release.apkUrl,
                     sizeBytes = release.apkSizeBytes,
+                    releaseUrl = release.htmlUrl,
                 )
             }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/AppUpdateRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AppUpdateRepositoryImplTest.kt
@@ -63,8 +63,8 @@ class AppUpdateRepositoryImplTest {
 
     // --- listReleasesSince ---
 
-    private fun release(tag: String, body: String = "", apkUrl: String = "https://x/$tag.apk", size: Long = 1000L) =
-        GitHubRelease(tagName = tag, apkUrl = apkUrl, apkSizeBytes = size, body = body)
+    private fun release(tag: String, body: String = "", apkUrl: String = "https://x/$tag.apk", size: Long = 1000L, htmlUrl: String = "https://github.com/pkmetski/riffle/releases/tag/$tag") =
+        GitHubRelease(tagName = tag, apkUrl = apkUrl, apkSizeBytes = size, body = body, htmlUrl = htmlUrl)
 
     @Test
     fun `listReleasesSince returns only releases newer than sinceVersionCode`() {
@@ -82,6 +82,7 @@ class AppUpdateRepositoryImplTest {
         assertEquals("Notes 1.6", result[0].changelog)
         assertEquals("https://x/v1.6.0.apk", result[0].downloadUrl)
         assertEquals(1000L, result[0].sizeBytes)
+        assertEquals("https://github.com/pkmetski/riffle/releases/tag/v1.6.0", result[0].releaseUrl)
     }
 
     @Test

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/ReleaseInfo.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/ReleaseInfo.kt
@@ -6,4 +6,5 @@ data class ReleaseInfo(
     val changelog: String,
     val downloadUrl: String,
     val sizeBytes: Long,
+    val releaseUrl: String = "",
 )

--- a/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
@@ -84,6 +84,7 @@ class GitHubReleaseApi(
                         apkUrl = apk?.downloadUrl ?: "",
                         apkSizeBytes = apk?.size ?: 0L,
                         body = release.body,
+                        htmlUrl = release.htmlUrl,
                     )
                 }
         } catch (e: IOException) {
@@ -138,6 +139,7 @@ data class GitHubRelease(
     val apkUrl: String,
     val apkSizeBytes: Long,
     val body: String = "",
+    val htmlUrl: String = "",
 )
 
 @Serializable
@@ -147,6 +149,7 @@ private data class ReleaseResponse(
     val prerelease: Boolean = false,
     val assets: List<AssetResponse> = emptyList(),
     val body: String = "",
+    @SerialName("html_url") val htmlUrl: String = "",
 )
 
 @Serializable

--- a/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
@@ -53,6 +53,7 @@ class GitHubReleaseApi(
                         tagName = release.tagName,
                         apkUrl = apk.downloadUrl,
                         apkSizeBytes = apk.size,
+                        htmlUrl = release.htmlUrl,
                     )
                 )
             }


### PR DESCRIPTION
Each entry in the **Release history** screen now renders the version number as an underlined, primary-color tappable link. Tapping opens the corresponding GitHub release page in the browser via `LocalUriHandler`.

## What changed

- `GitHubReleaseApi` — deserializes `html_url` from the GitHub Releases API response into both `ReleaseResponse` and `GitHubRelease` (in both `latestRelease()` and `listReleases()` paths)
- `ReleaseInfo` — new `releaseUrl: String = ""` field carries the URL through the domain layer
- `AppUpdateRepositoryImpl.listReleasesSince` — maps `htmlUrl → releaseUrl`
- `ChangelogScreen.ReleaseEntry` — renders a `LinkAnnotation.Clickable`-backed `AnnotatedString` when `releaseUrl` is non-blank; falls back to plain text otherwise; the `AnnotatedString` is `remember`-ed to avoid rebuilding it on every recomposition

## Tests

- `AppUpdateRepositoryImplTest` — asserts `releaseUrl` is correctly threaded from `htmlUrl` through `listReleasesSince`
- `ChangelogViewModelTest` — new test asserts `releaseUrl` is preserved in `ChangelogUiState.Loaded` so the UI can gate on it