### PR TITLE
fix(update): gate prompts on APK availability

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/update/StartupUpdateViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/update/StartupUpdateViewModel.kt
@@ -3,6 +3,7 @@ package com.riffle.app.feature.update
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.app.BuildConfig
+import com.riffle.core.common.Clock
 import com.riffle.core.domain.AppUpdatePreferencesStore
 import com.riffle.core.domain.AppUpdateRepository
 import com.riffle.core.domain.AvailableUpdate
@@ -25,10 +26,13 @@ data class StartupUpdateDialogState(
 class StartupUpdateViewModel @Inject constructor(
     private val appUpdateRepository: AppUpdateRepository,
     private val appUpdatePreferencesStore: AppUpdatePreferencesStore,
+    private val clock: Clock,
 ) : ViewModel() {
 
     // Read directly like SettingsViewModel does — avoids injecting a bare Int into Hilt.
     private val currentVersionCode: Int get() = BuildConfig.VERSION_CODE
+
+    private var lastCheckAtMs: Long? = null
 
     private val _dialogState = MutableStateFlow<StartupUpdateDialogState?>(null)
     val dialogState: StateFlow<StartupUpdateDialogState?> = _dialogState.asStateFlow()
@@ -45,8 +49,15 @@ class StartupUpdateViewModel @Inject constructor(
         viewModelScope.launch {
             val autoEnabled = appUpdatePreferencesStore.autoUpdateEnabled.first()
             if (!autoEnabled) return@launch
+            val nowMs = clock.nowMs()
+            val lastCheck = lastCheckAtMs
+            if (lastCheck != null && nowMs >= lastCheck && nowMs - lastCheck < AUTO_CHECK_INTERVAL_MS) {
+                return@launch
+            }
+            lastCheckAtMs = nowMs
             val ignoredCode = appUpdatePreferencesStore.ignoredVersionCode.first()
             val releases = appUpdateRepository.listReleasesSince(currentVersionCode)
+                .filter { it.downloadUrl.isNotBlank() }
             if (releases.isEmpty()) return@launch
             val latest = releases.first()
             if (latest.versionCode == ignoredCode) return@launch
@@ -79,5 +90,9 @@ class StartupUpdateViewModel @Inject constructor(
 
     fun dismissDialog() {
         _dialogState.value = null
+    }
+
+    companion object {
+        internal const val AUTO_CHECK_INTERVAL_MS = 2 * 60 * 60 * 1000L
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/update/StartupUpdateViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/update/StartupUpdateViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.update
 
+import com.riffle.core.common.Clock
 import com.riffle.core.domain.AppUpdatePreferencesStore
 import com.riffle.core.domain.AppUpdateRepository
 import com.riffle.core.domain.AvailableUpdate
@@ -28,14 +29,24 @@ class StartupUpdateViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
 
+    private class MutableClock(var timeMs: Long = 0L) : Clock {
+        override fun nowMs(): Long = timeMs
+        override fun nowNs(): Long = timeMs * 1_000_000
+    }
+
     @Before fun setUp() { Dispatchers.setMain(testDispatcher) }
     @After fun tearDown() { Dispatchers.resetMain() }
 
-    private fun releaseInfo(versionName: String, versionCode: Int, changelog: String = "") = ReleaseInfo(
+    private fun releaseInfo(
+        versionName: String,
+        versionCode: Int,
+        changelog: String = "",
+        downloadUrl: String = "https://x/$versionName.apk",
+    ) = ReleaseInfo(
         versionName = versionName,
         versionCode = versionCode,
         changelog = changelog,
-        downloadUrl = "https://x/$versionName.apk",
+        downloadUrl = downloadUrl,
         sizeBytes = 1000L,
     )
 
@@ -66,6 +77,7 @@ class StartupUpdateViewModelTest {
         val vm = StartupUpdateViewModel(
             appUpdateRepository = fakeRepo(listOf(releaseInfo("1.6.0", 10600))),
             appUpdatePreferencesStore = fakePrefs(autoEnabled = false),
+            clock = MutableClock(),
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -77,6 +89,7 @@ class StartupUpdateViewModelTest {
         val vm = StartupUpdateViewModel(
             appUpdateRepository = fakeRepo(emptyList()),
             appUpdatePreferencesStore = fakePrefs(),
+            clock = MutableClock(),
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -84,10 +97,46 @@ class StartupUpdateViewModelTest {
     }
 
     @Test
+    fun `dialog is null when newer release tags have no APK artifact`() = runTest {
+        val vm = StartupUpdateViewModel(
+            appUpdateRepository = fakeRepo(
+                listOf(releaseInfo("1.6.0", 10600, downloadUrl = "")),
+            ),
+            appUpdatePreferencesStore = fakePrefs(),
+            clock = MutableClock(),
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(vm.dialogState.value)
+    }
+
+    @Test
+    fun `dialog skips a newer unfinished release and offers the latest release with an APK`() = runTest {
+        val vm = StartupUpdateViewModel(
+            appUpdateRepository = fakeRepo(
+                listOf(
+                    releaseInfo("1.6.0", 10600, downloadUrl = ""),
+                    releaseInfo("1.5.1", 10501, downloadUrl = "https://x/1.5.1.apk"),
+                ),
+            ),
+            appUpdatePreferencesStore = fakePrefs(),
+            clock = MutableClock(),
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = vm.dialogState.value
+        assertNotNull(state)
+        assertEquals("1.5.1", state!!.update.versionName)
+        assertEquals("https://x/1.5.1.apk", state.update.downloadUrl)
+        assertEquals(listOf("1.5.1"), state.releases.map(ReleaseInfo::versionName))
+    }
+
+    @Test
     fun `dialog is null when latest version matches ignoredVersionCode`() = runTest {
         val vm = StartupUpdateViewModel(
             appUpdateRepository = fakeRepo(listOf(releaseInfo("1.6.0", 10600))),
             appUpdatePreferencesStore = fakePrefs(ignored = 10600),
+            clock = MutableClock(),
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -103,6 +152,7 @@ class StartupUpdateViewModelTest {
         val vm = StartupUpdateViewModel(
             appUpdateRepository = fakeRepo(releases),
             appUpdatePreferencesStore = fakePrefs(),
+            clock = MutableClock(),
         )
         testDispatcher.scheduler.advanceUntilIdle()
 
@@ -120,6 +170,7 @@ class StartupUpdateViewModelTest {
         val vm = StartupUpdateViewModel(
             appUpdateRepository = fakeRepo(listOf(releaseInfo("1.6.0", 10600))),
             appUpdatePreferencesStore = prefs,
+            clock = MutableClock(),
         )
         testDispatcher.scheduler.advanceUntilIdle()
         assertNotNull(vm.dialogState.value)
@@ -132,16 +183,24 @@ class StartupUpdateViewModelTest {
     }
 
     @Test
-    fun `checkNow re-shows dialog after dismiss`() = runTest {
+    fun `checkNow re-shows dialog after dismiss once the throttle interval has elapsed`() = runTest {
+        val clock = MutableClock()
         val vm = StartupUpdateViewModel(
             appUpdateRepository = fakeRepo(listOf(releaseInfo("1.6.0", 10600))),
             appUpdatePreferencesStore = fakePrefs(),
+            clock = clock,
         )
         testDispatcher.scheduler.advanceUntilIdle()
         assertNotNull(vm.dialogState.value)
 
         vm.dismissDialog()
         assertNull(vm.dialogState.value)
+
+        vm.checkNow()
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertNull(vm.dialogState.value)
+
+        clock.timeMs = StartupUpdateViewModel.AUTO_CHECK_INTERVAL_MS
 
         vm.checkNow()
         testDispatcher.scheduler.advanceUntilIdle()
@@ -166,6 +225,7 @@ class StartupUpdateViewModelTest {
         val vm = StartupUpdateViewModel(
             appUpdateRepository = repo,
             appUpdatePreferencesStore = fakePrefs(),
+            clock = MutableClock(),
         )
         testDispatcher.scheduler.advanceUntilIdle()
         val checksAfterInit = checkCount
@@ -177,11 +237,47 @@ class StartupUpdateViewModelTest {
     }
 
     @Test
+    fun `checkNow does not repeat a recent check when no dialog is showing`() = runTest {
+        var checkCount = 0
+        val clock = MutableClock()
+        val repo = object : AppUpdateRepository {
+            override suspend fun checkForUpdate(currentVersionCode: Int): UpdateCheckResult =
+                UpdateCheckResult.UpToDate
+            override fun downloadAndInstall(update: AvailableUpdate): Flow<UpdateDownloadState> =
+                flowOf(UpdateDownloadState.Installing)
+            override fun sweepStaleApks() {}
+            override suspend fun listReleasesSince(sinceVersionCode: Int): List<ReleaseInfo> {
+                checkCount++
+                return emptyList()
+            }
+        }
+        val vm = StartupUpdateViewModel(
+            appUpdateRepository = repo,
+            appUpdatePreferencesStore = fakePrefs(),
+            clock = clock,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        clock.timeMs = StartupUpdateViewModel.AUTO_CHECK_INTERVAL_MS - 1
+        vm.checkNow()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("checks before the two-hour boundary are throttled", 1, checkCount)
+
+        clock.timeMs = StartupUpdateViewModel.AUTO_CHECK_INTERVAL_MS
+        vm.checkNow()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("the two-hour boundary permits a new check", 2, checkCount)
+    }
+
+    @Test
     fun `dismissDialog clears dialog without writing ignoredVersionCode`() = runTest {
         val prefs = fakePrefs()
         val vm = StartupUpdateViewModel(
             appUpdateRepository = fakeRepo(listOf(releaseInfo("1.6.0", 10600))),
             appUpdatePreferencesStore = prefs,
+            clock = MutableClock(),
         )
         testDispatcher.scheduler.advanceUntilIdle()
         assertNotNull(vm.dialogState.value)


### PR DESCRIPTION
## Summary

- ignore release tags without an APK when deciding whether to show the startup update modal
- fall back to the newest downloadable release when a newer tag is still building
- throttle automatic foreground update checks to once every two hours while leaving the manual Settings check immediate

## Tests

- `./gradlew :app:testDebugUnitTest --tests com.riffle.app.feature.update.StartupUpdateViewModelTest`
- verifies artifact-less tags do not prompt and unfinished tags cannot shadow a downloadable release
- verifies checks are suppressed immediately before the two-hour boundary and run at the boundary