### PR TITLE
fix(library): enable pinch zoom in web sources

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/source/websource/UnboundedCatalogGridZoomTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/source/websource/UnboundedCatalogGridZoomTest.kt
@@ -37,28 +37,7 @@ class UnboundedCatalogGridZoomTest {
     @Test
     fun pinchOutMakesCatalogItemsLarger() {
         var observedScale = 1f
-        rule.setContent {
-            var scale by remember { mutableFloatStateOf(1f) }
-            CompositionLocalProvider(LocalCoverGridScale provides scale) {
-                UnboundedCatalogGrid(
-                    items = (0 until 30).toList(),
-                    isPaging = false,
-                    hasMore = false,
-                    onLoadMore = {},
-                    onCoverScaleChange = {
-                        scale = it
-                        observedScale = it
-                    },
-                    itemKey = { it },
-                ) {
-                    Box(
-                        modifier = Modifier
-                            .aspectRatio(2f / 3f)
-                            .semantics { contentDescription = TILE_DESCRIPTION },
-                    )
-                }
-            }
-        }
+        setGridContent { observedScale = it }
 
         val columnsBefore = firstVisibleRowCount()
         rule.onRoot().performTouchInput {
@@ -77,6 +56,49 @@ class UnboundedCatalogGridZoomTest {
             "larger covers should reduce the first-row column count ($columnsBefore -> $columnsAfter)",
             columnsAfter < columnsBefore,
         )
+    }
+
+    @Test
+    fun pinchInMakesCatalogItemsSmaller() {
+        var observedScale = 1f
+        setGridContent { observedScale = it }
+
+        rule.onRoot().performTouchInput {
+            pinch(
+                start0 = Offset(left + 16f, centerY),
+                end0 = Offset(centerX - 24f, centerY),
+                start1 = Offset(right - 16f, centerY),
+                end1 = Offset(centerX + 24f, centerY),
+            )
+        }
+        rule.waitForIdle()
+
+        assertTrue("pinch-in should decrease the cover scale", observedScale < 1f)
+    }
+
+    private fun setGridContent(onScaleObserved: (Float) -> Unit) {
+        rule.setContent {
+            var scale by remember { mutableFloatStateOf(1f) }
+            CompositionLocalProvider(LocalCoverGridScale provides scale) {
+                UnboundedCatalogGrid(
+                    items = (0 until 30).toList(),
+                    isPaging = false,
+                    hasMore = false,
+                    onLoadMore = {},
+                    onCoverScaleChange = {
+                        scale = it
+                        onScaleObserved(it)
+                    },
+                    itemKey = { it },
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .aspectRatio(2f / 3f)
+                            .semantics { contentDescription = TILE_DESCRIPTION },
+                    )
+                }
+            }
+        }
     }
 
     private fun firstVisibleRowCount(): Int {

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/source/websource/UnboundedCatalogGridZoomTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/source/websource/UnboundedCatalogGridZoomTest.kt
@@ -1,0 +1,92 @@
+package com.riffle.app.feature.source.websource
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.pinch
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.riffle.app.feature.library.LocalCoverGridScale
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression coverage for the Chitanka/Gutenberg unbounded-catalog grids. These screens used
+ * fixed columns and omitted the library pinch modifier, so the global cover-density preference
+ * could neither be changed nor reflected while browsing them.
+ */
+@RunWith(AndroidJUnit4::class)
+class UnboundedCatalogGridZoomTest {
+
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun pinchOutMakesCatalogItemsLarger() {
+        var observedScale = 1f
+        rule.setContent {
+            var scale by remember { mutableFloatStateOf(1f) }
+            CompositionLocalProvider(LocalCoverGridScale provides scale) {
+                UnboundedCatalogGrid(
+                    items = (0 until 30).toList(),
+                    isPaging = false,
+                    hasMore = false,
+                    onLoadMore = {},
+                    onCoverScaleChange = {
+                        scale = it
+                        observedScale = it
+                    },
+                    itemKey = { it },
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .aspectRatio(2f / 3f)
+                            .semantics { contentDescription = TILE_DESCRIPTION },
+                    )
+                }
+            }
+        }
+
+        val columnsBefore = firstVisibleRowCount()
+        rule.onRoot().performTouchInput {
+            pinch(
+                start0 = Offset(centerX - 24f, centerY),
+                end0 = Offset(left + 16f, centerY),
+                start1 = Offset(centerX + 24f, centerY),
+                end1 = Offset(right - 16f, centerY),
+            )
+        }
+        rule.waitForIdle()
+
+        val columnsAfter = firstVisibleRowCount()
+        assertTrue("pinch-out should increase the cover scale", observedScale > 1f)
+        assertTrue(
+            "larger covers should reduce the first-row column count ($columnsBefore -> $columnsAfter)",
+            columnsAfter < columnsBefore,
+        )
+    }
+
+    private fun firstVisibleRowCount(): Int {
+        val nodes = rule.onAllNodesWithContentDescription(TILE_DESCRIPTION).fetchSemanticsNodes()
+        assertTrue("expected catalog tiles to render", nodes.isNotEmpty())
+        val firstRowTop = nodes.minOf { it.boundsInRoot.top }
+        return nodes.count { it.boundsInRoot.top == firstRowTop }
+    }
+
+    private companion object {
+        const val TILE_DESCRIPTION = "catalog_cover_tile"
+    }
+}

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/source/websource/UnboundedCatalogGridZoomTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/source/websource/UnboundedCatalogGridZoomTest.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.pinch
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.riffle.app.feature.library.LocalCoverGridScale
+import com.riffle.app.feature.library.MAX_COVER_SCALE
+import com.riffle.app.feature.library.MIN_COVER_SCALE
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -35,11 +37,10 @@ class UnboundedCatalogGridZoomTest {
     val rule = createComposeRule()
 
     @Test
-    fun pinchOutMakesCatalogItemsLarger() {
+    fun pinchOutIncreasesCoverScale() {
         var observedScale = 1f
-        setGridContent { observedScale = it }
+        setGridContent(onScaleObserved = { observedScale = it })
 
-        val columnsBefore = firstVisibleRowCount()
         rule.onRoot().performTouchInput {
             pinch(
                 start0 = Offset(centerX - 24f, centerY),
@@ -50,18 +51,13 @@ class UnboundedCatalogGridZoomTest {
         }
         rule.waitForIdle()
 
-        val columnsAfter = firstVisibleRowCount()
         assertTrue("pinch-out should increase the cover scale", observedScale > 1f)
-        assertTrue(
-            "larger covers should reduce the first-row column count ($columnsBefore -> $columnsAfter)",
-            columnsAfter < columnsBefore,
-        )
     }
 
     @Test
     fun pinchInMakesCatalogItemsSmaller() {
         var observedScale = 1f
-        setGridContent { observedScale = it }
+        setGridContent(onScaleObserved = { observedScale = it })
 
         rule.onRoot().performTouchInput {
             pinch(
@@ -76,9 +72,37 @@ class UnboundedCatalogGridZoomTest {
         assertTrue("pinch-in should decrease the cover scale", observedScale < 1f)
     }
 
-    private fun setGridContent(onScaleObserved: (Float) -> Unit) {
+    @Test
+    fun scaleBoundsReflowCatalogGridInBothDirections() {
+        lateinit var updateScale: (Float) -> Unit
+        setGridContent(onScaleObserved = {}, onScaleSetter = { updateScale = it })
+
+        val defaultColumns = firstVisibleRowCount()
+        rule.runOnIdle { updateScale(MAX_COVER_SCALE) }
+        rule.waitForIdle()
+        val largeCoverColumns = firstVisibleRowCount()
+
+        rule.runOnIdle { updateScale(MIN_COVER_SCALE) }
+        rule.waitForIdle()
+        val smallCoverColumns = firstVisibleRowCount()
+
+        assertTrue(
+            "maximum scale should reduce columns ($defaultColumns -> $largeCoverColumns)",
+            largeCoverColumns < defaultColumns,
+        )
+        assertTrue(
+            "minimum scale should increase columns ($defaultColumns -> $smallCoverColumns)",
+            smallCoverColumns > defaultColumns,
+        )
+    }
+
+    private fun setGridContent(
+        onScaleObserved: (Float) -> Unit,
+        onScaleSetter: ((Float) -> Unit) -> Unit = {},
+    ) {
         rule.setContent {
             var scale by remember { mutableFloatStateOf(1f) }
+            onScaleSetter { scale = it }
             CompositionLocalProvider(LocalCoverGridScale provides scale) {
                 UnboundedCatalogGrid(
                     items = (0 until 30).toList(),

--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
@@ -11,11 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.GridItemSpan
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
@@ -43,15 +38,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -66,6 +58,8 @@ import com.riffle.app.feature.annotations.AnnotationsListViewModel
 import com.riffle.app.feature.library.HomeTabContent
 import com.riffle.app.feature.library.LocalCoversAreSquare
 import com.riffle.app.feature.library.ToReadTabContent
+import com.riffle.app.feature.source.websource.UnboundedCatalogGrid
+import com.riffle.app.feature.source.websource.UnboundedCoverGridZoomProvider
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.core.catalog.CatalogItem
 import com.riffle.core.catalog.chitanka.ChitankaCatalog
@@ -107,6 +101,7 @@ fun ChitankaBrowseScreen(
 
     val isAudioRoot = viewModel.rootId == ChitankaCatalog.ROOT_AUDIOBOOKS
     var searchOpen by remember { mutableStateOf(false) }
+    val persistedCoverScale by viewModel.coverGridScale.collectAsState()
 
     val visibility by hiltViewModel<com.riffle.app.feature.library.LibraryTabVisibilityViewModel>()
         .visibility.collectAsState()
@@ -186,16 +181,29 @@ fun ChitankaBrowseScreen(
             windowSizeClass = windowSizeClass,
             modifier = Modifier.fillMaxSize().padding(padding),
         ) {
-            CompositionLocalProvider(LocalCoversAreSquare provides isAudioRoot) {
-                when (selectedTab) {
-                    TAB_HOME -> ChitankaHomeTab(onOpenDetail = onOpenDetail)
-                    TAB_TO_READ -> ChitankaToReadTab(onOpenDetail = onOpenDetail)
-                    TAB_ANNOTATIONS -> ChitankaAnnotationsTab(onAnnotatedBookClick = onAnnotatedBookClick)
-                    TAB_LIBRARY -> LibraryTabContent(
-                        viewModel = viewModel,
-                        isAudioRoot = isAudioRoot,
-                        searchOpen = searchOpen,
-                    )
+            UnboundedCoverGridZoomProvider(
+                persistedScale = persistedCoverScale,
+                onPersistScaleChange = viewModel::setCoverGridScale,
+            ) { onCoverScaleChange ->
+                CompositionLocalProvider(LocalCoversAreSquare provides isAudioRoot) {
+                    when (selectedTab) {
+                        TAB_HOME -> ChitankaHomeTab(
+                            onOpenDetail = onOpenDetail,
+                            onCoverScaleChange = onCoverScaleChange,
+                        )
+                        TAB_TO_READ -> ChitankaToReadTab(
+                            onOpenDetail = onOpenDetail,
+                            onCoverScaleChange = onCoverScaleChange,
+                        )
+                        TAB_ANNOTATIONS ->
+                            ChitankaAnnotationsTab(onAnnotatedBookClick = onAnnotatedBookClick)
+                        TAB_LIBRARY -> LibraryTabContent(
+                            viewModel = viewModel,
+                            isAudioRoot = isAudioRoot,
+                            searchOpen = searchOpen,
+                            onCoverScaleChange = onCoverScaleChange,
+                        )
+                    }
                 }
             }
         }
@@ -207,15 +215,12 @@ private const val TAB_TO_READ = 1
 private const val TAB_ANNOTATIONS = 2
 private const val TAB_LIBRARY = 3
 
-// Kick off a next-page fetch when the user scrolls to within this many items of the end so the
-// grid stays populated ahead of the viewport (≈ two rows in Books mode, three rows in Audiobooks).
-private const val PAGINATION_PREFETCH_THRESHOLD = 6
-
 @Composable
 private fun LibraryTabContent(
     viewModel: ChitankaBrowseViewModel,
     isAudioRoot: Boolean,
     searchOpen: Boolean,
+    onCoverScaleChange: (Float) -> Unit,
 ) {
     val items by viewModel.items.collectAsState()
     val facets by viewModel.facets.collectAsState()
@@ -279,53 +284,20 @@ private fun LibraryTabContent(
                     )
                 }
                 else -> {
-                    val gridState = rememberLazyGridState()
-                    // Trigger a next-page fetch once the user scrolls to within ~6 items of the
-                    // end. `derivedStateOf` collapses re-emissions from `firstVisibleItem*` down
-                    // to a single boolean so the LaunchedEffect below only re-fires on the actual
-                    // threshold crossing. `distinctUntilChanged` further protects against Compose
-                    // recomposing the same true value repeatedly.
-                    val shouldLoadMore by remember {
-                        derivedStateOf {
-                            val info = gridState.layoutInfo
-                            val total = info.totalItemsCount
-                            if (total == 0) return@derivedStateOf false
-                            val lastVisible = info.visibleItemsInfo.lastOrNull()?.index ?: 0
-                            lastVisible >= total - PAGINATION_PREFETCH_THRESHOLD
-                        }
-                    }
-                    LaunchedEffect(gridState, hasMore) {
-                        snapshotFlow { shouldLoadMore }.distinctUntilChanged().collect { should ->
-                            if (should && hasMore) viewModel.loadMore()
-                        }
-                    }
-                    LazyVerticalGrid(
-                        state = gridState,
-                        columns = GridCells.Fixed(if (isAudioRoot) 2 else 3),
-                        contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(14.dp),
-                        modifier = Modifier.fillMaxSize(),
-                    ) {
-                        items(items, key = { it.id }) { item ->
-                            CatalogItemCard(
-                                item = item,
-                                isAudio = isAudioRoot,
-                                onClick = { viewModel.openDetail(item) },
-                            )
-                        }
-                        // Footer spinner while the next page is fetching. Spans all columns so the
-                        // grid layout doesn't leave one item's worth of empty space beside it.
-                        if (isPaging) {
-                            item(span = { GridItemSpan(maxLineSpan) }) {
-                                Box(
-                                    modifier = Modifier.fillMaxWidth().padding(16.dp),
-                                    contentAlignment = Alignment.Center,
-                                ) {
-                                    CircularProgressIndicator()
-                                }
-                            }
-                        }
+                    UnboundedCatalogGrid(
+                        items = items,
+                        isPaging = isPaging,
+                        hasMore = hasMore,
+                        onLoadMore = viewModel::loadMore,
+                        onCoverScaleChange = onCoverScaleChange,
+                        itemKey = { it.id },
+                        coverCellSizeMultiplier = if (isAudioRoot) 4f / 3f else 1f,
+                    ) { item ->
+                        CatalogItemCard(
+                            item = item,
+                            isAudio = isAudioRoot,
+                            onClick = { viewModel.openDetail(item) },
+                        )
                     }
                 }
             }
@@ -336,6 +308,7 @@ private fun LibraryTabContent(
 @Composable
 private fun ChitankaHomeTab(
     onOpenDetail: (itemId: String) -> Unit,
+    onCoverScaleChange: (Float) -> Unit,
     viewModel: ChitankaLibraryViewModel = hiltViewModel(),
 ) {
     val inProgress by viewModel.inProgress.collectAsState()
@@ -355,12 +328,14 @@ private fun ChitankaHomeTab(
         token = "",
         onItemSelected = { item -> onOpenDetail(item.id) },
         onSectionSeeMore = {},
+        onCoverScaleChange = onCoverScaleChange,
     )
 }
 
 @Composable
 private fun ChitankaToReadTab(
     onOpenDetail: (itemId: String) -> Unit,
+    onCoverScaleChange: (Float) -> Unit,
     viewModel: ChitankaLibraryViewModel = hiltViewModel(),
 ) {
     val items by viewModel.toReadItems.collectAsState()
@@ -369,6 +344,7 @@ private fun ChitankaToReadTab(
         isLoading = false,
         token = "",
         onItemSelected = { item -> onOpenDetail(item.id) },
+        onCoverScaleChange = onCoverScaleChange,
     )
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModel.kt
@@ -6,6 +6,7 @@ import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.catalog.chitanka.ChitankaCatalog
 import com.riffle.core.data.websource.WebSourceItemGate
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
+import com.riffle.core.domain.CoverGridDensityStore
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -26,12 +27,14 @@ class ChitankaBrowseViewModel @Inject constructor(
     catalogRegistry: CatalogRegistry,
     libraryItemUpserter: WebSourceLibraryItemUpserter,
     webSourceItemGate: WebSourceItemGate,
+    coverGridDensityStore: CoverGridDensityStore,
 ) : UnboundedBrowseViewModel(
     savedStateHandle = savedStateHandle,
     sourceRepository = sourceRepository,
     catalogRegistry = catalogRegistry,
     libraryItemUpserter = libraryItemUpserter,
     webSourceItemGate = webSourceItemGate,
+    coverGridDensityStore = coverGridDensityStore,
     sourceType = SourceType.CHITANKA,
     defaultRootId = ChitankaCatalog.ROOT_BOOKS,
     // Chitanka lists ~30 items per page in most views; 50 gives us a small safety margin so the

--- a/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
@@ -11,11 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.GridItemSpan
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
@@ -42,15 +37,12 @@ import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -64,6 +56,8 @@ import com.riffle.app.feature.annotations.AnnotationsListScreen
 import com.riffle.app.feature.annotations.AnnotationsListViewModel
 import com.riffle.app.feature.library.HomeTabContent
 import com.riffle.app.feature.library.ToReadTabContent
+import com.riffle.app.feature.source.websource.UnboundedCatalogGrid
+import com.riffle.app.feature.source.websource.UnboundedCoverGridZoomProvider
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.core.catalog.CatalogItem
 
@@ -86,6 +80,7 @@ fun GutenbergBrowseScreen(
 ) {
     var selectedTab by rememberSaveable(key = "gutenberg_selected_tab_v1") { mutableIntStateOf(TAB_HOME) }
     var searchOpen by remember { mutableStateOf(false) }
+    val persistedCoverScale by viewModel.coverGridScale.collectAsState()
 
     val visibility by hiltViewModel<com.riffle.app.feature.library.LibraryTabVisibilityViewModel>()
         .visibility.collectAsState()
@@ -163,14 +158,27 @@ fun GutenbergBrowseScreen(
             windowSizeClass = windowSizeClass,
             modifier = Modifier.fillMaxSize().padding(padding),
         ) {
-            when (selectedTab) {
-                TAB_HOME -> GutenbergHomeTab(onOpenDetail = onOpenDetail)
-                TAB_TO_READ -> GutenbergToReadTab(onOpenDetail = onOpenDetail)
-                TAB_ANNOTATIONS -> GutenbergAnnotationsTab(onAnnotatedBookClick = onAnnotatedBookClick)
-                TAB_LIBRARY -> LibraryTabContent(
-                    viewModel = viewModel,
-                    searchOpen = searchOpen,
-                )
+            UnboundedCoverGridZoomProvider(
+                persistedScale = persistedCoverScale,
+                onPersistScaleChange = viewModel::setCoverGridScale,
+            ) { onCoverScaleChange ->
+                when (selectedTab) {
+                    TAB_HOME -> GutenbergHomeTab(
+                        onOpenDetail = onOpenDetail,
+                        onCoverScaleChange = onCoverScaleChange,
+                    )
+                    TAB_TO_READ -> GutenbergToReadTab(
+                        onOpenDetail = onOpenDetail,
+                        onCoverScaleChange = onCoverScaleChange,
+                    )
+                    TAB_ANNOTATIONS ->
+                        GutenbergAnnotationsTab(onAnnotatedBookClick = onAnnotatedBookClick)
+                    TAB_LIBRARY -> LibraryTabContent(
+                        viewModel = viewModel,
+                        searchOpen = searchOpen,
+                        onCoverScaleChange = onCoverScaleChange,
+                    )
+                }
             }
         }
     }
@@ -181,12 +189,11 @@ private const val TAB_TO_READ = 1
 private const val TAB_ANNOTATIONS = 2
 private const val TAB_LIBRARY = 3
 
-private const val PAGINATION_PREFETCH_THRESHOLD = 6
-
 @Composable
 private fun LibraryTabContent(
     viewModel: GutenbergBrowseViewModel,
     searchOpen: Boolean,
+    onCoverScaleChange: (Float) -> Unit,
 ) {
     val items by viewModel.items.collectAsState()
     val facets by viewModel.facets.collectAsState()
@@ -250,45 +257,18 @@ private fun LibraryTabContent(
                     )
                 }
                 else -> {
-                    val gridState = rememberLazyGridState()
-                    val shouldLoadMore by remember {
-                        derivedStateOf {
-                            val info = gridState.layoutInfo
-                            val total = info.totalItemsCount
-                            if (total == 0) return@derivedStateOf false
-                            val lastVisible = info.visibleItemsInfo.lastOrNull()?.index ?: 0
-                            lastVisible >= total - PAGINATION_PREFETCH_THRESHOLD
-                        }
-                    }
-                    LaunchedEffect(gridState, hasMore) {
-                        snapshotFlow { shouldLoadMore }.distinctUntilChanged().collect { should ->
-                            if (should && hasMore) viewModel.loadMore()
-                        }
-                    }
-                    LazyVerticalGrid(
-                        state = gridState,
-                        columns = GridCells.Fixed(3),
-                        contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(14.dp),
-                        modifier = Modifier.fillMaxSize(),
-                    ) {
-                        items(items, key = { it.id }) { item ->
-                            CatalogItemCard(
-                                item = item,
-                                onClick = { viewModel.openDetail(item) },
-                            )
-                        }
-                        if (isPaging) {
-                            item(span = { GridItemSpan(maxLineSpan) }) {
-                                Box(
-                                    modifier = Modifier.fillMaxWidth().padding(16.dp),
-                                    contentAlignment = Alignment.Center,
-                                ) {
-                                    CircularProgressIndicator()
-                                }
-                            }
-                        }
+                    UnboundedCatalogGrid(
+                        items = items,
+                        isPaging = isPaging,
+                        hasMore = hasMore,
+                        onLoadMore = viewModel::loadMore,
+                        onCoverScaleChange = onCoverScaleChange,
+                        itemKey = { it.id },
+                    ) { item ->
+                        CatalogItemCard(
+                            item = item,
+                            onClick = { viewModel.openDetail(item) },
+                        )
                     }
                 }
             }
@@ -299,6 +279,7 @@ private fun LibraryTabContent(
 @Composable
 private fun GutenbergHomeTab(
     onOpenDetail: (itemId: String) -> Unit,
+    onCoverScaleChange: (Float) -> Unit,
     viewModel: GutenbergLibraryViewModel = hiltViewModel(),
 ) {
     val inProgress by viewModel.inProgress.collectAsState()
@@ -315,12 +296,14 @@ private fun GutenbergHomeTab(
         token = "",
         onItemSelected = { item -> onOpenDetail(item.id) },
         onSectionSeeMore = {},
+        onCoverScaleChange = onCoverScaleChange,
     )
 }
 
 @Composable
 private fun GutenbergToReadTab(
     onOpenDetail: (itemId: String) -> Unit,
+    onCoverScaleChange: (Float) -> Unit,
     viewModel: GutenbergLibraryViewModel = hiltViewModel(),
 ) {
     val items by viewModel.toReadItems.collectAsState()
@@ -329,6 +312,7 @@ private fun GutenbergToReadTab(
         isLoading = false,
         token = "",
         onItemSelected = { item -> onOpenDetail(item.id) },
+        onCoverScaleChange = onCoverScaleChange,
     )
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModel.kt
@@ -6,6 +6,7 @@ import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.catalog.gutenberg.GutenbergCatalog
 import com.riffle.core.data.websource.WebSourceItemGate
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
+import com.riffle.core.domain.CoverGridDensityStore
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -26,12 +27,14 @@ class GutenbergBrowseViewModel @Inject constructor(
     catalogRegistry: CatalogRegistry,
     libraryItemUpserter: WebSourceLibraryItemUpserter,
     webSourceItemGate: WebSourceItemGate,
+    coverGridDensityStore: CoverGridDensityStore,
 ) : UnboundedBrowseViewModel(
     savedStateHandle = savedStateHandle,
     sourceRepository = sourceRepository,
     catalogRegistry = catalogRegistry,
     libraryItemUpserter = libraryItemUpserter,
     webSourceItemGate = webSourceItemGate,
+    coverGridDensityStore = coverGridDensityStore,
     sourceType = SourceType.GUTENBERG,
     defaultRootId = GutenbergCatalog.ROOT_BOOKS,
     // Gutendex ships 32 items per page — matching the server-side size keeps our request-page

--- a/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
@@ -9,6 +9,7 @@ import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.catalog.FacetSelection
 import com.riffle.core.data.websource.WebSourceItemGate
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
+import com.riffle.core.domain.CoverGridDensityStore
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
 import kotlinx.coroutines.CancellationException
@@ -18,9 +19,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 /**
@@ -39,8 +42,10 @@ import kotlinx.coroutines.launch
  *     catalogRegistry: CatalogRegistry,
  *     libraryItemUpserter: WebSourceLibraryItemUpserter,
  *     webSourceItemGate: WebSourceItemGate,
+ *     coverGridDensityStore: CoverGridDensityStore,
  * ) : UnboundedBrowseViewModel(
- *     savedStateHandle, sourceRepository, catalogRegistry, libraryItemUpserter, webSourceItemGate,
+ *     savedStateHandle, sourceRepository, catalogRegistry, libraryItemUpserter,
+ *     webSourceItemGate, coverGridDensityStore,
  *     sourceType = SourceType.FOO,
  *     defaultRootId = FooCatalog.ROOT_BOOKS,
  *     pageSize = 40,
@@ -58,6 +63,7 @@ abstract class UnboundedBrowseViewModel(
     private val catalogRegistry: CatalogRegistry,
     private val libraryItemUpserter: WebSourceLibraryItemUpserter,
     private val webSourceItemGate: WebSourceItemGate,
+    private val coverGridDensityStore: CoverGridDensityStore,
     private val sourceType: SourceType,
     defaultRootId: String,
     private val pageSize: Int,
@@ -70,6 +76,20 @@ abstract class UnboundedBrowseViewModel(
      */
     private val facetDebounceMs: Long = 250L,
 ) : ViewModel() {
+
+    /** Global per-device cover density, shared with bounded library screens. */
+    val coverGridScale: StateFlow<Float> = coverGridDensityStore.scale
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 1f)
+
+    private var coverScalePersistJob: Job? = null
+
+    fun setCoverGridScale(value: Float) {
+        coverScalePersistJob?.cancel()
+        coverScalePersistJob = viewModelScope.launch {
+            delay(200)
+            coverGridDensityStore.setScale(value)
+        }
+    }
 
     // The unbounded browse route uses the Riffle `libraryId` as the Catalog `rootId` — each of
     // the source's Riffle "libraries" (e.g. Chitanka's Books + Audiobooks) maps 1:1 to a Catalog

--- a/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedCatalogGrid.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedCatalogGrid.kt
@@ -1,0 +1,115 @@
+package com.riffle.app.feature.source.websource
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.riffle.app.feature.library.LocalCoverGridScale
+import com.riffle.app.feature.library.coverGridMinCellSize
+import com.riffle.app.feature.library.pinchCoverZoom
+import com.riffle.app.ui.fadingScrollbar
+import kotlinx.coroutines.flow.distinctUntilChanged
+
+private const val PAGINATION_PREFETCH_THRESHOLD = 6
+
+/**
+ * Supplies the global, persisted cover density to every tab in an unbounded web source while
+ * keeping gesture updates live. Persistence is deliberately delegated to the ViewModel so writes
+ * can be debounced once the gesture settles.
+ */
+@Composable
+internal fun UnboundedCoverGridZoomProvider(
+    persistedScale: Float,
+    onPersistScaleChange: (Float) -> Unit,
+    content: @Composable (onScaleChange: (Float) -> Unit) -> Unit,
+) {
+    var liveScale by remember { mutableFloatStateOf(persistedScale) }
+    LaunchedEffect(persistedScale) { liveScale = persistedScale }
+    val onScaleChange: (Float) -> Unit = {
+        liveScale = it
+        onPersistScaleChange(it)
+    }
+
+    CompositionLocalProvider(LocalCoverGridScale provides liveScale) {
+        content(onScaleChange)
+    }
+}
+
+/**
+ * Shared zoomable, adaptive grid for Chitanka, Gutenberg, and future unbounded web catalogues.
+ * [coverCellSizeMultiplier] keeps square audiobook art roomier at the default density while using
+ * the same global pinch scale as portrait book covers.
+ */
+@Composable
+internal fun <T> UnboundedCatalogGrid(
+    items: List<T>,
+    isPaging: Boolean,
+    hasMore: Boolean,
+    onLoadMore: () -> Unit,
+    onCoverScaleChange: (Float) -> Unit,
+    itemKey: (T) -> Any,
+    coverCellSizeMultiplier: Float = 1f,
+    itemContent: @Composable (T) -> Unit,
+) {
+    val gridState = rememberLazyGridState()
+    val shouldLoadMore by remember {
+        derivedStateOf {
+            val info = gridState.layoutInfo
+            val total = info.totalItemsCount
+            if (total == 0) return@derivedStateOf false
+            val lastVisible = info.visibleItemsInfo.lastOrNull()?.index ?: 0
+            lastVisible >= total - PAGINATION_PREFETCH_THRESHOLD
+        }
+    }
+    LaunchedEffect(gridState, hasMore) {
+        snapshotFlow { shouldLoadMore }.distinctUntilChanged().collect { should ->
+            if (should && hasMore) onLoadMore()
+        }
+    }
+
+    LazyVerticalGrid(
+        state = gridState,
+        columns = GridCells.Adaptive(coverGridMinCellSize() * coverCellSizeMultiplier),
+        contentPadding = PaddingValues(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+        modifier = Modifier
+            .pinchCoverZoom(onCoverScaleChange)
+            .fillMaxSize()
+            .fadingScrollbar(gridState),
+    ) {
+        items(items, key = itemKey) { item ->
+            itemContent(item)
+        }
+        if (isPaging) {
+            item(span = { GridItemSpan(maxLineSpan) }) {
+                Box(
+                    modifier = Modifier.fillMaxWidth().padding(16.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+        }
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
@@ -7,6 +7,7 @@ import com.riffle.core.catalog.CatalogItem
 import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.catalog.chitanka.ChitankaCatalog
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
+import com.riffle.core.domain.CoverGridDensityStore
 import com.riffle.core.models.Source
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
@@ -18,6 +19,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -58,6 +60,7 @@ class ChitankaBrowseViewModelTest {
         rootId: String = ChitankaCatalog.ROOT_BOOKS,
         upserter: WebSourceLibraryItemUpserter = mockk(relaxed = true),
         sourceRepo: SourceRepository = fakeSourceRepo(chitankaSource),
+        coverGridDensityStore: CoverGridDensityStore = fakeCoverGridDensityStore(),
         catalog: Catalog = mockk<Catalog>(relaxed = true).also {
             // Relaxed mocks return a stub CatalogItem instead of null for `getItem`, which breaks
             // the openDetail enrichment fallback in tests that don't explicitly stub it. Pin to
@@ -77,7 +80,14 @@ class ChitankaBrowseViewModelTest {
                 com.riffle.core.data.websource.WebSourceItemGate.Outcome.Fetched(listing)
             }
         }
-        return ChitankaBrowseViewModel(savedStateHandle, sourceRepo, registry, upserter, gate)
+        return ChitankaBrowseViewModel(
+            savedStateHandle,
+            sourceRepo,
+            registry,
+            upserter,
+            gate,
+            coverGridDensityStore,
+        )
     }
 
     private fun item(id: String) = CatalogItem(
@@ -139,6 +149,7 @@ class ChitankaBrowseViewModelTest {
             registry,
             mockk<WebSourceLibraryItemUpserter>(relaxed = true),
             gate,
+            fakeCoverGridDensityStore(),
         )
         advanceUntilIdle()
 
@@ -169,6 +180,7 @@ class ChitankaBrowseViewModelTest {
             registry,
             mockk<WebSourceLibraryItemUpserter>(relaxed = true),
             gate,
+            fakeCoverGridDensityStore(),
         )
         advanceUntilIdle()
 
@@ -199,6 +211,7 @@ class ChitankaBrowseViewModelTest {
             registry,
             upserter,
             gate,
+            fakeCoverGridDensityStore(),
         )
         advanceUntilIdle()
 
@@ -230,6 +243,19 @@ class ChitankaBrowseViewModelTest {
         val msg = friendlyErrorMessage(java.io.IOException("connection reset"))
         assertEquals("Couldn't reach chitanka.info. Check your connection and try again.", msg)
     }
+
+    @Test
+    fun `cover scale changes persist through the global density store after debounce`() =
+        runTest(dispatcher) {
+            val densityStore = RecordingCoverGridDensityStore()
+            val vm = makeVm(coverGridDensityStore = densityStore)
+            advanceUntilIdle()
+
+            vm.setCoverGridScale(1.4f)
+            advanceUntilIdle()
+
+            assertEquals(1.4f, densityStore.persistedScale)
+        }
 
     // ─── Pagination ──────────────────────────────────────────────────────────────────────────────
     //
@@ -353,5 +379,20 @@ class ChitankaBrowseViewModelTest {
         override suspend fun setActive(sourceId: String) { }
         override suspend fun remove(sourceId: String) { }
         override suspend fun getSourceVersion(sourceId: String): String? = null
+    }
+
+    private fun fakeCoverGridDensityStore(): CoverGridDensityStore =
+        object : CoverGridDensityStore {
+            override val scale = flowOf(1f)
+            override suspend fun setScale(value: Float) = Unit
+        }
+
+    private class RecordingCoverGridDensityStore : CoverGridDensityStore {
+        override val scale = flowOf(1f)
+        var persistedScale: Float? = null
+
+        override suspend fun setScale(value: Float) {
+            persistedScale = value
+        }
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModelTest.kt
@@ -8,6 +8,7 @@ import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.catalog.gutenberg.GutenbergCatalog
 import com.riffle.core.data.websource.WebSourceItemGate
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
+import com.riffle.core.domain.CoverGridDensityStore
 import com.riffle.core.models.Source
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
@@ -19,6 +20,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -75,7 +77,14 @@ class GutenbergBrowseViewModelTest {
         }
         val registry = mockk<CatalogRegistry>().also { coEvery { it.forSource(any()) } returns catalog }
         val handle = SavedStateHandle(mapOf("libraryId" to GutenbergCatalog.ROOT_BOOKS))
-        val vm = GutenbergBrowseViewModel(handle, sourceRepo, registry, upserter, gate)
+        val vm = GutenbergBrowseViewModel(
+            handle,
+            sourceRepo,
+            registry,
+            upserter,
+            gate,
+            fakeCoverGridDensityStore(),
+        )
         return vm to gate
     }
 
@@ -118,4 +127,10 @@ class GutenbergBrowseViewModelTest {
         override suspend fun remove(sourceId: String) { }
         override suspend fun getSourceVersion(sourceId: String): String? = null
     }
+
+    private fun fakeCoverGridDensityStore(): CoverGridDensityStore =
+        object : CoverGridDensityStore {
+            override val scale = flowOf(1f)
+            override suspend fun setScale(value: Float) = Unit
+        }
 }


### PR DESCRIPTION
## Summary

- replace Chitanka and Gutenberg fixed-column catalogue grids with one shared adaptive, pinch-zoomable grid
- apply the global persisted cover density across each web source's Home, To Read, and Library tabs while keeping Chitanka audiobook covers roomier by default
- add regression coverage for pinch-in, pinch-out, responsive column reflow, and debounced preference persistence

## Tests

- `./gradlew :app:testDebugUnitTest --tests 'com.riffle.app.feature.source.chitanka.ChitankaBrowseViewModelTest' --tests 'com.riffle.app.feature.source.gutenberg.GutenbergBrowseViewModelTest'`
- `./gradlew :app:compileDebugAndroidTestKotlin`
- `./gradlew :app:lintDebug`
