### PR TITLE
fix(reader): create the annotation when a note is added on a fresh draft

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/session/DismissEmptyHighlightHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/session/DismissEmptyHighlightHarnessTest.kt
@@ -110,6 +110,7 @@ class DismissEmptyHighlightHarnessTest {
             syncOnOpen = { _, _, _ -> },
             syncOnClose = { _, _, _ -> },
             mergeAfterEdit = { _, _, _ -> },
+            commitDraftWithNote = { _ -> },
         )
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/DraftPopupSelection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/DraftPopupSelection.kt
@@ -52,7 +52,22 @@ internal data class DraftPopupSelection(
 internal fun shouldDiscardPhantomDraftCommit(
     initialColor: String,
     combinedStyles: Set<EmphasisStyle>,
-): Boolean = initialColor.isEmpty() && combinedStyles.isEmpty()
+    note: String? = null,
+): Boolean = initialColor.isEmpty() && combinedStyles.isEmpty() && note == null
+
+/**
+ * Note-editor close on a pending draft: returns `true` when the draft must be committed.
+ *
+ * A non-null [note] always commits — the user typed a note on a fresh selection, and a ∅-colour
+ * annotation carrying a note is a valid row, not a phantom. With no note, the close is equivalent
+ * to dismissing the actions popup, so [shouldAutoCommitDraftOnDismiss] decides preset-commit vs
+ * discard.
+ */
+internal fun shouldCommitDraftOnNoteEditorClose(
+    note: String?,
+    lastUsedColorIsNone: Boolean,
+    lastUsedEmphasisStyles: Set<EmphasisStyle>,
+): Boolean = note != null || shouldAutoCommitDraftOnDismiss(lastUsedColorIsNone, lastUsedEmphasisStyles)
 
 /**
  * Dismiss behaviour predicate for a pending draft (Bug 2, 2026-07-19).

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -394,6 +394,7 @@ class EpubReaderViewModel @Inject constructor(
             mergeAfterEdit = { id, color, note ->
                 mergeAdjacentIntoHighlight(id, color, note)
             },
+            commitDraftWithNote = { note -> commitDraftFromNoteEditor(note) },
         )
 
     private val itemId: String = checkNotNull(savedStateHandle["itemId"])
@@ -2097,6 +2098,23 @@ class EpubReaderViewModel @Inject constructor(
     }
 
     /**
+     * Note-editor close on a pending draft (see [AnnotationSession.commitNoteEdit]). A non-null
+     * [note] always commits — even with the ∅ colour preset and no emphasis, a noted annotation
+     * is not a phantom row. A null note (cancel / blank confirm) falls back to the popup-dismiss
+     * semantics: auto-commit the per-book preset, or discard when the preset is ∅ + nothing.
+     */
+    private suspend fun commitDraftFromNoteEditor(note: String?) {
+        val presetColorIsNone = annotationSession.lastUsedColorIsNone.value
+        val presetEmphasis = annotationSession.lastUsedEmphasisStyles.value
+        if (!shouldCommitDraftOnNoteEditorClose(note, presetColorIsNone, presetEmphasis)) {
+            annotationSession.discardDraft()
+            return
+        }
+        val colorToken = if (presetColorIsNone) "" else annotationSession.lastUsedHighlightColor.value.token
+        commitDraft(initialColor = colorToken, note = note, keepSheetOpen = false)
+    }
+
+    /**
      * ADR 0046 §4: persist the pending draft with [initialColor] and (optionally) a sibling
      * emphasis row carrying the per-book last-used styles. Runs the deferred overlapping-highlight
      * dedup and standalone-TYPE_IMAGE absorption here — those side effects were previously done
@@ -2108,6 +2126,7 @@ class EpubReaderViewModel @Inject constructor(
         initialColor: String,
         addEmphasisStyle: com.riffle.core.models.EmphasisStyle? = null,
         keepSheetOpen: Boolean = true,
+        note: String? = null,
     ) {
         val draft = annotationSession.draftAnnotation.value ?: return
         // Compute combinedStyles early so we can guard against a phantom empty row (∅ colour +
@@ -2118,7 +2137,7 @@ class EpubReaderViewModel @Inject constructor(
         // (discard) — consistent behaviour in both places.
         val presetStyles = annotationSession.lastUsedEmphasisStyles.value
         val combinedStyles = combineDraftEmphasisStyles(presetStyles, addEmphasisStyle)
-        if (shouldDiscardPhantomDraftCommit(initialColor, combinedStyles)) {
+        if (shouldDiscardPhantomDraftCommit(initialColor, combinedStyles, note)) {
             // Persist the ∅ preference so a subsequent dismiss-auto-commit evaluates
             // shouldAutoCommitDraftOnDismiss(true, …) = false and does not try to auto-commit
             // with whatever the previous colour was. Draft stays alive for the caller to handle.
@@ -2232,6 +2251,9 @@ class EpubReaderViewModel @Inject constructor(
             // would misalign formatting against the wider text.
             textSnippetHtml = if (overlapMerge == null && adjacentMerge == null) draft.textSnippetHtml else null,
         )
+        if (note != null) {
+            annotationStore.updateNote(created.id, note)
+        }
         if (combinedStyles.isNotEmpty()) {
             annotationStore.createEmphasis(
                 sourceId = draft.sourceId,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
@@ -80,6 +80,16 @@ class AnnotationSession @AssistedInject constructor(
      * See docs/superpowers/specs/2026-07-05-highlight-auto-merge-design.md.
      */
     @Assisted("merge") private val mergeAfterEdit: suspend (id: String, color: String, note: String?) -> Unit,
+    /**
+     * Called when the note editor closes on a PENDING DRAFT (ADR 0046 §4). The draft has no DB
+     * row yet, so [commitNoteEdit]'s `updateNote` would match zero rows and the annotation (and
+     * its note) would silently vanish — the reported "annotate + add note at the same time saves
+     * nothing" bug (2026-08-03). Publication-dependent (the commit path rebuilds CFI ranges), so
+     * the VM owns the implementation: a non-null note commits the draft with the per-book preset
+     * colour + emphasis and the note; null (cancel / blank confirm) applies the popup-dismiss
+     * semantics — auto-commit the preset, or discard when the preset is ∅ + no emphasis.
+     */
+    @Assisted("draftNote") private val commitDraftWithNote: suspend (note: String?) -> Unit,
 ) {
 
     @AssistedFactory
@@ -91,6 +101,7 @@ class AnnotationSession @AssistedInject constructor(
             @Assisted("open") syncOnOpen: suspend (String, String, String) -> Unit,
             @Assisted("close") syncOnClose: suspend (String, String, String) -> Unit,
             @Assisted("merge") mergeAfterEdit: suspend (String, String, String?) -> Unit,
+            @Assisted("draftNote") commitDraftWithNote: suspend (String?) -> Unit,
         ): AnnotationSession
     }
 
@@ -535,6 +546,13 @@ class AnnotationSession @AssistedInject constructor(
      */
     suspend fun commitNoteEdit(id: String, note: String?) {
         val normalized = note?.takeIf { it.isNotBlank() }
+        // Pending draft — no DB row exists yet, so updateNote would match zero rows and the
+        // annotation + note would silently vanish. Route to the VM's draft-commit instead.
+        if (id == DRAFT_ANNOTATION_ID) {
+            _noteEditorTarget.value = null
+            commitDraftWithNote(normalized)
+            return
+        }
         annotationStore.updateNote(id, normalized)
         _noteEditorTarget.value = null
         val row = _annotations.value.firstOrNull { it.id == id }
@@ -555,6 +573,13 @@ class AnnotationSession @AssistedInject constructor(
         val target = _noteEditorTarget.value
         _noteEditorTarget.value = null
         val id = target?.id ?: return
+        // Pending draft — hand it back to the VM (null note → popup-dismiss semantics: preset
+        // auto-commit or discard). Pre-fix this returned early on the missing row and the draft
+        // leaked: preview decoration kept painting with no popup attached.
+        if (id == DRAFT_ANNOTATION_ID) {
+            scope.launch { commitDraftWithNote(null) }
+            return
+        }
         val row = _annotations.value.firstOrNull { it.id == id } ?: return
         if (row.type != AnnotationEntity.TYPE_HIGHLIGHT) return
         scope.launch { mergeAfterEdit(id, row.color, row.note) }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/DraftPopupSelectionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/DraftPopupSelectionTest.kt
@@ -127,6 +127,44 @@ class DraftPopupSelectionTest {
     }
 
     @Test
+    fun phantomGuard_allowsCommitWhenNotePresent_evenWithEmptyColorAndStyles() {
+        // Regression (2026-08-03): a draft committed FROM THE NOTE EDITOR carries a note — a
+        // ∅-colour, no-emphasis annotation with a note is a valid row, not a phantom. Flips red
+        // if commitDraft's guard stops considering the note.
+        assertEquals(
+            false,
+            shouldDiscardPhantomDraftCommit(initialColor = "", combinedStyles = emptySet(), note = "my thought"),
+        )
+    }
+
+    // ---- note-editor close on a draft ----
+
+    @Test
+    fun noteEditorClose_commitsWhenNotePresent_evenWithNoPreset() {
+        // Regression (2026-08-03): typing a note on a fresh selection must ALWAYS create the
+        // annotation, even when the per-book preset is ∅ + no emphasis (where a plain dismiss
+        // would discard).
+        assertEquals(
+            true,
+            shouldCommitDraftOnNoteEditorClose(note = "my thought", lastUsedColorIsNone = true, lastUsedEmphasisStyles = emptySet()),
+        )
+    }
+
+    @Test
+    fun noteEditorClose_withoutNote_followsDismissSemantics() {
+        // No note → identical to dismissing the actions popup: preset commit when a colour or
+        // emphasis preset exists, discard when the preset is ∅ + nothing.
+        assertEquals(
+            true,
+            shouldCommitDraftOnNoteEditorClose(note = null, lastUsedColorIsNone = false, lastUsedEmphasisStyles = emptySet()),
+        )
+        assertEquals(
+            false,
+            shouldCommitDraftOnNoteEditorClose(note = null, lastUsedColorIsNone = true, lastUsedEmphasisStyles = emptySet()),
+        )
+    }
+
+    @Test
     fun persistedRow_ignoresLastUsedState() {
         // Regression: persisted-row pre-selection MUST NOT leak the per-book last-used state —
         // that would show a chip active when no matching emphasis row exists.

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -245,6 +245,7 @@ class AnnotationSessionTest {
             TestApplicationScope(CoroutineScope(UnconfinedTestDispatcher() + SupervisorJob()))
         ),
         mergeAfterEdit: suspend (String, String, String?) -> Unit = { _, _, _ -> },
+        commitDraftWithNote: suspend (String?) -> Unit = { _ -> },
     ) = AnnotationSession(
         scope = scope,
         annotationStore = store,
@@ -257,6 +258,7 @@ class AnnotationSessionTest {
         syncOnOpen = syncOps.makeSyncOnOpen(),
         syncOnClose = syncOps.makeSyncOnClose(),
         mergeAfterEdit = mergeAfterEdit,
+        commitDraftWithNote = commitDraftWithNote,
     )
 
     private fun defaultBind(
@@ -806,6 +808,81 @@ class AnnotationSessionTest {
         assertEquals("h1", mergeCalls[0].first)
         assertEquals("green", mergeCalls[0].second)
         assertNull(mergeCalls[0].third)
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
+
+    /**
+     * Regression (2026-08-03): confirming the note editor on a PENDING DRAFT must route to the
+     * draft-commit callback, NOT annotationStore.updateNote. The draft has no DB row, so
+     * `updateNote("__draft__", …)` matched zero rows and both the annotation and its note
+     * silently vanished ("doing an annotation AND adding a note at the same time — the
+     * annotation is not saved").
+     */
+    @Test
+    fun `commitNoteEdit on a draft routes to the draft-commit callback instead of updateNote`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val store = FakeAnnotationStore()
+        val draftNoteCalls = mutableListOf<String?>()
+        val session = makeSession(
+            store = store, syncOps = FakeSyncOps(), scope = sessionScope,
+            commitDraftWithNote = { note -> draftNoteCalls += note },
+        )
+        defaultBind(session)
+        session.openHighlightActions(AnnotationSession.DRAFT_ANNOTATION_ID, androidx.compose.ui.unit.IntRect(0, 0, 0, 0))
+        session.openNoteEditor(AnnotationSession.DRAFT_ANNOTATION_ID, androidx.compose.ui.unit.IntRect(0, 0, 0, 0))
+
+        session.commitNoteEdit(AnnotationSession.DRAFT_ANNOTATION_ID, "my thought")
+
+        assertEquals(listOf<String?>("my thought"), draftNoteCalls)
+        assertEquals(emptyList<Pair<String, String?>>(), store.updatedNotes)
+        assertNull(session.noteEditorTarget.value)
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
+
+    /** A blank note confirmed on a draft normalizes to null — dismiss semantics, not a note. */
+    @Test
+    fun `commitNoteEdit on a draft with blank note routes null to the callback`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val store = FakeAnnotationStore()
+        val draftNoteCalls = mutableListOf<String?>()
+        val session = makeSession(
+            store = store, syncOps = FakeSyncOps(), scope = sessionScope,
+            commitDraftWithNote = { note -> draftNoteCalls += note },
+        )
+        defaultBind(session)
+        session.openNoteEditor(AnnotationSession.DRAFT_ANNOTATION_ID, androidx.compose.ui.unit.IntRect(0, 0, 0, 0))
+
+        session.commitNoteEdit(AnnotationSession.DRAFT_ANNOTATION_ID, "   ")
+
+        assertEquals(listOf<String?>(null), draftNoteCalls)
+        assertEquals(emptyList<Pair<String, String?>>(), store.updatedNotes)
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
+
+    /**
+     * Regression (2026-08-03): cancelling the note editor on a draft must hand the draft back to
+     * the VM (null note → dismiss semantics: preset auto-commit or discard). Pre-fix it returned
+     * early on the missing "__draft__" row and the draft leaked — preview decoration kept
+     * painting with no popup attached.
+     */
+    @Test
+    fun `cancelNoteEdit on a draft routes null to the draft-commit callback`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val draftNoteCalls = mutableListOf<String?>()
+        val session = makeSession(
+            store = FakeAnnotationStore(), syncOps = FakeSyncOps(), scope = sessionScope,
+            commitDraftWithNote = { note -> draftNoteCalls += note },
+        )
+        defaultBind(session)
+        session.openNoteEditor(AnnotationSession.DRAFT_ANNOTATION_ID, androidx.compose.ui.unit.IntRect(0, 0, 0, 0))
+
+        session.cancelNoteEdit()
+
+        assertEquals(listOf<String?>(null), draftNoteCalls)
+        assertNull(session.noteEditorTarget.value)
         sessionScope.coroutineContext[Job]?.cancel()
     }
 


### PR DESCRIPTION
## Problem

Selecting text → **Annotate** → **Add note** → confirming saved nothing: neither the annotation nor the note. Cancelling the note editor on a fresh selection likewise leaked the draft (preview decoration kept painting with no popup attached).

## Root cause

The actions popup on a fresh selection is in **draft** mode (ADR 0046 §4) — no DB row exists until the first swatch/chip pick routes through `commitDraft`. Every sheet action had a draft-aware branch except the note path: `AnnotationSession.commitNoteEdit` ran `UPDATE annotations WHERE id = '__draft__'`, which matched zero rows and returned silently.

## Fix

`commitNoteEdit` / `cancelNoteEdit` now detect the draft sentinel and route to a new `commitDraftWithNote` assisted callback owned by `EpubReaderViewModel` (same pattern as `mergeAfterEdit`):

- **Note typed** → commit the draft through the normal `commitDraft` path (preset colour + emphasis, overlap/adjacency merges included) and attach the note to the created row. Works even when the per-book preset is ∅ — the phantom-row guard now treats a noted colourless annotation as a valid row.
- **Cancelled / blank confirm** → popup-dismiss semantics: auto-commit the per-book preset, or discard when the preset is ∅ with no emphasis.

The popup/dialog layer is mode-independent (session state, no Readium/WebView involvement), so the fix applies in paginated, vertical, and continuous modes alike.

## Tests

Written red-first:
- `AnnotationSessionTest`: three regressions pinning that a draft note routes to the callback and never calls `updateNote("__draft__")` (confirm with note, confirm blank, cancel).
- `DraftPopupSelectionTest`: extended phantom guard (`note` present → not a phantom) and the new `shouldCommitDraftOnNoteEditorClose` decision.

Reverting the session branches or the guard extension flips these red. Full `./gradlew test` suite green locally.