### PR TITLE
feat(update): re-check for updates on each app foreground return

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/update/StartupUpdateViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/update/StartupUpdateViewModel.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 
 data class StartupUpdateDialogState(
@@ -37,36 +36,29 @@ class StartupUpdateViewModel @Inject constructor(
     private val _downloadState = MutableStateFlow<UpdateDownloadState?>(null)
     val downloadState: StateFlow<UpdateDownloadState?> = _downloadState.asStateFlow()
 
-    private val checking = AtomicBoolean(false)
-
     init {
         checkNow()
     }
 
     fun checkNow() {
         if (_dialogState.value != null) return
-        if (!checking.compareAndSet(false, true)) return
         viewModelScope.launch {
-            try {
-                val autoEnabled = appUpdatePreferencesStore.autoUpdateEnabled.first()
-                if (!autoEnabled) return@launch
-                val ignoredCode = appUpdatePreferencesStore.ignoredVersionCode.first()
-                val releases = appUpdateRepository.listReleasesSince(currentVersionCode)
-                if (releases.isEmpty()) return@launch
-                val latest = releases.first()
-                if (latest.versionCode == ignoredCode) return@launch
-                _dialogState.value = StartupUpdateDialogState(
-                    releases = releases,
-                    update = AvailableUpdate(
-                        versionName = latest.versionName,
-                        versionCode = latest.versionCode,
-                        downloadUrl = latest.downloadUrl,
-                        sizeBytes = latest.sizeBytes,
-                    ),
-                )
-            } finally {
-                checking.set(false)
-            }
+            val autoEnabled = appUpdatePreferencesStore.autoUpdateEnabled.first()
+            if (!autoEnabled) return@launch
+            val ignoredCode = appUpdatePreferencesStore.ignoredVersionCode.first()
+            val releases = appUpdateRepository.listReleasesSince(currentVersionCode)
+            if (releases.isEmpty()) return@launch
+            val latest = releases.first()
+            if (latest.versionCode == ignoredCode) return@launch
+            _dialogState.value = StartupUpdateDialogState(
+                releases = releases,
+                update = AvailableUpdate(
+                    versionName = latest.versionName,
+                    versionCode = latest.versionCode,
+                    downloadUrl = latest.downloadUrl,
+                    sizeBytes = latest.sizeBytes,
+                ),
+            )
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/update/StartupUpdateViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/update/StartupUpdateViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 
 data class StartupUpdateDialogState(
@@ -36,24 +37,36 @@ class StartupUpdateViewModel @Inject constructor(
     private val _downloadState = MutableStateFlow<UpdateDownloadState?>(null)
     val downloadState: StateFlow<UpdateDownloadState?> = _downloadState.asStateFlow()
 
+    private val checking = AtomicBoolean(false)
+
     init {
+        checkNow()
+    }
+
+    fun checkNow() {
+        if (_dialogState.value != null) return
+        if (!checking.compareAndSet(false, true)) return
         viewModelScope.launch {
-            val autoEnabled = appUpdatePreferencesStore.autoUpdateEnabled.first()
-            if (!autoEnabled) return@launch
-            val ignoredCode = appUpdatePreferencesStore.ignoredVersionCode.first()
-            val releases = appUpdateRepository.listReleasesSince(currentVersionCode)
-            if (releases.isEmpty()) return@launch
-            val latest = releases.first()
-            if (latest.versionCode == ignoredCode) return@launch
-            _dialogState.value = StartupUpdateDialogState(
-                releases = releases,
-                update = AvailableUpdate(
-                    versionName = latest.versionName,
-                    versionCode = latest.versionCode,
-                    downloadUrl = latest.downloadUrl,
-                    sizeBytes = latest.sizeBytes,
-                ),
-            )
+            try {
+                val autoEnabled = appUpdatePreferencesStore.autoUpdateEnabled.first()
+                if (!autoEnabled) return@launch
+                val ignoredCode = appUpdatePreferencesStore.ignoredVersionCode.first()
+                val releases = appUpdateRepository.listReleasesSince(currentVersionCode)
+                if (releases.isEmpty()) return@launch
+                val latest = releases.first()
+                if (latest.versionCode == ignoredCode) return@launch
+                _dialogState.value = StartupUpdateDialogState(
+                    releases = releases,
+                    update = AvailableUpdate(
+                        versionName = latest.versionName,
+                        versionCode = latest.versionCode,
+                        downloadUrl = latest.downloadUrl,
+                        sizeBytes = latest.sizeBytes,
+                    ),
+                )
+            } finally {
+                checking.set(false)
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -1,6 +1,10 @@
 package com.riffle.app.navigation
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.DisposableEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.riffle.core.models.SourceType
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.rememberDrawerState
@@ -180,6 +184,15 @@ fun MainScreen(
         drawerTargetOpen = drawerState.targetValue == DrawerValue.Open,
     )) {
         scope.launch { drawerState.close() }
+    }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_START) startupUpdateVm.checkNow()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     // A media-notification tap jumps to whatever is playing. launchSingleTop makes this a no-op when

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -188,8 +188,18 @@ fun MainScreen(
 
     val lifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
+        // Gate on seenStop so that rotation (which replays ON_START on the new observer
+        // with a fresh seenStop=false) doesn't re-show the dialog after the user dismissed
+        // it. Only a genuine background→foreground transition sets seenStop=true first.
+        // Cold start is handled by StartupUpdateViewModel.init; this observer only covers
+        // subsequent foreground returns.
+        var seenStop = false
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_START) startupUpdateVm.checkNow()
+            when (event) {
+                Lifecycle.Event.ON_STOP -> seenStop = true
+                Lifecycle.Event.ON_START -> if (seenStop) startupUpdateVm.checkNow()
+                else -> Unit
+            }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }

--- a/app/src/test/kotlin/com/riffle/app/feature/update/StartupUpdateViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/update/StartupUpdateViewModelTest.kt
@@ -132,6 +132,51 @@ class StartupUpdateViewModelTest {
     }
 
     @Test
+    fun `checkNow re-shows dialog after dismiss`() = runTest {
+        val vm = StartupUpdateViewModel(
+            appUpdateRepository = fakeRepo(listOf(releaseInfo("1.6.0", 10600))),
+            appUpdatePreferencesStore = fakePrefs(),
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertNotNull(vm.dialogState.value)
+
+        vm.dismissDialog()
+        assertNull(vm.dialogState.value)
+
+        vm.checkNow()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNotNull(vm.dialogState.value)
+    }
+
+    @Test
+    fun `checkNow does not launch a duplicate check while dialog is showing`() = runTest {
+        var checkCount = 0
+        val repo = object : AppUpdateRepository {
+            override suspend fun checkForUpdate(currentVersionCode: Int): UpdateCheckResult =
+                UpdateCheckResult.UpToDate
+            override fun downloadAndInstall(update: AvailableUpdate): Flow<UpdateDownloadState> =
+                flowOf(UpdateDownloadState.Installing)
+            override fun sweepStaleApks() {}
+            override suspend fun listReleasesSince(sinceVersionCode: Int): List<ReleaseInfo> {
+                checkCount++
+                return listOf(releaseInfo("1.6.0", 10600))
+            }
+        }
+        val vm = StartupUpdateViewModel(
+            appUpdateRepository = repo,
+            appUpdatePreferencesStore = fakePrefs(),
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+        val checksAfterInit = checkCount
+
+        vm.checkNow()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("checkNow() is a no-op while dialog is already showing", checksAfterInit, checkCount)
+    }
+
+    @Test
     fun `dismissDialog clears dialog without writing ignoredVersionCode`() = runTest {
         val prefs = fakePrefs()
         val vm = StartupUpdateViewModel(


### PR DESCRIPTION
## Summary

- The update dialog previously only appeared on cold start (check ran once in `ViewModel.init`); users who never killed the app would never see a new-release prompt
- Add a `checkNow()` fun and register a `LifecycleEventObserver` in `MainScreen` that calls it on every `ON_START` that follows an `ON_STOP` — covering genuine background→foreground returns while leaving rotation unaffected
- Cold start is still handled by `ViewModel.init`; a `_dialogState != null` guard prevents a duplicate dialog if the init coroutine is still in-flight when the first foreground event fires

## Review fixes applied

- **Rotation bug**: the original observer fired `checkNow()` on every `ON_START`, including the replay that occurs when `addObserver` is called on an already-STARTED lifecycle after rotation. This re-showed the dialog even after the user tapped "Later". Fixed by tracking a local `seenStop` flag — the dialog only re-fires after a genuine `ON_STOP` has been observed first.
- **AtomicBoolean removed**: all `checkNow()` callers are on the Main thread so there is no concurrent access to guard. The `_dialogState != null` early-return is sufficient.

## Tests

- `checkNow re-shows dialog after dismiss` — verifies background→foreground re-check
- `checkNow does not launch a duplicate check while dialog is showing` — pins the dialog-null guard