### PR TITLE
fix(reader): prevent phantom empty annotation on ∅-dismiss

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
@@ -29,6 +29,13 @@ internal class ContinuousHighlightRenderer(
          * highlights either. `internal` for regression pinning.
          */
         internal const val ACCENT_BAR_TRANSPARENT_CSS = "transparent"
+
+        /**
+         * ARGB wash painted on a draft annotation while the actions sheet is open and the user
+         * has ∅ (no colour) as their last pick. Matches [ReadiumHighlightRenderer.EMPTY_COLOR_EDITING_HINT_ARGB]
+         * so the feedback is identical across all three reader modes.
+         */
+        internal const val EMPTY_COLOR_EDITING_HINT_ARGB: Int = 0x30808080
     }
 
     override suspend fun applySentenceHighlight(
@@ -86,10 +93,16 @@ internal class ContinuousHighlightRenderer(
                         // the colour — the exact bug that "removing color keeps it yellow"
                         // triggers in continuous mode. The mark is retained (never dropped) so
                         // layered emphasis and tap-to-edit still work on a colourless annotation.
-                        cssColor = if (h.useAccentBarStyle || h.color.isEmpty()) {
-                            ACCENT_BAR_TRANSPARENT_CSS
-                        } else {
-                            HighlightColor.fromToken(h.color).argb.toCssRgba()
+                        // ADR 0046 §4: mirror ReadiumHighlightRenderer's three-way tint logic.
+                        //  - useAccentBarStyle: transparent (mark kept for tap dispatch only).
+                        //  - empty colour + sheet open (draft): neutral wash so user sees range.
+                        //  - empty colour + sheet closed: transparent (emphasis-only annotation).
+                        //  - real colour: palette fill.
+                        cssColor = when {
+                            h.useAccentBarStyle -> ACCENT_BAR_TRANSPARENT_CSS
+                            h.color.isEmpty() && h.isBeingEdited -> EMPTY_COLOR_EDITING_HINT_ARGB.toCssRgba()
+                            h.color.isEmpty() -> ACCENT_BAR_TRANSPARENT_CSS
+                            else -> HighlightColor.fromToken(h.color).argb.toCssRgba()
                         },
                         hasNote = h.note != null,
                         before = h.locator.text.before.orEmpty(),

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRenderer.kt
@@ -30,12 +30,6 @@ internal class ContinuousHighlightRenderer(
          */
         internal const val ACCENT_BAR_TRANSPARENT_CSS = "transparent"
 
-        /**
-         * ARGB wash painted on a draft annotation while the actions sheet is open and the user
-         * has ∅ (no colour) as their last pick. Matches [ReadiumHighlightRenderer.EMPTY_COLOR_EDITING_HINT_ARGB]
-         * so the feedback is identical across all three reader modes.
-         */
-        internal const val EMPTY_COLOR_EDITING_HINT_ARGB: Int = 0x30808080
     }
 
     override suspend fun applySentenceHighlight(
@@ -100,7 +94,7 @@ internal class ContinuousHighlightRenderer(
                         //  - real colour: palette fill.
                         cssColor = when {
                             h.useAccentBarStyle -> ACCENT_BAR_TRANSPARENT_CSS
-                            h.color.isEmpty() && h.isBeingEdited -> EMPTY_COLOR_EDITING_HINT_ARGB.toCssRgba()
+                            h.color.isEmpty() && h.isBeingEdited -> ReadiumHighlightRenderer.EMPTY_COLOR_EDITING_HINT_ARGB.toCssRgba()
                             h.color.isEmpty() -> ACCENT_BAR_TRANSPARENT_CSS
                             else -> HighlightColor.fromToken(h.color).argb.toCssRgba()
                         },

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/DraftPopupSelection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/DraftPopupSelection.kt
@@ -40,6 +40,21 @@ internal data class DraftPopupSelection(
 )
 
 /**
+ * Commit-time guard: returns `true` when [commitDraft] should abort without creating any DB row.
+ *
+ * ∅ colour + no emphasis means the resulting annotation row would be invisible and carry no
+ * formatting — a phantom that the tombstone in [AnnotationSession.dismissHighlightActions] would
+ * normally clean up. The tombstone relies on `awaitAnnotation(500ms)`, which can race with Room
+ * Flow propagation and leave the phantom row behind. Skipping the create entirely is more
+ * reliable, and is consistent with [shouldAutoCommitDraftOnDismiss]: dismiss with ∅+nothing also
+ * discards without committing.
+ */
+internal fun shouldDiscardPhantomDraftCommit(
+    initialColor: String,
+    combinedStyles: Set<EmphasisStyle>,
+): Boolean = initialColor.isEmpty() && combinedStyles.isEmpty()
+
+/**
  * Dismiss behaviour predicate for a pending draft (Bug 2, 2026-07-19).
  *
  * Returns `true` when the popup's dismiss should COMMIT the draft using the per-book last-used

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -2099,13 +2099,21 @@ class EpubReaderViewModel @Inject constructor(
         keepSheetOpen: Boolean = true,
     ) {
         val draft = annotationSession.draftAnnotation.value ?: return
-        // Cleanup of a fully-empty annotation (no colour + no emphasis + no note) is deferred
-        // to [AnnotationSession.dismissHighlightActions]' tombstone-on-empty check, which uses
-        // the ACTUAL post-commit persisted state. An eager guard here that peeks at
-        // `lastUsedEmphasisStyles.value` (a StateFlow cache) races the observer that populates
-        // it — on a cold cache immediately after bind, the preset reads empty even when the
-        // store has real styles, and tapping ∅ would then discard a draft whose real preset
-        // would have layered emphasis onto the highlight ("annotation is discarded").
+        // Compute combinedStyles early so we can guard against a phantom empty row (∅ colour +
+        // no emphasis + no note) before doing any DB work. A cold-cache StateFlow reading {} is
+        // safe here: if the DataStore truly has e.g. {BOLD}, combinedStyles becomes {BOLD} and
+        // the guard does not fire; if the cache is stale-empty AND the store is also empty, the
+        // result is the same as the dismiss path's shouldAutoCommitDraftOnDismiss(true, {}) = false
+        // (discard) — consistent behaviour in both places.
+        val presetStyles = annotationSession.lastUsedEmphasisStyles.value
+        val combinedStyles = combineDraftEmphasisStyles(presetStyles, addEmphasisStyle)
+        if (shouldDiscardPhantomDraftCommit(initialColor, combinedStyles)) {
+            // Persist the ∅ preference so a subsequent dismiss-auto-commit evaluates
+            // shouldAutoCommitDraftOnDismiss(true, …) = false and does not try to auto-commit
+            // with whatever the previous colour was. Draft stays alive for the caller to handle.
+            annotationSession.persistLastUsedColorToken("")
+            return
+        }
         // Deferred overlap MERGE — a new selection that partially or fully overlaps existing
         // highlights in the same chapter is unioned with them into ONE highlight covering
         // `[min(starts), max(ends))`. Pre-fix behaviour (before 2026-07-19) required snippet
@@ -2204,8 +2212,6 @@ class EpubReaderViewModel @Inject constructor(
             // would misalign formatting against the wider text.
             textSnippetHtml = if (overlapMerge == null && adjacentMerge == null) draft.textSnippetHtml else null,
         )
-        val presetStyles = annotationSession.lastUsedEmphasisStyles.value
-        val combinedStyles = combineDraftEmphasisStyles(presetStyles, addEmphasisStyle)
         if (combinedStyles.isNotEmpty()) {
             annotationStore.createEmphasis(
                 sourceId = draft.sourceId,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
@@ -250,7 +250,7 @@ internal class ReadiumHighlightRenderer(
         // ADR 0046: temporary neutral wash painted only while the sheet is open on a ∅-color
         // annotation, so the user can see the range they're working on. Not persistent — a
         // ∅ annotation with the sheet closed and no emphasis draws nothing at all.
-        private const val EMPTY_COLOR_EDITING_HINT_ARGB: Int = 0x30808080
+        internal const val EMPTY_COLOR_EDITING_HINT_ARGB: Int = 0x30808080
         // Bold and italic don't paint overlays anymore — they reflow the underlying text via
         // the DOM injector. See [EmphasisDomInjector].
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
@@ -658,8 +658,13 @@ class AnnotationSession @AssistedInject constructor(
         val sid = boundServerId ?: return
         val iid = boundItemId ?: return
         if (colorToken.isEmpty()) {
+            // Optimistic update so dismissHighlightActions reads the correct value immediately,
+            // without waiting for DataStore to propagate through the Flow collector.
+            _lastUsedColorIsNone.value = true
             highlightColorPreferencesStore.setLastUsedIsNone(sid, iid, true)
         } else {
+            _lastUsedColorIsNone.value = false
+            _lastUsedHighlightColor.value = HighlightColor.fromToken(colorToken)
             highlightColorPreferencesStore.setLastUsedColor(sid, iid, HighlightColor.fromToken(colorToken))
             highlightColorPreferencesStore.setLastUsedIsNone(sid, iid, false)
         }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRendererTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRendererTest.kt
@@ -88,6 +88,7 @@ class ContinuousHighlightRendererTest {
         after: String? = null,
         useAccentBarStyle: Boolean = false,
         emphasisStyles: Set<EmphasisStyle> = emptySet(),
+        isBeingEdited: Boolean = false,
     ) = EpubReaderViewModel.HighlightRender(
         id = id,
         locator = Locator(
@@ -99,6 +100,7 @@ class ContinuousHighlightRendererTest {
         note = note,
         useAccentBarStyle = useAccentBarStyle,
         emphasisStyles = emphasisStyles,
+        isBeingEdited = isBeingEdited,
     )
 
     /** Creates a [Locator] with href and text highlight, suitable for search result tests. */
@@ -280,6 +282,35 @@ class ContinuousHighlightRendererTest {
     fun `applyAnnotations emits transparent cssColor when color is empty (remove-color)`() = runTest {
         val renders = listOf(
             makeRender("h1", "ch1.xhtml", "text one", color = ""),
+        )
+        renderer.applyAnnotations(renders)
+        val ann = fakeTarget.appliedAnnotations.single().values.single().single()
+        assertEquals(ContinuousHighlightRenderer.ACCENT_BAR_TRANSPARENT_CSS, ann.cssColor)
+    }
+
+    // Regression: draft annotation (isBeingEdited=true, color="") must show a neutral wash so the
+    // user can see the selection range while the actions sheet is open. Previously continuous mode
+    // collapsed both "draft, no color" and "committed, no color" into the same transparent branch,
+    // making the selection invisible — matching the fix that already existed in ReadiumHighlightRenderer.
+    @Test
+    fun `applyAnnotations emits editing-hint wash when color is empty and isBeingEdited`() = runTest {
+        val renders = listOf(
+            makeRender("h1", "ch1.xhtml", "text one", color = "", isBeingEdited = true),
+        )
+        renderer.applyAnnotations(renders)
+        val ann = fakeTarget.appliedAnnotations.single().values.single().single()
+        assertEquals(
+            ContinuousHighlightRenderer.EMPTY_COLOR_EDITING_HINT_ARGB.toCssRgba(),
+            ann.cssColor,
+        )
+    }
+
+    @Test
+    fun `applyAnnotations emits transparent when color is empty and not being edited`() = runTest {
+        // A committed ∅-colour annotation (sheet closed) must stay invisible — only the
+        // emphasis formatting (bold/italic/underline) is the visible surface.
+        val renders = listOf(
+            makeRender("h1", "ch1.xhtml", "text one", color = "", isBeingEdited = false),
         )
         renderer.applyAnnotations(renders)
         val ann = fakeTarget.appliedAnnotations.single().values.single().single()

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRendererTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousHighlightRendererTest.kt
@@ -300,7 +300,7 @@ class ContinuousHighlightRendererTest {
         renderer.applyAnnotations(renders)
         val ann = fakeTarget.appliedAnnotations.single().values.single().single()
         assertEquals(
-            ContinuousHighlightRenderer.EMPTY_COLOR_EDITING_HINT_ARGB.toCssRgba(),
+            ReadiumHighlightRenderer.EMPTY_COLOR_EDITING_HINT_ARGB.toCssRgba(),
             ann.cssColor,
         )
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/DraftPopupSelectionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/DraftPopupSelectionTest.kt
@@ -104,6 +104,28 @@ class DraftPopupSelectionTest {
         assertEquals(false, shouldAutoCommitDraftOnDismiss(lastUsedColorIsNone = true, lastUsedEmphasisStyles = emptySet()))
     }
 
+    // ---- commitDraft phantom-empty guard ----
+
+    @Test
+    fun phantomGuard_discardsWhenColorEmptyAndStylesEmpty() {
+        // Regression: tapping ∅ on a draft with no emphasis preset must NOT persist a phantom
+        // empty annotation row. This assertion flips red if the shouldDiscardPhantomDraftCommit
+        // guard in commitDraft is removed or the condition is inverted.
+        assertEquals(true, shouldDiscardPhantomDraftCommit(initialColor = "", combinedStyles = emptySet()))
+    }
+
+    @Test
+    fun phantomGuard_allowsCommitWhenColorEmpty_butStylesPresent() {
+        // ∅ colour + BOLD emphasis is a valid emphasis-only annotation — must not be discarded.
+        assertEquals(false, shouldDiscardPhantomDraftCommit(initialColor = "", combinedStyles = setOf(EmphasisStyle.BOLD)))
+    }
+
+    @Test
+    fun phantomGuard_allowsCommitWhenColorSet_stylesEmpty() {
+        // Real colour + no emphasis is a standard highlight — must not be discarded.
+        assertEquals(false, shouldDiscardPhantomDraftCommit(initialColor = "YELLOW", combinedStyles = emptySet()))
+    }
+
     @Test
     fun persistedRow_ignoresLastUsedState() {
         // Regression: persisted-row pre-selection MUST NOT leak the per-book last-used state —


### PR DESCRIPTION
## What

When a user long-presses text → taps **ANNOTATE** → dismisses the sheet without choosing any color or emphasis, `commitDraft` previously wrote an invisible DB row (∅ color + no styles + no note). The tombstone in `dismissHighlightActions` cleaned it up via `awaitAnnotation(500 ms)`, but that races Room Flow propagation and could leave the phantom row behind.

## Changes

**Phantom-empty guard** (`DraftPopupSelection.kt`, `EpubReaderViewModel.kt`):  
`shouldDiscardPhantomDraftCommit(initialColor, combinedStyles)` at the top of `commitDraft()` — if both are empty, skip the DB write entirely and persist `""` as the color preference so the subsequent dismiss-auto-commit path (`shouldAutoCommitDraftOnDismiss`) also evaluates to `false`.

**Continuous mode draft visibility** (`ContinuousHighlightRenderer.kt`):  
Three-way `cssColor` matching `ReadiumHighlightRenderer`'s logic: `useAccentBarStyle→transparent`, `color="" && isBeingEdited→0x30808080 wash`, `color=""→transparent`, `else→palette`. Previously the two draft/committed empty-color states were collapsed, making the selection range invisible while the sheet was open.

**Dismiss-path race fix** (`AnnotationSession.kt`):  
`persistLastUsedColorToken("")` now immediately updates `_lastUsedColorIsNone` and `_lastUsedHighlightColor` StateFlows before the DataStore write, eliminating the window where `dismissHighlightActions` could read stale `lastUsedColorIsNone=false` and auto-commit a highlight the user had discarded.

**Constant dedup** (`ReadiumHighlightRenderer.kt`, `ContinuousHighlightRenderer.kt`):  
`EMPTY_COLOR_EDITING_HINT_ARGB` promoted from `private` to `internal` in `ReadiumHighlightRenderer`; the duplicate in `ContinuousHighlightRenderer` removed.

## Validation

- Verified end-to-end on API-25 AVD in continuous reader mode: logcat confirmed `EARLY-DISCARD` fires on ∅-dismiss; no phantom row in annotations DB.
- `./gradlew :app:test` — BUILD SUCCESSFUL (123 tasks).
- Regression tests: `phantomGuard_*` (3), `applyAnnotations emits editing-hint wash/transparent` (2).