### PR TITLE
fix(update): stream APK download progress

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/AppUpdateRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AppUpdateRepositoryImpl.kt
@@ -39,7 +39,7 @@ class AppUpdateRepositoryImpl @Inject constructor(
         sweepStaleApks()
         val apk = File(updateDir.apply { mkdirs() }, "riffle-${update.versionName}.apk")
         send(UpdateDownloadState.Downloading(0))
-        val ok = releaseApi.download(update.downloadUrl, apk) { percent ->
+        val ok = releaseApi.download(update.downloadUrl, apk, update.sizeBytes) { percent ->
             trySend(UpdateDownloadState.Downloading(percent))
         }
         if (ok) {

--- a/core/data/src/test/kotlin/com/riffle/core/data/AppUpdateRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AppUpdateRepositoryImplTest.kt
@@ -1,16 +1,71 @@
 package com.riffle.core.data
 
+import android.content.Context
 import com.riffle.core.data.AppUpdateRepositoryImpl.Companion.evaluate
 import com.riffle.core.data.AppUpdateRepositoryImpl.Companion.listReleasesSince
 import com.riffle.core.data.AppUpdateRepositoryImpl.Companion.versionCodeOf
+import com.riffle.core.domain.ApkInstaller
+import com.riffle.core.domain.AvailableUpdate
+import com.riffle.core.domain.DefaultDispatcherProvider
 import com.riffle.core.domain.UpdateCheckResult
+import com.riffle.core.domain.UpdateDownloadState
 import com.riffle.core.network.GitHubRelease
+import com.riffle.core.network.GitHubReleaseApi
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.nio.file.Files
 
 class AppUpdateRepositoryImplTest {
+
+    @Test
+    fun `download forwards release size and emits network progress`() = runBlocking {
+        val cacheDir = Files.createTempDirectory("app-update").toFile()
+        val context = mockk<Context> {
+            every { this@mockk.cacheDir } returns cacheDir
+        }
+        val releaseApi = mockk<GitHubReleaseApi>()
+        val installer = mockk<ApkInstaller>(relaxed = true)
+        val update = AvailableUpdate(
+            versionName = "2.35.0",
+            versionCode = 23500,
+            downloadUrl = "https://example/riffle.apk",
+            sizeBytes = 29_244_681L,
+        )
+        coEvery {
+            releaseApi.download(update.downloadUrl, any(), update.sizeBytes, any())
+        } coAnswers {
+            arg<(Int) -> Unit>(3)(42)
+            true
+        }
+        val repository = AppUpdateRepositoryImpl(
+            context = context,
+            releaseApi = releaseApi,
+            installer = installer,
+            dispatchers = DefaultDispatcherProvider,
+        )
+
+        val states = repository.downloadAndInstall(update).toList()
+
+        assertEquals(
+            listOf(
+                UpdateDownloadState.Downloading(0),
+                UpdateDownloadState.Downloading(42),
+                UpdateDownloadState.Installing,
+            ),
+            states,
+        )
+        coVerify(exactly = 1) {
+            releaseApi.download(update.downloadUrl, any(), update.sizeBytes, any())
+        }
+    }
 
     @Test
     fun `versionCodeOf mirrors the release workflow formula`() {

--- a/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
@@ -4,6 +4,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
+import io.ktor.client.request.prepareGet
 import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentLength
@@ -95,35 +96,47 @@ class GitHubReleaseApi(
     /**
      * Streams [url] into [dest], reporting whole-percent progress. Returns true on success. On any
      * failure [dest] is deleted, so a truncated APK is never handed to the installer.
+     *
+     * [expectedBytes] is used as a fallback file size when the server doesn't send a Content-Length
+     * header (e.g. GitHub CDN chunked responses). Pass -1 to indicate unknown.
      */
-    suspend fun download(url: String, dest: File, onProgress: (percent: Int) -> Unit): Boolean =
+    suspend fun download(
+        url: String,
+        dest: File,
+        expectedBytes: Long = -1L,
+        onProgress: (percent: Int) -> Unit,
+    ): Boolean =
         try {
-            val response = httpClient.get(url)
-            if (!response.status.isSuccess()) {
-                dest.delete()
-                return false
-            }
-            val total = response.contentLength() ?: -1L
-            val channel = response.bodyAsChannel()
-            dest.outputStream().use { out ->
-                val buffer = ByteArray(64 * 1024)
-                var copied = 0L
-                var lastPercent = -1
-                while (!channel.isClosedForRead) {
-                    val read = channel.readAvailable(buffer)
-                    if (read <= 0) break
-                    out.write(buffer, 0, read)
-                    copied += read
-                    if (total > 0) {
-                        val percent = ((copied * 100) / total).toInt().coerceIn(0, 100)
-                        if (percent != lastPercent) {
-                            lastPercent = percent
-                            onProgress(percent)
+            httpClient.prepareGet(url).execute { response ->
+                if (!response.status.isSuccess()) {
+                    dest.delete()
+                    return@execute false
+                }
+                val total = response.contentLength()
+                    ?.takeIf { it > 0 }
+                    ?: expectedBytes.takeIf { it > 0 }
+                    ?: -1L
+                val channel = response.bodyAsChannel()
+                dest.outputStream().use { out ->
+                    val buffer = ByteArray(64 * 1024)
+                    var copied = 0L
+                    var lastPercent = -1
+                    while (!channel.isClosedForRead) {
+                        val read = channel.readAvailable(buffer)
+                        if (read <= 0) break
+                        out.write(buffer, 0, read)
+                        copied += read
+                        if (total > 0) {
+                            val percent = ((copied * 100) / total).toInt().coerceIn(0, 100)
+                            if (percent != lastPercent) {
+                                lastPercent = percent
+                                onProgress(percent)
+                            }
                         }
                     }
                 }
+                true
             }
-            true
         } catch (e: IOException) {
             dest.delete()
             false

--- a/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
@@ -2,7 +2,11 @@ package com.riffle.core.network
 
 import com.riffle.core.network.createDefaultHttpClient
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -14,6 +18,7 @@ import org.junit.Before
 import org.junit.Test
 import java.io.File
 import java.nio.file.Files
+import java.util.concurrent.TimeUnit
 
 class GitHubReleaseApiTest {
 
@@ -176,6 +181,67 @@ class GitHubReleaseApiTest {
         assertTrue(dest.readBytes().contentEquals(payload))
         assertTrue("expected progress callbacks", seen.isNotEmpty())
         assertEquals(100, seen.last())
+    }
+
+    @Test
+    fun `download reports progress before the response finishes`() = runBlocking {
+        val payload = ByteArray(256 * 1024) { (it % 251).toByte() }
+        server.enqueue(
+            MockResponse()
+                .setBody(okio.Buffer().write(payload))
+                .throttleBody(64 * 1024, 1, TimeUnit.SECONDS)
+        )
+        val dest = File(Files.createTempDirectory("upd").toFile(), "riffle.apk")
+        val firstProgress = kotlinx.coroutines.CompletableDeferred<Int>()
+
+        val download = async(Dispatchers.IO) {
+            api.download(server.url("/riffle.apk").toString(), dest) { percent ->
+                firstProgress.complete(percent)
+            }
+        }
+
+        val percentWhileResponseIsInFlight = withTimeout(1_500) { firstProgress.await() }
+
+        assertTrue(percentWhileResponseIsInFlight in 1..99)
+        assertFalse("download should still be receiving the throttled response", download.isCompleted)
+        assertTrue(download.await())
+    }
+
+    // Regression: GitHub CDN can serve APK assets without Content-Length (chunked transfer), leaving
+    // total == -1 and suppressing all progress callbacks — the dialog stays frozen at 0% even though
+    // the download completes. When the caller provides expectedBytes the fallback kicks in so progress
+    // advances normally.
+    @Test
+    fun `download reports progress via expectedBytes when Content-Length is absent`() = runTest {
+        val payload = ByteArray(200_000) { (it % 251).toByte() }
+        server.enqueue(MockResponse().setChunkedBody(okio.Buffer().write(payload), 8192))
+        val dest = File(Files.createTempDirectory("upd").toFile(), "riffle.apk")
+        val seen = mutableListOf<Int>()
+
+        val ok = api.download(
+            server.url("/riffle.apk").toString(),
+            dest,
+            expectedBytes = payload.size.toLong(),
+        ) { seen.add(it) }
+
+        assertTrue(ok)
+        assertEquals(payload.size.toLong(), dest.length())
+        assertTrue("expected progress callbacks with expectedBytes fallback", seen.isNotEmpty())
+        assertEquals(100, seen.last())
+    }
+
+    @Test
+    fun `download reports no progress when both Content-Length and expectedBytes are absent`() = runTest {
+        val payload = ByteArray(200_000) { (it % 251).toByte() }
+        server.enqueue(MockResponse().setChunkedBody(okio.Buffer().write(payload), 8192))
+        val dest = File(Files.createTempDirectory("upd").toFile(), "riffle.apk")
+        val seen = mutableListOf<Int>()
+
+        val ok = api.download(server.url("/riffle.apk").toString(), dest) { seen.add(it) }
+
+        assertTrue(ok)
+        assertEquals(payload.size.toLong(), dest.length())
+        assertTrue("no progress expected without Content-Length or expectedBytes", seen.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
## Summary

- stream the APK response as it arrives instead of reporting progress after Ktor has buffered the full download
- use GitHub release asset size when the response omits a usable Content-Length
- cover both in-flight progress and repository size forwarding with regression tests

## Tests

- `./gradlew :core:network:test :core:data:testDebugUnitTest`
- `./gradlew :app:testDebugUnitTest --tests com.riffle.app.feature.update.StartupUpdateViewModelTest --tests com.riffle.app.feature.settings.SettingsViewModelTest`