### PR TITLE
fix(reader): preserve line breaks in annotation merges

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -2418,10 +2418,12 @@ class EpubReaderViewModel @Inject constructor(
             logger.d(LogChannel.HighlightMerge) { "edit-merge FAIL id=$id reason=dom-text-empty startChar=$startChar endChar=$endChar" }
             return
         }
-        // Safety: our composed snippet and the DOM text must agree modulo whitespace normalisation.
-        // If they diverge, the adjacency check false-matched (probably a suffix-of-context
-        // coincidence) — abort rather than commit a broken merge.
-        if (!snippetsAgreeIgnoringWhitespace(domSnippet, trialAnchor.textSnippet)) {
+        // Safety: our composed snippet and the DOM text must agree modulo whitespace. On success,
+        // retain the composed Readium TextQuote rather than the flattened DOM text: paragraph and
+        // <br> boundaries have zero width in the readable-char model, but their captured newline
+        // is required for the merged decoration to resolve in all three reader modes.
+        val mergedSnippet = validatedMergedSnippet(domSnippet, trialAnchor.textSnippet)
+        if (mergedSnippet == null) {
             logger.d(LogChannel.HighlightMerge) {
                 "edit-merge FAIL id=$id reason=dom-mismatch " +
                     "dom='${domSnippet.take(60)}' composed='${trialAnchor.textSnippet.take(60)}'"
@@ -2480,7 +2482,7 @@ class EpubReaderViewModel @Inject constructor(
             sourceId = sourceId,
             itemId = itemId,
             cfi = cfiRange,
-            textSnippet = domSnippet,
+            textSnippet = mergedSnippet,
             chapterHref = trialAnchor.chapterHref,
             textBefore = trialAnchor.textBefore,
             textAfter = trialAnchor.textAfter,
@@ -2495,7 +2497,7 @@ class EpubReaderViewModel @Inject constructor(
                 sourceId = sourceId,
                 itemId = itemId,
                 cfi = cfiRange,
-                textSnippet = domSnippet,
+                textSnippet = mergedSnippet,
                 chapterHref = trialAnchor.chapterHref,
                 textBefore = trialAnchor.textBefore,
                 textAfter = trialAnchor.textAfter,
@@ -2509,7 +2511,7 @@ class EpubReaderViewModel @Inject constructor(
             "edit-merge done anchorReplaced=$id newId=${created.id} absorbedText=${toAbsorb.size} " +
                 "figures=${mergedEmbeddedFigures?.size ?: 0} " +
                 "emphasisStyles=$mergedEmphasisStyles " +
-                "domLen=${domSnippet.length} startChar=$startChar"
+                "snippetLen=${mergedSnippet.length} startChar=$startChar"
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightMerge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightMerge.kt
@@ -192,6 +192,26 @@ internal fun snippetsAgreeIgnoringWhitespace(a: String, b: String): Boolean {
     return na.equals(nb, ignoreCase = true)
 }
 
+/**
+ * Select the merged snippet that should be persisted after [domSnippet] has validated the merge.
+ *
+ * The readable-char DOM model deliberately drops blank-only nodes and gives block boundaries /
+ * `<br>` elements zero width. [composedSnippet], however, is assembled from the two Readium
+ * TextQuotes and their captured adjacency whitespace, so it retains the newline that makes a
+ * cross-line quote renderable. Persisting [domSnippet] would turn `"first\nsecond"` into
+ * `"firstsecond"`: the annotation row survives, but neither Readium nor continuous mode can
+ * resolve the merged visual range.
+ *
+ * Returns null when the non-whitespace content differs, preserving the existing false-match
+ * safety gate.
+ */
+internal fun validatedMergedSnippet(
+    domSnippet: String,
+    composedSnippet: String,
+): String? = composedSnippet.takeIf {
+    snippetsAgreeIgnoringWhitespace(domSnippet, composedSnippet)
+}
+
 /** Collapse every run of whitespace (any Unicode WS) to a single ASCII space. */
 private fun normaliseWs(s: String): String {
     val out = StringBuilder(s.length)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRangeOverlap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRangeOverlap.kt
@@ -250,7 +250,10 @@ internal fun computeAdjacentCreateMerge(
     val endChar = snippetEndCharInBody(html, rightmostStart, rightmost.textSnippet).coerceAtMost(totalChars)
     if (endChar <= startChar) return null
     val domSnippet = readableTextBetween(html, startChar, endChar) ?: return null
-    if (!snippetsAgreeIgnoringWhitespace(domSnippet, trialAnchor.textSnippet)) return null
+    // Use the DOM text to validate the assembled range, but persist the Readium-composed quote.
+    // The readable-char model drops paragraph / <br> boundaries; the composed quote retains the
+    // newline that every reader mode needs to resolve and paint a cross-line annotation.
+    val mergedSnippet = validatedMergedSnippet(domSnippet, trialAnchor.textSnippet) ?: return null
     val spineStep = (draftSpineIndex + 1) * 2
     val cfiRange = buildHighlightCfiRange(spineStep, html, startChar, endChar - 1L) ?: return null
     val body = readableBodyText(html)
@@ -281,7 +284,7 @@ internal fun computeAdjacentCreateMerge(
     return AdjacentCreateMerge(
         fields = MergedDraftFields(
             cfiRange = cfiRange,
-            textSnippet = domSnippet,
+            textSnippet = mergedSnippet,
             textBefore = textBefore,
             textAfter = textAfter,
             progression = progression,

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightMergeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightMergeTest.kt
@@ -316,6 +316,30 @@ class HighlightMergeTest {
         assertTrue(isMergeEligible(a, n))
     }
 
+    @Test
+    fun `validated merged snippet retains Readium line break omitted by readable DOM text`() {
+        val merged = validatedMergedSnippet(
+            domSnippet = "end of first lineStart of second line",
+            composedSnippet = "end of first line\nStart of second line",
+        )
+
+        assertEquals(
+            "the persisted TextQuote must retain the boundary used by every renderer",
+            "end of first line\nStart of second line",
+            merged,
+        )
+    }
+
+    @Test
+    fun `validated merged snippet rejects different readable content`() {
+        assertNull(
+            validatedMergedSnippet(
+                domSnippet = "end of first lineDifferent text",
+                composedSnippet = "end of first line\nStart of second line",
+            ),
+        )
+    }
+
     // -------- Cross-figure merge (revised 2026-07-10): reject when a figure sits between --------
 
     /**

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightRangeOverlapTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/HighlightRangeOverlapTest.kt
@@ -542,6 +542,10 @@ class HighlightRangeOverlapTest {
             "merged snippet must contain para-2 text",
             snippet.contains("paragraph two"),
         )
+        assertEquals(
+            "first sentence in paragraph one.\nThe second sentence in paragraph two.",
+            snippet,
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

- preserve the Readium-captured line-break whitespace when adjacent annotations merge
- keep DOM-derived text as the merge validation and CFI range source
- apply the preserved quote to recreated highlight and emphasis rows across all reader modes
- add regression coverage for cross-paragraph create-time merges and false-match rejection

## Tests

- `:app:testDebugUnitTest --tests com.riffle.app.feature.reader.HighlightMergeTest`
- `:app:testDebugUnitTest --tests com.riffle.app.feature.reader.HighlightRangeOverlapTest`
- `:app:testDebugUnitTest --tests com.riffle.app.feature.reader.EpubCfiRangeTest`
- `:app:testDebugUnitTest --tests com.riffle.app.feature.reader.ContinuousStyleInjectorTest`