### PR TITLE
fix(reader): clarify notes in elided view

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/highlights/ElidedNoteCalloutWebViewTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/highlights/ElidedNoteCalloutWebViewTest.kt
@@ -1,0 +1,143 @@
+package com.riffle.app.feature.reader.highlights
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.riffle.app.feature.reader.evalSync
+import com.riffle.app.feature.reader.withSizedWebViewFixture
+import com.riffle.app.feature.reader.withWebViewFixture
+import com.riffle.core.database.AnnotationEntity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Real-WebView coverage for the elided reader's note callout.
+ *
+ * The synthesised chapter HTML is shared by paginated, vertical, and continuous modes, so loading
+ * that production HTML in the API-25 harness WebView verifies the CSS engine used by all three.
+ */
+@RunWith(AndroidJUnit4::class)
+class ElidedNoteCalloutWebViewTest {
+
+    private val factory = HighlightsPublicationFactory()
+
+    @Test
+    fun initialNoteIsLabelledAndVisuallyCloserToItsOwnerThanTheNextHighlight() {
+        val html = factory.renderChapterHtml(
+            ChapterElision(
+                href = "chapter.xhtml",
+                title = "Chapter",
+                highlights = listOf(
+                    highlight("owner", "Owning highlight", note = "My note"),
+                    highlight("next", "Next highlight"),
+                ),
+            ),
+        )
+
+        withSizedWebViewFixture(html, widthPx = 1080, heightPx = 1600) { webView ->
+            assertEquals(
+                ELIDED_NOTE_LABEL,
+                webView.evalSync(
+                    "getComputedStyle(document.querySelector('.riffle-note'),'::before')" +
+                        ".content.replace(/[\\\"']/g,'')",
+                ).trim('"'),
+            )
+            assertEquals(
+                "note",
+                webView.evalSync("document.querySelector('.riffle-note').getAttribute('role')").trim('"'),
+            )
+            assertEquals(
+                ELIDED_NOTE_ARIA_LABEL,
+                webView.evalSync(
+                    "document.querySelector('.riffle-note').getAttribute('aria-label')",
+                ).trim('"'),
+            )
+            assertEquals(
+                "normal",
+                webView.evalSync(
+                    "getComputedStyle(document.querySelector('.riffle-note')).fontStyle",
+                ).trim('"'),
+            )
+            assertTrue(
+                "callout must retain a visible neutral surface on the real WebView",
+                webView.evalSync(
+                    "getComputedStyle(document.querySelector('.riffle-note')).backgroundColor",
+                ).trim('"').startsWith("rgba(127, 127, 127,"),
+            )
+
+            val ownerGap = webView.evalSync(
+                "(function(){var n=document.querySelector('.riffle-note').getBoundingClientRect();" +
+                    "var p=document.querySelector('[data-ann-id=\"owner\"]').closest('p')" +
+                    ".getBoundingClientRect();return n.top-p.bottom;})()",
+            ).trim('"').toDouble()
+            val nextGap = webView.evalSync(
+                "(function(){var n=document.querySelector('.riffle-note').getBoundingClientRect();" +
+                    "var p=document.querySelector('[data-ann-id=\"next\"]').closest('p')" +
+                    ".getBoundingClientRect();return p.top-n.bottom;})()",
+            ).trim('"').toDouble()
+            assertTrue(
+                "note must sit closer to its owner ($ownerGap px) than to the next highlight ($nextGap px)",
+                ownerGap < nextGap,
+            )
+        }
+    }
+
+    @Test
+    fun liveAddedNoteReceivesTheSameLabelAndSemantics() {
+        val html = factory.renderChapterHtml(
+            ChapterElision(
+                href = "chapter.xhtml",
+                title = "Chapter",
+                highlights = listOf(highlight("owner", "Owning highlight")),
+            ),
+        )
+
+        withWebViewFixture(html) { webView ->
+            webView.evalSync(
+                HighlightsDomPatch.SetNote(
+                    annotationId = "owner",
+                    accentCssRgba = "rgba(255,193,0,1)",
+                    noteText = "Added live",
+                ).applyJs(),
+            )
+            assertEquals(
+                "Added live",
+                webView.evalSync("document.querySelector('.riffle-note').textContent").trim('"'),
+            )
+            assertEquals(
+                ELIDED_NOTE_LABEL,
+                webView.evalSync(
+                    "getComputedStyle(document.querySelector('.riffle-note'),'::before')" +
+                        ".content.replace(/[\\\"']/g,'')",
+                ).trim('"'),
+            )
+            assertEquals(
+                "note",
+                webView.evalSync("document.querySelector('.riffle-note').getAttribute('role')").trim('"'),
+            )
+            assertEquals(
+                ELIDED_NOTE_ARIA_LABEL,
+                webView.evalSync(
+                    "document.querySelector('.riffle-note').getAttribute('aria-label')",
+                ).trim('"'),
+            )
+        }
+    }
+
+    private fun highlight(id: String, text: String, note: String? = null) =
+        AnnotationEntity(
+            id = id,
+            sourceId = "source",
+            itemId = "item",
+            type = AnnotationEntity.TYPE_HIGHLIGHT,
+            cfi = "epubcfi(/6/2!/4/2/1:0)",
+            color = AnnotationEntity.COLOR_YELLOW,
+            note = note,
+            textSnippet = text,
+            chapterHref = "chapter.xhtml",
+            createdAt = 0L,
+            updatedAt = 0L,
+            originDeviceId = "test",
+            lastModifiedByDeviceId = "test",
+        )
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatch.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatch.kt
@@ -127,9 +127,10 @@ internal fun buildSetNoteJs(annotationId: String, accentCssRgba: String, noteTex
         |    aside = document.createElement('aside');
         |    aside.setAttribute('class', 'riffle-note');
         |    aside.setAttribute('data-ann-id', id);
+        |    aside.setAttribute('role', 'note');
+        |    aside.setAttribute('aria-label', '$ELIDED_NOTE_ARIA_LABEL');
         |    aside.setAttribute('style',
-        |      'border-left: 2px solid ' + color + ' !important; padding-left: 12px; ' +
-        |      'font-style: italic; opacity: 0.75;');
+        |      'border-left: 2px solid ' + color + ' !important;');
         |    anchorHost.parentNode.insertBefore(aside, anchorHost.nextSibling);
         |  } else {
         |    aside.style.setProperty('border-left-color', color, 'important');

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -330,6 +330,7 @@ class HighlightsPublicationFactory @Inject constructor() {
             |<html xmlns="http://www.w3.org/1999/xhtml"><head><title>$title</title>$READIUM_DEFAULT_CSS_LINK<style>$publisherFontFaceCss
             |$ACCENT_BAR_TAP_CSS
             |$FIGURE_CENTERING_CSS
+            |$NOTE_CALLOUT_CSS
             |$bodyFontStyleBlock</style></head>
             |<body>
             |  <h1>$title</h1>
@@ -372,6 +373,28 @@ internal const val ACCENT_BAR_TAP_CSS =
 internal const val FIGURE_CENTERING_CSS =
     ".riffle-fig{margin:1em auto !important;text-align:center;position:relative;}" +
         ".riffle-fig>img,.riffle-fig>svg{display:block;margin:0 auto;max-width:100%;height:auto;}"
+
+internal const val ELIDED_NOTE_LABEL = "Note"
+internal const val ELIDED_NOTE_ARIA_LABEL = "Note on this highlight"
+
+/**
+ * Makes an inline note unmistakable and visually attaches it to the highlighted excerpt above.
+ *
+ * The negative top margin cancels part of the excerpt's bottom margin, while the 16px left inset
+ * nests the callout under the excerpt text rather than presenting it as another peer annotation.
+ * A neutral translucent surface works across every reader theme; the owning highlight's palette
+ * colour remains on the inline border. The visible label is pseudo-content so live DOM patches can
+ * continue updating the aside safely through `textContent` without destroying nested markup.
+ */
+internal const val NOTE_CALLOUT_CSS =
+    ".riffle-note{display:block;box-sizing:border-box;" +
+        "margin:-0.55em 0 1.5em 16px !important;" +
+        "padding:0.65em 0.8em 0.7em 12px !important;" +
+        "border-radius:0 6px 6px 0;background:rgba(127,127,127,0.12) !important;" +
+        "font-style:normal !important;opacity:1 !important;white-space:pre-wrap;}" +
+        ".riffle-note::before{content:\"$ELIDED_NOTE_LABEL\";display:block;margin-bottom:0.3em;" +
+        "font-size:0.72em;font-style:normal !important;font-weight:700;" +
+        "letter-spacing:0.08em;text-transform:uppercase;opacity:0.65;}"
 
 /**
  * Renders a TYPE_HIGHLIGHT with its embedded figures interleaved at each figure's
@@ -457,19 +480,7 @@ private fun appendInterleavedHighlight(
             appendFigureBlock(sb, effectiveFigure, highlight.id, highlight.color, dataUriByHref, emphasisBarCss)
         }
     }
-    val note = highlight.note
-    if (note != null) {
-        val accent = if (highlight.color.isNotBlank()) highlightBackgroundCss(highlight.color)
-                     else emphasisBarCss
-        val idEscaped = highlight.id.xmlEscape()
-        sb.append("  <aside class=\"riffle-note\" data-ann-id=\"")
-        sb.append(idEscaped)
-        sb.append("\" style=\"border-left: 2px solid ")
-        sb.append(accent)
-        sb.append(" !important; padding-left: 12px; font-style: italic; opacity: 0.75;\">")
-        sb.append(note.xmlEscape())
-        sb.append("</aside>\n")
-    }
+    appendNoteAside(sb, highlight, emphasisBarCss)
 }
 
 /**
@@ -567,16 +578,29 @@ private fun appendTextHighlight(
         sb.append(highlight.textSnippet.xmlEscape())
     }
     sb.append("</span></p>\n")
-    val note = highlight.note
-    if (note != null) {
-        sb.append("  <aside class=\"riffle-note\" data-ann-id=\"")
-        sb.append(idEscaped)
-        sb.append("\" style=\"border-left: 2px solid ")
-        sb.append(accent)
-        sb.append(" !important; padding-left: 12px; font-style: italic; opacity: 0.75;\">")
-        sb.append(note.xmlEscape())
-        sb.append("</aside>\n")
+    appendNoteAside(sb, highlight, emphasisBarCss)
+}
+
+private fun appendNoteAside(
+    sb: StringBuilder,
+    highlight: AnnotationEntity,
+    emphasisBarCss: String,
+) {
+    val note = highlight.note ?: return
+    val accent = if (highlight.color.isNotBlank()) {
+        highlightBackgroundCss(highlight.color)
+    } else {
+        emphasisBarCss
     }
+    sb.append("  <aside class=\"riffle-note\" data-ann-id=\"")
+    sb.append(highlight.id.xmlEscape())
+    sb.append("\" role=\"note\" aria-label=\"")
+    sb.append(ELIDED_NOTE_ARIA_LABEL)
+    sb.append("\" style=\"border-left: 2px solid ")
+    sb.append(accent)
+    sb.append(" !important;\">")
+    sb.append(note.xmlEscape())
+    sb.append("</aside>\n")
 }
 
 /**

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatchTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsDomPatchTest.kt
@@ -57,6 +57,11 @@ class HighlightsDomPatchTest {
         assertTrue(js, js.contains("\"Hello\""))
         assertTrue("must create an ASIDE element when missing", js.contains("createElement('aside')"))
         assertTrue("must set the class and data-ann-id on new asides", js.contains("'riffle-note'"))
+        assertTrue(
+            "live-created notes must expose the same note semantics as initial chapter HTML",
+            js.contains("setAttribute('role', 'note')") &&
+                js.contains("setAttribute('aria-label', '$ELIDED_NOTE_ARIA_LABEL')"),
+        )
         assertTrue("must look up the existing aside by its own data-ann-id (adjacency is unreliable through Readium's HTMLInjector)",
             js.contains("aside.riffle-note[data-ann-id="))
         assertTrue("must update textContent (not innerHTML — avoid injection)", js.contains("textContent"))

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
@@ -290,10 +290,12 @@ class HighlightsPublicationFactoryTest {
         )
     }
 
-    // Notes need their own paler/neutral background so they read as visually distinct from the
-    // highlight paragraph above them.
+    // A note must identify itself and sit visually under its owning highlight. Italics alone are
+    // ambiguous in an elided document because the source excerpt can itself contain italic text.
+    // The class-level CSS supplies the visible "Note" label, neutral callout surface, and tightened
+    // top margin; role/aria-label preserve the same relationship for accessibility.
     @Test
-    fun noteAsideCarriesNeutralBackground() {
+    fun noteAsideIsAnExplicitCalloutAttachedToItsHighlight() {
         val pub = factory.build(
             sourceId = "S1",
             itemId = "B1",
@@ -304,8 +306,27 @@ class HighlightsPublicationFactoryTest {
             urlFactory = ::testUrlFactory,
         )
         val html = readChapterHtml(pub, index = 0)
-        assertTrue(html.contains("<aside class=\"riffle-note\" data-ann-id=\"h1\" style=\"border-left: 2px solid "))
-        assertTrue(html.contains("font-style: italic; opacity: 0.75;\">my thought</aside>"))
+        assertTrue(
+            "note must expose note semantics and name its relationship to the preceding highlight",
+            html.contains(
+                "<aside class=\"riffle-note\" data-ann-id=\"h1\" role=\"note\" " +
+                    "aria-label=\"$ELIDED_NOTE_ARIA_LABEL\"",
+            ),
+        )
+        assertTrue(
+            "note CSS must add an explicit visible label",
+            html.contains(".riffle-note::before") &&
+                html.contains("content:\"$ELIDED_NOTE_LABEL\""),
+        )
+        assertTrue(
+            "note CSS must pull the note toward the owning excerpt and distinguish it as a callout",
+            html.contains("margin:-0.55em 0 1.5em 16px !important") &&
+                html.contains("background:rgba(127,127,127,0.12)"),
+        )
+        assertTrue(
+            "note must retain the owner's annotation id and accent colour",
+            html.contains("border-left: 2px solid") && html.contains(">my thought</aside>"),
+        )
     }
 
     // Issue #484: an annotation with a captured `originFontFamily` renders its excerpt `<p>` with


### PR DESCRIPTION
## Summary

- render elided-view notes as explicit labelled callouts with a neutral surface and owner-colour accent
- keep notes visually closer to their owning highlight and add accessible note semantics
- apply the same contract to notes added live without reloading the reader
- add JVM and API-25 real-WebView regressions covering initial and live note rendering

## Tests

- focused JVM suites: 53 tests passed
- `make harness-test`: 315 tests completed, 0 failures, 1 existing skip

## Regression guards

A line-for-line revert fails the generated-HTML label/callout assertions, the live DOM-patch semantics assertions, and the real-WebView `ownerGap < nextGap` relationship.