### PR TITLE
fix(reader): restore annotation note glyph rendering

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2416,11 +2416,10 @@ private fun EpubNavigatorView(
     // worth applying to as soon as the ref is non-null — a slot the highlightRenderer key
     // alone doesn't cover.)
     LaunchedEffect(highlightRenderer, highlightRenders, reflowGeneration, pageLoadGeneration.value, activeFragmentRef?.substringBefore('#')) {
-        highlightRenderer.applyAnnotations(highlightRenders)
-    }
-
-    LaunchedEffect(highlightRenderer, highlightRenders, reflowGeneration, pageLoadGeneration.value) {
-        highlightRenderer.applyNoteGlyphs(highlightRenders)
+        // Readium's annotation pass may mutate/reflow the DOM for bold/italic emphasis. Keep the
+        // note-glyph pass in this same coroutine so it measures only the final DOM; separate
+        // effects race and can strand the glyph at stale, off-page bounds.
+        renderPersistedAnnotations(highlightRenderer, highlightRenders)
     }
 
     // ---- Figure borders (Task 8) ------------------------------------------------------------

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightRenderer.kt
@@ -78,3 +78,21 @@ internal interface HighlightRenderer {
      */
     fun highlightSearchMatch(href: String, text: String)
 }
+
+/**
+ * Applies persisted annotation rendering in DOM-safe order.
+ *
+ * Paginated/vertical [ReadiumHighlightRenderer.applyAnnotations] mutates the chapter DOM for
+ * bold/italic emphasis before Readium measures annotation decorations. Note glyphs must be
+ * measured only after that mutation finishes; launching the two passes independently lets the
+ * glyph pass race ahead and retain pre-reflow bounds. Continuous mode keeps the same ordering even
+ * though its [HighlightRenderer.applyNoteGlyphs] implementation is a no-op because glyphs are
+ * emitted as part of [HighlightRenderer.applyAnnotations].
+ */
+internal suspend fun renderPersistedAnnotations(
+    renderer: HighlightRenderer,
+    renders: List<EpubReaderViewModel.HighlightRender>,
+) {
+    renderer.applyAnnotations(renders)
+    renderer.applyNoteGlyphs(renders)
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/PersistedAnnotationRenderingTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/PersistedAnnotationRenderingTest.kt
@@ -1,0 +1,78 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.SentenceQuote
+import com.riffle.core.models.HighlightColor
+import java.io.File
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.readium.r2.shared.publication.Locator
+
+class PersistedAnnotationRenderingTest {
+
+    @Test
+    fun `note glyphs are applied after annotation DOM mutation and decoration measurement`() = runTest {
+        val calls = mutableListOf<String>()
+        val renderer = RecordingHighlightRenderer(calls)
+
+        renderPersistedAnnotations(renderer, emptyList())
+
+        assertEquals(listOf("annotations", "note-glyphs"), calls)
+    }
+
+    @Test
+    fun `screen owns one persisted annotation effect so render passes cannot race`() {
+        val source = locateScreenSource().readText()
+        val block = source.substringAfter("// ---- Persisted highlights (annotations + note glyphs)")
+            .substringBefore("// ---- Figure borders")
+
+        assertEquals(
+            "persisted highlights and note glyphs must share one Compose effect",
+            1,
+            Regex("""(?m)^\s*LaunchedEffect\(""").findAll(block).count(),
+        )
+        assertTrue(
+            "the shared effect must use the ordered rendering seam",
+            block.contains("renderPersistedAnnotations(highlightRenderer, highlightRenders)"),
+        )
+        assertFalse(
+            "the screen must not launch the note-glyph pass independently",
+            block.contains("highlightRenderer.applyNoteGlyphs(highlightRenders)"),
+        )
+    }
+
+    private fun locateScreenSource(): File =
+        sequenceOf(
+            File("src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt"),
+            File("app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt"),
+        ).firstOrNull(File::exists)
+            ?: error("EpubReaderScreen.kt not found from ${File(".").absolutePath}")
+
+    private class RecordingHighlightRenderer(
+        private val calls: MutableList<String>,
+    ) : HighlightRenderer {
+        override suspend fun applySentenceHighlight(
+            fragmentRef: String?,
+            quotes: Map<String, SentenceQuote>,
+            color: HighlightColor,
+        ) = Unit
+
+        override suspend fun applyAnnotations(
+            renders: List<EpubReaderViewModel.HighlightRender>,
+        ) {
+            calls += "annotations"
+        }
+
+        override suspend fun applyNoteGlyphs(
+            renders: List<EpubReaderViewModel.HighlightRender>,
+        ) {
+            calls += "note-glyphs"
+        }
+
+        override suspend fun applySearch(results: List<Locator>, activeIndex: Int) = Unit
+
+        override fun highlightSearchMatch(href: String, text: String) = Unit
+    }
+}


### PR DESCRIPTION
## Summary

- serialize persisted annotation rendering so annotation styling finishes before note glyph measurement
- keep continuous mode on the same ordered rendering seam
- guard the ordering and single-effect orchestration with regression tests

## Root cause

Paginated and vertical modes launched annotation styling and note glyph rendering in independent effects. Bold or italic DOM mutation could therefore race glyph measurement, leaving glyphs positioned from stale bounds and effectively invisible.

## Tests

- PersistedAnnotationRenderingTest asserts the exact call order annotations then note-glyphs; reverting the ordering makes this assertion fail.
- PersistedAnnotationRenderingTest asserts the persisted annotation block owns exactly one LaunchedEffect and delegates through the shared helper; splitting glyph rendering back into an independent effect makes this assertion fail.
- Targeted JVM renderer suites passed locally before finalization: PersistedAnnotationRenderingTest, ReadiumHighlightRendererTest, ContinuousHighlightRendererTest, and NoteGlyphDecorationTest.
- Full build, unit, integration, database, and phone/tablet harness validation runs in CI.