### PR TITLE
fix(reader): preserve formatting boundaries during annotation merge

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AnnotationMergeFormattingHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AnnotationMergeFormattingHarnessTest.kt
@@ -1,0 +1,183 @@
+package com.riffle.app.feature.reader
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.riffle.core.data.AnnotationStoreImpl
+import com.riffle.core.database.AnnotationEntity
+import com.riffle.core.database.RiffleDatabase
+import com.riffle.core.database.SourceEntity
+import com.riffle.core.domain.DeviceIdStore
+import com.riffle.core.models.Annotation
+import com.riffle.core.models.EmphasisStyle
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.zip.ZipInputStream
+
+/**
+ * On-device regression for the 2026-07-24 recording: a plain green annotation partially
+ * overlapped by a green + bold annotation must remain two edit targets. This exercises the
+ * production merge decision against the bundled EPUB, then persists the expected result through
+ * real Room + [AnnotationStoreImpl] to prove the bold sibling stays scoped to annotation B.
+ */
+@RunWith(AndroidJUnit4::class)
+class AnnotationMergeFormattingHarnessTest {
+
+    private lateinit var database: RiffleDatabase
+    private lateinit var store: AnnotationStoreImpl
+
+    private class FixedDeviceIdStore : DeviceIdStore {
+        override suspend fun getOrCreate(): String = "device-test"
+    }
+
+    @Before
+    fun setUp() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        database = Room.inMemoryDatabaseBuilder(context, RiffleDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        val nextId = AtomicInteger()
+        store = AnnotationStoreImpl(
+            dao = database.annotationDao(),
+            deviceIdStore = FixedDeviceIdStore(),
+            clock = { 1_000L + nextId.get() },
+            idGenerator = { "annotation-${nextId.incrementAndGet()}" },
+        )
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun plainGreenOverlappedByGreenBold_staysSeparateAndKeepsBoldOnNewRange() = runTest {
+        database.sourceDao().upsert(
+            SourceEntity(
+                id = "source-1",
+                url = "http://source-1",
+                isActive = true,
+                insecureConnectionAllowed = false,
+                username = "test",
+            ),
+        )
+        val html = chapter1Html()
+        val body = readableBodyText(html)
+        val plainSnippet = "In the beginning there was text. The text was formless"
+        val boldSnippet = "text was formless and the page was empty. Then came the reader"
+        val plainStart = body.indexOf(plainSnippet).toLong()
+        val boldStart = body.indexOf(boldSnippet).toLong()
+        require(plainStart >= 0 && boldStart >= 0)
+        val plainBefore = body.substring(0, plainStart.toInt()).takeLast(60)
+        val boldBefore = body.substring(0, boldStart.toInt()).takeLast(60)
+        val plainCfi = buildHighlightCfiRange(
+            spineStep = 2,
+            html = html,
+            startChar = plainStart,
+            endChar = plainStart + plainSnippet.length - 1L,
+        ) ?: error("failed to build plain annotation CFI")
+        val boldCfi = buildHighlightCfiRange(
+            spineStep = 2,
+            html = html,
+            startChar = boldStart,
+            endChar = boldStart + boldSnippet.length - 1L,
+        ) ?: error("failed to build bold annotation CFI")
+        val plainCandidate = annotation(
+            cfi = plainCfi,
+            textSnippet = plainSnippet,
+            textBefore = plainBefore,
+        )
+
+        val merge = computeOverlapMerge(
+            html = html,
+            draftSnippet = boldSnippet,
+            draftTextBefore = boldBefore,
+            candidates = listOf(plainCandidate),
+            draftEmphasisStyles = setOf(EmphasisStyle.BOLD),
+            emphasisPool = emptyList(),
+        )
+        assertNull("plain green and overlapping green + bold must not merge", merge)
+
+        store.createHighlight(
+            sourceId = "source-1",
+            itemId = "book-1",
+            cfi = plainCfi,
+            textSnippet = plainSnippet,
+            chapterHref = "OEBPS/chapter1.xhtml",
+            textBefore = plainBefore,
+            color = "green",
+            originFontFamily = "serif",
+        )
+        store.createHighlight(
+            sourceId = "source-1",
+            itemId = "book-1",
+            cfi = boldCfi,
+            textSnippet = boldSnippet,
+            chapterHref = "OEBPS/chapter1.xhtml",
+            textBefore = boldBefore,
+            color = "green",
+            originFontFamily = "serif",
+        )
+        store.createEmphasis(
+            sourceId = "source-1",
+            itemId = "book-1",
+            cfi = boldCfi,
+            textSnippet = boldSnippet,
+            chapterHref = "OEBPS/chapter1.xhtml",
+            textBefore = boldBefore,
+            styles = setOf(EmphasisStyle.BOLD),
+            originFontFamily = "serif",
+        )
+
+        val highlights = store.observeHighlights("source-1", "book-1").first()
+        val emphasis = store.observeEmphasis("source-1", "book-1").first()
+        assertEquals("both green edit targets must survive", 2, highlights.size)
+        assertEquals(1, emphasis.size)
+        assertEquals("bold must remain scoped to annotation B", boldCfi, emphasis.single().cfi)
+        assertEquals(setOf(EmphasisStyle.BOLD), emphasis.single().emphasisStyles)
+    }
+
+    private fun annotation(
+        cfi: String,
+        textSnippet: String,
+        textBefore: String,
+    ) = Annotation(
+        id = "plain-green",
+        sourceId = "source-1",
+        itemId = "book-1",
+        type = AnnotationEntity.TYPE_HIGHLIGHT,
+        cfi = cfi,
+        color = "green",
+        note = null,
+        textSnippet = textSnippet,
+        textBefore = textBefore,
+        textAfter = "",
+        chapterHref = "OEBPS/chapter1.xhtml",
+        spineIndex = 0,
+        progression = 0.0,
+        bookmarkTitle = "",
+        createdAt = 0L,
+        updatedAt = 0L,
+    )
+
+    private fun chapter1Html(): String {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        ZipInputStream(context.assets.open("test.epub")).use { zip ->
+            var entry = zip.nextEntry
+            while (entry != null) {
+                if (entry.name.endsWith("chapter1.xhtml")) {
+                    return zip.readBytes().decodeToString()
+                }
+                entry = zip.nextEntry
+            }
+        }
+        error("chapter1.xhtml not found in test.epub")
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -2129,8 +2129,6 @@ class EpubReaderViewModel @Inject constructor(
         // orphans on a debug device); manifested as "annotations don't show in the panel and the
         // underlying text stays formatted forever" (panel filters TYPE_EMPHASIS out, DOM injector
         // does not).
-        val presetStyles = annotationSession.lastUsedEmphasisStyles.value
-        val combinedStyles = combineDraftEmphasisStyles(presetStyles, addEmphasisStyle)
         val html = readChapterHtml(draft.spineIndex)
         val candidates = annotationSession.annotations.value
             .filter { it.type == com.riffle.core.database.AnnotationEntity.TYPE_HIGHLIGHT }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -2129,12 +2129,21 @@ class EpubReaderViewModel @Inject constructor(
         // orphans on a debug device); manifested as "annotations don't show in the panel and the
         // underlying text stays formatted forever" (panel filters TYPE_EMPHASIS out, DOM injector
         // does not).
+        val presetStyles = annotationSession.lastUsedEmphasisStyles.value
+        val combinedStyles = combineDraftEmphasisStyles(presetStyles, addEmphasisStyle)
         val html = readChapterHtml(draft.spineIndex)
         val candidates = annotationSession.annotations.value
             .filter { it.type == com.riffle.core.database.AnnotationEntity.TYPE_HIGHLIGHT }
             .filter { normalizeEpubHref(it.chapterHref) == normalizeEpubHref(draft.chapterHref) }
         val overlapMerge = html?.let {
-            computeOverlapMerge(it, draft.textSnippet, draft.textBefore, candidates)
+            computeOverlapMerge(
+                html = it,
+                draftSnippet = draft.textSnippet,
+                draftTextBefore = draft.textBefore,
+                candidates = candidates,
+                draftEmphasisStyles = combinedStyles,
+                emphasisPool = annotationSession.emphasisPool.value,
+            )
         }
         overlapMerge?.victimIds?.forEach { victimId ->
             val victim = candidates.firstOrNull { it.id == victimId }
@@ -2172,6 +2181,8 @@ class EpubReaderViewModel @Inject constructor(
                 draftColor = initialColor,
                 draftEmbeddedFigures = overlapFields.embeddedFigures,
                 candidates = adjacentCandidates,
+                draftEmphasisStyles = combinedStyles,
+                emphasisPool = annotationSession.emphasisPool.value,
             )
         }
         adjacentMerge?.victimIds?.forEach { victimId ->
@@ -2301,7 +2312,19 @@ class EpubReaderViewModel @Inject constructor(
             logger.d(LogChannel.HighlightMerge) { "edit-merge skip id=$id reason=type=${current.type}" }
             return
         }
-        val pool = annotationSession.annotations.value
+        val unfilteredPool = annotationSession.annotations.value
+        val currentEmphasisStyles = collectMergedEmphasisStyles(
+            pool = annotationSession.emphasisPool.value,
+            cascadeCfis = setOf(current.cfi),
+        )
+        // Highlight and Emphasis are independent axes (ADR 0046). Only merge highlight ranges
+        // whose sibling emphasis sets are identical; otherwise a plain range adjacent to a bold
+        // range would collapse into one edit target and formatting would spread across the union.
+        val pool = highlightsWithEmphasisStyles(
+            candidates = unfilteredPool,
+            emphasisPool = annotationSession.emphasisPool.value,
+            expectedStyles = currentEmphasisStyles,
+        )
         // Trial-run the merge WITHOUT touching the DB. Track the leftmost source highlight as we
         // chain-absorb — its stored textBefore is our anchor for text-searching the actual char
         // position of the merged range in the chapter DOM. We can NOT use the stored progression
@@ -2434,6 +2457,13 @@ class EpubReaderViewModel @Inject constructor(
         // no-longer-existent range). Same cascade the panel-delete + overlap-dedup paths do.
         val anchorCfi = pool.firstOrNull { it.id == id }?.cfi
         val cascadeCfis = toAbsorb.map { it.cfi }.toSet() + (anchorCfi?.let { setOf(it) } ?: emptySet())
+        // Every source passed the identical-emphasis gate above. Capture that shared set BEFORE
+        // deleting the rows so the replacement keeps the same formatting; otherwise the cascade
+        // below would wipe the sibling emphasis and leave the merged range plain.
+        val mergedEmphasisStyles = collectMergedEmphasisStyles(
+            pool = annotationSession.emphasisPool.value,
+            cascadeCfis = cascadeCfis,
+        )
         if (cascadeCfis.isNotEmpty()) {
             annotationSession.emphasisPool.value
                 .filter { it.cfi in cascadeCfis }
@@ -2462,9 +2492,25 @@ class EpubReaderViewModel @Inject constructor(
             embeddedFigures = mergedEmbeddedFigures,
             originFontFamily = mergedOriginFont,
         )
+        if (mergedEmphasisStyles.isNotEmpty()) {
+            annotationStore.createEmphasis(
+                sourceId = sourceId,
+                itemId = itemId,
+                cfi = cfiRange,
+                textSnippet = domSnippet,
+                chapterHref = trialAnchor.chapterHref,
+                textBefore = trialAnchor.textBefore,
+                textAfter = trialAnchor.textAfter,
+                styles = mergedEmphasisStyles,
+                spineIndex = trialAnchor.spineIndex,
+                progression = storedProgression,
+                originFontFamily = mergedOriginFont,
+            )
+        }
         logger.d(LogChannel.HighlightMerge) {
             "edit-merge done anchorReplaced=$id newId=${created.id} absorbedText=${toAbsorb.size} " +
                 "figures=${mergedEmbeddedFigures?.size ?: 0} " +
+                "emphasisStyles=$mergedEmphasisStyles " +
                 "domLen=${domSnippet.length} startChar=$startChar"
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightMerge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightMerge.kt
@@ -307,3 +307,17 @@ internal fun hasFigureInGap(
     return findEnclosedFiguresInHtml(html, gapStart, gapEnd).isNotEmpty()
 }
 
+/**
+ * Collect the union of all [EmphasisStyle] values from emphasis rows in [pool] whose CFI is in
+ * [cascadeCfis]. The merge paths first require every participating highlight to have an identical
+ * style set, then use this helper before replacing those rows so the merged range can recreate
+ * that same formatting. Returns empty when the source annotations carry no emphasis.
+ */
+internal fun collectMergedEmphasisStyles(
+    pool: List<Annotation>,
+    cascadeCfis: Set<String>,
+): Set<EmphasisStyle> = pool
+    .filter { it.cfi in cascadeCfis }
+    .flatMap { it.emphasisStyles.orEmpty() }
+    .toSet()
+

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRangeOverlap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRangeOverlap.kt
@@ -1,7 +1,9 @@
 package com.riffle.app.feature.reader
 
+import com.riffle.core.database.AnnotationEntity
 import com.riffle.core.models.Annotation
 import com.riffle.core.models.EmbeddedFigure
+import com.riffle.core.models.EmphasisStyle
 import com.riffle.core.domain.countBodyChars
 import org.jsoup.Jsoup
 
@@ -10,6 +12,19 @@ internal data class AdjacentCreateMerge(
     val fields: MergedDraftFields,
     val victimIds: List<String>,
 )
+
+/**
+ * Highlight auto-merge is formatting-aware: two highlight rows may share a colour but still
+ * represent distinct edit targets when their sibling Emphasis style sets differ.
+ */
+internal fun highlightsWithEmphasisStyles(
+    candidates: List<Annotation>,
+    emphasisPool: List<Annotation>,
+    expectedStyles: Set<EmphasisStyle>,
+): List<Annotation> = candidates.filter {
+    it.type == AnnotationEntity.TYPE_HIGHLIGHT &&
+        collectMergedEmphasisStyles(emphasisPool, setOf(it.cfi)) == expectedStyles
+}
 
 /** Overlap-merge context length: how much text to snapshot either side of the merged range as
  *  the persisted textBefore/textAfter. Matches [OVERLAP_CONTEXT_LEN] used by the legacy detector. */
@@ -25,8 +40,9 @@ private const val MERGED_CONTEXT_LEN = 60
  * → both highlights coexisted over the shared span (the doubled-orange bug in the video).
  *
  * The new detector operates on character-offset ranges resolved via [locateSnippetInBody] and
- * a strict interval-overlap test. Detection is a pure function so it is JVM-testable independently
- * of DOM I/O.
+ * a strict interval-overlap test. Candidates whose sibling emphasis styles differ from the draft
+ * are excluded so formatting boundaries remain separate edit targets. Detection is a pure
+ * function so it is JVM-testable independently of DOM I/O.
  */
 
 /** Half-open char range `[startChar, endChar)` — endChar exclusive so touching endpoints are
@@ -58,8 +74,8 @@ internal fun annotationCharRange(html: String, textSnippet: String, textBefore: 
 /**
  * Detect overlap victims for a new draft against every candidate existing highlight in the same
  * chapter. Returns the set of victim ids to delete AND the union range `[mergedStart, mergedEnd)`
- * spanning the draft + all overlapping victims. Null when no overlap or the draft itself can't
- * be located.
+ * spanning the draft + all formatting-compatible overlapping victims. Null when no compatible
+ * overlap exists or the draft itself can't be located.
  *
  * The caller (commitDraft) uses the union range to rebuild the merged snippet / textBefore /
  * textAfter / CFI, delete each victim (cascading its sibling emphasis rows), and persist ONE
@@ -174,7 +190,8 @@ internal fun buildMergedDraftFields(
  * the caller must delete (with their sibling emphasis rows) before persisting the merged highlight.
  *
  * [candidates] should already be filtered to same-chapter TYPE_HIGHLIGHT rows with overlap victims
- * excluded so they aren't double-processed.
+ * excluded so they aren't double-processed. This function additionally filters by the sibling
+ * Emphasis set because that is part of a Highlight's merge identity.
  */
 internal fun computeAdjacentCreateMerge(
     html: String,
@@ -187,7 +204,14 @@ internal fun computeAdjacentCreateMerge(
     draftColor: String,
     draftEmbeddedFigures: List<EmbeddedFigure>?,
     candidates: List<Annotation>,
+    draftEmphasisStyles: Set<EmphasisStyle> = emptySet(),
+    emphasisPool: List<Annotation> = emptyList(),
 ): AdjacentCreateMerge? {
+    val formattingCompatibleCandidates = highlightsWithEmphasisStyles(
+        candidates = candidates,
+        emphasisPool = emphasisPool,
+        expectedStyles = draftEmphasisStyles,
+    )
     var trialAnchor = MergeAnchor(
         spineIndex = draftSpineIndex,
         color = draftColor,
@@ -203,7 +227,12 @@ internal fun computeAdjacentCreateMerge(
     val toAbsorb = mutableListOf<Annotation>()
     val absorbedIds = mutableSetOf<String>()
     while (true) {
-        val match = findAnyMergeableNeighbor(trialAnchor, candidates, absorbedIds, html) ?: break
+        val match = findAnyMergeableNeighbor(
+            trialAnchor,
+            formattingCompatibleCandidates,
+            absorbedIds,
+            html,
+        ) ?: break
         when (match.side) {
             MergeSide.CANDIDATE_BEFORE_ANCHOR -> leftmost = match.neighbor.toMergeAnchor()
             MergeSide.CANDIDATE_AFTER_ANCHOR -> rightmost = match.neighbor.toMergeAnchor()
@@ -267,12 +296,19 @@ internal fun computeOverlapMerge(
     draftSnippet: String,
     draftTextBefore: String,
     candidates: List<Annotation>,
+    draftEmphasisStyles: Set<EmphasisStyle> = emptySet(),
+    emphasisPool: List<Annotation> = emptyList(),
 ): OverlapMergeResult? {
     val draftRange = annotationCharRange(html, draftSnippet, draftTextBefore) ?: return null
     var mergedStart = draftRange.startChar
     var mergedEnd = draftRange.endChar
     val victims = mutableListOf<String>()
-    for (candidate in candidates) {
+    val formattingCompatibleCandidates = highlightsWithEmphasisStyles(
+        candidates = candidates,
+        emphasisPool = emphasisPool,
+        expectedStyles = draftEmphasisStyles,
+    )
+    for (candidate in formattingCompatibleCandidates) {
         val range = annotationCharRange(html, candidate.textSnippet, candidate.textBefore) ?: continue
         if (!charRangesOverlap(draftRange, range)) continue
         victims += candidate.id

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EmphasisMergeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EmphasisMergeTest.kt
@@ -204,4 +204,65 @@ class EmphasisMergeTest {
         assertEquals("first second third", current.textSnippet)
         assertEquals(BOLD, current.emphasisStyles)
     }
+
+    // -------- collectMergedEmphasisStyles (pins the emphasis-carry-forward fix) ---------------
+
+    @Test
+    fun `anchor emphasis at cascade CFI is carried forward to merged result`() {
+        // Regression: before the fix, mergeAdjacentIntoHighlight deleted all emphasis rows then
+        // never called createEmphasis — formatting on the newer annotation was silently lost.
+        val cfi = "epubcfi(/6/2!/4/2,/1:0,/1:5)"
+        val emphasisRow = emphasis(id = "e1", styles = BOLD).copy(cfi = cfi)
+        val result = collectMergedEmphasisStyles(
+            pool = listOf(emphasisRow),
+            cascadeCfis = setOf(cfi),
+        )
+        assertEquals(BOLD, result)
+    }
+
+    @Test
+    fun `absorbed neighbour emphasis is included in merged styles`() {
+        val anchorCfi = "epubcfi(/6/2!/4/2,/1:0,/1:5)"
+        val neighborCfi = "epubcfi(/6/2!/4/4,/1:0,/1:7)"
+        val neighborEmphasis = emphasis(id = "eN", styles = ITALIC).copy(cfi = neighborCfi)
+        val result = collectMergedEmphasisStyles(
+            pool = listOf(neighborEmphasis),
+            cascadeCfis = setOf(anchorCfi, neighborCfi),
+        )
+        assertEquals(ITALIC, result)
+    }
+
+    @Test
+    fun `union of anchor and absorbed emphasis styles is returned`() {
+        val anchorCfi = "epubcfi(/6/2!/4/2,/1:0,/1:5)"
+        val neighborCfi = "epubcfi(/6/2!/4/4,/1:0,/1:7)"
+        val anchorEmphasis = emphasis(id = "eA", styles = BOLD).copy(cfi = anchorCfi)
+        val neighborEmphasis = emphasis(id = "eN", styles = ITALIC).copy(cfi = neighborCfi)
+        val result = collectMergedEmphasisStyles(
+            pool = listOf(anchorEmphasis, neighborEmphasis),
+            cascadeCfis = setOf(anchorCfi, neighborCfi),
+        )
+        assertEquals(setOf(EmphasisStyle.BOLD, EmphasisStyle.ITALIC), result)
+    }
+
+    @Test
+    fun `emphasis at unrelated CFI is not included in merged styles`() {
+        val cascadeCfi = "epubcfi(/6/2!/4/2,/1:0,/1:5)"
+        val unrelatedCfi = "epubcfi(/6/2!/4/99,/1:0,/1:5)"
+        val unrelatedEmphasis = emphasis(id = "eU", styles = BOLD).copy(cfi = unrelatedCfi)
+        val result = collectMergedEmphasisStyles(
+            pool = listOf(unrelatedEmphasis),
+            cascadeCfis = setOf(cascadeCfi),
+        )
+        assertTrue("emphasis at an unrelated CFI must not bleed into the merged result", result.isEmpty())
+    }
+
+    @Test
+    fun `empty pool returns empty styles`() {
+        val result = collectMergedEmphasisStyles(
+            pool = emptyList(),
+            cascadeCfis = setOf("epubcfi(/6/2!/4/2,/1:0,/1:5)"),
+        )
+        assertTrue(result.isEmpty())
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightRangeOverlapTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightRangeOverlapTest.kt
@@ -2,6 +2,7 @@ package com.riffle.app.feature.reader
 
 import com.riffle.core.database.AnnotationEntity
 import com.riffle.core.models.Annotation
+import com.riffle.core.models.EmphasisStyle
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -120,6 +121,59 @@ class HighlightRangeOverlapTest {
         val expectedEnd = bodyText.indexOf("on the page").toLong() + "on the page".length
         assertEquals(expectedStart, result.mergedStart)
         assertEquals(expectedEnd, result.mergedEnd)
+    }
+
+    @Test
+    fun partialOverlap_differentTextFormatting_doesNotMerge() {
+        // Video regression (2026-07-24): annotation A is plain green; annotation B partially
+        // overlaps it and is green + bold. Merging them turns the whole union bold and destroys
+        // the user's two distinct formatting ranges.
+        val plainExisting = annotation(
+            id = "plain-green",
+            textSnippet = "was nothing more than a comma",
+            textBefore = "Apart from that, he ",
+        ).copy(color = "green")
+
+        val result = computeOverlapMerge(
+            html = html,
+            draftSnippet = "nothing more than a comma on the page",
+            draftTextBefore = "he was ",
+            candidates = listOf(plainExisting),
+            draftEmphasisStyles = setOf(EmphasisStyle.BOLD),
+            emphasisPool = emptyList(),
+        )
+
+        assertNull(
+            "plain green and green + bold must remain separate annotations",
+            result,
+        )
+    }
+
+    @Test
+    fun partialOverlap_matchingTextFormatting_stillMerges() {
+        val boldExisting = annotation(
+            id = "bold-green",
+            textSnippet = "was nothing more than a comma",
+            textBefore = "Apart from that, he ",
+        ).copy(color = "green")
+        val boldSibling = boldExisting.copy(
+            id = "emphasis-bold-green",
+            type = AnnotationEntity.TYPE_EMPHASIS,
+            color = "",
+            emphasisStyles = setOf(EmphasisStyle.BOLD),
+        )
+
+        val result = computeOverlapMerge(
+            html = html,
+            draftSnippet = "nothing more than a comma on the page",
+            draftTextBefore = "he was ",
+            candidates = listOf(boldExisting),
+            draftEmphasisStyles = setOf(EmphasisStyle.BOLD),
+            emphasisPool = listOf(boldSibling),
+        )
+
+        assertNotNull("green + bold ranges with matching formatting should still merge", result)
+        assertEquals(listOf("bold-green"), result!!.victimIds)
     }
 
     @Test
@@ -329,6 +383,16 @@ class HighlightRangeOverlapTest {
         updatedAt = 0L,
     )
 
+    private fun emphasisFor(
+        annotation: Annotation,
+        styles: Set<EmphasisStyle>,
+    ) = annotation.copy(
+        id = "emphasis-${annotation.id}",
+        type = AnnotationEntity.TYPE_EMPHASIS,
+        color = "",
+        emphasisStyles = styles,
+    )
+
     @Test
     fun adjacentTouching_singleParagraph_mergedAtCreateTime() {
         // Existing "eight sons." immediately before the new draft "Apart from".
@@ -382,6 +446,66 @@ class HighlightRangeOverlapTest {
             candidates = listOf(existing),
         )
         assertNull(result)
+    }
+
+    @Test
+    fun adjacentSameColor_differentTextFormatting_notMerged() {
+        val plainExisting = adjacentAnnotation(
+            id = "plain-green",
+            textSnippet = "eight sons.",
+            textBefore = "he had ",
+            textAfter = " Apart from that",
+            color = "green",
+        )
+
+        val result = computeAdjacentCreateMerge(
+            html = html,
+            draftSnippet = "Apart from that",
+            draftTextBefore = "eight sons. ",
+            draftTextAfter = ", he was nothing",
+            draftProgression = 0.3,
+            draftSpineIndex = 0,
+            draftChapterHref = "ch1.xhtml",
+            draftColor = "green",
+            draftEmbeddedFigures = null,
+            candidates = listOf(plainExisting),
+            draftEmphasisStyles = setOf(EmphasisStyle.BOLD),
+            emphasisPool = emptyList(),
+        )
+
+        assertNull(
+            "plain green and adjacent green + bold must remain separate annotations",
+            result,
+        )
+    }
+
+    @Test
+    fun adjacentSameColor_matchingTextFormatting_isMerged() {
+        val boldExisting = adjacentAnnotation(
+            id = "bold-green",
+            textSnippet = "eight sons.",
+            textBefore = "he had ",
+            textAfter = " Apart from that",
+            color = "green",
+        )
+
+        val result = computeAdjacentCreateMerge(
+            html = html,
+            draftSnippet = "Apart from that",
+            draftTextBefore = "eight sons. ",
+            draftTextAfter = ", he was nothing",
+            draftProgression = 0.3,
+            draftSpineIndex = 0,
+            draftChapterHref = "ch1.xhtml",
+            draftColor = "green",
+            draftEmbeddedFigures = null,
+            candidates = listOf(boldExisting),
+            draftEmphasisStyles = setOf(EmphasisStyle.BOLD),
+            emphasisPool = listOf(emphasisFor(boldExisting, setOf(EmphasisStyle.BOLD))),
+        )
+
+        assertNotNull("matching green + bold ranges should still auto-merge", result)
+        assertEquals(listOf("bold-green"), result!!.victimIds)
     }
 
     @Test

--- a/docs/adr/0046-emphasis-annotations-as-highlight-sibling.md
+++ b/docs/adr/0046-emphasis-annotations-as-highlight-sibling.md
@@ -53,6 +53,8 @@ Two Emphasis rows auto-merge iff their `styles` sets are **identical** *and* the
 
 Rows with *different* `styles` sets never merge — they stay independent and the renderer unions their styles character-by-character at paint time. Same-range writes edit the existing row (mirror of `highlightOverlapsAtSamePosition` → `emphasisOverlapsAtSamePosition`). Toggling a style off from a *partial* selection of a merged row shrinks the row's range to the un-selected side.
 
+Highlight auto-merge is also gated by the sibling Emphasis set. Two same-colour Highlight rows merge only when their Emphasis sets are identical (including both empty). A plain green range and an overlapping or adjacent green + bold range therefore remain separate edit targets; collapsing them would either discard the bold intent or spread it across the previously plain text.
+
 ### 6. Annotations View — piggyback only, no query change
 
 The Annotations View tab query and empty-state remain `TYPE_HIGHLIGHT`-only. Standalone Emphasis does *not* surface a book in the tab. But an Emphasis row whose CFI range overlaps a rendered highlight snippet is applied to that snippet's text in the elided reader (bold, italic, underline, strike as stored), so the "editor's" marks on top of "collector's" marks flow through automatically.


### PR DESCRIPTION
## Summary
- treat sibling emphasis styles as part of highlight merge identity
- preserve matching emphasis siblings when edit-time merges replace source annotations
- document the formatting-aware merge invariant in ADR 0046

## Regression coverage
- overlap and adjacency tests assert differently formatted highlights remain separate
- matching-format tests assert existing merge behavior is preserved
- an instrumentation harness uses the real annotation store and bundled EPUB to assert two highlights and one bold emphasis survive the recorded scenario

## Validation
- full app JVM unit suite passed
- focused instrumentation harness passed 1/1 on a newly created Android 7.1.1 phone AVD