### PR TITLE
fix(local-files): restore original metadata cover

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -30,6 +30,7 @@ import com.riffle.core.data.localfiles.CopyCoverImageUseCase
 import com.riffle.core.data.localfiles.SaveLocalFileMetadataOverrideUseCase
 import com.riffle.core.models.SourceType
 import com.riffle.core.catalog.DownloadsCapability
+import com.riffle.core.catalog.OriginalCoverCapability
 import com.riffle.core.catalog.PlaylistsCapability
 import com.riffle.core.catalog.ReadaloudCapability
 import com.riffle.core.catalog.SeriesCapability
@@ -346,6 +347,13 @@ class LibraryItemDetailViewModel @Inject constructor(
                         hasAddToPlaylist = catalog is PlaylistsCapability && item.isListenable && !item.isReadable,
                         canEditMetadata = catalog?.sourceType == SourceType.LOCAL_FILES,
                     )
+                    val originalItem = if (capabilities.canEditMetadata) {
+                        val originalCoverUrl = (catalog as? OriginalCoverCapability)
+                            ?.originalCoverUrl(item.id)
+                        item.copy(coverUrl = originalCoverUrl)
+                    } else {
+                        null
+                    }
                     LibraryItemDetailUiState.Ready(
                         item = item,
                         seriesId = seriesId,
@@ -353,7 +361,7 @@ class LibraryItemDetailViewModel @Inject constructor(
                         isCachedOrDownloaded = isCachedOrDownloaded,
                         isOffline = !connectivityObserver.isOnline.value,
                         capabilities = capabilities,
-                        originalItem = if (capabilities.canEditMetadata) item else null,
+                        originalItem = originalItem,
                     )
                 } else {
                     LibraryItemDetailUiState.Error

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -1010,16 +1010,24 @@ class LibraryItemDetailViewModelTest {
     // saveMetadataOverride / originalItem
     // -------------------------------------------------------------------------
 
-    private object LocalFilesCatalogStub : com.riffle.core.catalog.Catalog by NoopCatalog {
+    private class LocalFilesCatalogStub(
+        private val originalCoverUrl: String?,
+    ) : com.riffle.core.catalog.Catalog by NoopCatalog,
+        com.riffle.core.catalog.OriginalCoverCapability {
         override val sourceType: com.riffle.core.models.SourceType = com.riffle.core.models.SourceType.LOCAL_FILES
+        override suspend fun originalCoverUrl(itemId: String): String? = originalCoverUrl
     }
 
-    private fun localFilesCatalogRegistry() = fakeCatalogRegistry(LocalFilesCatalogStub)
+    private fun localFilesCatalogRegistry(originalCoverUrl: String? = null) =
+        fakeCatalogRegistry(LocalFilesCatalogStub(originalCoverUrl))
 
     @Test
     fun `originalItem equals scanner item when catalog sourceType is LOCAL_FILES`() = runTest {
         val item = knownItem.copy(coverUrl = "file:///scan-cover.jpg")
-        val vm = makeVm(fakeRepo(item), catalogRegistryOverride = localFilesCatalogRegistry())
+        val vm = makeVm(
+            fakeRepo(item),
+            catalogRegistryOverride = localFilesCatalogRegistry(item.coverUrl),
+        )
         backgroundScope.launch { vm.uiState.collect {} }
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -1046,7 +1054,7 @@ class LibraryItemDetailViewModelTest {
         val recordingDao = RecordingOverrideDao()
         val vm = makeVm(
             fakeRepo(item),
-            catalogRegistryOverride = localFilesCatalogRegistry(),
+            catalogRegistryOverride = localFilesCatalogRegistry(scannerCoverUrl),
             saveOverride = com.riffle.core.data.localfiles.SaveLocalFileMetadataOverrideUseCase(recordingDao),
         )
         backgroundScope.launch { vm.uiState.collect {} }
@@ -1059,6 +1067,35 @@ class LibraryItemDetailViewModelTest {
         // UI shows the scanner cover after the user restores from metadata.
         assertEquals(scannerCoverUrl, ready.item.coverUrl)
         // The override row stores null so the catalog falls back to the embedded cover.
+        assertEquals(null, recordingDao.lastUpsertedCoverUrl)
+    }
+
+    @Test
+    fun `restore uses scanner cover when loaded item already contains a cover override`() = runTest {
+        val scannerCoverUrl = "file:///scanner-covers/item-1.jpg"
+        val overrideCoverUrl = "file:///local_covers/item-1.jpg"
+        val item = knownItem.copy(coverUrl = overrideCoverUrl)
+        val recordingDao = RecordingOverrideDao()
+        val vm = makeVm(
+            fakeRepo(item),
+            catalogRegistryOverride = localFilesCatalogRegistry(scannerCoverUrl),
+            saveOverride = com.riffle.core.data.localfiles.SaveLocalFileMetadataOverrideUseCase(recordingDao),
+        )
+        backgroundScope.launch { vm.uiState.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.saveMetadataOverride(
+            "Title",
+            "Author",
+            "",
+            null,
+            coverContentUri = null,
+            clearCoverOverride = true,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val ready = vm.uiState.value as Ready
+        assertEquals(scannerCoverUrl, ready.item.coverUrl)
         assertEquals(null, recordingDao.lastUpsertedCoverUrl)
     }
 

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/OriginalCoverCapability.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/OriginalCoverCapability.kt
@@ -1,0 +1,10 @@
+package com.riffle.core.catalog
+
+/**
+ * Exposes the cover discovered from an item's source metadata before any user-selected override
+ * is applied. Sources that support editable metadata use this to implement "restore from
+ * metadata" without treating an override-applied catalog item as the original.
+ */
+interface OriginalCoverCapability : CatalogCapability {
+    suspend fun originalCoverUrl(itemId: String): String?
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalog.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalog.kt
@@ -11,6 +11,7 @@ import com.riffle.core.catalog.CatalogSeries
 import com.riffle.core.catalog.CatalogSeriesEntry
 import com.riffle.core.catalog.FacetSelection
 import com.riffle.core.catalog.OfflineBrowseCapability
+import com.riffle.core.catalog.OriginalCoverCapability
 import com.riffle.core.catalog.ReadCapability
 import com.riffle.core.catalog.SeriesCapability
 import com.riffle.core.catalog.SeriesEntryOrdering
@@ -52,7 +53,8 @@ class LocalFilesCatalog(
     SeriesCapability,
     OfflineBrowseCapability,
     ToReadListCapability,
-    ReadCapability {
+    ReadCapability,
+    OriginalCoverCapability {
 
     override val sourceType: SourceType = SourceType.LOCAL_FILES
 
@@ -70,7 +72,7 @@ class LocalFilesCatalog(
     ): List<CatalogItem> {
         // LocalFiles has no server-side facets — `facet` is ignored.
         val items = itemsInFolderLibraryWithOverrides(rootId)
-            .map { (entity, override) -> entity.toCatalogItem(override) }
+            .map { it.toCatalogItem() }
             .sortedWith(comparatorFor(sort))
         return items.pageOf(page, pageSize)
     }
@@ -84,7 +86,7 @@ class LocalFilesCatalog(
         val needle = query.trim().lowercase()
         if (needle.isEmpty()) return emptyList()
         val hits = itemsInFolderLibraryWithOverrides(rootId)
-            .map { (entity, override) -> entity.toCatalogItem(override) }
+            .map { it.toCatalogItem() }
             .filter {
                 it.title.lowercase().contains(needle) || it.author.lowercase().contains(needle)
             }
@@ -95,8 +97,13 @@ class LocalFilesCatalog(
     override suspend fun getItem(itemId: String): CatalogItem? {
         val entity = itemDao.getById(sourceId, itemId) ?: return null
         val override = overrideDao.getForItem(sourceId, itemId)
-        return entity.toCatalogItem(override)
+        val file = fileDao.findById(sourceId, itemId)
+        val originalCoverUrl = if (file == null) entity.coverUrl else file.coverPath?.toFileUrl()
+        return entity.toCatalogItem(override, originalCoverUrl)
     }
+
+    override suspend fun originalCoverUrl(itemId: String): String? =
+        fileDao.findById(sourceId, itemId)?.coverPath?.toFileUrl()
 
     override suspend fun fetchFile(itemId: String, format: BookFormat): CatalogFileHandle {
         val file = requireFile(itemId, format)
@@ -138,24 +145,27 @@ class LocalFilesCatalog(
 
     override suspend fun listSeries(rootId: String): List<CatalogSeries> {
         val rows = itemsInFolderLibraryWithOverrides(rootId)
-        val withSeries = rows.filter { (entity, override) ->
-            !(override?.seriesName ?: entity.seriesName).isNullOrBlank()
+        val withSeries = rows.filter { row ->
+            !(row.override?.seriesName ?: row.entity.seriesName).isNullOrBlank()
         }
         if (withSeries.isEmpty()) return emptyList()
-        return withSeries.groupBy { (entity, override) -> override?.seriesName ?: entity.seriesName!! }
+        return withSeries.groupBy { row -> row.override?.seriesName ?: row.entity.seriesName!! }
             .toSortedMap()
-            .map { (name, pairs) ->
-                val sorted = pairs.sortedWith(
-                    Comparator { a, b -> entityOrdering.compare(a.first, b.first) },
+            .map { (name, rowsForSeries) ->
+                val sorted = rowsForSeries.sortedWith(
+                    Comparator { a, b -> entityOrdering.compare(a.entity, b.entity) },
                 )
                 CatalogSeries(
                     id = name,
                     rootId = rootId,
                     name = name,
-                    coverUrl = sorted.firstNotNullOfOrNull { it.first.coverUrl },
+                    coverUrl = sorted.firstNotNullOfOrNull { it.toCatalogItem().coverUrl },
                     bookCount = sorted.size,
-                    items = sorted.map { (e, _) ->
-                        CatalogSeriesEntry(itemId = e.id, sequence = e.seriesSequence)
+                    items = sorted.map { row ->
+                        CatalogSeriesEntry(
+                            itemId = row.entity.id,
+                            sequence = row.entity.seriesSequence,
+                        )
                     },
                 )
             }
@@ -163,9 +173,9 @@ class LocalFilesCatalog(
 
     override suspend fun listItemsInSeries(rootId: String, seriesId: String): List<CatalogItem> =
         itemsInFolderLibraryWithOverrides(rootId)
-            .filter { (entity, override) -> (override?.seriesName ?: entity.seriesName) == seriesId }
-            .sortedWith(Comparator { a, b -> entityOrdering.compare(a.first, b.first) })
-            .map { (entity, override) -> entity.toCatalogItem(override) }
+            .filter { row -> (row.override?.seriesName ?: row.entity.seriesName) == seriesId }
+            .sortedWith(Comparator { a, b -> entityOrdering.compare(a.entity, b.entity) })
+            .map { it.toCatalogItem() }
 
     // endregion
 
@@ -180,18 +190,33 @@ class LocalFilesCatalog(
 
     /**
      * Like [itemsInFolderLibrary] but also bulk-loads any metadata overrides for the result set
-     * and pairs each entity with its override (null if the user has set none). Callers that build
-     * [CatalogItem]s — browse, search, listSeries — use this to apply user overrides in one pass.
+     * and the scanner-owned cover path. The latter is deliberately read from
+     * `local_files_files`, not `library_items`: a library refresh writes override-applied catalog
+     * metadata back to `library_items`, so that row cannot reliably identify the original cover.
      */
     private suspend fun itemsInFolderLibraryWithOverrides(
         libraryId: String,
-    ): List<Pair<LibraryItemEntity, LocalFileMetadataOverrideEntity?>> {
+    ): List<LocalItemRow> {
         val entities = itemsInFolderLibrary(libraryId)
         if (entities.isEmpty()) return emptyList()
         val overrides = entities.map { it.id }.chunked(BIND_VAR_CHUNK)
             .flatMap { overrideDao.getForItems(sourceId, it) }
             .associateBy { it.sourceItemId }
-        return entities.map { it to overrides[it.id] }
+        val files = entities.map { it.id }.chunked(BIND_VAR_CHUNK)
+            .flatMap { fileDao.getForItems(sourceId, it) }
+            .associateBy { it.sourceItemId }
+        return entities.map { entity ->
+            val file = files[entity.id]
+            LocalItemRow(
+                entity = entity,
+                override = overrides[entity.id],
+                originalCoverUrl = if (file == null) {
+                    entity.coverUrl
+                } else {
+                    file.coverPath?.toFileUrl()
+                },
+            )
+        }
     }
 
     private suspend fun requireFile(itemId: String, format: BookFormat): LocalFilesFileEntity {
@@ -217,12 +242,13 @@ class LocalFilesCatalog(
 
     private fun LibraryItemEntity.toCatalogItem(
         override: LocalFileMetadataOverrideEntity? = null,
+        originalCoverUrl: String? = coverUrl,
     ): CatalogItem = CatalogItem(
         id = id,
         rootId = libraryId,
         title = override?.title ?: title,
         author = override?.author ?: author,
-        coverUrl = override?.coverUrl ?: coverUrl,
+        coverUrl = override?.coverUrl ?: originalCoverUrl,
         ebookFormat = when (ebookFormat) {
             EbookFormat.STORAGE_EPUB -> BookFormat.Epub
             EbookFormat.STORAGE_PDF -> BookFormat.Pdf
@@ -246,6 +272,17 @@ class LocalFilesCatalog(
         asin = asin,
         readingProgress = readingProgress,
         updatedAt = null,
+    )
+
+    private fun LocalItemRow.toCatalogItem(): CatalogItem =
+        entity.toCatalogItem(override, originalCoverUrl)
+
+    private fun String.toFileUrl(): String = File(this).toURI().toString()
+
+    private data class LocalItemRow(
+        val entity: LibraryItemEntity,
+        val override: LocalFileMetadataOverrideEntity?,
+        val originalCoverUrl: String?,
     )
 
     private val entityOrdering: Comparator<LibraryItemEntity> =

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalogTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalogTest.kt
@@ -7,6 +7,7 @@ import com.riffle.core.catalog.CatalogFileHandle
 import com.riffle.core.catalog.CollectionsCapability
 import com.riffle.core.catalog.DownloadsCapability
 import com.riffle.core.catalog.OfflineBrowseCapability
+import com.riffle.core.catalog.OriginalCoverCapability
 import com.riffle.core.catalog.PlaylistsCapability
 import com.riffle.core.catalog.ProgressPeerCapability
 import com.riffle.core.catalog.ReadCapability
@@ -54,6 +55,7 @@ class LocalFilesCatalogTest {
         assertTrue(c is OfflineBrowseCapability)
         assertTrue(c is ToReadListCapability)
         assertTrue(c is ReadCapability)
+        assertTrue(c is OriginalCoverCapability)
         // Not declared — LocalFiles has no fetch step, no readaloud bundles, no audiobook streaming.
         assertTrue(c !is DownloadsCapability)
         assertTrue(c !is ReadaloudCapability)
@@ -432,6 +434,30 @@ class LocalFilesCatalogTest {
         assertEquals("S", results[0].seriesName)
     }
 
+    @Test
+    fun `cleared cover override restores scanner cover even when library item contains stale override`() = runTest {
+        val items = FakeLibraryItemDao()
+        val staleOverrideUrl = "file:///local_covers/book-5.jpg"
+        val scannerCoverPath = "/scanner-covers/book-5.jpg"
+        items.emit(
+            sourceId,
+            listOf(epubItem("book-5", "Book").copy(coverUrl = staleOverrideUrl)),
+        )
+        val fileDao = InMemoryFileDao().also { dao ->
+            dao.upsert(localFile("book-5", coverPath = scannerCoverPath))
+        }
+        val catalog = catalog(
+            folderDao = folderWith(libraryId),
+            fileDao = fileDao,
+            fileFolderDao = fileFolderWith(listOf("book-5")),
+            items = items,
+        )
+
+        val result = catalog.browse(libraryId, SortKey.TITLE).single()
+
+        assertEquals(File(scannerCoverPath).toURI().toString(), result.coverUrl)
+    }
+
     // endregion
 
     // region helpers
@@ -511,6 +537,19 @@ class LocalFilesCatalogTest {
         seriesSequence = seriesSequence,
     )
 
+    private fun localFile(id: String, coverPath: String?) = LocalFilesFileEntity(
+        sourceId = sourceId,
+        sourceItemId = id,
+        originalUri = "content://books/$id.epub",
+        copiedPath = "/copied/$id.epub",
+        coverPath = coverPath,
+        format = "epub",
+        sizeBytes = 100L,
+        mtimeEpochMs = 0L,
+        lastSeenAtEpochMs = 0L,
+        displayName = "$id.epub",
+    )
+
     // endregion
 
     // region in-memory DAOs
@@ -540,6 +579,11 @@ class LocalFilesCatalogTest {
             rows[sourceId to sourceItemId]
         override suspend fun forSource(sourceId: String): List<LocalFilesFileEntity> =
             rows.values.filter { it.sourceId == sourceId }
+        override suspend fun getForItems(
+            sourceId: String,
+            sourceItemIds: List<String>,
+        ): List<LocalFilesFileEntity> =
+            rows.values.filter { it.sourceId == sourceId && it.sourceItemId in sourceItemIds }
         override suspend fun touchLastSeen(sourceId: String, sourceItemId: String, seenAt: Long) {}
         override suspend fun updateDisplayName(sourceId: String, sourceItemId: String, displayName: String) {
             rows[sourceId to sourceItemId]?.let { rows[sourceId to sourceItemId] = it.copy(displayName = displayName) }

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesScannerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesScannerTest.kt
@@ -341,6 +341,11 @@ class LocalFilesScannerTest {
             rows[sourceId to sourceItemId]
         override suspend fun forSource(sourceId: String): List<LocalFilesFileEntity> =
             rows.values.filter { it.sourceId == sourceId }
+        override suspend fun getForItems(
+            sourceId: String,
+            sourceItemIds: List<String>,
+        ): List<LocalFilesFileEntity> =
+            rows.values.filter { it.sourceId == sourceId && it.sourceItemId in sourceItemIds }
         override suspend fun touchLastSeen(sourceId: String, sourceItemId: String, seenAt: Long) {
             val row = rows[sourceId to sourceItemId] ?: return
             rows[sourceId to sourceItemId] = row.copy(lastSeenAtEpochMs = seenAt)

--- a/core/database-api/src/main/kotlin/com/riffle/core/database/LocalFilesFileDao.kt
+++ b/core/database-api/src/main/kotlin/com/riffle/core/database/LocalFilesFileDao.kt
@@ -18,6 +18,15 @@ interface LocalFilesFileDao {
     suspend fun forSource(sourceId: String): List<LocalFilesFileEntity>
 
     @Query(
+        "SELECT * FROM local_files_files " +
+            "WHERE sourceId = :sourceId AND sourceItemId IN (:sourceItemIds)",
+    )
+    suspend fun getForItems(
+        sourceId: String,
+        sourceItemIds: List<String>,
+    ): List<LocalFilesFileEntity>
+
+    @Query(
         "UPDATE local_files_files SET lastSeenAtEpochMs = :seenAt " +
             "WHERE sourceId = :sourceId AND sourceItemId = :sourceItemId",
     )


### PR DESCRIPTION
## Summary

- expose the scanner-owned cover through a catalog capability
- restore that cover in local-file metadata editing even when the cached library item contains an override
- keep catalog refreshes anchored to `local_files_files.coverPath` after the override is cleared
- bulk-load original cover records for folder browsing

## Tests

- `LibraryItemDetailViewModelTest`
- `LocalFilesCatalogTest`
- `LocalFilesScannerTest`