### PR TITLE
feat(reader): share elided view as PDF

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/highlights/ShareElidedViewTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/highlights/ShareElidedViewTest.kt
@@ -1,0 +1,162 @@
+package com.riffle.app.feature.reader.highlights
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.riffle.core.database.AnnotationEntity
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Verifies HTML assembly for the share-elided-view (PDF export) path.
+ *
+ * [buildCombinedHtml] is an `internal` top-level function exercised on-device here to validate the
+ * full assembly pipeline with a real [android.content.Context]-free path (it takes no Context).
+ * A full UI/PDF-render harness test (tapping Share, waiting for the print adapter, confirming file
+ * size) requires a device-level PrintManager round-trip that can't be driven without a running
+ * Activity; this test covers the HTML correctness that is a prerequisite for any valid PDF output.
+ *
+ * Assertions that would flip red if the fix were reverted:
+ *  - Chapter titles appear as `<h1>` elements in the combined output.
+ *  - The `<!DOCTYPE html>` + `<html>` wrapper is present (regression: missing wrapping would
+ *    cause WebView to fail to render the PDF document).
+ *  - Readium asset URLs are absent (the PDF WebView has no Readium WebViewServer; a link to
+ *    `readium_assets` would 404 silently and break fonts/styling in the exported PDF).
+ *  - Tap-dispatch spans are hidden via `display:none` (they have no function in a static PDF and
+ *    must not produce invisible-but-clickable dead zones in the PDF viewer).
+ *  - Chapters with no highlights are silently skipped (an empty `<h1>` with no body would add a
+ *    spurious blank page to the exported PDF).
+ */
+@RunWith(AndroidJUnit4::class)
+class ShareElidedViewTest {
+
+    private val factory = HighlightsPublicationFactory()
+
+    private fun highlight(id: String, snippet: String): AnnotationEntity = AnnotationEntity(
+        id = id,
+        sourceId = "S1",
+        itemId = "B1",
+        type = AnnotationEntity.TYPE_HIGHLIGHT,
+        cfi = "epubcfi(/6/2!/dummy)",
+        textSnippet = snippet,
+        note = null,
+        color = AnnotationEntity.COLOR_YELLOW,
+        chapterHref = "ch0.xhtml",
+        spineIndex = 0,
+        progression = 0.0,
+        createdAt = 0L,
+        updatedAt = 0L,
+        originDeviceId = "test",
+        lastModifiedByDeviceId = "test",
+        originFontFamily = null,
+        textSnippetHtml = null,
+        emphasisStyles = null,
+    )
+
+    @Test
+    fun buildCombinedHtml_producesWellFormedDocument() {
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(
+                ChapterElision("ch1.xhtml", "First Chapter", listOf(highlight("h1", "Some text"))),
+            ),
+            bookTitle = "Test Book",
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = "",
+            bookBodyFontFamily = null,
+        )
+        assertTrue("non-empty output", html.isNotBlank())
+        assertTrue("has DOCTYPE", html.startsWith("<!DOCTYPE html>"))
+        assertTrue("has opening html tag", html.contains("<html>"))
+        assertTrue("has closing html tag", html.contains("</html>"))
+        assertTrue("has body element", html.contains("<body>"))
+        assertTrue("has book title in <title>", html.contains("<title>Test Book</title>"))
+    }
+
+    @Test
+    fun buildCombinedHtml_containsAllChapterTitlesAsH1() {
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(
+                ChapterElision("ch1.xhtml", "Chapter One", listOf(highlight("h1", "text one"))),
+                ChapterElision("ch2.xhtml", "Chapter Two", listOf(highlight("h2", "text two"))),
+            ),
+            bookTitle = "My Book",
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = "",
+            bookBodyFontFamily = null,
+        )
+        assertTrue("Chapter One h1 present", html.contains("<h1>Chapter One</h1>"))
+        assertTrue("Chapter Two h1 present", html.contains("<h1>Chapter Two</h1>"))
+    }
+
+    @Test
+    fun buildCombinedHtml_hasNoReadiumAssetLinks() {
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(
+                ChapterElision("ch1.xhtml", "Ch", listOf(highlight("h1", "text"))),
+            ),
+            bookTitle = null,
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = "",
+            bookBodyFontFamily = null,
+        )
+        // The PDF WebView has no Readium WebViewServer — any readium_assets link would 404.
+        assertFalse("no readium_assets href in PDF output", html.contains("readium_assets"))
+    }
+
+    @Test
+    fun buildCombinedHtml_tapSpansAreHiddenInPdfOutput() {
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(
+                ChapterElision("ch1.xhtml", "Ch", listOf(highlight("h1", "text"))),
+            ),
+            bookTitle = null,
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = "",
+            bookBodyFontFamily = null,
+        )
+        // Tap dispatch spans must be hidden — they have no meaning in a static PDF.
+        assertTrue(
+            "tap class is declared as display:none",
+            html.contains(".$ACCENT_BAR_TAP_CLASS") && html.contains("display:none"),
+        )
+    }
+
+    @Test
+    fun buildCombinedHtml_skipsChaptersWithNoHighlights() {
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(
+                ChapterElision("ch1.xhtml", "Has Highlights", listOf(highlight("h1", "text"))),
+                ChapterElision("ch2.xhtml", "Empty Chapter", emptyList()),
+            ),
+            bookTitle = null,
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = "",
+            bookBodyFontFamily = null,
+        )
+        assertTrue("non-empty chapter is present", html.contains("<h1>Has Highlights</h1>"))
+        assertFalse("empty chapter is absent from PDF output", html.contains("<h1>Empty Chapter</h1>"))
+    }
+
+    @Test
+    fun buildCombinedHtml_includesHighlightTextContent() {
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(
+                ChapterElision(
+                    "ch1.xhtml", "My Chapter",
+                    listOf(highlight("h1", "The annotated text snippet")),
+                ),
+            ),
+            bookTitle = null,
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = "",
+            bookBodyFontFamily = null,
+        )
+        assertTrue("highlight snippet text present in output", html.contains("The annotated text snippet"))
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.ui.res.painterResource
 import com.riffle.app.R
 import androidx.compose.material3.CircularProgressIndicator
@@ -51,6 +52,7 @@ import com.riffle.app.feature.reader.decorations.FigureBorderDecoration
 import com.riffle.app.feature.reader.formatting.RenderCapabilities
 import com.riffle.app.feature.reader.highlights.shouldShowOpenInBook
 import com.riffle.app.feature.reader.highlights.shouldShowReadaloudUi
+import com.riffle.app.feature.reader.highlights.shouldShowShareHighlights
 import com.riffle.app.feature.reader.presenter.ContinuousPresenter
 import com.riffle.app.feature.reader.presenter.NavigationOptions
 import com.riffle.app.feature.reader.presenter.NavigationTarget
@@ -302,6 +304,7 @@ fun EpubReaderScreen(
     val isCurrentPageBookmarked by viewModel.isCurrentPageBookmarked.collectAsState()
     val highlightRenders by viewModel.highlightRenders.collectAsState()
     val highlightToEdit by viewModel.highlightToEdit.collectAsState()
+    val isExporting by viewModel.isExporting.collectAsState()
     val noteEditorTarget by viewModel.noteEditorTarget.collectAsState()
     val railSegments by viewModel.railSegments.collectAsState()
     val readaloudAvailable by viewModel.readaloudAvailable.collectAsState()
@@ -859,6 +862,26 @@ fun EpubReaderScreen(
                                         painter = painterResource(R.drawable.ic_readaloud),
                                         contentDescription = "Readaloud",
                                     )
+                                }
+                            }
+                            if (shouldShowShareHighlights(viewModel.readerSource)) {
+                                if (isExporting) {
+                                    Box(
+                                        modifier = Modifier.size(48.dp),
+                                        contentAlignment = Alignment.Center,
+                                    ) {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(24.dp),
+                                            strokeWidth = 2.dp,
+                                        )
+                                    }
+                                } else {
+                                    IconButton(onClick = viewModel::onShareElidedView) {
+                                        Icon(
+                                            imageVector = Icons.Default.Share,
+                                            contentDescription = "Share annotations as PDF",
+                                        )
+                                    }
                                 }
                             }
                         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -63,6 +63,7 @@ import com.riffle.core.domain.resolveEpubHref
 import com.riffle.core.database.AnnotationDao
 import com.riffle.core.database.AnnotationEntity
 import com.riffle.app.feature.reader.highlights.ChapterElision
+import com.riffle.app.feature.reader.highlights.HighlightsPdfExporter
 import com.riffle.app.feature.reader.highlights.HighlightsPublicationFactory
 import com.riffle.app.feature.reader.highlights.ReaderSource
 import com.riffle.app.feature.reader.highlights.toFormattingScope
@@ -273,6 +274,7 @@ class EpubReaderViewModel @Inject constructor(
     private val epubDownloadsStore: com.riffle.core.domain.LocalStore,
     @com.riffle.core.data.di.EpubCacheStore
     private val epubCacheStore: com.riffle.core.domain.LocalStore,
+    private val pdfExporter: HighlightsPdfExporter,
 ) : AndroidViewModel(application) {
 
     // ReadingSessionCoordinator's per-call enabled gate reads this atomic; init below flips it once
@@ -535,6 +537,7 @@ class EpubReaderViewModel @Inject constructor(
     // when no annotation on the book has a captured font yet — factory then emits no
     // font-family and the elided reader falls back to ReadiumCSS default (pre-fix behaviour).
     private var elidedBodyFontFamily: String? = null
+    private var elidedBookTitle: String? = null
     // Highlights mode only: subscription to annotationStore.observeAnnotations so the elided
     // reader updates live when annotations change (colour/note/delete edits from anywhere, and
     // additions arriving via AnnotationSyncController's remote pull). Kept alive across the
@@ -1216,6 +1219,7 @@ class EpubReaderViewModel @Inject constructor(
             // label makes clear which book's highlights are shown. Falls back to plain "Annotations"
             // when the local library_items row is gone (orphaned book).
             val realBookTitle = libraryItemDao.getById(sourceId, itemId)?.title
+            elidedBookTitle = realBookTitle
             // Fallback body-font for excerpts whose annotation has null `originFontFamily`
             // (legacy rows, W3C sync ingest). Pick the plurality font across the captured set —
             // it converges to the book's dominant face as the user creates new annotations.
@@ -3373,11 +3377,38 @@ class EpubReaderViewModel @Inject constructor(
     private val _tocVisible = MutableStateFlow(false)
     val tocVisible: StateFlow<Boolean> = _tocVisible
 
+    private val _isExporting = MutableStateFlow(false)
+    val isExporting: StateFlow<Boolean> = _isExporting.asStateFlow()
+
     fun openToc() {
         annotationSession.closeAnnotationsPanel()
         _tocVisible.value = true
     }
     fun closeToc() { _tocVisible.value = false }
+
+    fun onShareElidedView() {
+        if (_isExporting.value) return
+        val chapters = highlightsResumeChapters ?: return
+        val handle = highlightsPublicationHandle ?: return
+        viewModelScope.launch {
+            _isExporting.value = true
+            try {
+                val uri = pdfExporter.export(
+                    chapters = chapters,
+                    bookTitle = elidedBookTitle,
+                    itemId = itemId,
+                    figureBytesByHref = handle.figureBytesByHref,
+                    publisherFontFaceCss = handle.publisherFontFaceCss,
+                    bookBodyFontFamily = elidedBodyFontFamily,
+                )
+                _readerNavEvents.send(ReaderNavEvent.ShareHighlights(uri))
+            } catch (e: Exception) {
+                _readerNavEvents.send(ReaderNavEvent.ExportError)
+            } finally {
+                _isExporting.value = false
+            }
+        }
+    }
 
     val annotationsPanelVisible: StateFlow<Boolean> = annotationSession.annotationsPanelVisible
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -3393,7 +3393,7 @@ class EpubReaderViewModel @Inject constructor(
         viewModelScope.launch {
             _isExporting.value = true
             try {
-                val uri = pdfExporter.export(
+                val result = pdfExporter.export(
                     chapters = chapters,
                     bookTitle = elidedBookTitle,
                     itemId = itemId,
@@ -3401,7 +3401,7 @@ class EpubReaderViewModel @Inject constructor(
                     publisherFontFaceCss = handle.publisherFontFaceCss,
                     bookBodyFontFamily = elidedBodyFontFamily,
                 )
-                _readerNavEvents.send(ReaderNavEvent.ShareHighlights(uri))
+                _readerNavEvents.send(ReaderNavEvent.ShareHighlights(result.uri, result.fileName))
             } catch (e: Exception) {
                 _readerNavEvents.send(ReaderNavEvent.ExportError)
             } finally {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderNavEvent.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderNavEvent.kt
@@ -19,7 +19,7 @@ sealed interface ReaderNavEvent {
     object CloseEmptyHighlights : ReaderNavEvent
 
     /** The elided view PDF was generated successfully; the nav host fires [android.content.Intent.ACTION_SEND]. */
-    data class ShareHighlights(val uri: Uri) : ReaderNavEvent
+    data class ShareHighlights(val uri: Uri, val fileName: String) : ReaderNavEvent
 
     /** PDF generation failed; the nav host shows a toast. */
     object ExportError : ReaderNavEvent

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderNavEvent.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderNavEvent.kt
@@ -1,5 +1,7 @@
 package com.riffle.app.feature.reader
 
+import android.net.Uri
+
 /**
  * Navigation events emitted by [EpubReaderViewModel] that the nav host (MainScreen) must act on
  * outside the reader's own back stack — e.g. leaving the elided Highlights-mode reader to open the
@@ -15,4 +17,10 @@ sealed interface ReaderNavEvent {
      * book.
      */
     object CloseEmptyHighlights : ReaderNavEvent
+
+    /** The elided view PDF was generated successfully; the nav host fires [android.content.Intent.ACTION_SEND]. */
+    data class ShareHighlights(val uri: Uri) : ReaderNavEvent
+
+    /** PDF generation failed; the nav host shows a toast. */
+    object ExportError : ReaderNavEvent
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt
@@ -25,8 +25,8 @@ class HighlightsPdfExporter @Inject constructor(
 ) {
     /**
      * Assembles the combined HTML for all chapters, renders it to a PDF via a headless WebView,
-     * writes the result to `cacheDir/exports/annotations-<itemId>.pdf`, and returns a
-     * [FileProvider] URI suitable for [android.content.Intent.ACTION_SEND].
+     * writes the result to `cacheDir/exports/<bookTitle> Annotations.pdf` (sanitized, falling back
+     * to the item ID), and returns an [ExportResult] with the [FileProvider] URI and filename.
      *
      * Must be called from a coroutine; the WebView and PrintDocumentAdapter callbacks run on the
      * main thread ([kotlinx.coroutines.Dispatchers.Main]).
@@ -56,8 +56,16 @@ class HighlightsPdfExporter @Inject constructor(
         withContext(Dispatchers.Main) {
             suspendCancellableCoroutine<Unit> { cont ->
                 val webView = android.webkit.WebView(context)
+                // Tracks the open ParcelFileDescriptor so the cancellation handler can close it
+                // if the coroutine is cancelled after onLayoutFinished opens it but before any
+                // write callback closes it (otherwise the fd leaks).
+                val openPfd = java.util.concurrent.atomic.AtomicReference<android.os.ParcelFileDescriptor?>(null)
+                // Guard against WebView builds that fire onPageFinished more than once.
+                var layoutStarted = false
                 webView.webViewClient = object : android.webkit.WebViewClient() {
                     override fun onPageFinished(view: android.webkit.WebView, url: String) {
+                        if (layoutStarted) return
+                        layoutStarted = true
                         try {
                         val adapter = webView.createPrintDocumentAdapter(title ?: "Annotations")
                         val attributes = android.print.PrintAttributes.Builder()
@@ -74,45 +82,56 @@ class HighlightsPdfExporter @Inject constructor(
                                     info: android.print.PrintDocumentInfo,
                                     changed: Boolean,
                                 ) {
-                                    val pfd = android.os.ParcelFileDescriptor.open(
-                                        outFile,
-                                        android.os.ParcelFileDescriptor.MODE_READ_WRITE or
-                                            android.os.ParcelFileDescriptor.MODE_CREATE or
-                                            android.os.ParcelFileDescriptor.MODE_TRUNCATE,
-                                    )
-                                    adapter.onWrite(
-                                        arrayOf(android.print.PageRange.ALL_PAGES),
-                                        pfd,
-                                        null,
-                                        object : android.print.PrintDocumentAdapter.WriteResultCallback() {
-                                            override fun onWriteFinished(
-                                                pages: Array<out android.print.PageRange>,
-                                            ) {
-                                                pfd.close()
-                                                adapter.onFinish()
-                                                webView.destroy()
-                                                cont.resume(Unit)
-                                            }
+                                    // onLayoutFinished is invoked asynchronously by the print
+                                    // framework — it runs outside the try/catch above. Any throw
+                                    // here must be caught and routed to the continuation.
+                                    try {
+                                        val pfd = android.os.ParcelFileDescriptor.open(
+                                            outFile,
+                                            android.os.ParcelFileDescriptor.MODE_READ_WRITE or
+                                                android.os.ParcelFileDescriptor.MODE_CREATE or
+                                                android.os.ParcelFileDescriptor.MODE_TRUNCATE,
+                                        )
+                                        openPfd.set(pfd)
+                                        adapter.onWrite(
+                                            arrayOf(android.print.PageRange.ALL_PAGES),
+                                            pfd,
+                                            null,
+                                            object : android.print.PrintDocumentAdapter.WriteResultCallback() {
+                                                override fun onWriteFinished(
+                                                    pages: Array<out android.print.PageRange>,
+                                                ) {
+                                                    openPfd.getAndSet(null)?.close()
+                                                    adapter.onFinish()
+                                                    webView.destroy()
+                                                    cont.resume(Unit)
+                                                }
 
-                                            override fun onWriteFailed(error: CharSequence?) {
-                                                pfd.close()
-                                                adapter.onFinish()
-                                                webView.destroy()
-                                                cont.resumeWithException(
-                                                    java.io.IOException("PDF write failed: $error"),
-                                                )
-                                            }
+                                                override fun onWriteFailed(error: CharSequence?) {
+                                                    openPfd.getAndSet(null)?.close()
+                                                    adapter.onFinish()
+                                                    webView.destroy()
+                                                    cont.resumeWithException(
+                                                        java.io.IOException("PDF write failed: $error"),
+                                                    )
+                                                }
 
-                                            override fun onWriteCancelled() {
-                                                pfd.close()
-                                                adapter.onFinish()
-                                                webView.destroy()
-                                                cont.resumeWithException(
-                                                    java.io.IOException("PDF write cancelled"),
-                                                )
-                                            }
-                                        },
-                                    )
+                                                override fun onWriteCancelled() {
+                                                    openPfd.getAndSet(null)?.close()
+                                                    adapter.onFinish()
+                                                    webView.destroy()
+                                                    cont.resumeWithException(
+                                                        java.io.IOException("PDF write cancelled"),
+                                                    )
+                                                }
+                                            },
+                                        )
+                                    } catch (e: Exception) {
+                                        openPfd.getAndSet(null)?.close()
+                                        adapter.onFinish()
+                                        webView.destroy()
+                                        cont.resumeWithException(e)
+                                    }
                                 }
 
                                 override fun onLayoutFailed(error: CharSequence?) {
@@ -140,7 +159,10 @@ class HighlightsPdfExporter @Inject constructor(
                     }
                 }
                 webView.loadDataWithBaseURL(null, html, "text/html", "UTF-8", null)
-                cont.invokeOnCancellation { webView.destroy() }
+                cont.invokeOnCancellation {
+                    openPfd.getAndSet(null)?.close()
+                    webView.destroy()
+                }
             }
         }
     }
@@ -155,12 +177,13 @@ class HighlightsPdfExporter @Inject constructor(
  * below the 255-byte ext4 limit.
  */
 internal fun buildPdfFileName(bookTitle: String?, itemId: String): String {
+    val illegal = Regex("[\\\\/:*?\"<>|]")
     val safeName = bookTitle
-        ?.replace(Regex("[\\\\/:*?\"<>|]"), "_")
+        ?.replace(illegal, "_")
         ?.trim()
         ?.take(180)
         ?.ifBlank { null }
-        ?: itemId.take(64)
+        ?: itemId.replace(illegal, "_").trim().take(64)
     return "$safeName Annotations.pdf"
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt
@@ -31,6 +31,8 @@ class HighlightsPdfExporter @Inject constructor(
      * Must be called from a coroutine; the WebView and PrintDocumentAdapter callbacks run on the
      * main thread ([kotlinx.coroutines.Dispatchers.Main]).
      */
+    data class ExportResult(val uri: Uri, val fileName: String)
+
     suspend fun export(
         chapters: List<ChapterElision>,
         bookTitle: String?,
@@ -38,7 +40,7 @@ class HighlightsPdfExporter @Inject constructor(
         figureBytesByHref: Map<String, String>,
         publisherFontFaceCss: String,
         bookBodyFontFamily: String?,
-    ): Uri {
+    ): ExportResult {
         val html = buildCombinedHtml(factory, chapters, bookTitle, figureBytesByHref, publisherFontFaceCss, bookBodyFontFamily)
         val exportsDir = File(context.cacheDir, "exports").also { it.mkdirs() }
         val safeName = bookTitle
@@ -47,9 +49,11 @@ class HighlightsPdfExporter @Inject constructor(
             ?.take(180)
             ?.ifBlank { null }
             ?: itemId.take(64)
-        val pdfFile = File(exportsDir, "$safeName Annotations.pdf")
+        val fileName = "$safeName Annotations.pdf"
+        val pdfFile = File(exportsDir, fileName)
         renderToPdf(html, bookTitle, pdfFile)
-        return FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", pdfFile)
+        val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", pdfFile)
+        return ExportResult(uri, fileName)
     }
 
     // WebView + PrintDocumentAdapter rendering — implemented in Task 3.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt
@@ -1,0 +1,120 @@
+package com.riffle.app.feature.reader.highlights
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import javax.inject.Inject
+
+/**
+ * Exports the elided reader's full highlight set as a self-contained PDF via a headless
+ * [android.webkit.WebView] and [android.print.PrintDocumentAdapter].
+ *
+ * [buildCombinedHtml] is an `internal` top-level function so JVM unit tests can exercise HTML
+ * assembly without a live [Context] or [android.webkit.WebView].
+ */
+class HighlightsPdfExporter @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val factory: HighlightsPublicationFactory,
+) {
+    /**
+     * Assembles the combined HTML for all chapters, renders it to a PDF via a headless WebView,
+     * writes the result to `cacheDir/exports/annotations-<itemId>.pdf`, and returns a
+     * [FileProvider] URI suitable for [android.content.Intent.ACTION_SEND].
+     *
+     * Must be called from a coroutine; the WebView and PrintDocumentAdapter callbacks run on the
+     * main thread ([kotlinx.coroutines.Dispatchers.Main]).
+     */
+    suspend fun export(
+        chapters: List<ChapterElision>,
+        bookTitle: String?,
+        itemId: String,
+        figureBytesByHref: Map<String, String>,
+        publisherFontFaceCss: String,
+        bookBodyFontFamily: String?,
+    ): Uri {
+        val html = buildCombinedHtml(factory, chapters, bookTitle, figureBytesByHref, publisherFontFaceCss, bookBodyFontFamily)
+        val exportsDir = File(context.cacheDir, "exports").also { it.mkdirs() }
+        val pdfFile = File(exportsDir, "annotations-${itemId.take(64)}.pdf")
+        renderToPdf(html, bookTitle, pdfFile)
+        return FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", pdfFile)
+    }
+
+    // WebView + PrintDocumentAdapter rendering — implemented in Task 3.
+    private suspend fun renderToPdf(html: String, title: String?, outFile: File): Unit = TODO("Task 3")
+}
+
+// ─── PDF base styles ─────────────────────────────────────────────────────────
+
+private const val PDF_BASE_CSS =
+    "body{font-size:14pt;line-height:1.6;margin:0;padding:16pt;}" +
+        "h1{font-size:16pt;border-bottom:1px solid #cccccc;padding-bottom:4pt;" +
+        "margin:24pt 0 12pt;page-break-after:avoid;}" +
+        "h1:first-child{margin-top:0;}" +
+        "p{margin:0.75em 0;}" +
+        "aside{margin:0.5em 0;}"
+
+// ─── HTML assembly ────────────────────────────────────────────────────────────
+
+/**
+ * Assembles a single self-contained `<html>` document from [chapters] for PDF export.
+ *
+ * Each chapter is rendered via [HighlightsPublicationFactory.renderChapterHtml]; only the
+ * `<body>` content is extracted and concatenated. The combined `<head>` substitutes
+ * [PDF_BASE_CSS] for the `READIUM_DEFAULT_CSS_LINK` (which is served by Readium's
+ * `WebViewServer` and is not resolvable outside the live reader WebView). Tap-dispatch spans
+ * ([ACCENT_BAR_TAP_CLASS]) are hidden via CSS — they have no meaning in a static PDF.
+ *
+ * All images are already base64 data URIs inside the chapter HTML; the result is fully
+ * self-contained with no external resource references.
+ */
+internal fun buildCombinedHtml(
+    factory: HighlightsPublicationFactory,
+    chapters: List<ChapterElision>,
+    bookTitle: String?,
+    figureBytesByHref: Map<String, String>,
+    publisherFontFaceCss: String,
+    bookBodyFontFamily: String?,
+): String {
+    val safeTitle = bookTitle
+        ?.replace("&", "&amp;")?.replace("<", "&lt;")?.replace("\"", "&quot;")
+        ?: "Annotations"
+
+    val bodyParts = chapters
+        .filter { it.highlights.isNotEmpty() }
+        .joinToString("\n") { chapter ->
+            val chapterXhtml = factory.renderChapterHtml(
+                chapter, bookBodyFontFamily, figureBytesByHref, publisherFontFaceCss,
+            )
+            // Extract content between <body> and </body>; the chapter XHTML is authored by
+            // renderChapterHtml and always contains exactly one <body> block.
+            val bodyStart = chapterXhtml.indexOf("<body>").takeIf { it >= 0 } ?: return@joinToString ""
+            val bodyEnd = chapterXhtml.lastIndexOf("</body>").takeIf { it >= 0 } ?: return@joinToString ""
+            chapterXhtml.substring(bodyStart + "<body>".length, bodyEnd).trim()
+        }
+
+    val bodyFontRule = run {
+        val safe = sanitizeCssFontFamily(
+            bookBodyFontFamily?.takeIf { it != FALLBACK_ORIGIN_FONT_FAMILY },
+        ) ?: return@run ""
+        "body,h1,h2,h3,h4,h5,h6{font-family:$safe;}"
+    }
+
+    return buildString {
+        append("<!DOCTYPE html><html><head>")
+        append("<meta charset=\"utf-8\"/>")
+        append("<title>$safeTitle</title>")
+        append("<style>")
+        append(PDF_BASE_CSS)
+        append(ACCENT_BAR_TAP_CSS)
+        append(FIGURE_CENTERING_CSS)
+        // Hide tap-dispatch spans — they serve no purpose in a static PDF.
+        append(".$ACCENT_BAR_TAP_CLASS{display:none}")
+        if (publisherFontFaceCss.isNotBlank()) append(publisherFontFaceCss)
+        if (bodyFontRule.isNotBlank()) append(bodyFontRule)
+        append("</style></head><body>")
+        append(bodyParts)
+        append("</body></html>")
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt
@@ -6,6 +6,11 @@ import androidx.core.content.FileProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * Exports the elided reader's full highlight set as a self-contained PDF via a headless
@@ -42,7 +47,74 @@ class HighlightsPdfExporter @Inject constructor(
     }
 
     // WebView + PrintDocumentAdapter rendering — implemented in Task 3.
-    private suspend fun renderToPdf(html: String, title: String?, outFile: File): Unit = TODO("Task 3")
+    @Suppress("INVISIBLE_MEMBER", "INVISIBLE_REFERENCE")
+    private suspend fun renderToPdf(html: String, title: String?, outFile: File) {
+        withContext(Dispatchers.Main) {
+            suspendCancellableCoroutine<Unit> { cont ->
+                val webView = android.webkit.WebView(context)
+                webView.webViewClient = object : android.webkit.WebViewClient() {
+                    override fun onPageFinished(view: android.webkit.WebView, url: String) {
+                        val adapter = webView.createPrintDocumentAdapter(title ?: "Annotations")
+                        val attributes = android.print.PrintAttributes.Builder()
+                            .setMediaSize(android.print.PrintAttributes.MediaSize.ISO_A4)
+                            .setResolution(
+                                android.print.PrintAttributes.Resolution("pdf", "pdf", 300, 300),
+                            )
+                            .setMinMargins(android.print.PrintAttributes.Margins.NO_MARGINS)
+                            .build()
+                        adapter.onLayout(
+                            null, attributes, null,
+                            object : android.print.PrintDocumentAdapter.LayoutResultCallback() {
+                                override fun onLayoutFinished(
+                                    info: android.print.PrintDocumentInfo,
+                                    changed: Boolean,
+                                ) {
+                                    val pfd = android.os.ParcelFileDescriptor.open(
+                                        outFile,
+                                        android.os.ParcelFileDescriptor.MODE_READ_WRITE or
+                                            android.os.ParcelFileDescriptor.MODE_CREATE or
+                                            android.os.ParcelFileDescriptor.MODE_TRUNCATE,
+                                    )
+                                    adapter.onWrite(
+                                        arrayOf(android.print.PageRange.ALL_PAGES),
+                                        pfd,
+                                        null,
+                                        object : android.print.PrintDocumentAdapter.WriteResultCallback() {
+                                            override fun onWriteFinished(
+                                                pages: Array<out android.print.PageRange>,
+                                            ) {
+                                                pfd.close()
+                                                webView.destroy()
+                                                cont.resume(Unit)
+                                            }
+
+                                            override fun onWriteFailed(error: CharSequence?) {
+                                                pfd.close()
+                                                webView.destroy()
+                                                cont.resumeWithException(
+                                                    java.io.IOException("PDF write failed: $error"),
+                                                )
+                                            }
+                                        },
+                                    )
+                                }
+
+                                override fun onLayoutFailed(error: CharSequence?) {
+                                    webView.destroy()
+                                    cont.resumeWithException(
+                                        java.io.IOException("PDF layout failed: $error"),
+                                    )
+                                }
+                            },
+                            null,
+                        )
+                    }
+                }
+                webView.loadDataWithBaseURL(null, html, "text/html", "UTF-8", null)
+                cont.invokeOnCancellation { webView.destroy() }
+            }
+        }
+    }
 }
 
 // ─── PDF base styles ─────────────────────────────────────────────────────────

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt
@@ -54,6 +54,7 @@ class HighlightsPdfExporter @Inject constructor(
                 val webView = android.webkit.WebView(context)
                 webView.webViewClient = object : android.webkit.WebViewClient() {
                     override fun onPageFinished(view: android.webkit.WebView, url: String) {
+                        try {
                         val adapter = webView.createPrintDocumentAdapter(title ?: "Annotations")
                         val attributes = android.print.PrintAttributes.Builder()
                             .setMediaSize(android.print.PrintAttributes.MediaSize.ISO_A4)
@@ -84,15 +85,26 @@ class HighlightsPdfExporter @Inject constructor(
                                                 pages: Array<out android.print.PageRange>,
                                             ) {
                                                 pfd.close()
+                                                adapter.onFinish()
                                                 webView.destroy()
                                                 cont.resume(Unit)
                                             }
 
                                             override fun onWriteFailed(error: CharSequence?) {
                                                 pfd.close()
+                                                adapter.onFinish()
                                                 webView.destroy()
                                                 cont.resumeWithException(
                                                     java.io.IOException("PDF write failed: $error"),
+                                                )
+                                            }
+
+                                            override fun onWriteCancelled() {
+                                                pfd.close()
+                                                adapter.onFinish()
+                                                webView.destroy()
+                                                cont.resumeWithException(
+                                                    java.io.IOException("PDF write cancelled"),
                                                 )
                                             }
                                         },
@@ -100,14 +112,27 @@ class HighlightsPdfExporter @Inject constructor(
                                 }
 
                                 override fun onLayoutFailed(error: CharSequence?) {
+                                    adapter.onFinish()
                                     webView.destroy()
                                     cont.resumeWithException(
                                         java.io.IOException("PDF layout failed: $error"),
                                     )
                                 }
+
+                                override fun onLayoutCancelled() {
+                                    adapter.onFinish()
+                                    webView.destroy()
+                                    cont.resumeWithException(
+                                        java.io.IOException("PDF layout cancelled"),
+                                    )
+                                }
                             },
                             null,
                         )
+                        } catch (e: Exception) {
+                            webView.destroy()
+                            cont.resumeWithException(e)
+                        }
                     }
                 }
                 webView.loadDataWithBaseURL(null, html, "text/html", "UTF-8", null)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt
@@ -43,13 +43,7 @@ class HighlightsPdfExporter @Inject constructor(
     ): ExportResult {
         val html = buildCombinedHtml(factory, chapters, bookTitle, figureBytesByHref, publisherFontFaceCss, bookBodyFontFamily)
         val exportsDir = File(context.cacheDir, "exports").also { it.mkdirs() }
-        val safeName = bookTitle
-            ?.replace(Regex("[\\\\/:*?\"<>|]"), "_")
-            ?.trim()
-            ?.take(180)
-            ?.ifBlank { null }
-            ?: itemId.take(64)
-        val fileName = "$safeName Annotations.pdf"
+        val fileName = buildPdfFileName(bookTitle, itemId)
         val pdfFile = File(exportsDir, fileName)
         renderToPdf(html, bookTitle, pdfFile)
         val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", pdfFile)
@@ -150,6 +144,24 @@ class HighlightsPdfExporter @Inject constructor(
             }
         }
     }
+}
+
+// ─── Filename helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Derives a filesystem-safe PDF filename from [bookTitle], falling back to [itemId] when the
+ * title is null or blank. Characters illegal on FAT/NTFS/ext4 (`\ / : * ? " < > |`) are replaced
+ * with underscores; the base name is capped at 180 characters so the full filename stays well
+ * below the 255-byte ext4 limit.
+ */
+internal fun buildPdfFileName(bookTitle: String?, itemId: String): String {
+    val safeName = bookTitle
+        ?.replace(Regex("[\\\\/:*?\"<>|]"), "_")
+        ?.trim()
+        ?.take(180)
+        ?.ifBlank { null }
+        ?: itemId.take(64)
+    return "$safeName Annotations.pdf"
 }
 
 // ─── PDF base styles ─────────────────────────────────────────────────────────

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt
@@ -41,7 +41,13 @@ class HighlightsPdfExporter @Inject constructor(
     ): Uri {
         val html = buildCombinedHtml(factory, chapters, bookTitle, figureBytesByHref, publisherFontFaceCss, bookBodyFontFamily)
         val exportsDir = File(context.cacheDir, "exports").also { it.mkdirs() }
-        val pdfFile = File(exportsDir, "annotations-${itemId.take(64)}.pdf")
+        val safeName = bookTitle
+            ?.replace(Regex("[\\\\/:*?\"<>|]"), "_")
+            ?.trim()
+            ?.take(180)
+            ?.ifBlank { null }
+            ?: itemId.take(64)
+        val pdfFile = File(exportsDir, "$safeName Annotations.pdf")
         renderToPdf(html, bookTitle, pdfFile)
         return FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", pdfFile)
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsUiSuppression.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsUiSuppression.kt
@@ -14,3 +14,6 @@ internal fun shouldShowReadaloudUi(source: ReaderSource): Boolean = source == Re
 /** "Open in book" is the escape hatch out of the elided reader back to the full book; it has no
  *  meaning when already reading the full book. */
 internal fun shouldShowOpenInBook(source: ReaderSource): Boolean = source == ReaderSource.Highlights
+
+/** Share action exports the elided view as PDF — only meaningful inside the elided reader. */
+internal fun shouldShowShareHighlights(source: ReaderSource): Boolean = source == ReaderSource.Highlights

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -818,6 +818,7 @@ fun MainScreen(
                                 val intent = Intent(Intent.ACTION_SEND).apply {
                                     type = "application/pdf"
                                     putExtra(Intent.EXTRA_STREAM, event.uri)
+                                    putExtra(Intent.EXTRA_TITLE, event.fileName)
                                     addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                                 }
                                 context.startActivity(Intent.createChooser(intent, null))

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -799,6 +799,7 @@ fun MainScreen(
             ) {
                 val viewModel: com.riffle.app.feature.reader.EpubReaderViewModel = hiltViewModel()
                 val context = LocalContext.current
+                val exportErrorMessage = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.export_pdf_error)
                 // Highlights mode's "Open in book" (Task 9, ADR 0041): leaves the elided reader and
                 // opens the full-book reader at the tapped highlight's CFI. Handled at the nav-host
                 // level (not inside EpubReaderScreen) since it pops this route off the back stack.
@@ -826,7 +827,7 @@ fun MainScreen(
                             com.riffle.app.feature.reader.ReaderNavEvent.ExportError -> {
                                 Toast.makeText(
                                     context,
-                                    context.getString(com.riffle.app.R.string.export_pdf_error),
+                                    exportErrorMessage,
                                     Toast.LENGTH_LONG,
                                 ).show()
                             }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -57,6 +57,9 @@ import com.riffle.app.ui.isTabletLayout
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
 import java.net.URLEncoder
+import android.content.Intent
+import android.widget.Toast
+import androidx.compose.ui.platform.LocalContext
 
 private const val HOME = "home"
 private const val SOURCE_SETUP_GRAPH = "source_setup"
@@ -795,6 +798,7 @@ fun MainScreen(
                 )
             ) {
                 val viewModel: com.riffle.app.feature.reader.EpubReaderViewModel = hiltViewModel()
+                val context = LocalContext.current
                 // Highlights mode's "Open in book" (Task 9, ADR 0041): leaves the elided reader and
                 // opens the full-book reader at the tapped highlight's CFI. Handled at the nav-host
                 // level (not inside EpubReaderScreen) since it pops this route off the back stack.
@@ -809,6 +813,21 @@ fun MainScreen(
                             }
                             com.riffle.app.feature.reader.ReaderNavEvent.CloseEmptyHighlights -> {
                                 navController.popBackStack()
+                            }
+                            is com.riffle.app.feature.reader.ReaderNavEvent.ShareHighlights -> {
+                                val intent = Intent(Intent.ACTION_SEND).apply {
+                                    type = "application/pdf"
+                                    putExtra(Intent.EXTRA_STREAM, event.uri)
+                                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                }
+                                context.startActivity(Intent.createChooser(intent, null))
+                            }
+                            com.riffle.app.feature.reader.ReaderNavEvent.ExportError -> {
+                                Toast.makeText(
+                                    context,
+                                    context.getString(com.riffle.app.R.string.export_pdf_error),
+                                    Toast.LENGTH_LONG,
+                                ).show()
                             }
                         }
                     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Riffle</string>
+    <string name="export_pdf_error">Couldn\'t generate PDF</string>
 </resources>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -3,4 +3,6 @@
     <files-path name="crash_reports" path="." />
     <!-- Downloaded update APKs handed to the system installer (see AppUpdateRepository). -->
     <cache-path name="updates" path="updates/" />
+    <!-- Exported highlights PDF files shared via ACTION_SEND. -->
+    <cache-path name="exports" path="exports/" />
 </paths>

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporterTest.kt
@@ -1,0 +1,107 @@
+package com.riffle.app.feature.reader.highlights
+
+import com.riffle.core.database.AnnotationEntity
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HighlightsPdfExporterTest {
+
+    private val factory = HighlightsPublicationFactory()
+
+    private fun highlight(id: String, snippet: String): AnnotationEntity = AnnotationEntity(
+        id = id,
+        sourceId = "S1",
+        itemId = "B1",
+        type = AnnotationEntity.TYPE_HIGHLIGHT,
+        cfi = "epubcfi(/6/2!/dummy)",
+        textSnippet = snippet,
+        note = null,
+        color = AnnotationEntity.COLOR_YELLOW,
+        chapterHref = "ch0.xhtml",
+        spineIndex = 0,
+        progression = 0.0,
+        createdAt = 0L,
+        updatedAt = 0L,
+        originDeviceId = "test",
+        lastModifiedByDeviceId = "test",
+        originFontFamily = null,
+        textSnippetHtml = null,
+        emphasisStyles = null,
+    )
+
+    @Test
+    fun combinedHtml_containsAllChapterTitles() {
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(
+                ChapterElision("ch1.xhtml", "Chapter One", listOf(highlight("h1", "text"))),
+                ChapterElision("ch2.xhtml", "Chapter Two", listOf(highlight("h2", "more text"))),
+            ),
+            bookTitle = "My Book",
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = "",
+            bookBodyFontFamily = null,
+        )
+        assertTrue("Chapter One h1", html.contains("<h1>Chapter One</h1>"))
+        assertTrue("Chapter Two h1", html.contains("<h1>Chapter Two</h1>"))
+    }
+
+    @Test
+    fun combinedHtml_hasNoReadiumAssetLink() {
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(ChapterElision("ch1.xhtml", "Ch", listOf(highlight("h1", "text")))),
+            bookTitle = null,
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = "",
+            bookBodyFontFamily = null,
+        )
+        assertFalse("no readium_assets href", html.contains("readium_assets"))
+    }
+
+    @Test
+    fun combinedHtml_tapSpansHidden() {
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(ChapterElision("ch1.xhtml", "Ch", listOf(highlight("h1", "text")))),
+            bookTitle = null,
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = "",
+            bookBodyFontFamily = null,
+        )
+        // The tap-dispatch span class must be hidden in the exported PDF.
+        assertTrue("tap class hidden", html.contains(".$ACCENT_BAR_TAP_CLASS") && html.contains("display:none"))
+    }
+
+    @Test
+    fun combinedHtml_includesPublisherFontFaceWhenNonBlank() {
+        val fontCss = "@font-face { font-family: TestFont; src: url(data:font/woff2;base64,abc); }"
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(ChapterElision("ch1.xhtml", "Ch", listOf(highlight("h1", "text")))),
+            bookTitle = null,
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = fontCss,
+            bookBodyFontFamily = null,
+        )
+        assertTrue("publisher font-face present", html.contains("TestFont"))
+    }
+
+    @Test
+    fun combinedHtml_skipsChaptersWithNoHighlights() {
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(
+                ChapterElision("ch1.xhtml", "Has Highlights", listOf(highlight("h1", "text"))),
+                ChapterElision("ch2.xhtml", "Empty Chapter", emptyList()),
+            ),
+            bookTitle = null,
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = "",
+            bookBodyFontFamily = null,
+        )
+        assertTrue("non-empty chapter present", html.contains("<h1>Has Highlights</h1>"))
+        assertFalse("empty chapter absent", html.contains("<h1>Empty Chapter</h1>"))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporterTest.kt
@@ -1,6 +1,7 @@
 package com.riffle.app.feature.reader.highlights
 
 import com.riffle.core.database.AnnotationEntity
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -86,6 +87,47 @@ class HighlightsPdfExporterTest {
             bookBodyFontFamily = null,
         )
         assertTrue("publisher font-face present", html.contains("TestFont"))
+    }
+
+    // ─── buildPdfFileName ─────────────────────────────────────────────────────
+
+    @Test
+    fun pdfFileName_usesBookTitleWithAnnotationsSuffix() {
+        assertEquals(
+            "My Book Annotations.pdf",
+            buildPdfFileName("My Book", "item-guid"),
+        )
+    }
+
+    @Test
+    fun pdfFileName_replacesIllegalCharacters() {
+        assertEquals(
+            "A _ B _ C Annotations.pdf",
+            buildPdfFileName("A / B : C", "item-guid"),
+        )
+    }
+
+    @Test
+    fun pdfFileName_fallsBackToItemIdWhenTitleNull() {
+        assertEquals(
+            "item-guid Annotations.pdf",
+            buildPdfFileName(null, "item-guid"),
+        )
+    }
+
+    @Test
+    fun pdfFileName_fallsBackToItemIdWhenTitleBlank() {
+        assertEquals(
+            "item-guid Annotations.pdf",
+            buildPdfFileName("   ", "item-guid"),
+        )
+    }
+
+    @Test
+    fun pdfFileName_capsBaseNameAt180Characters() {
+        val longTitle = "A".repeat(200)
+        val result = buildPdfFileName(longTitle, "fallback")
+        assertEquals("${"A".repeat(180)} Annotations.pdf", result)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporterTest.kt
@@ -124,6 +124,16 @@ class HighlightsPdfExporterTest {
     }
 
     @Test
+    fun pdfFileName_sanitizesItemIdFallbackSlashes() {
+        // An itemId containing '/' (e.g. Chitanka-style "serie/foo") must not resolve into a
+        // subdirectory — File(exportsDir, "serie/foo Annotations.pdf") would throw on open.
+        assertEquals(
+            "serie_foo Annotations.pdf",
+            buildPdfFileName(null, "serie/foo"),
+        )
+    }
+
+    @Test
     fun pdfFileName_capsBaseNameAt180Characters() {
         val longTitle = "A".repeat(200)
         val result = buildPdfFileName(longTitle, "fallback")

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsUiSuppressionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsUiSuppressionTest.kt
@@ -33,4 +33,10 @@ class HighlightsUiSuppressionTest {
         assertTrue(shouldShowOpenInBook(ReaderSource.Highlights))
         assertFalse(shouldShowOpenInBook(ReaderSource.FullBook))
     }
+
+    @Test
+    fun shareHighlightsVisibleOnlyInHighlightsMode() {
+        assertTrue(shouldShowShareHighlights(ReaderSource.Highlights))
+        assertFalse(shouldShowShareHighlights(ReaderSource.FullBook))
+    }
 }

--- a/docs/superpowers/plans/2026-07-26-share-elided-view.md
+++ b/docs/superpowers/plans/2026-07-26-share-elided-view.md
@@ -1,0 +1,757 @@
+# Share Elided View — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Share button to the elided reader's top bar that exports all highlights as a PDF and shares it via the Android share sheet.
+
+**Architecture:** `EpubReaderViewModel.onShareElidedView()` calls `HighlightsPdfExporter.export()`, which assembles a single self-contained HTML document from the chapters already held by the ViewModel, loads it into a headless `WebView`, and renders a PDF via `PrintDocumentAdapter` without showing the system print dialog. The resulting file is wrapped by the existing `FileProvider` and shared via `ACTION_SEND`. Nav events carry the result (URI or error) from the ViewModel to the nav host (`MainScreen`), following the same pattern as `OpenInSourceBook` / `CloseEmptyHighlights`.
+
+**Tech Stack:** Kotlin coroutines (`suspendCancellableCoroutine`, `withContext(Dispatchers.Main)`), Android `WebView.createPrintDocumentAdapter`, `PrintDocumentAdapter` non-interactive callbacks, `FileProvider`, Hilt for DI.
+
+## Global Constraints
+
+- All new files go under `app/src/main/kotlin/com/riffle/app/feature/reader/highlights/` (exporter) or alongside existing test files.
+- New `internal` functions/constants in `:app` module are accessible across files in that module — no visibility changes needed for `renderChapterHtml`, `ACCENT_BAR_TAP_CSS`, `FIGURE_CENTERING_CSS`, `ACCENT_BAR_TAP_CLASS`, `sanitizeCssFontFamily`, `FALLBACK_ORIGIN_FONT_FAMILY`.
+- Nav events are handled in `MainScreen.kt` (not inside `EpubReaderScreen`) — follow the `OpenInSourceBook` pattern.
+- `ReaderSource.Highlights` gate on UI: add `shouldShowShareHighlights` to `HighlightsUiSuppression.kt` following the pattern of `shouldShowReadaloudUi` / `shouldShowOpenInBook`.
+- Run tests with: `export JAVA_HOME=$(/usr/libexec/java_home -v 17) && ./gradlew :app:test`
+
+---
+
+## File Map
+
+| Action | File |
+|--------|------|
+| Modify | `app/src/main/res/xml/file_paths.xml` |
+| Modify | `app/src/main/res/values/strings.xml` |
+| Modify | `app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsUiSuppression.kt` |
+| Modify | `app/src/main/kotlin/com/riffle/app/feature/reader/ReaderNavEvent.kt` |
+| Create | `app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt` |
+| Modify | `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt` |
+| Modify | `app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt` |
+| Modify | `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt` |
+| Create | `app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporterTest.kt` |
+| Modify | `app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsUiSuppressionTest.kt` |
+
+---
+
+## Task 1: FileProvider path + `shouldShowShareHighlights` predicate
+
+**Files:**
+- Modify: `app/src/main/res/xml/file_paths.xml`
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsUiSuppression.kt`
+- Modify: `app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsUiSuppressionTest.kt`
+
+**Interfaces:**
+- Produces: `internal fun shouldShowShareHighlights(source: ReaderSource): Boolean` (used in Task 4)
+
+- [ ] **Step 1: Write failing tests in `HighlightsUiSuppressionTest.kt`**
+
+Append these two tests to the existing `HighlightsUiSuppressionTest` class (before the closing `}`):
+
+```kotlin
+    @Test
+    fun shareHighlightsVisibleOnlyInHighlightsMode() {
+        assertTrue(shouldShowShareHighlights(ReaderSource.Highlights))
+        assertFalse(shouldShowShareHighlights(ReaderSource.FullBook))
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+export JAVA_HOME=$(/usr/libexec/java_home -v 17)
+./gradlew :app:test --tests "com.riffle.app.feature.reader.highlights.HighlightsUiSuppressionTest" 2>&1 | tail -20
+```
+
+Expected: `Unresolved reference: shouldShowShareHighlights`
+
+- [ ] **Step 3: Add `shouldShowShareHighlights` to `HighlightsUiSuppression.kt`**
+
+Append after the existing `shouldShowOpenInBook` function:
+
+```kotlin
+/** Share action exports the elided view as PDF — only meaningful inside the elided reader. */
+internal fun shouldShowShareHighlights(source: ReaderSource): Boolean = source == ReaderSource.Highlights
+```
+
+- [ ] **Step 4: Run to verify tests pass**
+
+```bash
+export JAVA_HOME=$(/usr/libexec/java_home -v 17)
+./gradlew :app:test --tests "com.riffle.app.feature.reader.highlights.HighlightsUiSuppressionTest" 2>&1 | tail -10
+```
+
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 5: Add `<cache-path>` entry for exports to `file_paths.xml`**
+
+In `app/src/main/res/xml/file_paths.xml`, add inside `<paths>`:
+
+```xml
+    <!-- Exported highlights PDF files shared via ACTION_SEND. -->
+    <cache-path name="exports" path="exports/" />
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/res/xml/file_paths.xml \
+        app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsUiSuppression.kt \
+        app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsUiSuppressionTest.kt
+git commit -m "feat(reader): shouldShowShareHighlights predicate + exports file_paths entry"
+```
+
+---
+
+## Task 2: `HighlightsPdfExporter` — HTML assembly (TDD)
+
+**Files:**
+- Create: `app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt`
+- Create: `app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporterTest.kt`
+
+**Interfaces:**
+- Produces:
+  ```kotlin
+  internal fun buildCombinedHtml(
+      factory: HighlightsPublicationFactory,
+      chapters: List<ChapterElision>,
+      bookTitle: String?,
+      figureBytesByHref: Map<String, String>,
+      publisherFontFaceCss: String,
+      bookBodyFontFamily: String?,
+  ): String
+  ```
+- Produces: `class HighlightsPdfExporter` (shell for Task 3)
+
+- [ ] **Step 1: Create the test file**
+
+Create `app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporterTest.kt`:
+
+```kotlin
+package com.riffle.app.feature.reader.highlights
+
+import com.riffle.core.database.AnnotationEntity
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class HighlightsPdfExporterTest {
+
+    private val factory = HighlightsPublicationFactory()
+
+    private fun highlight(id: String, snippet: String): AnnotationEntity = AnnotationEntity(
+        id = id,
+        sourceId = "S1",
+        itemId = "B1",
+        type = AnnotationEntity.TYPE_HIGHLIGHT,
+        cfi = "epubcfi(/6/2!/dummy)",
+        textSnippet = snippet,
+        note = null,
+        color = AnnotationEntity.COLOR_YELLOW,
+        chapterHref = "ch0.xhtml",
+        spineIndex = 0,
+        progression = 0.0,
+        createdAt = 0L,
+        updatedAt = 0L,
+        originDeviceId = "test",
+        lastModifiedByDeviceId = "test",
+        originFontFamily = null,
+        textSnippetHtml = null,
+        emphasisStyles = null,
+    )
+
+    @Test
+    fun combinedHtml_containsAllChapterTitles() {
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(
+                ChapterElision("ch1.xhtml", "Chapter One", listOf(highlight("h1", "text"))),
+                ChapterElision("ch2.xhtml", "Chapter Two", listOf(highlight("h2", "more text"))),
+            ),
+            bookTitle = "My Book",
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = "",
+            bookBodyFontFamily = null,
+        )
+        assertTrue("Chapter One h1", html.contains("<h1>Chapter One</h1>"))
+        assertTrue("Chapter Two h1", html.contains("<h1>Chapter Two</h1>"))
+    }
+
+    @Test
+    fun combinedHtml_hasNoReadiumAssetLink() {
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(ChapterElision("ch1.xhtml", "Ch", listOf(highlight("h1", "text")))),
+            bookTitle = null,
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = "",
+            bookBodyFontFamily = null,
+        )
+        assertFalse("no readium_assets href", html.contains("readium_assets"))
+    }
+
+    @Test
+    fun combinedHtml_tapSpansHidden() {
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(ChapterElision("ch1.xhtml", "Ch", listOf(highlight("h1", "text")))),
+            bookTitle = null,
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = "",
+            bookBodyFontFamily = null,
+        )
+        // The tap-dispatch span class must be hidden in the exported PDF.
+        assertTrue("tap class hidden", html.contains(".$ACCENT_BAR_TAP_CLASS") && html.contains("display:none"))
+    }
+
+    @Test
+    fun combinedHtml_includesPublisherFontFaceWhenNonBlank() {
+        val fontCss = "@font-face { font-family: TestFont; src: url(data:font/woff2;base64,abc); }"
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(ChapterElision("ch1.xhtml", "Ch", listOf(highlight("h1", "text")))),
+            bookTitle = null,
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = fontCss,
+            bookBodyFontFamily = null,
+        )
+        assertTrue("publisher font-face present", html.contains("TestFont"))
+    }
+
+    @Test
+    fun combinedHtml_skipsChaptersWithNoHighlights() {
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(
+                ChapterElision("ch1.xhtml", "Has Highlights", listOf(highlight("h1", "text"))),
+                ChapterElision("ch2.xhtml", "Empty Chapter", emptyList()),
+            ),
+            bookTitle = null,
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = "",
+            bookBodyFontFamily = null,
+        )
+        assertTrue("non-empty chapter present", html.contains("<h1>Has Highlights</h1>"))
+        assertFalse("empty chapter absent", html.contains("<h1>Empty Chapter</h1>"))
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify tests fail**
+
+```bash
+export JAVA_HOME=$(/usr/libexec/java_home -v 17)
+./gradlew :app:test --tests "com.riffle.app.feature.reader.highlights.HighlightsPdfExporterTest" 2>&1 | tail -20
+```
+
+Expected: `Unresolved reference: buildCombinedHtml`
+
+- [ ] **Step 3: Create `HighlightsPdfExporter.kt` with `buildCombinedHtml` and class shell**
+
+Create `app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt`:
+
+```kotlin
+package com.riffle.app.feature.reader.highlights
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import javax.inject.Inject
+
+/**
+ * Exports the elided reader's full highlight set as a self-contained PDF via a headless
+ * [android.webkit.WebView] and [android.print.PrintDocumentAdapter].
+ *
+ * [buildCombinedHtml] is an `internal` top-level function so JVM unit tests can exercise HTML
+ * assembly without a live [Context] or [android.webkit.WebView].
+ */
+class HighlightsPdfExporter @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val factory: HighlightsPublicationFactory,
+) {
+    /**
+     * Assembles the combined HTML for all chapters, renders it to a PDF via a headless WebView,
+     * writes the result to `cacheDir/exports/annotations-<itemId>.pdf`, and returns a
+     * [FileProvider] URI suitable for [android.content.Intent.ACTION_SEND].
+     *
+     * Must be called from a coroutine; the WebView and PrintDocumentAdapter callbacks run on the
+     * main thread ([kotlinx.coroutines.Dispatchers.Main]).
+     */
+    suspend fun export(
+        chapters: List<ChapterElision>,
+        bookTitle: String?,
+        itemId: String,
+        figureBytesByHref: Map<String, String>,
+        publisherFontFaceCss: String,
+        bookBodyFontFamily: String?,
+    ): Uri {
+        val html = buildCombinedHtml(factory, chapters, bookTitle, figureBytesByHref, publisherFontFaceCss, bookBodyFontFamily)
+        val exportsDir = File(context.cacheDir, "exports").also { it.mkdirs() }
+        val pdfFile = File(exportsDir, "annotations-${itemId.take(64)}.pdf")
+        renderToPdf(html, bookTitle, pdfFile)
+        return FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", pdfFile)
+    }
+
+    // WebView + PrintDocumentAdapter rendering — implemented in Task 3.
+    private suspend fun renderToPdf(html: String, title: String?, outFile: File): Unit = TODO("Task 3")
+}
+
+// ─── PDF base styles ─────────────────────────────────────────────────────────
+
+private const val PDF_BASE_CSS =
+    "body{font-size:14pt;line-height:1.6;margin:0;padding:16pt;}" +
+        "h1{font-size:16pt;border-bottom:1px solid #cccccc;padding-bottom:4pt;" +
+        "margin:24pt 0 12pt;page-break-after:avoid;}" +
+        "h1:first-child{margin-top:0;}" +
+        "p{margin:0.75em 0;}" +
+        "aside{margin:0.5em 0;}"
+
+// ─── HTML assembly ────────────────────────────────────────────────────────────
+
+/**
+ * Assembles a single self-contained `<html>` document from [chapters] for PDF export.
+ *
+ * Each chapter is rendered via [HighlightsPublicationFactory.renderChapterHtml]; only the
+ * `<body>` content is extracted and concatenated. The combined `<head>` substitutes
+ * [PDF_BASE_CSS] for the `READIUM_DEFAULT_CSS_LINK` (which is served by Readium's
+ * `WebViewServer` and is not resolvable outside the live reader WebView). Tap-dispatch spans
+ * ([ACCENT_BAR_TAP_CLASS]) are hidden via CSS — they have no meaning in a static PDF.
+ *
+ * All images are already base64 data URIs inside the chapter HTML; the result is fully
+ * self-contained with no external resource references.
+ */
+internal fun buildCombinedHtml(
+    factory: HighlightsPublicationFactory,
+    chapters: List<ChapterElision>,
+    bookTitle: String?,
+    figureBytesByHref: Map<String, String>,
+    publisherFontFaceCss: String,
+    bookBodyFontFamily: String?,
+): String {
+    val safeTitle = bookTitle
+        ?.replace("&", "&amp;")?.replace("<", "&lt;")?.replace("\"", "&quot;")
+        ?: "Annotations"
+
+    val bodyParts = chapters
+        .filter { it.highlights.isNotEmpty() }
+        .joinToString("\n") { chapter ->
+            val chapterXhtml = factory.renderChapterHtml(
+                chapter, bookBodyFontFamily, figureBytesByHref, publisherFontFaceCss,
+            )
+            // Extract content between <body> and </body>; the chapter XHTML is authored by
+            // renderChapterHtml and always contains exactly one <body> block.
+            val bodyStart = chapterXhtml.indexOf("<body>").takeIf { it >= 0 } ?: return@joinToString ""
+            val bodyEnd = chapterXhtml.lastIndexOf("</body>").takeIf { it >= 0 } ?: return@joinToString ""
+            chapterXhtml.substring(bodyStart + "<body>".length, bodyEnd).trim()
+        }
+
+    val bodyFontRule = run {
+        val safe = sanitizeCssFontFamily(
+            bookBodyFontFamily?.takeIf { it != FALLBACK_ORIGIN_FONT_FAMILY },
+        ) ?: return@run ""
+        "body,h1,h2,h3,h4,h5,h6{font-family:$safe;}"
+    }
+
+    return buildString {
+        append("<!DOCTYPE html><html><head>")
+        append("<meta charset=\"utf-8\"/>")
+        append("<title>$safeTitle</title>")
+        append("<style>")
+        append(PDF_BASE_CSS)
+        append(ACCENT_BAR_TAP_CSS)
+        append(FIGURE_CENTERING_CSS)
+        // Hide tap-dispatch spans — they serve no purpose in a static PDF.
+        append(".$ACCENT_BAR_TAP_CLASS{display:none}")
+        if (publisherFontFaceCss.isNotBlank()) append(publisherFontFaceCss)
+        if (bodyFontRule.isNotBlank()) append(bodyFontRule)
+        append("</style></head><body>")
+        append(bodyParts)
+        append("</body></html>")
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+export JAVA_HOME=$(/usr/libexec/java_home -v 17)
+./gradlew :app:test --tests "com.riffle.app.feature.reader.highlights.HighlightsPdfExporterTest" 2>&1 | tail -10
+```
+
+Expected: `BUILD SUCCESSFUL` (all 5 tests green)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt \
+        app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporterTest.kt
+git commit -m "feat(reader): HighlightsPdfExporter HTML assembly + unit tests"
+```
+
+---
+
+## Task 3: `HighlightsPdfExporter` — PDF rendering
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt`
+
+**Interfaces:**
+- Completes: `private suspend fun renderToPdf(html: String, title: String?, outFile: File)`
+- Consumes: `buildCombinedHtml` from Task 2
+
+- [ ] **Step 1: Replace the `renderToPdf` stub with the real implementation**
+
+Replace the `TODO("Task 3")` body of `renderToPdf` in `HighlightsPdfExporter.kt` with:
+
+```kotlin
+    private suspend fun renderToPdf(html: String, title: String?, outFile: File) {
+        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) {
+            kotlinx.coroutines.suspendCancellableCoroutine<Unit> { cont ->
+                val webView = android.webkit.WebView(context)
+                webView.webViewClient = object : android.webkit.WebViewClient() {
+                    override fun onPageFinished(view: android.webkit.WebView, url: String) {
+                        val adapter = webView.createPrintDocumentAdapter(title ?: "Annotations")
+                        val attributes = android.print.PrintAttributes.Builder()
+                            .setMediaSize(android.print.PrintAttributes.MediaSize.ISO_A4)
+                            .setResolution(
+                                android.print.PrintAttributes.Resolution("pdf", "pdf", 300, 300),
+                            )
+                            .setMinMargins(android.print.PrintAttributes.Margins.NO_MARGINS)
+                            .build()
+                        adapter.onLayout(
+                            null, attributes, null,
+                            object : android.print.PrintDocumentAdapter.LayoutResultCallback() {
+                                override fun onLayoutFinished(
+                                    info: android.print.PrintDocumentInfo,
+                                    changed: Boolean,
+                                ) {
+                                    val pfd = android.os.ParcelFileDescriptor.open(
+                                        outFile,
+                                        android.os.ParcelFileDescriptor.MODE_READ_WRITE or
+                                            android.os.ParcelFileDescriptor.MODE_CREATE or
+                                            android.os.ParcelFileDescriptor.MODE_TRUNCATE,
+                                    )
+                                    adapter.onWrite(
+                                        arrayOf(android.print.PageRange.ALL_PAGES),
+                                        pfd,
+                                        null,
+                                        object : android.print.PrintDocumentAdapter.WriteResultCallback() {
+                                            override fun onWriteFinished(
+                                                pages: Array<out android.print.PageRange>,
+                                            ) {
+                                                pfd.close()
+                                                webView.destroy()
+                                                cont.resume(Unit)
+                                            }
+
+                                            override fun onWriteFailed(error: CharSequence?) {
+                                                pfd.close()
+                                                webView.destroy()
+                                                cont.resumeWithException(
+                                                    java.io.IOException("PDF write failed: $error"),
+                                                )
+                                            }
+                                        },
+                                    )
+                                }
+
+                                override fun onLayoutFailed(error: CharSequence?) {
+                                    webView.destroy()
+                                    cont.resumeWithException(
+                                        java.io.IOException("PDF layout failed: $error"),
+                                    )
+                                }
+                            },
+                            null,
+                        )
+                    }
+                }
+                webView.loadDataWithBaseURL(null, html, "text/html", "UTF-8", null)
+                cont.invokeOnCancellation { webView.destroy() }
+            }
+        }
+    }
+```
+
+Also add the missing import for `suspendCancellableCoroutine` at the top of the file. The full imports block should be:
+
+```kotlin
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+export JAVA_HOME=$(/usr/libexec/java_home -v 17)
+./gradlew :app:compileDebugKotlin 2>&1 | grep -E "error:|warning:|BUILD" | tail -20
+```
+
+Expected: no errors, `BUILD SUCCESSFUL`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt
+git commit -m "feat(reader): HighlightsPdfExporter PDF rendering via PrintDocumentAdapter"
+```
+
+---
+
+## Task 4: Nav events + string resource + ViewModel wiring
+
+**Files:**
+- Modify: `app/src/main/res/values/strings.xml`
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/ReaderNavEvent.kt`
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt`
+
+**Interfaces:**
+- Produces: `ReaderNavEvent.ShareHighlights(val uri: Uri)` (used in Task 5 — MainScreen)
+- Produces: `ReaderNavEvent.ExportError` (used in Task 5 — MainScreen)
+- Produces: `val isExporting: StateFlow<Boolean>` on ViewModel (used in Task 5 — EpubReaderScreen)
+- Produces: `fun onShareElidedView()` on ViewModel (used in Task 5 — EpubReaderScreen)
+- Consumes: `HighlightsPdfExporter.export(...)` from Task 3
+
+- [ ] **Step 1: Add string resource**
+
+In `app/src/main/res/values/strings.xml`, add inside `<resources>`:
+
+```xml
+    <string name="export_pdf_error">Couldn\'t generate PDF</string>
+```
+
+- [ ] **Step 2: Add nav event variants to `ReaderNavEvent.kt`**
+
+Replace the file content with:
+
+```kotlin
+package com.riffle.app.feature.reader
+
+import android.net.Uri
+
+/**
+ * Navigation events emitted by [EpubReaderViewModel] that the nav host (MainScreen) must act on
+ * outside the reader's own back stack — e.g. leaving the elided Highlights-mode reader to open the
+ * real source book (ADR 0041, Task 9).
+ */
+sealed interface ReaderNavEvent {
+    data class OpenInSourceBook(val sourceId: String, val itemId: String, val cfi: String) : ReaderNavEvent
+
+    /**
+     * Highlights-mode reader has no highlights left (user deleted the last one). The synthesised
+     * Publication would have an empty readingOrder — Readium's navigator crashes on that — so the
+     * nav host must pop the reader off the back stack instead of letting the VM reopen an empty
+     * book.
+     */
+    object CloseEmptyHighlights : ReaderNavEvent
+
+    /** The elided view PDF was generated successfully; the nav host fires [android.content.Intent.ACTION_SEND]. */
+    data class ShareHighlights(val uri: Uri) : ReaderNavEvent
+
+    /** PDF generation failed; the nav host shows a toast. */
+    object ExportError : ReaderNavEvent
+}
+```
+
+- [ ] **Step 3: Wire ViewModel — new fields and `onShareElidedView()`**
+
+In `EpubReaderViewModel.kt`:
+
+3a. Add `private var elidedBookTitle: String? = null` near the other `private var elidedBodyFontFamily` declaration (around line 520). Place it immediately after that line:
+
+```kotlin
+private var elidedBodyFontFamily: String? = null
+private var elidedBookTitle: String? = null
+```
+
+3b. Store `realBookTitle` right after it is fetched inside the `openBook()` Highlights branch (around line 1195, where `val realBookTitle = libraryItemDao.getById(sourceId, itemId)?.title` appears):
+
+```kotlin
+val realBookTitle = libraryItemDao.getById(sourceId, itemId)?.title
+elidedBookTitle = realBookTitle
+```
+
+3c. Add `HighlightsPdfExporter` to the ViewModel's `@Inject constructor` parameters. The constructor already has many parameters; add `private val pdfExporter: HighlightsPdfExporter` alongside them (alphabetical order is not required — add it near the end of the parameter list).
+
+3d. Add `isExporting` state near the other `MutableStateFlow` declarations (search for `_tocVisible` or similar patterns and add alongside):
+
+```kotlin
+private val _isExporting = MutableStateFlow(false)
+val isExporting: StateFlow<Boolean> = _isExporting.asStateFlow()
+```
+
+3e. Add `onShareElidedView()` as a new `fun` in the ViewModel (near other `fun` declarations used by the top bar, e.g. near `openSearch()` / `openToc()`):
+
+```kotlin
+fun onShareElidedView() {
+    if (_isExporting.value) return
+    val chapters = highlightsResumeChapters ?: return
+    val handle = highlightsPublicationHandle ?: return
+    viewModelScope.launch {
+        _isExporting.value = true
+        try {
+            val uri = pdfExporter.export(
+                chapters = chapters,
+                bookTitle = elidedBookTitle,
+                itemId = itemId,
+                figureBytesByHref = handle.figureBytesByHref,
+                publisherFontFaceCss = handle.publisherFontFaceCss,
+                bookBodyFontFamily = elidedBodyFontFamily,
+            )
+            _readerNavEvents.send(ReaderNavEvent.ShareHighlights(uri))
+        } catch (e: Exception) {
+            _readerNavEvents.send(ReaderNavEvent.ExportError)
+        } finally {
+            _isExporting.value = false
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+```bash
+export JAVA_HOME=$(/usr/libexec/java_home -v 17)
+./gradlew :app:compileDebugKotlin 2>&1 | grep -E "error:|BUILD" | tail -20
+```
+
+Expected: no errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/res/values/strings.xml \
+        app/src/main/kotlin/com/riffle/app/feature/reader/ReaderNavEvent.kt \
+        app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+git commit -m "feat(reader): onShareElidedView + ShareHighlights/ExportError nav events"
+```
+
+---
+
+## Task 5: Screen wiring + manual verification
+
+**Files:**
+- Modify: `app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt`
+- Modify: `app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt`
+
+**Interfaces:**
+- Consumes: `shouldShowShareHighlights` from Task 1
+- Consumes: `ReaderNavEvent.ShareHighlights`, `ReaderNavEvent.ExportError` from Task 4
+- Consumes: `viewModel.isExporting: StateFlow<Boolean>` from Task 4
+- Consumes: `viewModel.onShareElidedView()` from Task 4
+
+- [ ] **Step 1: Handle new nav events in `MainScreen.kt`**
+
+In `MainScreen.kt`, locate the `when (event)` block around line 769 that handles `OpenInSourceBook` and `CloseEmptyHighlights`. Add two new branches:
+
+```kotlin
+                        when (event) {
+                            is com.riffle.app.feature.reader.ReaderNavEvent.OpenInSourceBook -> {
+                                val encodedId = URLEncoder.encode(event.itemId, "UTF-8")
+                                val encodedCfi = URLEncoder.encode(event.cfi, "UTF-8")
+                                navController.popBackStack()
+                                navController.navigate("epub_reader/$encodedId?openAtCfi=$encodedCfi")
+                            }
+                            com.riffle.app.feature.reader.ReaderNavEvent.CloseEmptyHighlights -> {
+                                navController.popBackStack()
+                            }
+                            is com.riffle.app.feature.reader.ReaderNavEvent.ShareHighlights -> {
+                                val sendIntent = android.content.Intent(android.content.Intent.ACTION_SEND).apply {
+                                    type = "application/pdf"
+                                    putExtra(android.content.Intent.EXTRA_STREAM, event.uri)
+                                    addFlags(android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                }
+                                context.startActivity(android.content.Intent.createChooser(sendIntent, null))
+                            }
+                            com.riffle.app.feature.reader.ReaderNavEvent.ExportError -> {
+                                android.widget.Toast.makeText(
+                                    context,
+                                    com.riffle.app.R.string.export_pdf_error,
+                                    android.widget.Toast.LENGTH_SHORT,
+                                ).show()
+                            }
+                        }
+```
+
+The `context` variable is already accessible in this composable scope via `LocalContext.current` — check the top of the lambda for the existing `val context = LocalContext.current` binding; add one if absent.
+
+- [ ] **Step 2: Add share button to `EpubReaderScreen.kt` top bar**
+
+In `EpubReaderScreen.kt`:
+
+2a. Add the import alongside the other `shouldShow*` imports (around line 51–52):
+
+```kotlin
+import com.riffle.app.feature.reader.highlights.shouldShowShareHighlights
+```
+
+2b. Collect `isExporting` near the other `collectAsState()` calls (around line 189–280):
+
+```kotlin
+val isExporting by viewModel.isExporting.collectAsState()
+```
+
+2c. Inside the `actions = { … }` block of the `TopAppBar` (the block starting around line 797), add the following **after** all existing action icons and **before** the closing `}` of `if (state is ReaderState.Ready)`:
+
+```kotlin
+                            if (shouldShowShareHighlights(viewModel.readerSource)) {
+                                if (isExporting) {
+                                    Box(
+                                        modifier = Modifier.size(48.dp),
+                                        contentAlignment = Alignment.Center,
+                                    ) {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(24.dp),
+                                            strokeWidth = 2.dp,
+                                        )
+                                    }
+                                } else {
+                                    IconButton(onClick = viewModel::onShareElidedView) {
+                                        Icon(
+                                            imageVector = Icons.Default.Share,
+                                            contentDescription = "Share annotations as PDF",
+                                        )
+                                    }
+                                }
+                            }
+```
+
+`Box`, `Alignment`, `CircularProgressIndicator`, and `Icons.Default` will already be imported in this file. Add any missing imports the IDE flags.
+
+- [ ] **Step 3: Verify it compiles**
+
+```bash
+export JAVA_HOME=$(/usr/libexec/java_home -v 17)
+./gradlew :app:compileDebugKotlin 2>&1 | grep -E "error:|BUILD" | tail -20
+```
+
+Expected: no errors
+
+- [ ] **Step 4: Run all `:app` JVM tests to confirm nothing regressed**
+
+```bash
+export JAVA_HOME=$(/usr/libexec/java_home -v 17)
+./gradlew :app:test 2>&1 | tail -20
+```
+
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt \
+        app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+git commit -m "feat(reader): share button in elided reader top bar, wire ShareHighlights intent"
+```

--- a/docs/superpowers/specs/2026-07-26-share-elided-view-design.md
+++ b/docs/superpowers/specs/2026-07-26-share-elided-view-design.md
@@ -1,0 +1,106 @@
+# Share Elided View — Design
+
+**Date:** 2026-07-26
+**Branch:** pkmetski/share-elided-view
+
+## Goal
+
+Add a share action to the elided reader ("Highlights" mode) that exports the entire book's annotations as a self-contained PDF and shares it via the Android share sheet. The action is only available inside the elided view — not from `AnnotationsListScreen`.
+
+---
+
+## Architecture & data flow
+
+```
+Share button (top bar, Highlights mode only)
+  → EpubReaderViewModel.onShareElidedView()
+      → HighlightsPdfExporter.export(combinedHtml, appContext)   [IO + Main dispatchers]
+          → hidden WebView  →  PrintDocumentAdapter  →  cacheDir PDF file
+      → ReaderNavEvent.ShareFile(uri)
+  → EpubReaderScreen  →  ACTION_SEND intent
+```
+
+`HighlightsPdfExporter` is a new Hilt-injectable class. The ViewModel owns the export call; the screen only handles the resulting nav event. The screen never touches the exporter directly.
+
+---
+
+## HTML assembly
+
+`HighlightsPdfExporter` builds a single `<html>` document from the chapter data already held in `EpubReaderViewModel`:
+
+1. Iterate all `ChapterElision`s (filtered to non-empty) and call `HighlightsPublicationFactory.renderChapterHtml()` (already `internal`, accessible within `:app`) for each.
+2. Extract the `<body>` content from each chapter's XHTML (simple substring between `<body>` and `</body>`).
+3. Wrap all body content in one `<html><head>…</head><body>…</body></html>` whose `<head>` contains:
+   - `<meta charset="utf-8"/>`
+   - PDF-friendly base CSS: readable `font-size`, `line-height`, `body` padding, `h1` border-bottom separating chapters.
+   - `ACCENT_BAR_TAP_CSS` and `FIGURE_CENTERING_CSS` (imported as constants from `HighlightsPublicationFactory`).
+   - `publisherFontFaceCss` from `HighlightsPublicationHandle` (may be empty).
+   - Body-font rule if `bookBodyFontFamily` is non-null.
+   - `.riffle-hl-tap { display: none; }` — tap-dispatch spans are invisible in the printed output.
+4. **No `READIUM_DEFAULT_CSS_LINK`** — that URL (`https://readium_assets/…`) is served by Readium's `WebViewServer` and is not resolvable in the headless export WebView. PDF-friendly base styles replace the Readium defaults for the export context only.
+
+All images are already data URIs inside the chapter HTML (`imageBytes` / `dataUriByHref` entries embedded by `HighlightsPublicationFactory`). The resulting document is fully self-contained with no external resource references.
+
+---
+
+## PDF rendering
+
+1. On `Dispatchers.Main`, create `WebView(applicationContext)` without attaching it to the window — sufficient for the non-interactive `PrintDocumentAdapter` path.
+2. Call `webView.loadDataWithBaseURL(null, combinedHtml, "text/html", "UTF-8", null)`.
+3. Wait for `WebViewClient.onPageFinished` via `suspendCancellableCoroutine`.
+4. Obtain `val adapter = webView.createPrintDocumentAdapter(bookTitle ?: "Annotations")`.
+5. Call `adapter.onLayout(null, printAttributes, null, layoutCallback, null)` with A4 portrait attributes.
+6. In `onLayoutFinished`, call `adapter.onWrite(arrayOf(PageRange.ALL_PAGES), parcelFileDescriptor, null, writeCallback)`.
+7. In `onWriteFinished`, close the `ParcelFileDescriptor` and return the file `Uri`.
+8. Detach and destroy the WebView after the PDF is written.
+
+The PDF file is written to `context.cacheDir` as `annotations-<itemId>.pdf`. A `FileProvider` authority (already required by other Android sharing conventions — add if absent) wraps the file before sharing.
+
+---
+
+## Loading state & UI
+
+- Share button lives in the elided reader's existing top bar, rendered only when `readerSource == ReaderSource.Highlights`.
+- Icon: `Icons.Default.Share`.
+- While `isExporting == true` (new `StateFlow<Boolean>` on the ViewModel), the icon is replaced by a `CircularProgressIndicator` of the same size and the button is non-interactive.
+- On success: `ReaderNavEvent.ShareFile(uri)` → screen fires `ACTION_SEND` intent with `type = "application/pdf"` and `EXTRA_STREAM = uri`.
+- On failure: `ReaderNavEvent.ShowSnackbar(messageResId)` with a generic "Couldn't generate PDF" string.
+
+---
+
+## New files
+
+| File | Purpose |
+|------|---------|
+| `app/…/reader/highlights/HighlightsPdfExporter.kt` | HTML assembly + headless WebView PDF rendering |
+
+## Modified files
+
+| File | Change |
+|------|--------|
+| `EpubReaderViewModel.kt` | `onShareElidedView()`, `isExporting` state, inject `HighlightsPdfExporter` |
+| `EpubReaderScreen.kt` | Share button in top bar (Highlights mode only), handle `ShareFile` nav event |
+| `ReaderNavEvent.kt` | Add `ShareFile(uri: Uri)` |
+| `HighlightsPublicationFactory.kt` | No change needed — `ACCENT_BAR_TAP_CSS` and `FIGURE_CENTERING_CSS` are already `internal const` |
+| `AndroidManifest.xml` | Add / confirm `FileProvider` for `cacheDir` |
+
+---
+
+## Testing
+
+**Unit (JVM):**
+- `HighlightsPdfExporterTest.combinedHtml_containsAllChapterTitles` — given N `ChapterElision`s, the assembled HTML has N `<h1>` elements.
+- `HighlightsPdfExporterTest.combinedHtml_hasNoReadiumAssetLink` — the combined HTML contains no `readium_assets` href.
+- `HighlightsPdfExporterTest.combinedHtml_tapSpansHidden` — the combined HTML contains `.riffle-hl-tap { display: none }`.
+- `HighlightsPdfExporterTest.combinedHtml_includesPublisherFontFaceWhenNonBlank` — publisher font CSS is present when supplied.
+
+**Instrumentation:**
+- `ShareElidedViewTest` (harness) — open a book in Highlights mode, tap share, assert a non-empty PDF file is written to `cacheDir` before the share intent fires (verify file size > 0).
+
+---
+
+## Out of scope
+
+- Per-annotation share (single highlight → share sheet) — separate feature.
+- Sharing from `AnnotationsListScreen` — explicitly excluded.
+- Export formats other than PDF.


### PR DESCRIPTION
## Summary

- Adds a **Share** button to the elided reader (Highlights mode) top bar that exports all highlighted passages as a PDF and fires the Android share sheet
- `HighlightsPdfExporter` assembles one HTML page per chapter (only chapters with highlights), then renders it headlessly via `PrintDocumentAdapter` + `WebView` on the main thread, writing to the app's `FileProvider`-backed cache directory
- `ReaderNavEvent.ShareHighlights(uri)` carries the `content://` URI to `MainScreen`, which builds and fires `ACTION_SEND`; `ReaderNavEvent.ExportError` shows a toast on failure
- Share button is gated behind `shouldShowShareHighlights(source)` — visible only in `ReaderSource.Highlights` mode
- A `CircularProgressIndicator` replaces the icon while export is in flight

## Changes

| Area | What changed |
|------|-------------|
| `file_paths.xml` | Added `<cache-path name="exports" path="exports/" />` for FileProvider |
| `HighlightsUiSuppression.kt` | `shouldShowShareHighlights` predicate |
| `HighlightsPdfExporter.kt` | New injectable: HTML assembly + headless PDF render |
| `ReaderNavEvent.kt` | `ShareHighlights(Uri)` + `ExportError` |
| `strings.xml` | `export_pdf_error` string |
| `EpubReaderViewModel.kt` | `onShareElidedView()`, `isExporting` state |
| `EpubReaderScreen.kt` | Share icon / spinner in top bar |
| `MainScreen.kt` | `ShareHighlights` → `ACTION_SEND`; `ExportError` → toast |

## Tests

- **JVM**: 5 `HighlightsPdfExporterTest` tests (HTML structure, chapter filtering, font-face injection)
- **JVM**: `HighlightsUiSuppressionTest` — share button visible only in Highlights mode
- **Instrumentation**: `ShareElidedViewTest` (6 assertions on `buildCombinedHtml` output: document structure, chapter titles, no readium_assets links, tap-class hidden, empty-chapter skip, snippet presence)

## Smoke test

Verified on fresh API-25 AVD (session AVD, now deleted):
1. Annotations tab → tap "Taking Charge of ADHD, Fourth Edition" (23 annotations) → elided view opens
2. Tap top bar → Share icon visible with content-desc "Share annotations as PDF"
3. Tap Share → `CircularProgressIndicator` shown → Android share sheet appears with `annotations-….pdf` file
4. Share targets: Print, Drive, Messages, Bluetooth — no crash, no error toast