### PR TITLE
fix(reader): annotation focus lands on correct page in paginated mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -508,7 +508,7 @@ internal object ColumnSnap {
         val idLiteral = if (fragmentId.isNullOrEmpty()) "null" else JSONObject.quote(fragmentId)
         val noTargetSnap = when {
             landAtStartWhenNoTarget -> "se.scrollLeft=0;"
-            locatorProgression != null -> "se.scrollLeft=Math.round($locatorProgression*se.scrollWidth/iw)*iw;"
+            locatorProgression != null -> "se.scrollLeft=Math.floor($locatorProgression*se.scrollWidth/iw)*iw;"
             else -> "se.scrollLeft=Math.round(se.scrollLeft/iw)*iw;"
         }
         // For annotation focus (landAtStartWhenNoTarget=false with a progression), skip the

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -493,11 +493,39 @@ internal object ColumnSnap {
     // to column 0 (true, the default); a position-based jump (a background sync that already go()'d to a
     // within-chapter progression) rounds the current scroll to the column grid instead (false), preserving
     // where go() landed rather than yanking to the chapter top.
-    fun snapToTargetColumnJs(fragmentId: String?, landAtStartWhenNoTarget: Boolean = true): String {
+    //
+    // [locatorProgression] is used instead of the current scrollLeft when fragmentId is null and
+    // landAtStartWhenNoTarget is false. After a cross-chapter jump, typography-injection reflow resets
+    // scrollLeft to 0 before the rAF loop exits, so rounding scrollLeft snaps to column 0 instead of the
+    // annotation's actual column. Recomputing from progression * scrollWidth each tick is reflow-stable:
+    // scrollWidth re-settles to the post-reflow value, and progression * new_scrollWidth lands on the right
+    // column. The fragmentId path is already self-correcting via getBoundingClientRect, so it doesn't need this.
+    fun snapToTargetColumnJs(
+        fragmentId: String?,
+        landAtStartWhenNoTarget: Boolean = true,
+        locatorProgression: Double? = null,
+    ): String {
         val idLiteral = if (fragmentId.isNullOrEmpty()) "null" else JSONObject.quote(fragmentId)
-        val noTargetSnap = if (landAtStartWhenNoTarget) "se.scrollLeft=0;" else "se.scrollLeft=Math.round(se.scrollLeft/iw)*iw;"
+        val noTargetSnap = when {
+            landAtStartWhenNoTarget -> "se.scrollLeft=0;"
+            locatorProgression != null -> "se.scrollLeft=Math.round($locatorProgression*se.scrollWidth/iw)*iw;"
+            else -> "se.scrollLeft=Math.round(se.scrollLeft/iw)*iw;"
+        }
+        // For annotation focus (landAtStartWhenNoTarget=false with a progression), skip the
+        // vertical smooth-tail block entirely. The snap JS runs immediately after go(locator),
+        // before Readium has applied CSS multicol. At that moment scrollHeight > innerHeight (the
+        // natural page height), so the vertical check fires and returns early — the paginated rAF
+        // loop never runs. Then Readium applies multicol and resets scrollLeft to 0, always landing
+        // on page 1. By setting _skipV=true we fall straight into the rAF loop, which tracks
+        // scrollWidth each frame: it starts at innerWidth (pre-multicol → snap() is a near-no-op),
+        // then grows when multicol is applied, and on each subsequent frame the loop recomputes
+        // progression*scrollWidth/iw and snaps scrollLeft to the correct column. The loop exits
+        // only once scrollWidth has held steady for ≥3 frames, so typography-injection reflows
+        // (which transiently reset scrollLeft to 0) are automatically absorbed.
+        val skipVertical = !landAtStartWhenNoTarget && locatorProgression != null
         return "(function(){var id=$idLiteral;" +
             "var se=document.scrollingElement;" +
+            "var _skipV=$skipVertical;" +
             // Vertical (scroll-mode) smooth tail. Readium's `go(locator)` already teleported us to
             // the target, so we compute `targetV` from either the fragment element's rect or the
             // current scrollTop. The animation START point depends on whether the jump crossed
@@ -509,8 +537,8 @@ internal object ColumnSnap {
             // background sync must not reuse a stale origin from an unrelated navigation.
             // Skips the paginated rAF column-snap loop below — it only writes scrollLeft, which
             // is a no-op in vertical, and the smooth animation is one-shot rather than a
-            // reflow-tracking loop.
-            "if(se && se.scrollHeight > window.innerHeight + 4){" +
+            // reflow-tracking loop. Skipped entirely for annotation focus (_skipV=true) — see above.
+            "if(!_skipV && se && se.scrollHeight > window.innerHeight + 4){" +
             "var targetV;" +
             "if(id){var elV=document.getElementById(id);" +
             "if(elV){var rV=elV.getBoundingClientRect();" +

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -494,18 +494,22 @@ internal object ColumnSnap {
     // within-chapter progression) rounds the current scroll to the column grid instead (false), preserving
     // where go() landed rather than yanking to the chapter top.
     //
-    // [locatorProgression] is used instead of the current scrollLeft when fragmentId is null and
-    // landAtStartWhenNoTarget is false. After a cross-chapter jump, typography-injection reflow resets
-    // scrollLeft to 0 before the rAF loop exits, so rounding scrollLeft snaps to column 0 instead of the
-    // annotation's actual column. Recomputing from progression * scrollWidth each tick is reflow-stable:
-    // scrollWidth re-settles to the post-reflow value, and progression * new_scrollWidth lands on the right
-    // column. The fragmentId path is already self-correcting via getBoundingClientRect, so it doesn't need this.
+    // [locatorJson] is the preferred target for text-anchored navigation. Readium resolves its
+    // TextQuote to the exact DOM Range on every tracked frame, so reflow cannot move the target
+    // away from the landing column. [locatorProgression] remains the fallback when the quote is
+    // absent or stale. It is re-evaluated against scrollWidth on each frame, which is stable
+    // across typography reflow but only approximate for visual layout.
     fun snapToTargetColumnJs(
         fragmentId: String?,
         landAtStartWhenNoTarget: Boolean = true,
         locatorProgression: Double? = null,
+        locatorJson: String? = null,
     ): String {
         val idLiteral = if (fragmentId.isNullOrEmpty()) "null" else JSONObject.quote(fragmentId)
+        val locatorLiteral = locatorJson
+            ?.takeIf { it.isNotBlank() }
+            ?.let { "JSON.parse(${JSONObject.quote(it)})" }
+            ?: "null"
         val noTargetSnap = when {
             landAtStartWhenNoTarget -> "se.scrollLeft=0;"
             locatorProgression != null -> "se.scrollLeft=Math.floor($locatorProgression*se.scrollWidth/iw)*iw;"
@@ -524,6 +528,7 @@ internal object ColumnSnap {
         // (which transiently reset scrollLeft to 0) are automatically absorbed.
         val skipVertical = !landAtStartWhenNoTarget && locatorProgression != null
         return "(function(){var id=$idLiteral;" +
+            "var loc=$locatorLiteral;" +
             "var se=document.scrollingElement;" +
             "var _skipV=$skipVertical;" +
             // Vertical (scroll-mode) smooth tail. Readium's `go(locator)` already teleported us to
@@ -558,6 +563,13 @@ internal object ColumnSnap {
             "var gen=(window.__riffleSnapGen=(window.__riffleSnapGen||0)+1);" +
             "var lastW=-1,stable=0,frames=0;" +
             "function snap(){var iw=window.innerWidth;" +
+            // Readium's own locator resolver uses text.highlight + before/after to reconstruct
+            // the exact DOM Range. Re-run it on every tracked frame so a typography reflow
+            // cannot reset the landing to column 0. This is strictly more precise than mapping
+            // character progression onto scrollWidth; progression remains the fallback when a
+            // legacy/stale quote no longer matches the publication.
+            "if(loc&&window.readium&&typeof window.readium.scrollToLocator==='function'){" +
+            "try{if(window.readium.scrollToLocator(loc))return;}catch(e){}}" +
             "if(id){var el=document.getElementById(id);" +
             "if(el){se.scrollLeft=Math.floor((el.getBoundingClientRect().left+se.scrollLeft)/iw)*iw;}" +
             "else{se.scrollLeft=Math.round(se.scrollLeft/iw)*iw;}}" +

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
@@ -88,15 +88,28 @@ internal class DefaultRendererBridge(
 
     override suspend fun snapAfterGoTo(locator: Locator, landAtStartWhenNoTarget: Boolean) {
         val frag = fragment ?: return
-        // Prefer the fragment id carried in locations.fragments over any '#anchor' in the href.
-        // Annotation navigation resolves the CFI's DOM anchor into locations.fragments (never
-        // into the href string), so a naïve navTargetFragmentId(href) read would return null and
-        // the snap JS would fall back to a scroll-position round — which in paginated mode can
-        // leave the page one column short of the annotated paragraph even though Readium's own
-        // go(locator) already scrolled to it. Using the locator's fragment id makes the snap JS
-        // anchor on the DOM element directly.
-        val fragmentId = locator.locations.fragments.firstOrNull()
-            ?: navTargetFragmentId(locator.href.toString())
+        // For TOC/search/resume navigation (landAtStartWhenNoTarget=true), use the fragment id
+        // from locations.fragments or the href anchor to snap the JS to the exact target element.
+        //
+        // For annotation navigation (landAtStartWhenNoTarget=false), SKIP the fragment id even if
+        // one is present. extractAnchorFromCfi stores the innermost NAMED ancestor of the
+        // highlighted text node — typically a <section id="ch01"> or <div id="main"> that spans
+        // the entire chapter. Snapping to that element always resolves to column 0 (page 1)
+        // because getBoundingClientRect().left for a section that starts at the chapter top is 0.
+        // Character-count progression is more reliable: it maps the annotation's text position to
+        // the column it actually occupies, and the rAF loop recomputes it against the settled
+        // scrollWidth each tick, so typography-injection reflow doesn't knock it off.
+        val fragmentId = if (landAtStartWhenNoTarget) {
+            locator.locations.fragments.firstOrNull()
+                ?: navTargetFragmentId(locator.href.toString())
+        } else {
+            null
+        }
+        val progression = if (!landAtStartWhenNoTarget) {
+            locator.locations.progression
+        } else {
+            null
+        }
         // Stash the pre-go scroll origin so the post-go smooth-tail can start from where the
         // user actually was on same-doc jumps (return-to-position card, same-chapter TOC entry)
         // instead of pre-landing half a viewport short — which flashes as "goes back a bit and
@@ -105,9 +118,7 @@ internal class DefaultRendererBridge(
         // cover hides.
         frag.evaluateJavascript(ColumnSnap.STASH_VERTICAL_ORIGIN_JS)
         frag.go(locator)
-        frag.evaluateJavascript(
-            ColumnSnap.snapToTargetColumnJs(fragmentId, landAtStartWhenNoTarget),
-        )
+        frag.evaluateJavascript(ColumnSnap.snapToTargetColumnJs(fragmentId, landAtStartWhenNoTarget, progression))
     }
 
     override suspend fun snapToEnd() {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
@@ -96,9 +96,9 @@ internal class DefaultRendererBridge(
         // highlighted text node — typically a <section id="ch01"> or <div id="main"> that spans
         // the entire chapter. Snapping to that element always resolves to column 0 (page 1)
         // because getBoundingClientRect().left for a section that starts at the chapter top is 0.
-        // Character-count progression is more reliable: it maps the annotation's text position to
-        // the column it actually occupies, and the rAF loop recomputes it against the settled
-        // scrollWidth each tick, so typography-injection reflow doesn't knock it off.
+        // The locator's TextQuote is the precise target: Readium resolves it to the highlighted
+        // DOM Range on every rAF tick. Character-count progression remains the fallback for a
+        // missing/stale quote; unlike a range it can be a column off when block density varies.
         val fragmentId = if (landAtStartWhenNoTarget) {
             locator.locations.fragments.firstOrNull()
                 ?: navTargetFragmentId(locator.href.toString())
@@ -110,6 +110,12 @@ internal class DefaultRendererBridge(
         } else {
             null
         }
+        // A TextQuote locator lets Readium resolve the exact highlighted DOM range. Pass the
+        // complete locator into the reflow tracker so it can repeat that exact resolution after
+        // each scrollWidth change; progression is only a fallback when the quote is absent/stale.
+        val exactLocatorJson = locator.text.highlight
+            ?.takeIf { it.isNotBlank() }
+            ?.let { locator.toJSON().toString() }
         // Stash the pre-go scroll origin so the post-go smooth-tail can start from where the
         // user actually was on same-doc jumps (return-to-position card, same-chapter TOC entry)
         // instead of pre-landing half a viewport short — which flashes as "goes back a bit and
@@ -118,7 +124,14 @@ internal class DefaultRendererBridge(
         // cover hides.
         frag.evaluateJavascript(ColumnSnap.STASH_VERTICAL_ORIGIN_JS)
         frag.go(locator)
-        frag.evaluateJavascript(ColumnSnap.snapToTargetColumnJs(fragmentId, landAtStartWhenNoTarget, progression))
+        frag.evaluateJavascript(
+            ColumnSnap.snapToTargetColumnJs(
+                fragmentId = fragmentId,
+                landAtStartWhenNoTarget = landAtStartWhenNoTarget,
+                locatorProgression = progression,
+                locatorJson = exactLocatorJson,
+            ),
+        )
     }
 
     override suspend fun snapToEnd() {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationNavigationLocator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationNavigationLocator.kt
@@ -1,0 +1,29 @@
+package com.riffle.app.feature.reader.session
+
+import com.riffle.core.database.AnnotationEntity
+import com.riffle.core.models.Annotation
+import org.readium.r2.shared.publication.Locator
+
+/**
+ * Adds the persisted TextQuote to a resolved highlight locator.
+ *
+ * CFI resolution reconstructs chapter/progression/fragment without access to the annotation row.
+ * Readium needs highlight/before/after to resolve the exact DOM Range, so every annotation entry
+ * path enriches its locator once the matching row is available. Progression stays intact as the
+ * fallback when a legacy or stale quote no longer matches the publication.
+ */
+internal fun Locator.withAnnotationTextQuote(annotation: Annotation?): Locator {
+    if (
+        annotation?.type != AnnotationEntity.TYPE_HIGHLIGHT ||
+        annotation.textSnippet.isBlank()
+    ) {
+        return this
+    }
+    return copy(
+        text = Locator.Text(
+            before = annotation.textBefore,
+            highlight = annotation.textSnippet,
+            after = annotation.textAfter,
+        ),
+    )
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
@@ -139,9 +139,10 @@ class AnnotationSession @AssistedInject constructor(
      */
     /**
      * A "navigate to this annotation" event. [locator] resolves to (chapter, progression,
-     * fragment) — the fragment is the range's START paragraph id (see [extractAnchorFromCfi]),
-     * which is enough for Readium's own navigators (paginated + vertical scroll) to land on
-     * the paragraph containing the highlight.
+     * fragment) and, for text highlights, carries the persisted TextQuote
+     * (highlight/before/after). Readium uses the quote to resolve the exact DOM range; the
+     * fragment remains the range's START paragraph id (see [extractAnchorFromCfi]) and the
+     * progression is the fallback for legacy rows whose quote no longer matches.
      *
      * Continuous mode uses [annotationId] to look up the actual `<mark data-riffle-ann="…">`
      * element in the DOM and centre the viewport on IT, not just on the enclosing paragraph.
@@ -731,7 +732,16 @@ class AnnotationSession @AssistedInject constructor(
         scope.launch {
             val annotation = _annotations.value.firstOrNull { it.id == id } ?: return@launch
             val resolver = cfiLocatorResolverFn ?: return@launch
-            val locator = resolver(annotation.cfi) ?: return@launch
+            val resolvedLocator = resolver(annotation.cfi) ?: return@launch
+            // The CFI resolver reconstructs chapter/progression/fragment but does not have the
+            // annotation row, so it cannot attach the TextQuote that Readium's scrollToLocator
+            // needs for exact range resolution. Enrich highlight locators here, where the
+            // persisted snippet and both disambiguating context strings are available.
+            //
+            // Character progression remains on the locator as a fallback for legacy/stale
+            // quotes. It is not precise enough to be the primary paginated target: block
+            // elements and variable line density mean progression can map one column away.
+            val locator = resolvedLocator.withAnnotationTextQuote(annotation)
             // Annotation.type uses the database-layer constants from AnnotationEntity. A typo
             // matching a lowercased literal here silently flipped every annotation to
             // isBookmark=false, which inverted the continuous-mode landing.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
@@ -198,15 +198,22 @@ class ReaderSessionLifecycle @AssistedInject constructor(
         val openAtCfiNonBlank = params.openAtCfi?.takeIf { it.isNotBlank() }
         // A search-result / annotation-tap open overrides the saved position. Requires `publication`
         // (set above) — cfiStringToLocator resolves against it.
-        val openAtLocator = openAtCfiNonBlank?.let { cfiStringToLocator(it) }
-        // openAtCfiNonBlank is non-null whenever openAtLocator is (openAtLocator is derived from it).
-        val initialFocusAnnotationId = if (openAtLocator != null && resolvedReaderServerId != null && openAtCfiNonBlank != null) {
+        val resolvedOpenAtLocator = openAtCfiNonBlank?.let { cfiStringToLocator(it) }
+        // openAtCfiNonBlank is non-null whenever resolvedOpenAtLocator is (the locator is derived
+        // from it). Fetch the matching row once: its id drives Continuous mark focus and its
+        // TextQuote makes Readium's paginated/vertical locator exact.
+        val openAtAnnotation = if (
+            resolvedOpenAtLocator != null &&
+            resolvedReaderServerId != null
+        ) {
             runCatching {
                 annotationStore.findByItemAndCfi(resolvedReaderServerId, params.itemId, openAtCfiNonBlank)
-            }.getOrNull()?.id
+            }.getOrNull()
         } else {
             null
         }
+        val openAtLocator = resolvedOpenAtLocator?.withAnnotationTextQuote(openAtAnnotation)
+        val initialFocusAnnotationId = openAtAnnotation?.id
 
         // Stored lastPosition is Readium Locator JSON. Rows written before ADR 0030's translation
         // fix may still hold a raw ABS `epubcfi(...)` — heal those on open so legacy progress

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -237,7 +237,9 @@ class ReaderWebViewScriptsTest {
         val js = ColumnSnap.snapToTargetColumnJs(null, landAtStartWhenNoTarget = false, locatorProgression = 0.42)
         assertTrue("id is null", js.contains("var id=null"))
         // The noTargetSnap branch (else{...} after if(id){...}) must use progression * scrollWidth.
-        assertTrue("uses progression * scrollWidth", js.contains("else{se.scrollLeft=Math.round(0.42*se.scrollWidth/iw)*iw;}"))
+        // Must FLOOR (not round) so an annotation past the midpoint of its column lands on that
+        // column, not the next one — Math.round(2.7) = 3 (wrong page), Math.floor(2.7) = 2 (right page).
+        assertTrue("floors to the column boundary using progression * scrollWidth", js.contains("else{se.scrollLeft=Math.floor(0.42*se.scrollWidth/iw)*iw;}"))
         assertTrue("does NOT yank to column 0", !js.contains("se.scrollLeft=0;"))
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -216,16 +216,58 @@ class ReaderWebViewScriptsTest {
     }
 
     // A no-fragment jump that must PRESERVE where go() landed (search hits, resume/peer sync) passes
-    // landAtStartWhenNoTarget=false: with no DOM target it ROUNDS the current scroll to the column grid
-    // instead of snapping to column 0. This is the contract search navigation relies on so a search hit
-    // (located by its occurrence-specific progression via go()) lands flush on its own page rather than
-    // being yanked to the chapter top.
+    // landAtStartWhenNoTarget=false without progression: with no DOM target it ROUNDS the current scroll
+    // to the column grid instead of snapping to column 0. This is the contract background-sync uses when
+    // go() already positioned within the same chapter and only a grid-alignment round is needed.
     @Test
     fun `snapToTargetColumnJs rounds the current scroll to the grid when no target and not landing at start`() {
         val js = ColumnSnap.snapToTargetColumnJs(null, landAtStartWhenNoTarget = false)
         assertTrue("id is null", js.contains("var id=null"))
         assertTrue("rounds the current scroll to the grid", js.contains("se.scrollLeft=Math.round(se.scrollLeft/iw)*iw"))
         assertTrue("does NOT yank to column 0", !js.contains("se.scrollLeft=0;"))
+    }
+
+    // landAtStartWhenNoTarget=false WITH progression: used for annotation navigation where there is no named
+    // DOM element in the CFI. After a cross-chapter jump, typography-injection reflow resets scrollLeft to 0
+    // before the rAF loop exits, so rounding scrollLeft snaps to column 0 (first page). By recomputing from
+    // progression * scrollWidth each tick the snap lands on the right column even after reflow, because
+    // scrollWidth re-settles to the post-reflow value and progression * new_scrollWidth is reflow-stable.
+    @Test
+    fun `snapToTargetColumnJs uses progression times scrollWidth when no target, not landing at start, and progression provided`() {
+        val js = ColumnSnap.snapToTargetColumnJs(null, landAtStartWhenNoTarget = false, locatorProgression = 0.42)
+        assertTrue("id is null", js.contains("var id=null"))
+        // The noTargetSnap branch (else{...} after if(id){...}) must use progression * scrollWidth.
+        assertTrue("uses progression * scrollWidth", js.contains("else{se.scrollLeft=Math.round(0.42*se.scrollWidth/iw)*iw;}"))
+        assertTrue("does NOT yank to column 0", !js.contains("se.scrollLeft=0;"))
+    }
+
+    // progression is ignored when landAtStartWhenNoTarget=true — chapter-level jumps always floor to 0.
+    @Test
+    fun `snapToTargetColumnJs ignores progression and floors to column 0 when landAtStartWhenNoTarget is true`() {
+        val js = ColumnSnap.snapToTargetColumnJs(null, landAtStartWhenNoTarget = true, locatorProgression = 0.42)
+        assertTrue("floors to 0", js.contains("se.scrollLeft=0;"))
+        assertTrue("does NOT use progression", !js.contains("0.42"))
+    }
+
+    // Annotation focus must set _skipV=true so the vertical smooth-tail block (if scrollHeight >
+    // innerHeight) is bypassed. The snap JS runs before CSS multicol is applied; at that moment
+    // scrollHeight > innerHeight, so without _skipV the vertical branch fires and returns early —
+    // the rAF paginated loop never runs, and Readium resets scrollLeft to 0. With _skipV=true the
+    // rAF loop runs, waits for scrollWidth to stabilize after multicol, then snaps to the right column.
+    @Test
+    fun `snapToTargetColumnJs sets skipV true for annotation focus to bypass vertical early-return`() {
+        val js = ColumnSnap.snapToTargetColumnJs(null, landAtStartWhenNoTarget = false, locatorProgression = 0.42)
+        assertTrue("_skipV is true", js.contains("var _skipV=true;"))
+        assertTrue("vertical check uses !_skipV guard", js.contains("if(!_skipV && se && se.scrollHeight > window.innerHeight + 4)"))
+    }
+
+    // Non-annotation navigation (TOC, resume, search) must NOT set _skipV — those jumps use the
+    // vertical smooth-tail for the same-doc animation and the snap-to-0 for chapter starts.
+    @Test
+    fun `snapToTargetColumnJs sets skipV false for TOC and resume navigation`() {
+        val js = ColumnSnap.snapToTargetColumnJs("ch01", landAtStartWhenNoTarget = true, locatorProgression = null)
+        assertTrue("_skipV is false", js.contains("var _skipV=false;"))
+        assertTrue("vertical check uses !_skipV guard", js.contains("if(!_skipV && se && se.scrollHeight > window.innerHeight + 4)"))
     }
 
     // Regression for the "highlight not saved in continuous mode" bug: Chromium WebView collapses

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -243,6 +243,37 @@ class ReaderWebViewScriptsTest {
         assertTrue("does NOT yank to column 0", !js.contains("se.scrollLeft=0;"))
     }
 
+    // Annotation navigation carries a TextQuote locator. Readium's own resolver can reconstruct
+    // the exact DOM Range from highlight + before/after, which avoids the one-column error of
+    // estimating a visual page from character progression. The rAF tracker must repeat that
+    // exact resolution after reflow and return before the progression fallback writes scrollLeft.
+    @Test
+    fun `snapToTargetColumnJs prefers exact Readium text locator before progression fallback`() {
+        val locatorJson =
+            """{"href":"chapter1.xhtml","type":"application/xhtml+xml","locations":{"progression":0.42},"text":{"before":"before","highlight":"target","after":"after"}}"""
+        val js = ColumnSnap.snapToTargetColumnJs(
+            fragmentId = null,
+            landAtStartWhenNoTarget = false,
+            locatorProgression = 0.42,
+            locatorJson = locatorJson,
+        )
+
+        assertTrue("embeds the exact locator safely", js.contains("var loc=JSON.parse("))
+        assertTrue(
+            "asks Readium to resolve and scroll to the exact range",
+            js.contains("if(window.readium.scrollToLocator(loc))return;"),
+        )
+        assertTrue(
+            "keeps progression as the stale-quote fallback",
+            js.contains("else{se.scrollLeft=Math.floor(0.42*se.scrollWidth/iw)*iw;}"),
+        )
+        assertTrue(
+            "exact range resolution runs before progression fallback",
+            js.indexOf("window.readium.scrollToLocator(loc)") <
+                js.indexOf("Math.floor(0.42*se.scrollWidth/iw)"),
+        )
+    }
+
     // progression is ignored when landAtStartWhenNoTarget=true — chapter-level jumps always floor to 0.
     @Test
     fun `snapToTargetColumnJs ignores progression and floors to column 0 when landAtStartWhenNoTarget is true`() {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -29,6 +29,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.readium.r2.shared.publication.Locator
@@ -921,12 +922,23 @@ class AnnotationSessionTest {
         session.navigateToAnnotation("a1")
 
         assertEquals(1, received.size)
-        assertEquals(targetLocator, received[0].locator)
+        // The resolver-owned navigation identity is preserved while AnnotationSession enriches
+        // the locator with the persisted quote needed for exact Readium range resolution.
+        assertEquals(targetLocator.href, received[0].locator.href)
+        assertEquals(targetLocator.mediaType, received[0].locator.mediaType)
+        assertEquals(targetLocator.locations, received[0].locator.locations)
         // The seeded annotation in this test has type="highlight", so the event must carry
         // isBookmark=false. Continuous-mode landing now uses viewport-midpoint for both types;
         // the flag is preserved on the event because downstream (analytics, tests) still
         // branches on annotation type.
         assertFalse(received[0].isBookmark)
+        // Readium's scrollToLocator resolves an exact DOM range only when the locator carries
+        // the annotation's TextQuote context. Without these fields annotation navigation falls
+        // back to character progression, which can land one paginated column away because text
+        // density and block layout are not uniform.
+        assertEquals(anno.textSnippet, received[0].locator.text.highlight)
+        assertEquals(anno.textBefore, received[0].locator.text.before)
+        assertEquals(anno.textAfter, received[0].locator.text.after)
         // The annotation id must ride along on the event: continuous-mode navigation uses it to
         // look up the actual `<mark data-riffle-ann="…">` device-Y (via
         // `ChapterWebView.annotationOffsetTopDevicePx`) and centre the viewport on the mark
@@ -967,6 +979,11 @@ class AnnotationSessionTest {
 
         assertEquals(1, received.size)
         assertTrue(received[0].isBookmark)
+        assertSame(
+            "bookmarks are point locators and must not receive a highlight TextQuote",
+            targetLocator,
+            received[0].locator,
+        )
 
         collectJob.cancel()
         sessionScope.coroutineContext[Job]?.cancel()

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -467,8 +467,12 @@ class ReaderSessionLifecycleTest {
     @Test
     fun `open with openAtCfi resolves openAtLocator and initialFocusAnnotationId`() = runTest {
         val cfi = "epubcfi(/6/2!/4/2)"
-        val resolvedLocator = mockk<Locator>(relaxed = true)
-        val annotation = mockk<Annotation>(relaxed = true).also { every { it.id } returns "ann-99" }
+        val resolvedLocator = Locator(
+            href = mockk(relaxed = true),
+            mediaType = org.readium.r2.shared.util.mediatype.MediaType.XHTML,
+            locations = Locator.Locations(progression = 0.7),
+        )
+        val annotation = AnnotationSessionTest.makeAnnotation(id = "ann-99", cfi = cfi)
         val (lifecycle, _) = makeLifecycle(
             annotationStore = FakeAnnotationStore(
                 byCfi = mapOf(Triple("srv-abs", "item-1", cfi) to annotation),
@@ -477,10 +481,15 @@ class ReaderSessionLifecycleTest {
         )
         val outcome = lifecycle.open(params(openAtCfi = cfi)) as ReaderSessionLifecycle.OpenOutcome.Ready
 
-        assertSame(resolvedLocator, outcome.openAtLocator)
+        assertEquals(resolvedLocator.href, outcome.openAtLocator?.href)
+        assertEquals(resolvedLocator.mediaType, outcome.openAtLocator?.mediaType)
+        assertEquals(resolvedLocator.locations, outcome.openAtLocator?.locations)
+        assertEquals(annotation.textSnippet, outcome.openAtLocator?.text?.highlight)
+        assertEquals(annotation.textBefore, outcome.openAtLocator?.text?.before)
+        assertEquals(annotation.textAfter, outcome.openAtLocator?.text?.after)
         assertEquals("ann-99", outcome.initialFocusAnnotationId)
-        assertSame(resolvedLocator, outcome.initialLocator)
-        assertSame(resolvedLocator, outcome.effectiveInitialLocator)
+        assertSame(outcome.openAtLocator, outcome.initialLocator)
+        assertSame(outcome.openAtLocator, outcome.effectiveInitialLocator)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- keep the existing reflow tracker alive until paginated multicolumn layout settles
- enrich annotation locators with their persisted TextQuote on both in-reader panel and Library-search cold-open paths
- re-resolve the exact Readium DOM range on every tracked reflow frame, with character progression retained only as a stale/legacy quote fallback

## Root cause

The first fix recovered from Readium resetting scrollLeft during typography reflow, but it recovered by mapping character progression across scrollWidth. Character density does not map exactly to visual columns when headings, blocks, and line density vary, so the phone harness target landed one full column too far right. Readium already supports exact TextQuote range resolution; the annotation paths were discarding the stored highlight/before/after context before navigation.

## Tests

- make test
- regression assertions cover TextQuote propagation for both panel navigation and openAtCfi cold-open
- script-shape regression asserts exact Readium locator resolution runs before the progression fallback
- existing AnnotationFocusHarnessTest remains the end-to-end assertion that the phrase is actually visible in paginated, vertical, and continuous modes

AnnotationSessionTest previously asserted whole-locator equality with the raw CFI resolver result. That assertion now checks href, media type, and locations separately, then asserts the intentionally enriched TextQuote fields; reverting the enrichment makes those new assertions fail.