### PR TITLE
fix(settings): clarify WebDAV annotation sync is for Komga

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/annotationsync/WebdavUiCopy.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/annotationsync/WebdavUiCopy.kt
@@ -1,0 +1,20 @@
+package com.riffle.app.feature.annotationsync
+
+/**
+ * User-facing WebDAV copy shared by Settings and the connection form.
+ *
+ * Audiobookshelf annotations sync through ABS bookmarks, while Komga is currently the only source
+ * that uses WebDAV. The copy states that present scope without tying the generic WebDAV transport
+ * permanently to Komga; future sources can join without renaming the controls.
+ */
+internal object WebdavUiCopy {
+    const val SECTION_TITLE = "WebDAV annotation sync for Komga"
+    const val SCREEN_TITLE = "WebDAV annotation sync for Komga"
+    const val CONFIGURE_TITLE = "Configure WebDAV"
+    const val ADD_TITLE = "Add WebDAV"
+    const val EDIT_TITLE = "Edit WebDAV"
+    const val HELP_TEXT =
+        "Sync highlights, notes, and bookmarks between your devices via a WebDAV server. Available for Komga sources."
+    const val NOT_CONFIGURED_STATUS =
+        "Not configured · available for Komga sources"
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.riffle.app.feature.annotationsync.WebdavUiCopy
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.app.ui.source.SourceTypeIcon
 import com.riffle.core.domain.AddSourceCopy
@@ -87,7 +88,7 @@ fun AddSourceScreen(
         descriptor?.addSourceCopyFor(it.serverType)
     }
     val title = descriptorCopy?.let { if (isEditing) it.editTitle else it.addTitle }
-        ?: if (isEditing) "Edit WebDAV" else "Add WebDAV"
+        ?: if (isEditing) WebdavUiCopy.EDIT_TITLE else WebdavUiCopy.ADD_TITLE
     val urlLabel = descriptorCopy?.urlLabel ?: "WebDAV URL"
     val urlPlaceholder = descriptorCopy?.urlPlaceholder ?: "server.example.com/dav/annotations"
     val submitLabel = descriptorCopy
@@ -137,7 +138,7 @@ fun AddSourceScreen(
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 val helpText = descriptorCopy?.helpText
-                    ?: "Sync highlights, notes, and bookmarks between your devices via a WebDAV server."
+                    ?: WebdavUiCopy.HELP_TEXT
                 if (helpText.isNotEmpty()) {
                     Text(
                         text = helpText,

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -3,6 +3,9 @@ package com.riffle.app.feature.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.app.BuildConfig
+import com.riffle.app.feature.annotationsync.AnnotationSyncKind
+import com.riffle.app.feature.annotationsync.WebdavUiCopy
+import com.riffle.app.feature.annotationsync.deriveAnnotationSyncKind
 import com.riffle.core.domain.AppTheme
 import com.riffle.core.domain.AppThemeStore
 import com.riffle.core.domain.AppUpdatePreferencesStore
@@ -25,8 +28,6 @@ import com.riffle.core.domain.ReadaloudPreferencesStore
 import com.riffle.core.domain.ReadaloudReviewRepository
 import com.riffle.core.models.Source
 import com.riffle.core.models.ServerType
-import com.riffle.app.feature.annotationsync.AnnotationSyncKind
-import com.riffle.app.feature.annotationsync.deriveAnnotationSyncKind
 import com.riffle.core.sync.AnnotationSyncStatusStore
 import com.riffle.core.sync.CycleOutcome
 import com.riffle.core.data.localfiles.LocalFilesFolderHealthChecker
@@ -129,7 +130,7 @@ class SettingsViewModel @Inject constructor(
         // behavior. The kind is still Pending either way, so the badge stays in sync with the
         // banner via [deriveAnnotationSyncKind].
         val sub = when {
-            config == null -> "Not configured · tap to set up a WebDAV server"
+            config == null -> WebdavUiCopy.NOT_CONFIGURED_STATUS
             outcome is CycleOutcome.NeverRun -> "Waiting for first sync…"
             outcome is CycleOutcome.Failed.Auth -> "Authentication failed · tap to re-enter credentials"
             outcome is CycleOutcome.Failed.Tls -> "TLS error · tap to check server URL"

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationsSyncSettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationsSyncSettingsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.riffle.app.feature.annotationsync.WebdavUiCopy
 import com.riffle.app.feature.server.AddSourceBackend
 import com.riffle.app.feature.settings.AnnotationSyncBadge
 import com.riffle.app.feature.settings.AnnotationSyncRowState
@@ -35,7 +36,7 @@ import com.riffle.app.feature.settings.disabledListItemColors
 
 /**
  * Full-screen drill-in that hosts every WebDAV annotation-sync setting. Reached from the collapsed
- * "Annotations Sync" row on the main Settings screen. Groups:
+ * WebDAV row on the main Settings screen, whose copy names Komga as the current consumer. Groups:
  *  - **Server** — the Configure WebDAV row, tinted by [AnnotationSyncRowState] so status stays
  *    visible when the user opens the screen to check "is anything wrong?".
  *  - **Devices** — Maintenance row leading to [AnnotationSyncMaintenanceScreen] for rename /
@@ -57,7 +58,7 @@ fun AnnotationsSyncSettingsScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Annotations Sync") },
+                title = { Text(WebdavUiCopy.SCREEN_TITLE) },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
@@ -79,7 +80,7 @@ fun AnnotationsSyncSettingsScreen(
                     onNavigateToAddSource(AddSourceBackend.Webdav, null)
                 },
                 leadingContent = { AnnotationSyncBadge(row.badge) },
-                headlineContent = { Text("Configure WebDAV") },
+                headlineContent = { Text(WebdavUiCopy.CONFIGURE_TITLE) },
                 supportingContent = {
                     Text(
                         text = row.sub,

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/sections/AnnotationsSyncSection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/sections/AnnotationsSyncSection.kt
@@ -6,27 +6,36 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import com.riffle.app.feature.annotationsync.WebdavUiCopy
 import com.riffle.app.feature.settings.AnnotationSyncBadge
 import com.riffle.app.feature.settings.AnnotationSyncRowState
 import com.riffle.app.feature.settings.DrillInChevron
 import com.riffle.app.feature.settings.SettingsSectionHeader
 
 /**
- * "Annotations Sync" section — collapsed to a single drill-in row that leads to the dedicated
- * WebDAV settings screen. Row preserves the four-state badge (Local/Synced/Pending/Error) and the
- * tone-colored subtitle (error/pending/normal) from the pre-collapse layout so status stays
- * legible at the main-screen altitude.
+ * WebDAV annotation-sync section — collapsed to a single drill-in row that leads to the dedicated
+ * settings screen. The title identifies Komga as the current consumer without binding the generic
+ * transport to it permanently. The row preserves the four-state badge
+ * (Local/Synced/Pending/Error) and tone-colored status subtitle.
  */
 @Composable
 internal fun AnnotationsSyncSection(
     row: AnnotationSyncRowState,
     onOpen: () -> Unit,
 ) {
-    SettingsSectionHeader("Annotations Sync")
+    SettingsSectionHeader(WebdavUiCopy.SECTION_TITLE)
     ListItem(
         modifier = Modifier.clickable(onClick = onOpen),
         leadingContent = { AnnotationSyncBadge(row.badge) },
-        headlineContent = { Text(if (row.badge == AnnotationSyncRowState.Badge.Local) "Configure WebDAV" else row.headline) },
+        headlineContent = {
+            Text(
+                if (row.badge == AnnotationSyncRowState.Badge.Local) {
+                    WebdavUiCopy.CONFIGURE_TITLE
+                } else {
+                    row.headline
+                },
+            )
+        },
         supportingContent = {
             Text(
                 text = row.sub,

--- a/app/src/test/kotlin/com/riffle/app/feature/annotationsync/WebdavUiCopyTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/annotationsync/WebdavUiCopyTest.kt
@@ -1,0 +1,18 @@
+package com.riffle.app.feature.annotationsync
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WebdavUiCopyTest {
+    @Test
+    fun `WebDAV UI identifies Komga without Komga-specific controls`() {
+        assertEquals("WebDAV annotation sync for Komga", WebdavUiCopy.SECTION_TITLE)
+        assertEquals("WebDAV annotation sync for Komga", WebdavUiCopy.SCREEN_TITLE)
+        assertEquals("Configure WebDAV", WebdavUiCopy.CONFIGURE_TITLE)
+        assertEquals("Add WebDAV", WebdavUiCopy.ADD_TITLE)
+        assertEquals("Edit WebDAV", WebdavUiCopy.EDIT_TITLE)
+        assertTrue(WebdavUiCopy.HELP_TEXT.contains("Available for Komga sources"))
+        assertTrue(WebdavUiCopy.NOT_CONFIGURED_STATUS.contains("available for Komga sources"))
+    }
+}


### PR DESCRIPTION
## Summary

- label the WebDAV annotation-sync section and drill-in as being for Komga
- explain on the connection form and unconfigured status that WebDAV is available for Komga sources
- keep Configure/Add/Edit WebDAV controls transport-generic so future sources can reuse them

## Tests

- `./gradlew :app:testDebugUnitTest --tests com.riffle.app.feature.annotationsync.WebdavUiCopyTest --tests com.riffle.app.feature.settings.SettingsViewModelTest`

## Regression coverage

WebdavUiCopyTest pins both visible Komga-scoped titles, the generic WebDAV control labels, and the Komga qualification in help/status copy.