### PR TITLE
fix(reader): brighten unread chapter map colors and make bookmark dots distinct

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterNavigationRail.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterNavigationRail.kt
@@ -37,9 +37,11 @@ internal fun chapterRailUsesGroups(segments: List<RailSegment>): Boolean =
 internal fun chapterRailHeight(flatHeight: Dp): Dp =
     flatHeight
 
-internal const val CHAPTER_RAIL_UNREAD_ALPHA = 0.35f
+internal const val CHAPTER_RAIL_UNREAD_ALPHA = 0.5f
 internal val CHAPTER_RAIL_CURSOR_HALO_WIDTH = 4.dp
 internal val CHAPTER_RAIL_CURSOR_CORE_WIDTH = 2.dp
+internal val CHAPTER_RAIL_BOOKMARK_DOT_RADIUS = 2.5.dp
+internal val CHAPTER_RAIL_BOOKMARK_HALO_RADIUS = 4.dp
 
 internal fun chapterRailUsesColorProgress(
     segments: List<RailSegment>,
@@ -82,7 +84,7 @@ fun ChapterNavigationRail(
     val fillColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.85f)
     val cursorHaloColor = readerTheme.palette.background
     val cursorColor = pageForeground
-    val bookmarkColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.90f)
+    val bookmarkColor = MaterialTheme.colorScheme.primary
 
     val activeTitle = segments.getOrNull(activeIndex)?.title ?: ""
     val clampedCursor = cursorPosition.coerceIn(0f, 1f)
@@ -161,12 +163,20 @@ fun ChapterNavigationRail(
                         }
                     }
 
+                    // Bookmarks are round dots, not vertical ticks — a thin line reads as just
+                    // another chapter-boundary gap on the 4dp rail. The background-colored halo
+                    // separates the dot from whatever segment color sits underneath.
                     chapterRailBookmarkXs(bookmarkPositions, size.width).forEach { bookmarkX ->
-                        drawLine(
+                        val center = Offset(bookmarkX, size.height / 2f)
+                        drawCircle(
+                            color = cursorHaloColor,
+                            radius = CHAPTER_RAIL_BOOKMARK_HALO_RADIUS.toPx(),
+                            center = center,
+                        )
+                        drawCircle(
                             color = bookmarkColor,
-                            start = Offset(bookmarkX, 0f),
-                            end = Offset(bookmarkX, size.height),
-                            strokeWidth = 1.5.dp.toPx(),
+                            radius = CHAPTER_RAIL_BOOKMARK_DOT_RADIUS.toPx(),
+                            center = center,
                         )
                     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterNavigationRail.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterNavigationRail.kt
@@ -41,7 +41,11 @@ internal const val CHAPTER_RAIL_UNREAD_ALPHA = 0.5f
 internal val CHAPTER_RAIL_CURSOR_HALO_WIDTH = 4.dp
 internal val CHAPTER_RAIL_CURSOR_CORE_WIDTH = 2.dp
 internal val CHAPTER_RAIL_BOOKMARK_DOT_RADIUS = 2.5.dp
-internal val CHAPTER_RAIL_BOOKMARK_HALO_RADIUS = 4.dp
+
+// The halo is a ring around the dot, so it's defined relative to the dot radius rather than as an
+// independent size. Its 2dp bleed past the 4dp rail lands in the overlay backdrop, which is painted
+// the same reader-page background color the halo uses, so the overflow is invisible there.
+internal val CHAPTER_RAIL_BOOKMARK_HALO_RADIUS = CHAPTER_RAIL_BOOKMARK_DOT_RADIUS + 1.5.dp
 
 internal fun chapterRailUsesColorProgress(
     segments: List<RailSegment>,
@@ -82,7 +86,9 @@ fun ChapterNavigationRail(
     val pageForeground = readerTheme.palette.foreground
     val barColor = pageForeground.copy(alpha = 0.30f)
     val fillColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.85f)
-    val cursorHaloColor = readerTheme.palette.background
+    // Shared by the cursor and the bookmark dots: a page-background halo keeps either mark
+    // visible over every chapter color and on all three reader themes.
+    val haloColor = readerTheme.palette.background
     val cursorColor = pageForeground
     val bookmarkColor = MaterialTheme.colorScheme.primary
 
@@ -113,6 +119,10 @@ fun ChapterNavigationRail(
                 // Outer edges (start of the first segment, end of the last) stay flush.
                 val gap = 2.5.dp.toPx()
                 val fillX = clampedCursor * size.width
+                val bookmarkDotRadius = CHAPTER_RAIL_BOOKMARK_DOT_RADIUS.toPx()
+                val bookmarkHaloRadius = CHAPTER_RAIL_BOOKMARK_HALO_RADIUS.toPx()
+                val bookmarkCenters = chapterRailBookmarkXs(bookmarkPositions, size.width)
+                    .map { Offset(it, size.height / 2f) }
                 onDrawBehind {
                     bounds.forEachIndexed { i, (start, width) ->
                         val x0 = start + (if (i == 0) 0f else gap / 2f)
@@ -164,26 +174,22 @@ fun ChapterNavigationRail(
                     }
 
                     // Bookmarks are round dots, not vertical ticks — a thin line reads as just
-                    // another chapter-boundary gap on the 4dp rail. The background-colored halo
-                    // separates the dot from whatever segment color sits underneath.
-                    chapterRailBookmarkXs(bookmarkPositions, size.width).forEach { bookmarkX ->
-                        val center = Offset(bookmarkX, size.height / 2f)
+                    // another chapter-boundary gap on the 4dp rail.
+                    bookmarkCenters.forEach { center ->
                         drawCircle(
-                            color = cursorHaloColor,
-                            radius = CHAPTER_RAIL_BOOKMARK_HALO_RADIUS.toPx(),
+                            color = haloColor,
+                            radius = bookmarkHaloRadius,
                             center = center,
                         )
                         drawCircle(
                             color = bookmarkColor,
-                            radius = CHAPTER_RAIL_BOOKMARK_DOT_RADIUS.toPx(),
+                            radius = bookmarkDotRadius,
                             center = center,
                         )
                     }
 
-                    // A background-colored halo plus foreground core stays visible over every
-                    // chapter color and on all three reader themes.
                     drawLine(
-                        color = cursorHaloColor,
+                        color = haloColor,
                         start = Offset(fillX, 0f),
                         end = Offset(fillX, size.height),
                         strokeWidth = CHAPTER_RAIL_CURSOR_HALO_WIDTH.toPx(),

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterNavigationRailTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterNavigationRailTest.kt
@@ -32,8 +32,11 @@ class ChapterNavigationRailTest {
         assertEquals(4.dp, chapterRailHeight(4.dp))
         assertTrue(chapterRailUsesColorProgress(segments))
         assertFalse(chapterRailUsesColorProgress(segments, coloredChapterMap = false))
+        // 0.5f (bumped from the original 0.35f) keeps unread chapters clearly colored while the
+        // fully-saturated read portion still reads as the progress fill.
+        assertEquals(0.5f, CHAPTER_RAIL_UNREAD_ALPHA)
         assertEquals(
-            Color(0xFFE66100).copy(alpha = 0.35f),
+            Color(0xFFE66100).copy(alpha = 0.5f),
             chapterRailUnreadGroupColor(groupIndex = 0),
         )
         assertEquals(4.dp, CHAPTER_RAIL_CURSOR_HALO_WIDTH)
@@ -59,6 +62,16 @@ class ChapterNavigationRailTest {
         assertEquals(7, chapterRailGroupColorIndex(7))
         assertEquals(0, chapterRailGroupColorIndex(8))
         assertEquals(3, chapterRailGroupColorIndex(11))
+    }
+
+    @Test
+    fun `bookmark markers are haloed dots larger than the rail half-height`() {
+        // A dot must be distinct from the 1-ish-dp vertical chapter-boundary gaps: its radius
+        // exceeds the 2dp rail half-height so it bulges out of the 4dp strip, and the halo ring
+        // is wider still so the dot never blends into a same-hue segment underneath.
+        assertEquals(2.5.dp, CHAPTER_RAIL_BOOKMARK_DOT_RADIUS)
+        assertEquals(4.dp, CHAPTER_RAIL_BOOKMARK_HALO_RADIUS)
+        assertTrue(CHAPTER_RAIL_BOOKMARK_HALO_RADIUS > CHAPTER_RAIL_BOOKMARK_DOT_RADIUS)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterNavigationRailTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterNavigationRailTest.kt
@@ -36,7 +36,7 @@ class ChapterNavigationRailTest {
         // fully-saturated read portion still reads as the progress fill.
         assertEquals(0.5f, CHAPTER_RAIL_UNREAD_ALPHA)
         assertEquals(
-            Color(0xFFE66100).copy(alpha = 0.5f),
+            Color(0xFFE66100).copy(alpha = CHAPTER_RAIL_UNREAD_ALPHA),
             chapterRailUnreadGroupColor(groupIndex = 0),
         )
         assertEquals(4.dp, CHAPTER_RAIL_CURSOR_HALO_WIDTH)
@@ -65,17 +65,16 @@ class ChapterNavigationRailTest {
     }
 
     @Test
-    fun `bookmark markers are haloed dots larger than the rail half-height`() {
-        // A dot must be distinct from the 1-ish-dp vertical chapter-boundary gaps: its radius
-        // exceeds the 2dp rail half-height so it bulges out of the 4dp strip, and the halo ring
-        // is wider still so the dot never blends into a same-hue segment underneath.
+    fun `bookmark markers are haloed dots bulging out of the rail`() {
+        // Pins the dot-marker geometry: the 2.5dp dot radius exceeds the 2dp rail half-height so
+        // the dot bulges out of the 4dp strip (a flush mark would read as another chapter-boundary
+        // gap), and the halo ring around it keeps the dot visible over a same-hue segment.
         assertEquals(2.5.dp, CHAPTER_RAIL_BOOKMARK_DOT_RADIUS)
         assertEquals(4.dp, CHAPTER_RAIL_BOOKMARK_HALO_RADIUS)
-        assertTrue(CHAPTER_RAIL_BOOKMARK_HALO_RADIUS > CHAPTER_RAIL_BOOKMARK_DOT_RADIUS)
     }
 
     @Test
-    fun `bookmark ticks map rail fractions to x and clamp invalid bounds`() {
+    fun `bookmark dots map rail fractions to x and clamp invalid bounds`() {
         assertEquals(
             listOf(0f, 25f, 100f),
             chapterRailBookmarkXs(listOf(-0.2f, 0.25f, 1.4f), totalWidth = 100f),


### PR DESCRIPTION
Two visual tweaks to the chapter map (follow-up to #656):

- **Brighter unread chapters** — `CHAPTER_RAIL_UNREAD_ALPHA` bumped from 0.35 to 0.5 so sections beyond the current progress keep clearly visible chapter colors, while the fully-saturated read portion still stands out as the progress fill.
- **Distinct bookmark markers** — bookmarks were 1.5dp vertical lines, nearly identical to the chapter-separator gaps and the cursor. They are now round dots: a full-opacity primary dot (2.5dp radius, bulging slightly out of the 4dp rail) on a page-background halo ring, so the dot stays readable even over a same-hue chapter segment.

Review cleanups included: halo radius defined relative to the dot radius, per-frame `toPx` conversions and bookmark centers hoisted into the `drawWithCache` scope, and `cursorHaloColor` renamed to `haloColor` now that bookmarks share it.

Tests: `ChapterNavigationRailTest` pins the new alpha and the dot/halo geometry — the assertions flip red if either change is reverted.