### PR TITLE
feat(core): Phase 6 — platform-service abstractions (#556)

### DIFF
--- a/core/common/src/main/kotlin/com/riffle/core/common/EncryptedKeyValueStore.kt
+++ b/core/common/src/main/kotlin/com/riffle/core/common/EncryptedKeyValueStore.kt
@@ -1,0 +1,13 @@
+package com.riffle.core.common
+
+/**
+ * Tiny synchronous key/value contract used by config stores that need their values
+ * encrypted at rest. Exists so the config-store logic can be JVM-unit-tested with an
+ * in-memory fake while the production wiring binds an Android-Keystore-backed
+ * implementation.
+ */
+interface EncryptedKeyValueStore {
+    fun get(key: String): String?
+    fun put(key: String, value: String)
+    fun remove(key: String)
+}

--- a/core/common/src/main/kotlin/com/riffle/core/common/FileStore.kt
+++ b/core/common/src/main/kotlin/com/riffle/core/common/FileStore.kt
@@ -1,0 +1,22 @@
+package com.riffle.core.common
+
+/**
+ * Platform-agnostic abstraction over namespaced on-device file storage.
+ *
+ * Pure-Kotlin modules use [FileStore] to locate their storage directories without
+ * depending on [android.content.Context] or [java.io.File]. The Android implementation
+ * roots namespaces under [android.content.Context.getFilesDir]; test implementations
+ * can use a temporary directory.
+ *
+ * Namespaces are short stable identifiers (e.g. "annotation-sync", "epub-cache").
+ * Relative paths within a namespace use forward-slash separators.
+ */
+interface FileStore {
+    /**
+     * Returns the absolute path string for [namespace]/[relativePath], creating
+     * any missing parent directories as a side-effect.
+     *
+     * When [relativePath] is empty, returns the namespace root directory path.
+     */
+    fun resolve(namespace: String, relativePath: String = ""): String
+}

--- a/core/common/src/test/kotlin/com/riffle/core/common/FileStoreContractTest.kt
+++ b/core/common/src/test/kotlin/com/riffle/core/common/FileStoreContractTest.kt
@@ -1,0 +1,68 @@
+package com.riffle.core.common
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Contract test for [FileStore] using a temp-dir-backed implementation.
+ * Verifies the resolve() semantics that all platform implementations must honour.
+ */
+class FileStoreContractTest {
+
+    @get:Rule val tmp = TemporaryFolder()
+
+    private val store: FileStore by lazy {
+        TempDirFileStore(tmp.root)
+    }
+
+    @Test
+    fun `resolve namespace root creates directory and returns absolute path`() {
+        val path = store.resolve("my-namespace")
+
+        val dir = File(path)
+        assertTrue("namespace root directory must exist after resolve", dir.isDirectory)
+        assertTrue("returned path must be absolute", dir.isAbsolute)
+        assertTrue("namespace dir must be under root", path.startsWith(tmp.root.absolutePath))
+    }
+
+    @Test
+    fun `resolve with relativePath returns path under namespace`() {
+        val path = store.resolve("ns", "subdir/file.json")
+
+        assertTrue("returned path must be absolute", File(path).isAbsolute)
+        assertTrue("file path must contain namespace segment", path.contains("ns"))
+        assertTrue("file path must contain relative segment", path.endsWith("subdir/file.json"))
+    }
+
+    @Test
+    fun `resolve same namespace twice returns same root`() {
+        val first = store.resolve("stable")
+        val second = store.resolve("stable")
+
+        assertEquals("same namespace must resolve to the same path", first, second)
+    }
+
+    @Test
+    fun `different namespaces resolve to different directories`() {
+        val a = store.resolve("alpha")
+        val b = store.resolve("beta")
+
+        assertTrue("distinct namespaces must not share a root directory", a != b)
+    }
+
+    /** Minimal [FileStore] backed by a temp dir — usable for tests in pure-JVM modules. */
+    private class TempDirFileStore(private val root: File) : FileStore {
+        override fun resolve(namespace: String, relativePath: String): String {
+            val base = File(root, namespace)
+            return if (relativePath.isEmpty()) {
+                base.apply { mkdirs() }.absolutePath
+            } else {
+                File(base, relativePath).also { it.parentFile?.mkdirs() }.absolutePath
+            }
+        }
+    }
+}

--- a/core/data/src/androidTest/kotlin/com/riffle/core/data/AnnotationSyncControllerIntegrationTest.kt
+++ b/core/data/src/androidTest/kotlin/com/riffle/core/data/AnnotationSyncControllerIntegrationTest.kt
@@ -2,6 +2,7 @@ package com.riffle.core.data
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.riffle.core.logging.RecordingLogger
 import com.riffle.core.database.AnnotationDao
 import com.riffle.core.database.AnnotationEntity
 import com.riffle.core.domain.AnnotationMergeService
@@ -46,7 +47,7 @@ class AnnotationSyncControllerIntegrationTest {
     @Before
     fun setup() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        target = LocalDirectoryTarget(context)
+        target = LocalDirectoryTarget(context, RecordingLogger())
         filesDir = context.filesDir
 
         // Clean up any previous test data

--- a/core/data/src/androidTest/kotlin/com/riffle/core/data/LocalDirectoryTargetTest.kt
+++ b/core/data/src/androidTest/kotlin/com/riffle/core/data/LocalDirectoryTargetTest.kt
@@ -2,6 +2,7 @@ package com.riffle.core.data
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.riffle.core.logging.RecordingLogger
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -26,7 +27,7 @@ class LocalDirectoryTargetTest {
     @Before
     fun setup() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        target = LocalDirectoryTarget(context)
+        target = LocalDirectoryTarget(context, RecordingLogger())
         filesDir = context.filesDir
 
         // Clean up any previous test data
@@ -289,6 +290,7 @@ class LocalDirectoryTargetTest {
 
         val fresh = LocalDirectoryTarget(
             InstrumentationRegistry.getInstrumentation().targetContext,
+            RecordingLogger(),
         )
         val listed = fresh.list("abs_$absUuid", itemId).toSet()
 
@@ -333,6 +335,7 @@ class LocalDirectoryTargetTest {
         // Fresh target instance so `legacyAbsMigrated` starts false; then hit list().
         val fresh = LocalDirectoryTarget(
             InstrumentationRegistry.getInstrumentation().targetContext,
+            RecordingLogger(),
         )
         val listed = fresh.list("abs_$absUuid", itemId)
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncConfigStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationSyncConfigStoreImpl.kt
@@ -1,5 +1,6 @@
 package com.riffle.core.data
 
+import com.riffle.core.common.EncryptedKeyValueStore
 import com.riffle.core.domain.AnnotationSyncConfig
 import com.riffle.core.domain.AnnotationSyncConfigStore
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/core/data/src/main/kotlin/com/riffle/core/data/EncryptedKeyValueStore.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/EncryptedKeyValueStore.kt
@@ -1,13 +1,6 @@
 package com.riffle.core.data
 
-/**
- * Tiny synchronous key/value contract used by config stores that need their values
- * encrypted at rest. Exists so the config-store logic can be JVM-unit-tested with an
- * in-memory fake while the production wiring binds an Android-Keystore-backed
- * implementation.
- */
-interface EncryptedKeyValueStore {
-    fun get(key: String): String?
-    fun put(key: String, value: String)
-    fun remove(key: String)
-}
+// Moved to core:common in Phase 6. Typealias kept so any remaining same-package references
+// still resolve; all explicit imports have been updated to com.riffle.core.common.EncryptedKeyValueStore.
+@Deprecated("Use com.riffle.core.common.EncryptedKeyValueStore", ReplaceWith("com.riffle.core.common.EncryptedKeyValueStore"))
+typealias EncryptedKeyValueStore = com.riffle.core.common.EncryptedKeyValueStore

--- a/core/data/src/main/kotlin/com/riffle/core/data/FilesdirFileStore.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/FilesdirFileStore.kt
@@ -1,0 +1,26 @@
+package com.riffle.core.data
+
+import android.content.Context
+import com.riffle.core.common.FileStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import javax.inject.Inject
+
+/**
+ * [FileStore] implementation that roots all namespaces under [Context.getFilesDir].
+ *
+ * Directory layout: `<filesDir>/<namespace>/<relativePath>`
+ */
+class FilesdirFileStore @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : FileStore {
+
+    override fun resolve(namespace: String, relativePath: String): String {
+        val base = File(context.filesDir, namespace)
+        return if (relativePath.isEmpty()) {
+            base.apply { mkdirs() }.absolutePath
+        } else {
+            File(base, relativePath).also { it.parentFile?.mkdirs() }.absolutePath
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/KeystoreEncryptedKeyValueStore.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/KeystoreEncryptedKeyValueStore.kt
@@ -2,6 +2,7 @@ package com.riffle.core.data
 
 import android.content.Context
 import androidx.security.crypto.EncryptedSharedPreferences
+import com.riffle.core.common.EncryptedKeyValueStore
 import androidx.security.crypto.MasterKeys
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject

--- a/core/data/src/main/kotlin/com/riffle/core/data/LocalDirectoryTarget.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LocalDirectoryTarget.kt
@@ -1,13 +1,14 @@
 package com.riffle.core.data
 
 import android.content.Context
-import android.util.Log
 import com.riffle.core.domain.AnnotationFileRef
 import com.riffle.core.sources.webdav.LegacyAbsNamespaceMigration
 import com.riffle.core.domain.AnnotationSyncTarget
 import com.riffle.core.domain.DeviceFileSummary
 import com.riffle.core.domain.NamespaceDeviceListing
 import com.riffle.core.domain.NamespaceSummary
+import com.riffle.core.logging.LogChannel
+import com.riffle.core.logging.Logger
 import java.io.File
 
 /**
@@ -23,7 +24,10 @@ import java.io.File
  * (WebDAV) behind the same interface; the local-directory target remains useful for
  * tests and offline-only configurations.
  */
-class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget {
+class LocalDirectoryTarget(
+    private val context: Context,
+    private val logger: Logger,
+) : AnnotationSyncTarget {
 
     @Volatile private var legacyAbsMigrated: Boolean = false
 
@@ -61,7 +65,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
                 }
             }
         } catch (e: Exception) {
-            Log.e(TAG, "Legacy ABS dir migration failed (best-effort)", e)
+            logger.e(LogChannel.AnnotationSync, e) { "Legacy ABS dir migration failed (best-effort)" }
             allSucceeded = false
         }
         if (allSucceeded) legacyAbsMigrated = true
@@ -103,7 +107,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
                 file.isFile && file.name.startsWith(ANNOTATION_NAME_PREFIX) && file.name.endsWith(JSONLD_SUFFIX)
             }?.map { it.name } ?: emptyList()
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to list annotations for $namespace/$itemId", e)
+            logger.e(LogChannel.AnnotationSync, e) { "Failed to list annotations for $namespace/$itemId" }
             emptyList()
         }
     }
@@ -115,7 +119,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
             if (!file.exists()) return null
             file.readText()
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to read $filename for $namespace/$itemId", e)
+            logger.e(LogChannel.AnnotationSync, e) { "Failed to read $filename for $namespace/$itemId" }
             throw Exception("Failed to read $filename: ${e.message}", e)
         }
     }
@@ -129,7 +133,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
             }
             annotationFile(namespace, itemId, filename).writeText(content)
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to write $filename for $namespace/$itemId", e)
+            logger.e(LogChannel.AnnotationSync, e) { "Failed to write $filename for $namespace/$itemId" }
             throw Exception("Failed to write $filename: ${e.message}", e)
         }
     }
@@ -139,7 +143,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
             val file = annotationFile(namespace, itemId, filename)
             if (file.exists()) file.delete()
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to delete $filename for $namespace/$itemId", e)
+            logger.e(LogChannel.AnnotationSync, e) { "Failed to delete $filename for $namespace/$itemId" }
         }
     }
 
@@ -149,7 +153,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
             val file = deviceMetaFile(namespace, deviceId)
             if (!file.exists()) null else file.readText()
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to read device-meta $deviceId for $namespace", e)
+            logger.e(LogChannel.AnnotationSync, e) { "Failed to read device-meta $deviceId for $namespace" }
             null
         }
     }
@@ -163,7 +167,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
             }
             deviceMetaFile(namespace, deviceId).writeText(content)
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to write device-meta $deviceId for $namespace", e)
+            logger.e(LogChannel.AnnotationSync, e) { "Failed to write device-meta $deviceId for $namespace" }
             throw Exception("Failed to write device-meta $deviceId: ${e.message}", e)
         }
     }
@@ -173,7 +177,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
             val file = deviceMetaFile(namespace, deviceId)
             if (file.exists()) file.delete()
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to delete device-meta $deviceId for $namespace", e)
+            logger.e(LogChannel.AnnotationSync, e) { "Failed to delete device-meta $deviceId for $namespace" }
         }
     }
 
@@ -207,7 +211,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
             }
             NamespaceDeviceListing(devices = rows)
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to enumerate devices for $namespace", e)
+            logger.e(LogChannel.AnnotationSync, e) { "Failed to enumerate devices for $namespace" }
             NamespaceDeviceListing(emptyList())
         }
     }
@@ -230,7 +234,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
                 )
             }.orEmpty().sortedBy { it.namespace }
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to enumerate namespaces", e)
+            logger.e(LogChannel.AnnotationSync, e) { "Failed to enumerate namespaces" }
             emptyList()
         }
     }
@@ -252,7 +256,7 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
             dir.delete()
             deleted
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to forget namespace $namespace", e)
+            logger.e(LogChannel.AnnotationSync, e) { "Failed to forget namespace $namespace" }
             0
         }
     }
@@ -270,7 +274,6 @@ class LocalDirectoryTarget(private val context: Context) : AnnotationSyncTarget 
         File(namespaceDir(namespace), "$DEVICE_META_NAME_PREFIX$deviceId$JSON_SUFFIX")
 
     companion object {
-        private const val TAG = "LocalDirectoryTarget"
         private const val ROOT = "annotation-sync"
         private const val ANNOTATION_NAME_PREFIX = "annotations-"
         private const val DEVICE_META_NAME_PREFIX = "device-meta-"

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/LocalStoreModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/LocalStoreModule.kt
@@ -2,12 +2,14 @@ package com.riffle.core.data.di.modules
 
 import android.content.Context
 import com.riffle.core.data.AnnotationStoreImpl
+import com.riffle.core.data.FilesdirFileStore
 import com.riffle.core.data.AudiobookBookmarkStoreImpl
 import com.riffle.core.data.AudiobookPositionStoreImpl
 import com.riffle.core.data.CrossEpubIndexStoreImpl
 import com.riffle.core.data.DeviceIdStoreImpl
 import com.riffle.core.data.DownloadsRepositoryImpl
-import com.riffle.core.data.EncryptedKeyValueStore
+import com.riffle.core.common.EncryptedKeyValueStore
+import com.riffle.core.common.FileStore
 import com.riffle.core.data.KeystoreEncryptedKeyValueStore
 import com.riffle.core.data.KeystoreTokenStorage
 import com.riffle.core.data.LocalStoreImpl
@@ -47,6 +49,10 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class LocalStoreModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindFileStore(impl: FilesdirFileStore): FileStore
 
     @Binds
     @Singleton

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncConfigStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncConfigStoreImplTest.kt
@@ -1,5 +1,6 @@
 package com.riffle.core.data
 
+import com.riffle.core.common.EncryptedKeyValueStore
 import com.riffle.core.domain.AnnotationSyncConfig
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest

--- a/core/domain/src/main/kotlin/com/riffle/core/domain/AudioPlayer.kt
+++ b/core/domain/src/main/kotlin/com/riffle/core/domain/AudioPlayer.kt
@@ -1,0 +1,49 @@
+package com.riffle.core.domain
+
+/**
+ * Platform-agnostic audio playback contract.
+ *
+ * ExoPlayer (via Media3) implements this at the Android layer in [app]; a JVM test double
+ * or a future non-Android target can implement it independently. This phase only creates
+ * the boundary — the ExoPlayer wiring is not yet moved out of the Android module.
+ */
+interface AudioPlayer {
+
+    val isPlaying: Boolean
+
+    /** Current playback position in milliseconds (book-absolute for audiobooks). */
+    val currentPositionMs: Long
+
+    /** Total duration in milliseconds; -1 if unknown. */
+    val durationMs: Long
+
+    val playbackState: PlaybackState
+
+    fun play()
+
+    fun pause()
+
+    fun seekTo(positionMs: Long)
+
+    fun setPlaybackSpeed(speed: Float)
+
+    fun addListener(listener: Listener)
+
+    fun removeListener(listener: Listener)
+
+    interface Listener {
+        fun onIsPlayingChanged(isPlaying: Boolean) {}
+        fun onPlaybackStateChanged(state: PlaybackState) {}
+    }
+
+    enum class PlaybackState {
+        /** Player is idle; no media loaded. */
+        IDLE,
+        /** Player is loading or buffering. */
+        BUFFERING,
+        /** Player is ready to play. */
+        READY,
+        /** Playback has finished. */
+        ENDED,
+    }
+}

--- a/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
+++ b/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
@@ -24,4 +24,5 @@ enum class LogChannel(val tag: String) {
     Playlists("RIFFLE_PL"),
     ProgressSync("RIFFLE_PS"),
     Oom("RIFFLE_OOM"),
+    AnnotationSync("RIFFLE_ASYNC"),
 }

--- a/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
+++ b/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
@@ -24,5 +24,5 @@ enum class LogChannel(val tag: String) {
     Playlists("RIFFLE_PL"),
     ProgressSync("RIFFLE_PS"),
     Oom("RIFFLE_OOM"),
-    AnnotationSync("RIFFLE_ASYNC"),
+    AnnotationSync("RIFFLE_ANNSYNC"),
 }


### PR DESCRIPTION
Closes #556

## Summary

- **`FileStore` interface** (`core:common`) — platform-agnostic namespaced file-path resolution. Android impl `FilesdirFileStore` roots all namespaces under `Context.filesDir` and is wired as a Hilt singleton. Test double `TempDirFileStore` is included in `FileStoreContractTest`.
- **`EncryptedKeyValueStore` moved to `core:common`** — the interface now lives alongside `Clock`/`FileStore` in the pure-Kotlin module so `core:sync` and `core:sources` can depend on it without pulling in `core:data`. A `@Deprecated typealias` bridge is left in `core:data` so all existing consumers compile with no import changes; the bridge can be removed in a cleanup PR.
- **`AudioPlayer` interface** (`core:domain`) — platform-agnostic playback contract shaped for ExoPlayer to implement. This phase creates the boundary only; the ExoPlayer wiring remains in `app`.
- **Logger audit / `LocalDirectoryTarget`** — replaced the one stray `android.util.Log` import in `core:data` main sources with injected `Logger` + new `LogChannel.AnnotationSync` (`RIFFLE_ANNSYNC`). All `Log.e(TAG, …)` calls are now `logger.e(LogChannel.AnnotationSync, e) { … }`.

## Verification

- `./gradlew test` — BUILD SUCCESSFUL (all JVM tests, including new `FileStoreContractTest`)
- `./gradlew checkNoAndroidImports checkRiffleLogTags` — BUILD SUCCESSFUL
- `checkNoServerReferences` — pre-existing failure on `main` (unchanged by this branch)

## Code review notes

Findings 1–3 from review (race in `migrateLegacyAbsDirs`, double-log in `read()`, silent delete failures) are pre-existing behaviour in `LocalDirectoryTarget` unchanged by this diff. Finding 5 (Hilt constructor concern) is refuted — `LocalDirectoryTarget` has no production DI wiring. Finding 6 (tag ambiguity) fixed: `RIFFLE_ASYNC` → `RIFFLE_ANNSYNC`.