### PR TITLE
fix(reader): fill highlight line leading

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightLineCoverageWebViewTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightLineCoverageWebViewTest.kt
@@ -1,0 +1,152 @@
+package com.riffle.app.feature.reader
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.json.JSONArray
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Real-WebView regression coverage for Android-selection-style highlight line bands. */
+@RunWith(AndroidJUnit4::class)
+class HighlightLineCoverageWebViewTest {
+
+    private data class Rect(val top: Double, val bottom: Double)
+
+    private val fixture = """
+        <!doctype html>
+        <html>
+          <head><meta name="viewport" content="width=device-width, initial-scale=1"></head>
+          <body style="margin:0">
+            <p id="target" style="width:280px;margin:40px 0 0 20px;font-family:serif;font-size:32px;line-height:48px">
+              Medication is probably the most widely publicized, most hotly debated treatment for ADHD.
+            </p>
+          </body>
+        </html>
+    """.trimIndent()
+
+    @Test
+    fun continuousAnnotationMarkCoversFullLineBandsWithoutGaps() {
+        withSizedWebViewFixture(fixture, widthPx = 480, heightPx = 800) { webView ->
+            webView.awaitInnerHeight()
+            val annotation = AnnotationHighlight(
+                id = "ann",
+                text = "Medication is probably the most widely publicized, most hotly debated treatment for ADHD.",
+                cssColor = "rgba(251,191,36,0.50)",
+                hasNote = false,
+            )
+            webView.evalSync(ContinuousStyleInjector.applyAnnotationHighlightsJs(listOf(annotation)))
+
+            assertNativeSelectionLineCoverage(
+                painted = webView.rects("document.querySelector('[data-riffle-ann=\"ann\"]')"),
+                text = webView.rangeRects("document.querySelector('[data-riffle-ann=\"ann\"]')"),
+            )
+        }
+    }
+
+    @Test
+    fun readiumDecorationBoxesCoverFullLineBandsWithoutGaps() {
+        withSizedWebViewFixture(fixture, widthPx = 480, heightPx = 800) { webView ->
+            webView.awaitInnerHeight()
+            val stylesheet = highlightTintTemplate().stylesheet.orEmpty()
+                .replace("\\", "\\\\")
+                .replace("`", "\\`")
+                .replace("$", "\\$")
+            webView.evalSync(
+                """
+                (function() {
+                  var style = document.createElement('style');
+                  style.textContent = `$stylesheet`;
+                  document.head.appendChild(style);
+                  var range = document.createRange();
+                  range.selectNodeContents(document.getElementById('target'));
+                  window.__riffleRawHighlightRects = Array.prototype.map.call(
+                    range.getClientRects(),
+                    function(r) { return {top:r.top,bottom:r.bottom}; }
+                  );
+                  Array.prototype.forEach.call(range.getClientRects(), function(r) {
+                    var box = document.createElement('div');
+                    box.className = 'riffle-highlight-tint';
+                    box.style.cssText = 'position:absolute;pointer-events:none;' +
+                      'left:' + (r.left + window.pageXOffset) + 'px;' +
+                      'top:' + (r.top + window.pageYOffset) + 'px;' +
+                      'width:' + r.width + 'px;height:' + r.height + 'px;' +
+                      'background:rgba(251,191,36,0.50) !important;';
+                    document.body.appendChild(box);
+                  });
+                })();
+                """.trimIndent(),
+            )
+            webView.evalSync(readiumHighlightLeadingAdjustmentJs())
+            webView.awaitReadiumLeadingAdjustment()
+
+            assertNativeSelectionLineCoverage(
+                painted = webView.rects("document.querySelectorAll('.riffle-highlight-tint')"),
+                text = webView.savedRawRects(),
+            )
+        }
+    }
+
+    private fun assertNativeSelectionLineCoverage(painted: List<Rect>, text: List<Rect>) {
+        assertTrue("fixture must wrap to at least three lines; got $painted", painted.size >= 3)
+        val largestGap = painted.zipWithNext { current, next -> next.top - current.bottom }.max()
+        assertTrue("highlight lines must meet without white gaps; largest gap=$largestGap, rects=$painted", largestGap <= 0.75)
+        val topCoverage = text.first().top - painted.first().top
+        assertTrue("highlight must cover the line-leading above the glyph box; coverage=$topCoverage", topCoverage >= 2.0)
+    }
+
+    private fun android.webkit.WebView.rects(selector: String): List<Rect> =
+        parseRects(
+            evalSync(
+                """
+                (function() {
+                  var target = $selector;
+                  var list = target && typeof target.length === 'number' ? target : [target];
+                  var out = [];
+                  Array.prototype.forEach.call(list, function(el) {
+                    if (!el) return;
+                    Array.prototype.forEach.call(el.getClientRects(), function(r) {
+                      if (r.width > 0 && r.height > 0) out.push({top:r.top,bottom:r.bottom});
+                    });
+                  });
+                  out.sort(function(a,b) { return a.top - b.top; });
+                  return out;
+                })();
+                """.trimIndent(),
+            ),
+        )
+
+    private fun android.webkit.WebView.rangeRects(element: String): List<Rect> =
+        parseRects(
+            evalSync(
+                """
+                (function() {
+                  var range = document.createRange();
+                  range.selectNodeContents($element);
+                  return Array.prototype.map.call(range.getClientRects(), function(r) {
+                    return {top:r.top,bottom:r.bottom};
+                  });
+                })();
+                """.trimIndent(),
+            ),
+        )
+
+    private fun android.webkit.WebView.savedRawRects(): List<Rect> =
+        parseRects(evalSync("window.__riffleRawHighlightRects"))
+
+    private fun android.webkit.WebView.awaitReadiumLeadingAdjustment() {
+        val deadline = System.currentTimeMillis() + 3_000
+        while (System.currentTimeMillis() < deadline) {
+            if (evalSync("document.querySelectorAll('[data-riffle-base-height]').length").trim('"') != "0") return
+            Thread.sleep(20)
+        }
+        throw AssertionError("Readium highlight leading adjustment did not run")
+    }
+
+    private fun parseRects(raw: String): List<Rect> {
+        val array = JSONArray(raw)
+        return (0 until array.length()).map { index ->
+            val item = array.getJSONObject(index)
+            Rect(top = item.getDouble("top"), bottom = item.getDouble("bottom"))
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -335,6 +335,7 @@ internal object ContinuousStyleInjector {
         // Colors are machine-generated CSS rgba() strings — no quote escaping needed.
         return """
             $SAFE_WRAP_HELPER_JS
+            $HIGHLIGHT_LEADING_ADJUSTMENT_HELPER_JS
             (function(texts,inactiveCss,activeT,activeProg,activeCss) {
                 var sel = window.getSelection();
                 var seen = {};
@@ -383,6 +384,7 @@ internal object ContinuousStyleInjector {
                             sel.removeAllRanges(); sel.addRange(skipR);
                             continue;
                         }
+                        window.__riffleFillInlineHighlightLeading(mark);
                         var advance = document.createRange();
                         advance.setStartAfter(mark); advance.collapse(true);
                         sel.removeAllRanges(); sel.addRange(advance);
@@ -406,6 +408,7 @@ internal object ContinuousStyleInjector {
                         best.setAttribute('data-riffle-sa', '');
                         best.removeAttribute('data-riffle-si');
                         best.style.cssText = 'background:' + activeCss + '$HIGHLIGHT_INLINE_STYLE_SUFFIX';
+                        window.__riffleFillInlineHighlightLeading(best);
                     }
                 }
                 if (sel) sel.removeAllRanges();
@@ -468,6 +471,7 @@ internal object ContinuousStyleInjector {
         val safeSvgUri = NOTE_GLYPH_SVG_DATA_URI.replace("'", "\\'")
         return """
             $SAFE_WRAP_HELPER_JS
+            $HIGHLIGHT_LEADING_ADJUSTMENT_HELPER_JS
             (function(anns) {
                 var SVG_URI = '$safeSvgUri';
                 // ADR 0046: build the extra inline CSS the emphasis set contributes to a mark's
@@ -624,7 +628,10 @@ internal object ContinuousStyleInjector {
                     // per block. Update colour in-place across all of them and skip relocation.
                     var existingAll = document.querySelectorAll('[data-riffle-ann="' + ann.id + '"]');
                     if (existingAll.length > 0) {
-                        existingAll.forEach(function(m) { m.style.cssText = 'background:' + ann.c + '$HIGHLIGHT_INLINE_STYLE_SUFFIX' + emphasisStyle(ann.e); });
+                        existingAll.forEach(function(m) {
+                            m.style.cssText = 'background:' + ann.c + '$HIGHLIGHT_INLINE_STYLE_SUFFIX' + emphasisStyle(ann.e);
+                            window.__riffleFillInlineHighlightLeading(m);
+                        });
                         var eg = document.querySelector('[data-riffle-note-glyph="' + ann.id + '"]');
                         // Highlights mode (ann.s === 1) suppresses the note glyph: the glyph would
                         // overlap the accent-bar tap span in the left gutter and swallow taps that
@@ -650,6 +657,7 @@ internal object ContinuousStyleInjector {
                         mark.setAttribute('data-riffle-ann', ann.id);
                         mark.style.cssText = 'background:' + ann.c + '$HIGHLIGHT_INLINE_STYLE_SUFFIX' + emphasisStyle(ann.e);
                         if (!window.__riffleSafeWrap(range, mark)) return;
+                        window.__riffleFillInlineHighlightLeading(mark);
                         // The mark just split a text node — invalidate the flat index so the NEXT
                         // annotation's locateRanges() rebuilds against the updated DOM. The other
                         // ranges in THIS annotation already hold their own text-node refs (captured
@@ -709,6 +717,7 @@ internal object ContinuousStyleInjector {
         val safe = fragmentId.replace("\\", "\\\\").replace("'", "\\'")
         return """
             $SAFE_WRAP_HELPER_JS
+            $HIGHLIGHT_LEADING_ADJUSTMENT_HELPER_JS
             (function() {
                 var existing = document.getElementById('_riffle_hl');
                 if (existing && existing.parentNode) existing.outerHTML = existing.innerHTML;
@@ -720,6 +729,7 @@ internal object ContinuousStyleInjector {
                 mark.id = '_riffle_hl';
                 mark.style.cssText = '${highlightInlineStyle("$cssColor")}';
                 if (!window.__riffleSafeWrap(range, mark)) return;
+                window.__riffleFillInlineHighlightLeading(mark);
                 var sel = window.getSelection ? window.getSelection() : null;
                 if (sel) sel.removeAllRanges();
             })();
@@ -731,6 +741,7 @@ internal object ContinuousStyleInjector {
         val safe = text.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n").replace("\r", "\\r")
         return """
             $SAFE_WRAP_HELPER_JS
+            $HIGHLIGHT_LEADING_ADJUSTMENT_HELPER_JS
             (function() {
                 var existing = document.getElementById('_riffle_hl');
                 var sentinel = null;
@@ -760,6 +771,7 @@ internal object ContinuousStyleInjector {
                 // Skip cross-block matches — extractContents would reparent block elements as
                 // inline children of <mark>, breaking the surrounding paragraphs.
                 if (!window.__riffleSafeWrap(range, mark)) { sel.removeAllRanges(); return; }
+                window.__riffleFillInlineHighlightLeading(mark);
                 sel.removeAllRanges();
             })();
         """.trimIndent()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
@@ -58,9 +58,113 @@ internal fun highlightInlineStyle(cssColor: String): String =
     "background:$cssColor$HIGHLIGHT_INLINE_STYLE_SUFFIX"
 
 /**
- * Template for [HighlightTintStyle]. Geometry mirrors Readium's built-in highlight (BOXES layout,
- * 1px horizontal padding, 3px corner radius) so positioning is unchanged; the only difference is the
- * fill opacity comes from the tint's alpha channel rather than a fixed value.
+ * Installs the two geometry functions used by the Readium-overlay and continuous-`<mark>` paths.
+ *
+ * Android's native selection paint covers the full CSS line box. DOM range rectangles and inline
+ * backgrounds only cover the text box, leaving the line-leading transparent. The missing leading
+ * is `computed line-height - painted rect height`; splitting it above and below makes adjacent
+ * highlight bands meet exactly without changing text layout.
+ */
+internal val HIGHLIGHT_LEADING_ADJUSTMENT_HELPER_JS: String = """
+    (function() {
+      var lineHeightOf = function(element) {
+        var target = element || document.body || document.documentElement;
+        var style = window.getComputedStyle(target);
+        var lineHeight = parseFloat(style.lineHeight);
+        if (!isFinite(lineHeight)) {
+          var fontSize = parseFloat(style.fontSize);
+          lineHeight = (isFinite(fontSize) ? fontSize : 16) * 1.2;
+        }
+        return lineHeight;
+      };
+
+      window.__riffleFillInlineHighlightLeading = function(mark) {
+        if (!mark) return;
+        // Existing marks are recoloured by replacing cssText. Always remeasure from an unpadded
+        // inline box so repeat applications cannot compound the previous adjustment.
+        mark.style.removeProperty('padding-top');
+        mark.style.removeProperty('padding-bottom');
+        var rects = mark.getClientRects();
+        if (!rects || rects.length === 0) return;
+        var leading = Math.max(0, lineHeightOf(mark) - rects[0].height);
+        var half = leading / 2;
+        mark.style.setProperty('padding-top', half + 'px', 'important');
+        mark.style.setProperty('padding-bottom', half + 'px', 'important');
+        mark.style.setProperty('-webkit-box-decoration-break', 'clone');
+        mark.style.setProperty('box-decoration-break', 'clone');
+      };
+
+      window.__riffleFillReadiumHighlightLeading = function() {
+        var boxes = document.querySelectorAll('.$HIGHLIGHT_TINT_CLASS');
+        Array.prototype.forEach.call(boxes, function(box) {
+          var baseTop = parseFloat(box.getAttribute('data-riffle-base-top'));
+          var baseHeight = parseFloat(box.getAttribute('data-riffle-base-height'));
+          if (!isFinite(baseTop) || !isFinite(baseHeight)) {
+            baseTop = parseFloat(box.style.top);
+            baseHeight = parseFloat(box.style.height);
+            if (!isFinite(baseTop) || !isFinite(baseHeight)) return;
+            box.setAttribute('data-riffle-base-top', baseTop);
+            box.setAttribute('data-riffle-base-height', baseHeight);
+          }
+
+          // Reset before probing so a repeat apply measures the original Readium range box.
+          box.style.top = baseTop + 'px';
+          box.style.height = baseHeight + 'px';
+          var rect = box.getBoundingClientRect();
+          var source = null;
+          var x = rect.left + Math.min(Math.max(rect.width / 2, 1), Math.max(rect.width - 1, 1));
+          var y = rect.top + rect.height / 2;
+          if (x >= 0 && x < window.innerWidth && y >= 0 && y < window.innerHeight) {
+            // Decoration containers are pointer-events:none, so this resolves the source text
+            // underneath the overlay rather than the overlay itself.
+            source = document.elementFromPoint(x, y);
+          }
+          var lineHeight = lineHeightOf(source);
+          if (lineHeight <= baseHeight && box.parentNode) {
+            // A short final line's centre can fall beyond the paragraph's painted content, making
+            // elementFromPoint return body/html. Infer its line-height from the nearest sibling
+            // box's original top instead. The 1.5x ceiling excludes paragraph/page breaks.
+            var nearestAdvance = Infinity;
+            var siblings = box.parentNode.querySelectorAll('.$HIGHLIGHT_TINT_CLASS');
+            Array.prototype.forEach.call(siblings, function(sibling) {
+              if (sibling === box) return;
+              var siblingTop = parseFloat(sibling.getAttribute('data-riffle-base-top'));
+              if (!isFinite(siblingTop)) siblingTop = parseFloat(sibling.style.top);
+              var advance = Math.abs(siblingTop - baseTop);
+              if (advance > 0.5 && advance <= baseHeight * 1.5 && advance < nearestAdvance) {
+                nearestAdvance = advance;
+              }
+            });
+            if (isFinite(nearestAdvance)) lineHeight = nearestAdvance;
+          }
+          var leading = Math.max(0, lineHeight - baseHeight);
+          var half = leading / 2;
+          box.style.top = (baseTop - half) + 'px';
+          box.style.height = (baseHeight + leading) + 'px';
+        });
+        return boxes.length;
+      };
+    })();
+""".trimIndent()
+
+/** Runs after Readium's own requestAnimationFrame has materialised the fixed decoration boxes. */
+internal fun readiumHighlightLeadingAdjustmentJs(): String = """
+    $HIGHLIGHT_LEADING_ADJUSTMENT_HELPER_JS
+    (function() {
+      var attempts = 0;
+      var adjust = function() {
+        var count = window.__riffleFillReadiumHighlightLeading();
+        if (count === 0 && attempts++ < 3) window.setTimeout(adjust, 16);
+      };
+      if (window.requestAnimationFrame) window.requestAnimationFrame(adjust);
+      else window.setTimeout(adjust, 0);
+    })();
+""".trimIndent()
+
+/**
+ * Template for [HighlightTintStyle]. Readium creates one fixed box per DOM range rectangle; the
+ * post-apply [readiumHighlightLeadingAdjustmentJs] expands those boxes to the full line-height.
+ * Fill opacity comes from the tint's alpha channel rather than Readium's fixed value.
  */
 fun highlightTintTemplate(): HtmlDecorationTemplate =
     HtmlDecorationTemplate(
@@ -71,9 +175,9 @@ fun highlightTintTemplate(): HtmlDecorationTemplate =
         },
         stylesheet = """
             .$HIGHLIGHT_TINT_CLASS {
-                margin: -1px -1px 0 0;
+                margin: 0 -1px 0 0;
                 padding: 0 2px 0 0;
-                border-radius: 3px;
+                border-radius: 0;
                 box-sizing: border-box;
             }
         """.trimIndent(),

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
@@ -227,6 +227,9 @@ private fun spineIndexOf(spineHrefs: List<String>): Map<String, Int> =
 
 private fun hrefBase(href: String): String = normalizeEpubHref(href).substringBefore('#')
 
+private fun normalizedHref(href: String): String =
+    hrefBase(href) + href.substringAfter('#', "").takeIf { it.isNotEmpty() }?.let { "#$it" }.orEmpty()
+
 private fun String.normalize(): String = trim().lowercase().replace(Regex("\\s+"), " ")
 
 /**
@@ -246,11 +249,12 @@ fun findActiveSegmentIndex(
     progression: Float? = null,
 ): Int {
     if (segments.isEmpty()) return 0
-    val currentBase = hrefBase(currentHref)
-    // If currentHref has a fragment that exactly matches a segment href, prefer it
+    // If currentHref matches a segment href exactly (normalized, fragment preserved), prefer it
     // so that e.g. "chapter.xhtml#s2" resolves to the specific section segment.
-    val exactFragment = segments.indexOfFirst { it.href == currentHref }
-    if (exactFragment >= 0) return exactFragment
+    val normalizedCurrentHref = normalizedHref(currentHref)
+    val exact = segments.indexOfFirst { normalizedHref(it.href) == normalizedCurrentHref }
+    if (exact >= 0) return exact
+    val currentBase = hrefBase(currentHref)
     val baseMatches = segments.indices.filter {
         hrefBase(segments[it].href) == currentBase
     }
@@ -261,11 +265,6 @@ fun findActiveSegmentIndex(
         val offset = if (p >= 1f) baseMatches.lastIndex else minOf((p * baseMatches.size).toInt(), baseMatches.lastIndex)
         return baseMatches[offset]
     }
-    // No same-base-href segments and no exact fragment match: try normalized exact match
-    // (handles file:///...!/ prefixed hrefs) and then fall back to spine-based lookup.
-    val normalizedCurrentHref = normalizeEpubHref(currentHref)
-    val exact = segments.indexOfFirst { normalizeEpubHref(it.href) == normalizedCurrentHref }
-    if (exact >= 0) return exact
     if (spineHrefs.isEmpty()) return 0
     val spineBases = spineHrefs.map(::hrefBase)
     val currentSpineIndex = spineBases.indexOf(currentBase)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
@@ -61,6 +61,7 @@ internal class ReadiumHighlightRenderer(
             style = HighlightTintStyle(tint = color.argb),
         )
         applyDecorationsWithClear(listOf(decoration), "readaloud")
+        adjustHighlightLeading()
         hasSentenceDecoration = true
     }
 
@@ -118,6 +119,7 @@ internal class ReadiumHighlightRenderer(
         // pageLoadGeneration, LaunchedEffect keys the same renders) would keep the stale pre-reflow
         // rects until the 400ms settle tick fires. Matches [applySentenceHighlight]'s pre-clear semantics.
         applyDecorationsWithClear(decorations, "annotations")
+        adjustHighlightLeading()
         hasAnnotationDecorations = true
         // ADR 0046: layered emphasis paints via companion decorations. Underline uses Readium's
         // built-in Style.Underline; strike/bold/italic v1 render as tinted overlays (bold + italic
@@ -182,6 +184,11 @@ internal class ReadiumHighlightRenderer(
     private suspend fun applyDecorationsWithClear(decorations: List<Decoration>, group: String) {
         applyDecorationsBlock(emptyList(), group)
         applyDecorationsBlock(decorations, group)
+    }
+
+    /** Expand Readium's tight DOM-range boxes to Android-selection-style full line bands. */
+    private suspend fun adjustHighlightLeading() {
+        evaluateJavascript?.invoke(readiumHighlightLeadingAdjustmentJs())
     }
 
     /**

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
@@ -110,6 +110,32 @@ class ReadiumHighlightRendererTest {
         assertEquals("h2", annotationCalls[1].first[1].id)
     }
 
+    @Test
+    fun `applyAnnotations expands decoration boxes after Readium applies them`() = runTest {
+        val callOrder = mutableListOf<String>()
+        val rendererWithGeometryAdjustment = ReadiumHighlightRenderer(
+            applyDecorationsBlock = { _, group -> callOrder.add("decorate:$group") },
+            fragmentLocator = { ref, _ ->
+                if (ref.isNotBlank()) minimalLocator(ref.substringBefore('#')) else null
+            },
+            evaluateJavascript = { script ->
+                if (script.contains("__riffleFillReadiumHighlightLeading")) {
+                    callOrder.add("fillLineLeading")
+                }
+            },
+        )
+
+        rendererWithGeometryAdjustment.applyAnnotations(listOf(makeRender("h1", "c1.xhtml")))
+
+        val lastDecoration = callOrder.indexOfLast { it == "decorate:annotations" }
+        val lineLeading = callOrder.indexOf("fillLineLeading")
+        assertTrue("decoration apply must occur", lastDecoration >= 0)
+        assertTrue(
+            "line-leading adjustment must run after Readium creates its boxes; order=$callOrder",
+            lineLeading > lastDecoration,
+        )
+    }
+
     // Regression: bold/italic DOM injection must be queued BEFORE Readium measures decoration
     // positions. EmphasisDomInjector wraps bold/italic text in <span> elements causing text
     // reflow; if injected after applyDecorationsWithClear, Readium's baked tap-target rects


### PR DESCRIPTION
## Summary
- expand continuous highlight marks to cover the full CSS line box
- adjust Readium decoration boxes after materialization for gap-free highlight bands
- add JVM ordering coverage and real-WebView geometry regression tests
- preserve rail URL fragments after rebasing so same-file section progression remains selectable
- remove conflict markers inherited from `main` so CI workflows can run

## Tests
- `make test`
- `make lint`
- `make harness-test-class CLASS=com.riffle.app.feature.reader.HighlightLineCoverageWebViewTest`