### PR TITLE
feat(update): show release dates

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/update/ChangelogScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/update/ChangelogScreen.kt
@@ -127,6 +127,7 @@ private fun ReleaseEntry(release: ReleaseInfo) {
                 style = MaterialTheme.typography.titleSmall,
             )
         }
+        ReleaseDateText(release.publishedAt)
         Spacer(modifier = Modifier.height(4.dp))
         Text(
             text = release.changelog.ifBlank { "No release notes." },

--- a/app/src/main/kotlin/com/riffle/app/feature/update/ReleaseDate.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/update/ReleaseDate.kt
@@ -1,0 +1,40 @@
+package com.riffle.app.feature.update
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
+
+internal fun releaseDateLabel(
+    publishedAt: String,
+    locale: Locale = Locale.getDefault(),
+    zoneId: ZoneId = ZoneId.systemDefault(),
+): String? {
+    if (publishedAt.isBlank()) return null
+    return runCatching {
+        val date = Instant.parse(publishedAt).atZone(zoneId).toLocalDate()
+        DateTimeFormatter
+            .ofLocalizedDate(FormatStyle.MEDIUM)
+            .withLocale(locale)
+            .format(date)
+    }.getOrNull()
+}
+
+@Composable
+internal fun ReleaseDateText(
+    publishedAt: String,
+    color: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+) {
+    releaseDateLabel(publishedAt)?.let { label ->
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium,
+            color = color,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/update/UpdateAvailableDialog.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/update/UpdateAvailableDialog.kt
@@ -49,6 +49,7 @@ internal fun UpdateAvailableDialog(
                             text = "v${release.versionName}",
                             style = MaterialTheme.typography.titleSmall,
                         )
+                        ReleaseDateText(release.publishedAt)
                         Spacer(modifier = Modifier.height(4.dp))
                         Text(
                             text = release.changelog.ifBlank { "No release notes." },

--- a/app/src/test/kotlin/com/riffle/app/feature/update/ReleaseDateTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/update/ReleaseDateTest.kt
@@ -1,0 +1,40 @@
+package com.riffle.app.feature.update
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.ZoneOffset
+import java.util.Locale
+
+class ReleaseDateTest {
+
+    @Test
+    fun `release date label formats the GitHub timestamp as a localized date`() {
+        assertEquals(
+            "Jul 28, 2026",
+            releaseDateLabel(
+                publishedAt = "2026-07-28T21:14:00Z",
+                locale = Locale.US,
+                zoneId = ZoneOffset.UTC,
+            ),
+        )
+    }
+
+    @Test
+    fun `release date label uses the device time zone`() {
+        assertEquals(
+            "Jul 29, 2026",
+            releaseDateLabel(
+                publishedAt = "2026-07-28T23:30:00Z",
+                locale = Locale.US,
+                zoneId = ZoneOffset.ofHours(2),
+            ),
+        )
+    }
+
+    @Test
+    fun `release date label is omitted when the timestamp is absent or malformed`() {
+        assertNull(releaseDateLabel(""))
+        assertNull(releaseDateLabel("not-a-timestamp"))
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/AppUpdateRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AppUpdateRepositoryImpl.kt
@@ -97,6 +97,7 @@ class AppUpdateRepositoryImpl @Inject constructor(
                     downloadUrl = release.apkUrl,
                     sizeBytes = release.apkSizeBytes,
                     releaseUrl = release.htmlUrl,
+                    publishedAt = release.publishedAt,
                 )
             }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/AppUpdateRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AppUpdateRepositoryImplTest.kt
@@ -118,13 +118,26 @@ class AppUpdateRepositoryImplTest {
 
     // --- listReleasesSince ---
 
-    private fun release(tag: String, body: String = "", apkUrl: String = "https://x/$tag.apk", size: Long = 1000L, htmlUrl: String = "https://github.com/pkmetski/riffle/releases/tag/$tag") =
-        GitHubRelease(tagName = tag, apkUrl = apkUrl, apkSizeBytes = size, body = body, htmlUrl = htmlUrl)
+    private fun release(
+        tag: String,
+        body: String = "",
+        apkUrl: String = "https://x/$tag.apk",
+        size: Long = 1000L,
+        htmlUrl: String = "https://github.com/pkmetski/riffle/releases/tag/$tag",
+        publishedAt: String = "",
+    ) = GitHubRelease(
+        tagName = tag,
+        apkUrl = apkUrl,
+        apkSizeBytes = size,
+        body = body,
+        htmlUrl = htmlUrl,
+        publishedAt = publishedAt,
+    )
 
     @Test
     fun `listReleasesSince returns only releases newer than sinceVersionCode`() {
         val releases = listOf(
-            release("v1.6.0", "Notes 1.6"),
+            release("v1.6.0", "Notes 1.6", publishedAt = "2026-07-28T21:14:00Z"),
             release("v1.5.0", "Notes 1.5"),
             release("v1.4.0", "Notes 1.4"),
         )
@@ -138,6 +151,7 @@ class AppUpdateRepositoryImplTest {
         assertEquals("https://x/v1.6.0.apk", result[0].downloadUrl)
         assertEquals(1000L, result[0].sizeBytes)
         assertEquals("https://github.com/pkmetski/riffle/releases/tag/v1.6.0", result[0].releaseUrl)
+        assertEquals("2026-07-28T21:14:00Z", result[0].publishedAt)
     }
 
     @Test

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/ReleaseInfo.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/ReleaseInfo.kt
@@ -7,4 +7,5 @@ data class ReleaseInfo(
     val downloadUrl: String,
     val sizeBytes: Long,
     val releaseUrl: String = "",
+    val publishedAt: String = "",
 )

--- a/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
@@ -55,6 +55,7 @@ class GitHubReleaseApi(
                         apkUrl = apk.downloadUrl,
                         apkSizeBytes = apk.size,
                         htmlUrl = release.htmlUrl,
+                        publishedAt = release.publishedAt,
                     )
                 )
             }
@@ -87,6 +88,7 @@ class GitHubReleaseApi(
                         apkSizeBytes = apk?.size ?: 0L,
                         body = release.body,
                         htmlUrl = release.htmlUrl,
+                        publishedAt = release.publishedAt,
                     )
                 }
         } catch (e: IOException) {
@@ -154,6 +156,7 @@ data class GitHubRelease(
     val apkSizeBytes: Long,
     val body: String = "",
     val htmlUrl: String = "",
+    val publishedAt: String = "",
 )
 
 @Serializable
@@ -164,6 +167,7 @@ private data class ReleaseResponse(
     val assets: List<AssetResponse> = emptyList(),
     val body: String = "",
     @SerialName("html_url") val htmlUrl: String = "",
+    @SerialName("published_at") val publishedAt: String = "",
 )
 
 @Serializable

--- a/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
@@ -55,7 +55,7 @@ class GitHubReleaseApi(
                         apkUrl = apk.downloadUrl,
                         apkSizeBytes = apk.size,
                         htmlUrl = release.htmlUrl,
-                        publishedAt = release.publishedAt,
+                        publishedAt = release.publishedAt.orEmpty(),
                     )
                 )
             }
@@ -88,7 +88,7 @@ class GitHubReleaseApi(
                         apkSizeBytes = apk?.size ?: 0L,
                         body = release.body,
                         htmlUrl = release.htmlUrl,
-                        publishedAt = release.publishedAt,
+                        publishedAt = release.publishedAt.orEmpty(),
                     )
                 }
         } catch (e: IOException) {
@@ -167,7 +167,7 @@ private data class ReleaseResponse(
     val assets: List<AssetResponse> = emptyList(),
     val body: String = "",
     @SerialName("html_url") val htmlUrl: String = "",
-    @SerialName("published_at") val publishedAt: String = "",
+    @SerialName("published_at") val publishedAt: String? = null,
 )
 
 @Serializable

--- a/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
@@ -268,7 +268,7 @@ class GitHubReleaseApiTest {
                     "assets": [{ "name": "riffle-1.5.0-rc1.apk", "browser_download_url": "https://x/rc.apk", "size": 1 }] },
                   { "tag_name": "v1.5.0", "draft": false, "prerelease": false, "body": "### Fixes\n- Bug fix",
                     "assets": [{ "name": "riffle-1.5.0.apk", "browser_download_url": "https://x/1.5.0.apk", "size": 4200 }] },
-                  { "tag_name": "v1.4.0-draft", "draft": true, "prerelease": false, "body": "Draft",
+                  { "tag_name": "v1.4.0-draft", "draft": true, "prerelease": false, "body": "Draft", "published_at": null,
                     "assets": [] }
                 ]
                 """.trimIndent()

--- a/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
@@ -262,6 +262,7 @@ class GitHubReleaseApiTest {
                 """
                 [
                   { "tag_name": "v1.6.0", "draft": false, "prerelease": false, "body": "### What's new\n- Feature A",
+                    "published_at": "2026-07-28T21:14:00Z",
                     "assets": [{ "name": "riffle-1.6.0.apk", "browser_download_url": "https://x/1.6.0.apk", "size": 5000 }] },
                   { "tag_name": "v1.5.0-rc1", "draft": false, "prerelease": true, "body": "RC notes",
                     "assets": [{ "name": "riffle-1.5.0-rc1.apk", "browser_download_url": "https://x/rc.apk", "size": 1 }] },
@@ -281,6 +282,7 @@ class GitHubReleaseApiTest {
         assertEquals("### What's new\n- Feature A", releases[0].body)
         assertEquals("https://x/1.6.0.apk", releases[0].apkUrl)
         assertEquals(5000L, releases[0].apkSizeBytes)
+        assertEquals("2026-07-28T21:14:00Z", releases[0].publishedAt)
         assertEquals("v1.5.0", releases[1].tagName)
         assertEquals("### Fixes\n- Bug fix", releases[1].body)
     }


### PR DESCRIPTION
## Summary

- preserve GitHub release publication timestamps through the update data flow
- show a localized bare date beneath each version in release history and the update modal
- omit missing or malformed timestamps and safely accept nullable GitHub timestamps

## Tests

- `./gradlew :core:network:test --tests com.riffle.core.network.GitHubReleaseApiTest`
- `./gradlew :core:data:testDebugUnitTest --tests com.riffle.core.data.AppUpdateRepositoryImplTest :app:testDebugUnitTest --tests com.riffle.app.feature.update.ReleaseDateTest --tests com.riffle.app.feature.update.ChangelogViewModelTest --tests com.riffle.app.feature.update.StartupUpdateViewModelTest`