### PR TITLE
fix(reader): match continuous volume-key scroll animation to vertical mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
@@ -167,6 +167,26 @@ internal object ContinuousPositionTracker {
         return ms.toInt().coerceIn(PAGE_SCROLL_MIN_DURATION_MS, PAGE_SCROLL_MAX_DURATION_MS)
     }
 
+    /** A resolved volume-key page-scroll animation: scroll by [scrollBy] px over [durationMs]. */
+    data class PageScrollAnimation(val scrollBy: Int, val durationMs: Int)
+
+    /**
+     * Animation for a volume-key page scroll from [currentScrollY] to the (coalescer-resolved,
+     * clamped) [targetScrollY]. The duration follows the *actual* animated distance via
+     * [pageScrollDurationMs], not the nominal per-press delta: at a content boundary the clamped
+     * remainder shouldn't crawl over a full-press duration, and a coalesced press that extended the
+     * in-flight target gets the longer glide Chromium's √distance heuristic would give it. Returns
+     * null when there is nothing to animate (target equals current, or non-positive [density]).
+     */
+    fun pageScrollAnimation(currentScrollY: Int, targetScrollY: Int, density: Float): PageScrollAnimation? {
+        val scrollBy = targetScrollY - currentScrollY
+        if (scrollBy == 0 || density <= 0f) return null
+        return PageScrollAnimation(
+            scrollBy = scrollBy,
+            durationMs = pageScrollDurationMs(kotlin.math.abs(scrollBy), density),
+        )
+    }
+
     /**
      * Resolve a text selection to the narrated-sentence id whose sentence contains it, for
      * "Play from here" in Continuous mode. [quoteTexts] maps sentence id → sentence text (built from

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
@@ -143,6 +143,30 @@ internal object ContinuousPositionTracker {
     fun pageScrollDelta(viewportHeightPx: Int): Int =
         if (viewportHeightPx <= 0) 0 else (viewportHeightPx * ScrollBoundaryNavigationContainer.VOLUME_SCROLL_FRACTION).toInt()
 
+    /** Bounds for [pageScrollDurationMs]; the max also sizes the [PageScrollCoalescer] validity
+     *  window in [ContinuousWindowController] — a window slightly longer than a finished animation
+     *  is harmless because the pending target then equals the settled scroll position. */
+    internal const val PAGE_SCROLL_MIN_DURATION_MS = 200
+    internal const val PAGE_SCROLL_MAX_DURATION_MS = 700
+
+    /**
+     * Animation duration for a volume-key page scroll of [distancePx] physical pixels, on a screen
+     * with the given [density]. Approximates the delta-based duration Chromium picks for the
+     * `window.scrollBy({behavior: 'smooth'})` that paginated/vertical mode issues from
+     * [ScrollBoundaryNavigationContainer] — ~16.7 ms per √(CSS px), ease-shaped over ~445 ms for a
+     * typical 0.9-viewport press. A fixed 300 ms here made the same press visibly faster and more
+     * sudden in continuous mode than in vertical mode. Chromium computes in CSS pixels, so the
+     * physical distance is divided by [density] first; the result is clamped to
+     * [[PAGE_SCROLL_MIN_DURATION_MS], [PAGE_SCROLL_MAX_DURATION_MS]]. Returns 0 for a non-positive
+     * distance or density.
+     */
+    fun pageScrollDurationMs(distancePx: Int, density: Float): Int {
+        if (distancePx <= 0 || density <= 0f) return 0
+        val cssPx = distancePx / density
+        val ms = (1000.0 / 60.0) * kotlin.math.sqrt(cssPx.toDouble())
+        return ms.toInt().coerceIn(PAGE_SCROLL_MIN_DURATION_MS, PAGE_SCROLL_MAX_DURATION_MS)
+    }
+
     /**
      * Resolve a text selection to the narrated-sentence id whose sentence contains it, for
      * "Play from here" in Continuous mode. [quoteTexts] maps sentence id → sentence text (built from

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -85,13 +85,12 @@ internal class ContinuousWindowController(
          *  stale scrollY. */
         private const val LANDING_HOLD_MS = 600L
 
-        /**
-         * Fixed animation duration for a volume-key page scroll. Matches the Chromium `behavior:
-         * 'smooth'` scroll duration used by paginated/vertical mode via [ScrollBoundaryNavigationContainer]
-         * closely enough that rapid presses feel the same in both modes. Also the validity window for
-         * [PageScrollCoalescer], so a new press coalesces iff its predecessor is still animating.
-         */
-        internal const val PAGE_SCROLL_DURATION_MS = 300
+        // The volume-key page-scroll animation duration is distance-based via
+        // [ContinuousPositionTracker.pageScrollDurationMs] to match the Chromium
+        // `behavior: 'smooth'` glide paginated/vertical mode gets from
+        // [ScrollBoundaryNavigationContainer]; a fixed 300 ms was visibly faster and more sudden
+        // than vertical mode for the same 0.9-viewport press. The coalescer validity window uses
+        // the duration cap — see [pageScrollCoalescer].
     }
 
     /** The [LinearLayout] the [ContinuousReaderView] wraps; controller owns and mutates its children. */
@@ -743,10 +742,18 @@ internal class ContinuousWindowController(
             minScrollY = 0,
             maxScrollY = port.maxScrollY,
         )
-        port.smoothScrollBy(target - current, PAGE_SCROLL_DURATION_MS)
+        val durationMs = ContinuousPositionTracker.pageScrollDurationMs(
+            distancePx = delta,
+            density = context.resources.displayMetrics.density,
+        )
+        port.smoothScrollBy(target - current, durationMs)
     }
 
-    private val pageScrollCoalescer = PageScrollCoalescer(PAGE_SCROLL_DURATION_MS.toLong())
+    /** Window = the duration cap rather than the per-press duration: once an animation has
+     *  finished, the pending target equals the settled scroll position, so an over-long window
+     *  cannot mis-base the next press. */
+    private val pageScrollCoalescer =
+        PageScrollCoalescer(ContinuousPositionTracker.PAGE_SCROLL_MAX_DURATION_MS.toLong())
 
     override fun highlightInChapter(href: String, fragmentId: String?, text: String, cssColor: String) {
         decorations.highlightInChapter(href, fragmentId, text, cssColor)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -742,11 +742,12 @@ internal class ContinuousWindowController(
             minScrollY = 0,
             maxScrollY = port.maxScrollY,
         )
-        val durationMs = ContinuousPositionTracker.pageScrollDurationMs(
-            distancePx = delta,
+        val animation = ContinuousPositionTracker.pageScrollAnimation(
+            currentScrollY = current,
+            targetScrollY = target,
             density = context.resources.displayMetrics.density,
-        )
-        port.smoothScrollBy(target - current, durationMs)
+        ) ?: return
+        port.smoothScrollBy(animation.scrollBy, animation.durationMs)
     }
 
     /** Window = the duration cap rather than the per-press duration: once an animation has

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PageScrollCoalescer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PageScrollCoalescer.kt
@@ -9,9 +9,11 @@ package com.riffle.app.feature.reader
  *
  * Not thread-safe; expected to be called from the main thread.
  *
- * @param validityWindowMs how long a computed target stays "in flight" — should match the smooth-
- *   scroll animation duration passed to the port. A press arriving inside this window extends the
- *   previous target; a press arriving after resets to the current scroll position.
+ * @param validityWindowMs how long a computed target stays "in flight" — should be at least the
+ *   smooth-scroll animation duration passed to the port (a longer window is harmless: once the
+ *   animation finishes, the pending target equals the settled scroll position). A press arriving
+ *   inside this window extends the previous target; a press arriving after resets to the current
+ *   scroll position.
  */
 internal class PageScrollCoalescer(private val validityWindowMs: Long) {
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -466,6 +466,55 @@ class ContinuousPositionTrackerTest {
         )
     }
 
+    // ── pageScrollAnimation ───────────────────────────────────────────────────
+
+    @Test
+    fun `pageScrollAnimation duration follows the actual animated distance, not the press delta`() {
+        // A press near the bottom boundary: the coalescer clamps the target so only 30 px remain.
+        // The duration must come from the 30 px remainder (min-clamped to 200 ms), not the ~443 ms
+        // a full 0.9-viewport press would get — otherwise the remainder crawls.
+        val boundary = ContinuousPositionTracker.pageScrollAnimation(
+            currentScrollY = 9_970, targetScrollY = 10_000, density = 2.75f,
+        )
+        assertEquals(30, boundary?.scrollBy)
+        assertEquals(ContinuousPositionTracker.PAGE_SCROLL_MIN_DURATION_MS, boundary?.durationMs)
+
+        // A coalesced press that extended the in-flight target to ~2 presses of distance: the
+        // glide gets the longer √distance duration, not the single-press duration.
+        val delta = ContinuousPositionTracker.pageScrollDelta(2160)
+        val coalesced = ContinuousPositionTracker.pageScrollAnimation(
+            currentScrollY = 0, targetScrollY = 2 * delta, density = 2.75f,
+        )
+        val singlePressMs = ContinuousPositionTracker.pageScrollDurationMs(delta, density = 2.75f)
+        assertEquals(2 * delta, coalesced?.scrollBy)
+        assertEquals(
+            ContinuousPositionTracker.pageScrollDurationMs(2 * delta, density = 2.75f),
+            coalesced?.durationMs,
+        )
+        assertTrue(
+            "coalesced glide must be longer than a single press",
+            coalesced!!.durationMs > singlePressMs,
+        )
+    }
+
+    @Test
+    fun `pageScrollAnimation preserves direction for backward presses`() {
+        val backward = ContinuousPositionTracker.pageScrollAnimation(
+            currentScrollY = 5_000, targetScrollY = 3_000, density = 2.75f,
+        )
+        assertEquals(-2_000, backward?.scrollBy)
+        assertEquals(
+            ContinuousPositionTracker.pageScrollDurationMs(2_000, density = 2.75f),
+            backward?.durationMs,
+        )
+    }
+
+    @Test
+    fun `pageScrollAnimation is null when there is nothing to animate`() {
+        assertNull(ContinuousPositionTracker.pageScrollAnimation(500, 500, density = 2.75f))
+        assertNull(ContinuousPositionTracker.pageScrollAnimation(0, 100, density = 0f))
+    }
+
     @Test
     fun `pageScrollDurationMs is zero for non-positive distance or density`() {
         assertEquals(0, ContinuousPositionTracker.pageScrollDurationMs(0, 2.75f))

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -437,6 +437,42 @@ class ContinuousPositionTrackerTest {
         assertEquals(0, ContinuousPositionTracker.pageScrollDelta(-5))
     }
 
+    // ── pageScrollDurationMs ──────────────────────────────────────────────────
+
+    @Test
+    fun `pageScrollDurationMs matches Chromium's glide for a phone-sized page press`() {
+        // 0.9 of a 2160 px viewport at density 2.75 ≈ 707 CSS px; Chromium's delta-based
+        // duration is ~16.7 ms × √707 ≈ 443 ms. The old fixed 300 ms is what made continuous
+        // mode feel sudden next to vertical mode's smooth scroll — pin that we now exceed it.
+        val delta = ContinuousPositionTracker.pageScrollDelta(2160)
+        val duration = ContinuousPositionTracker.pageScrollDurationMs(delta, density = 2.75f)
+        assertEquals(443, duration)
+        assertTrue("duration must be longer than the old fixed 300 ms", duration > 300)
+    }
+
+    @Test
+    fun `pageScrollDurationMs is clamped to the min for tiny distances`() {
+        assertEquals(
+            ContinuousPositionTracker.PAGE_SCROLL_MIN_DURATION_MS,
+            ContinuousPositionTracker.pageScrollDurationMs(distancePx = 10, density = 2.75f),
+        )
+    }
+
+    @Test
+    fun `pageScrollDurationMs is clamped to the max for huge distances`() {
+        assertEquals(
+            ContinuousPositionTracker.PAGE_SCROLL_MAX_DURATION_MS,
+            ContinuousPositionTracker.pageScrollDurationMs(distancePx = 100_000, density = 1f),
+        )
+    }
+
+    @Test
+    fun `pageScrollDurationMs is zero for non-positive distance or density`() {
+        assertEquals(0, ContinuousPositionTracker.pageScrollDurationMs(0, 2.75f))
+        assertEquals(0, ContinuousPositionTracker.pageScrollDurationMs(-100, 2.75f))
+        assertEquals(0, ContinuousPositionTracker.pageScrollDurationMs(1000, 0f))
+    }
+
     // ── Bookmark vs. continuous-resume alignment ──────────────────────────────
     //
     // scrollYForProgression is the midpoint-inverse of locatorAt: it's correct for continuous


### PR DESCRIPTION
## Summary

In continuous mode, a volume-key page scroll animated over a fixed 300 ms — visibly faster and more sudden than the Chromium `behavior: 'smooth'` glide vertical mode gets for the same press (~445 ms for a 0.9-viewport distance). Continuous can't reuse vertical's mechanism (scrolling happens in the native `NestedScrollView`, not inside a WebView document), so the duration is now computed natively with Chromium's delta-based heuristic: ~16.7 ms per √(CSS px), clamped to 200–700 ms.

- `ContinuousPositionTracker.pageScrollDurationMs` — Chromium-matching duration from distance + density.
- `ContinuousPositionTracker.pageScrollAnimation` — resolves the animation from the coalescer target; duration follows the **actual** animated distance, so a boundary-clamped remainder doesn't crawl over a full-press duration and a coalesced rapid press gets the longer √distance glide.
- `PageScrollCoalescer` validity window now uses the duration cap (700 ms); harmless when longer than a finished animation since the pending target then equals the settled position.

## Tests

JVM unit tests pin the Chromium-match value (~443 ms for a phone-sized press, > the old 300 ms), both clamps, zero-guards, boundary-remainder and coalesced-press durations, and backward direction.