### PR TITLE
feat(library): show series positions on detail covers

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/library/SeriesDetailGridTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/library/SeriesDetailGridTest.kt
@@ -1,0 +1,47 @@
+package com.riffle.app.feature.library
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.riffle.core.models.EbookFormat
+import com.riffle.core.models.LibraryItem
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SeriesDetailGridTest {
+
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun coverShowsCompactSeriesPositionBadge() {
+        rule.setContent {
+            SeriesDetailGrid(
+                items = listOf(item(seriesName = "The Expanse #4")),
+                token = "",
+                onItemSelected = {},
+            )
+        }
+
+        rule.onNodeWithText("#4")
+            .assertTextEquals("#4")
+            .assertIsDisplayed()
+    }
+
+    private fun item(seriesName: String) = LibraryItem(
+        id = "book-4",
+        libraryId = "library-1",
+        title = "Cibola Burn",
+        author = "James S. A. Corey",
+        coverUrl = null,
+        readingProgress = 0f,
+        isCached = false,
+        isDownloaded = false,
+        ebookFormat = EbookFormat.Epub,
+        seriesName = seriesName,
+    )
+}

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/library/SeriesDetailGridTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/library/SeriesDetailGridTest.kt
@@ -1,7 +1,6 @@
 package com.riffle.app.feature.library
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -27,9 +26,7 @@ class SeriesDetailGridTest {
             )
         }
 
-        rule.onNodeWithText("#4")
-            .assertTextEquals("#4")
-            .assertIsDisplayed()
+        rule.onNodeWithText("#4").assertIsDisplayed()
     }
 
     private fun item(seriesName: String) = LibraryItem(

--- a/app/src/main/kotlin/com/riffle/app/feature/library/SeriesDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/SeriesDetailScreen.kt
@@ -68,11 +68,29 @@ fun SeriesDetailScreen(
                 ) {
                     items(items, key = { it.id }) { item ->
                         Box(modifier = Modifier.padding(4.dp)) {
-                            BookCoverTile(item = item, token = viewModel.authToken, onClick = { onItemSelected(item) })
+                            BookCoverTile(
+                                item = item,
+                                token = viewModel.authToken,
+                                onClick = { onItemSelected(item) },
+                                seriesNameBadge = seriesPositionBadge(item.seriesName),
+                            )
                         }
                     }
                 }
             }
         }
     }
+}
+
+/**
+ * [LibraryItem.seriesName] includes its sequence as a `#` suffix when the source provides one.
+ * A series detail screen already names the series in its app bar, so only the position belongs on
+ * each cover.
+ */
+internal fun seriesPositionBadge(seriesName: String?): String? {
+    val sequence = seriesName
+        ?.substringAfterLast(" #", missingDelimiterValue = "")
+        ?.trim()
+        .orEmpty()
+    return sequence.takeIf { it.isNotEmpty() }?.let { "#$it" }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/SeriesDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/SeriesDetailScreen.kt
@@ -21,8 +21,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.riffle.core.models.LibraryItem
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -56,27 +58,44 @@ fun SeriesDetailScreen(
                     Text("No books in this series")
                 }
             } else {
-                LazyVerticalGrid(
-                    columns = GridCells.Adaptive(coverGridMinCellSize()),
-                    contentPadding = PaddingValues(
-                        start = 12.dp,
-                        end = 12.dp,
-                        top = 8.dp,
-                        bottom = padding.calculateBottomPadding() + 16.dp,
-                    ),
+                SeriesDetailGrid(
+                    items = items,
+                    token = viewModel.authToken,
+                    bottomPadding = padding.calculateBottomPadding(),
+                    onItemSelected = onItemSelected,
                     modifier = Modifier.fillMaxSize(),
-                ) {
-                    items(items, key = { it.id }) { item ->
-                        Box(modifier = Modifier.padding(4.dp)) {
-                            BookCoverTile(
-                                item = item,
-                                token = viewModel.authToken,
-                                onClick = { onItemSelected(item) },
-                                seriesNameBadge = seriesPositionBadge(item.seriesName),
-                            )
-                        }
-                    }
-                }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun SeriesDetailGrid(
+    items: List<LibraryItem>,
+    token: String,
+    bottomPadding: Dp = 0.dp,
+    onItemSelected: (LibraryItem) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(coverGridMinCellSize()),
+        contentPadding = PaddingValues(
+            start = 12.dp,
+            end = 12.dp,
+            top = 8.dp,
+            bottom = bottomPadding + 16.dp,
+        ),
+        modifier = modifier,
+    ) {
+        items(items, key = { it.id }) { item ->
+            Box(modifier = Modifier.padding(4.dp)) {
+                BookCoverTile(
+                    item = item,
+                    token = token,
+                    onClick = { onItemSelected(item) },
+                    seriesNameBadge = seriesPositionBadge(item.seriesName),
+                )
             }
         }
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/SeriesPositionBadgeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/SeriesPositionBadgeTest.kt
@@ -1,0 +1,19 @@
+package com.riffle.app.feature.library
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SeriesPositionBadgeTest {
+
+    @Test
+    fun `series detail shows only the series position`() {
+        assertEquals("#4", seriesPositionBadge("The Expanse #4"))
+        assertEquals("#2.5", seriesPositionBadge("The Expanse #2.5"))
+    }
+
+    @Test
+    fun `series detail omits badge when the item has no position`() {
+        assertEquals(null, seriesPositionBadge("The Expanse"))
+        assertEquals(null, seriesPositionBadge(null))
+    }
+}


### PR DESCRIPTION
## Summary

- overlay compact series positions such as `#4` on covers in the series detail grid
- reuse the existing Continue Series cover badge styling
- omit the badge when a source does not provide a series position

## Tests

- `:app:testDebugUnitTest --tests com.riffle.app.feature.library.SeriesDetailViewModelTest --tests com.riffle.app.feature.library.SeriesPositionBadgeTest`
- `:app:compileDebugAndroidTestKotlin`
- render regression: `SeriesDetailGridTest.coverShowsCompactSeriesPositionBadge`