### PR TITLE
fix(reader): show time remaining in elided view chapter map

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -192,6 +192,17 @@ internal fun shouldRunReadingSideEffects(source: ReaderSource): Boolean =
 internal fun isElidedContinuousReader(source: ReaderSource): Boolean =
     source == ReaderSource.Highlights
 
+/**
+ * Returns true when [segments] carry meaningful position weights for time-remaining estimates.
+ *
+ * A real EPUB starts with all weights at the 1f fallback while Readium computes positions; we
+ * suppress estimates until at least one weight differs. The elided view uses
+ * PerResourcePositionsService which intentionally gives every resource exactly one position
+ * (equal weights), so we bypass the guard for [ReaderSource.Highlights].
+ */
+internal fun hasRealSegmentPositions(segments: List<RailSegment>, source: ReaderSource): Boolean =
+    segments.size <= 1 || segments.any { it.weight != 1f } || source == ReaderSource.Highlights
+
 sealed class ReaderState {
     data object Loading : ReaderState()
     data class Ready(
@@ -3625,10 +3636,7 @@ class EpubReaderViewModel @Inject constructor(
         val totalPositions = segments.fold(0f) { acc, seg -> acc + seg.weight }
         if (totalPositions == 0f) return@combine null
 
-        // If every segment has fallback weight 1f, position data wasn't available — estimates
-        // would be meaningless (always ~1 min). Return null until real data is loaded.
-        val hasRealPositions = segments.size <= 1 || segments.any { it.weight != 1f }
-        if (!hasRealPositions) return@combine null
+        if (!hasRealSegmentPositions(segments, source)) return@combine null
 
         if (pbState.connected && raTrack != null) {
             val posGlobal = pbState.positionGlobalSec
@@ -3666,10 +3674,7 @@ class EpubReaderViewModel @Inject constructor(
         val totalPositions = segments.fold(0f) { acc, seg -> acc + seg.weight }
         if (totalPositions == 0f) return@combine null
 
-        // If every segment has fallback weight 1f, position data wasn't available — estimates
-        // would be meaningless (always ~1 min). Return null until real data is loaded.
-        val hasRealPositions = segments.size <= 1 || segments.any { it.weight != 1f }
-        if (!hasRealPositions) return@combine null
+        if (!hasRealSegmentPositions(segments, source)) return@combine null
 
         if (pbState.connected && raTrack != null) {
             val posGlobal = pbState.positionGlobalSec

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.reader
 
+import com.riffle.app.feature.reader.highlights.ReaderSource
 import com.riffle.core.domain.normalizeEpubHref
 import com.riffle.core.domain.withResolvedTheme
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -1334,5 +1335,43 @@ class AnnotationNavigationOptionsTest {
         // anchor; annotation nav always carries one, but pin the flag so a change is intentional.
         assertFalse(annotationNavigationOptions(isBookmark = true).landAtStartWhenNoTarget)
         assertFalse(annotationNavigationOptions(isBookmark = false).landAtStartWhenNoTarget)
+    }
+}
+
+/**
+ * Regression tests for [hasRealSegmentPositions].
+ *
+ * The elided view registers PerResourcePositionsService which intentionally gives every spine
+ * resource exactly one position (weight = 1f). The guard must not suppress time-remaining
+ * estimates for ReaderSource.Highlights even when all segment weights are equal.
+ */
+class HasRealSegmentPositionsTest {
+
+    private fun seg(weight: Float = 1f) = RailSegment("Chapter", "ch.xhtml", weight)
+
+    @Test
+    fun `returns false for FullBook with multiple equal-weight segments`() {
+        val segments = listOf(seg(1f), seg(1f), seg(1f))
+        assertFalse(hasRealSegmentPositions(segments, ReaderSource.FullBook))
+    }
+
+    @Test
+    fun `returns true for Highlights with multiple equal-weight segments`() {
+        // Regression: PerResourcePositionsService gives weight=1f per resource in the elided view;
+        // the guard must not suppress time-remaining estimates for ReaderSource.Highlights.
+        val segments = listOf(seg(1f), seg(1f), seg(1f))
+        assertTrue(hasRealSegmentPositions(segments, ReaderSource.Highlights))
+    }
+
+    @Test
+    fun `returns true for FullBook once position weights differ`() {
+        val segments = listOf(seg(1f), seg(2.5f), seg(1f))
+        assertTrue(hasRealSegmentPositions(segments, ReaderSource.FullBook))
+    }
+
+    @Test
+    fun `returns true for single-segment books regardless of source`() {
+        assertTrue(hasRealSegmentPositions(listOf(seg(1f)), ReaderSource.FullBook))
+        assertTrue(hasRealSegmentPositions(listOf(seg(1f)), ReaderSource.Highlights))
     }
 }


### PR DESCRIPTION
## Summary

- The `hasRealPositions` guard in `chapterTimeRemaining` / `bookTimeRemaining` fires when all segment weights are `1f`, treating that as "position data not yet loaded"
- The elided view registers `PerResourcePositionsService` (added in #591) which intentionally gives every spine resource exactly one position — all weights stay `1f` by design, not by absence of data
- The guard therefore always suppressed time-remaining estimates in the elided view

## Fix

Extract the guard to `hasRealSegmentPositions(segments, source)`, which bypasses the equal-weights check for `ReaderSource.Highlights`. Both `chapterTimeRemaining` and `bookTimeRemaining` call the helper.

## Tests

`HasRealSegmentPositionsTest` — 4 unit tests including one that asserts `Highlights + all-1f weights → true` (fails against the old inline guard).