### PR TITLE
fix(reader): collapse section-flooded chapter maps; enforce test guardrails repo-wide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
+        with:
+          # checkTestGuardrails (riffleChecks) diffs against the merge base with origin/main.
+          fetch-depth: 0
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
@@ -59,7 +62,9 @@ jobs:
           key: fonts-v1-${{ hashFiles('Makefile') }}
           restore-keys: fonts-v1-
       - run: make fonts
-      - run: ./gradlew lint
+      # riffleChecks runs the custom lints + test guardrails; module `check` (their other hook)
+      # is never invoked on CI, so they must be listed explicitly here.
+      - run: ./gradlew lint riffleChecks
       - name: Upload lint reports
         if: always()
         uses: actions/upload-artifact@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,8 @@ Mechanical updates (renaming a symbol the test references, adjusting a construct
 
 Deleting or `@Ignore`-ing a red test to unblock a PR is never acceptable.
 
+**Enforced by `checkTestGuardrails`** (part of `check` and run on CI via `riffleChecks` in the Lint job): any `@Test` function that exists at the merge base with main but not on the branch — deleted or renamed — fails the build unless a commit message on the branch carries a `Removed-test: <exact test name>` trailer (one line per test; backticks optional). The trailer is a declaration, not a bypass: the commit body and PR must still explain which behavioral claim is being retired and why, per the questions above. Moving a test between files needs no trailer. Detection logic lives in `buildSrc/src/main/kotlin/com/riffle/buildlogic/TestGuardrailLint.kt`.
+
 ## Validate before claiming done
 
 Every fix or new feature must be validated as actually working before it is marked complete or sent for review. Acceptable validation is one of:

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
@@ -60,10 +60,17 @@ private fun assembleRailSegments(
     // the first base href. Intentional same-file section groups preserve their full fragment hrefs;
     // locator progression resolves which one is active during natural reading.
     val seen = HashSet<String>(expanded.size)
-    return expanded.mapNotNull { (segment, preserveFragment) ->
+    val deduped = expanded.mapNotNull { (segment, preserveFragment) ->
         val deduplicationKey = if (preserveFragment) segment.href else segment.href.substringBefore('#')
         segment.takeIf { seen.add(deduplicationKey) }
     }
+    // Group colors exist to show which segments belong together. When every group ends up as a
+    // single rendered segment (e.g. a section-heavy book collapsed to chapter granularity, or
+    // hierarchy fully swallowed by dedup), coloring each chapter differently is pure noise —
+    // render the classic flat rail instead.
+    val hasMultiSegmentGroup = deduped.groupingBy { it.groupIndex }.eachCount()
+        .any { (groupIndex, count) -> groupIndex != null && count > 1 }
+    return if (hasMultiSegmentGroup) deduped else deduped.map { it.copy(groupIndex = null) }
 }
 
 private data class TopLevelRailResult(
@@ -243,7 +250,7 @@ private const val MIN_SUBSTANTIAL_POSITIONS = 3
 // this, section granularity degrades the map instead of enriching it, so the rail falls back to
 // one segment per chapter. Cross-file expansions (Part → chapter files) are not capped: they
 // mirror the book's real spine granularity, which flat books have always shown uncapped.
-private const val MAX_SEGMENTS_WITH_SAME_FILE_SECTIONS = 48
+internal const val MAX_SEGMENTS_WITH_SAME_FILE_SECTIONS = 48
 
 private val NUMERIC_PREFIX = Regex("""^\s*(\d+)\s*[.)]\s+""")
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/RailSegmentGenerator.kt
@@ -12,8 +12,26 @@ fun buildRailSegments(
     val bookTitleNorm = bookTitle.normalize()
     val spineIndex = spineIndexOf(spineHrefs)
     val preprocessed = absorbFlatNumericRuns(tocEntries)
+    val withSections =
+        assembleRailSegments(preprocessed, bookTitleNorm, spineIndex, positionCounts, tocEntries, exposeSameFileSections = true)
+    if (withSections.size <= MAX_SEGMENTS_WITH_SAME_FILE_SECTIONS) return withSections
+    // Section-heavy books (many chapters × many same-file section anchors) would explode into
+    // 100+ segments; with 2.5dp gaps punched between segments the rail becomes mostly gaps and
+    // unreadable. Collapse ALL same-file section groups back to chapter granularity — a
+    // whole-book decision, so no chapter stays exploded while its siblings collapse.
+    return assembleRailSegments(preprocessed, bookTitleNorm, spineIndex, positionCounts, tocEntries, exposeSameFileSections = false)
+}
+
+private fun assembleRailSegments(
+    preprocessed: List<TocEntry>,
+    bookTitleNorm: String,
+    spineIndex: Map<String, Int>,
+    positionCounts: List<Int>,
+    tocEntries: List<TocEntry>,
+    exposeSameFileSections: Boolean,
+): List<RailSegment> {
     val topLevelResults = preprocessed.mapIndexed { groupIndex, entry ->
-        val exposesSameFileSections = shouldExposeSameFileSections(entry)
+        val exposesSameFileSections = exposeSameFileSections && shouldExposeSameFileSections(entry)
         val wasExpanded = exposesSameFileSections ||
             shouldReplaceWithChildren(entry, bookTitleNorm, spineIndex, positionCounts)
         val segments = if (wasExpanded) {
@@ -218,6 +236,14 @@ private fun spineLength(href: String, spineIndex: Map<String, Int>, positionCoun
 // paperback pages. Below this a "chapter" is really a fragment and shouldn't earn its own
 // rail segment even if it happens to be twice the length of a still-tinier parent.
 private const val MIN_SUBSTANTIAL_POSITIONS = 3
+
+// Readability cap for same-file section exposure. The rail punches a 2.5dp gap between adjacent
+// segments; on the narrowest supported phone rail (~320dp) 48 segments already spend ~118dp on
+// gaps, leaving ~4dp of visible fill per segment on average — the floor of legibility. Beyond
+// this, section granularity degrades the map instead of enriching it, so the rail falls back to
+// one segment per chapter. Cross-file expansions (Part → chapter files) are not capped: they
+// mirror the book's real spine granularity, which flat books have always shown uncapped.
+private const val MAX_SEGMENTS_WITH_SAME_FILE_SECTIONS = 48
 
 private val NUMERIC_PREFIX = Regex("""^\s*(\d+)\s*[.)]\s+""")
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/RailCorpusTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/RailCorpusTest.kt
@@ -1,0 +1,83 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.models.TocEntry
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Golden tests over real, full-scale book TOCs (the JSON fixtures in
+ * `src/test/resources/railcorpus/`).
+ *
+ * The rail heuristics in [buildRailSegments] have repeatedly been recalibrated against whichever
+ * single book was at hand (#566, #656, the section-flood fix), and each recalibration risks
+ * silently changing every other book's map. The miniature fixtures in [RailSegmentGeneratorTest]
+ * can't show that blast radius — the section-flood regression shipped precisely because the
+ * decision to expose same-file sections was made against a 2-chapter fixture. Each corpus book
+ * pins the full rendered segment list at real scale, so any heuristic change surfaces here as a
+ * reviewable per-book diff instead of an on-device surprise.
+ *
+ * When a corpus test fails after a heuristic change, do NOT mechanically regenerate `expected`:
+ * the diff is the decision. Update it only when the new rail granularity for that book is the
+ * intended outcome, and say so in the PR body. When a new book renders badly in the wild, add its
+ * TOC as a fixture (extract from the real EPUB where possible; each fixture's `provenance` field
+ * records how faithful it is).
+ */
+class RailCorpusTest {
+
+    @Test
+    fun `a philosophy of software design`() = assertCorpus("a-philosophy-of-software-design")
+
+    @Test
+    fun `monolith to microservices`() = assertCorpus("monolith-to-microservices")
+
+    private fun assertCorpus(name: String) {
+        val corpus = loadCorpusBook(name)
+        val segments = buildRailSegments(
+            tocEntries = corpus.toc.map { it.toModel() },
+            bookTitle = corpus.book,
+            spineHrefs = corpus.spine.map { it.href },
+            positionCounts = corpus.spine.map { it.positions },
+        )
+        assertEquals(
+            corpus.expected.map { RailSegment(it.title, it.href, groupIndex = it.groupIndex) },
+            segments,
+        )
+    }
+
+    private fun loadCorpusBook(name: String): CorpusBook {
+        val resource = requireNotNull(javaClass.getResourceAsStream("/railcorpus/$name.json")) {
+            "missing corpus fixture /railcorpus/$name.json"
+        }
+        return json.decodeFromString(resource.bufferedReader().readText())
+    }
+
+    @Serializable
+    private data class CorpusBook(
+        val book: String,
+        val provenance: String,
+        val toc: List<CorpusToc>,
+        val spine: List<CorpusSpineEntry>,
+        val expected: List<CorpusSegment>,
+    )
+
+    @Serializable
+    private data class CorpusToc(
+        val title: String,
+        val href: String,
+        val children: List<CorpusToc> = emptyList(),
+    ) {
+        fun toModel(): TocEntry = TocEntry(title, href, children.map { it.toModel() })
+    }
+
+    @Serializable
+    private data class CorpusSpineEntry(val href: String, val positions: Int)
+
+    @Serializable
+    private data class CorpusSegment(val title: String, val href: String, val groupIndex: Int? = null)
+
+    private companion object {
+        val json = Json { ignoreUnknownKeys = true }
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentGeneratorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentGeneratorTest.kt
@@ -76,7 +76,7 @@ class RailSegmentGeneratorTest {
         val story1 = TocEntry("Story 1", "story1.xhtml")
         val blank = TocEntry("", "container.xhtml", listOf(story1))
         assertEquals(
-            listOf(RailSegment("Story 1", "story1.xhtml", groupIndex = 0)),
+            listOf(RailSegment("Story 1", "story1.xhtml")),
             buildRailSegments(listOf(blank)),
         )
     }
@@ -90,8 +90,8 @@ class RailSegmentGeneratorTest {
 
         assertEquals(
             listOf(
-                RailSegment("Leaf", "leaf.xhtml", groupIndex = 0),
-                RailSegment("Other", "other.xhtml", groupIndex = 1),
+                RailSegment("Leaf", "leaf.xhtml"),
+                RailSegment("Other", "other.xhtml"),
             ),
             buildRailSegments(toc),
         )
@@ -131,7 +131,7 @@ class RailSegmentGeneratorTest {
         val ch1 = TocEntry("Chapter 1", "ch1.xhtml")
         val container = TocEntry("Lucky Starr And The Rings Of Saturn", "container.xhtml", listOf(ch1))
         assertEquals(
-            listOf(RailSegment("Chapter 1", "ch1.xhtml", groupIndex = 0)),
+            listOf(RailSegment("Chapter 1", "ch1.xhtml")),
             buildRailSegments(listOf(container), bookTitle = "Lucky Starr and the Rings of Saturn"),
         )
     }
@@ -141,7 +141,7 @@ class RailSegmentGeneratorTest {
         val ch1 = TocEntry("Chapter 1", "ch1.xhtml")
         val container = TocEntry("  The   Metamorphosis  ", "container.xhtml", listOf(ch1))
         assertEquals(
-            listOf(RailSegment("Chapter 1", "ch1.xhtml", groupIndex = 0)),
+            listOf(RailSegment("Chapter 1", "ch1.xhtml")),
             buildRailSegments(listOf(container), bookTitle = "The Metamorphosis"),
         )
     }
@@ -156,7 +156,7 @@ class RailSegmentGeneratorTest {
         val segments = buildRailSegments(listOf(container), bookTitle = "Foo")
         assertEquals(1, segments.size)
         assertEquals(
-            RailSegment("Foo Bar Baz", "container.xhtml", groupIndex = 0),
+            RailSegment("Foo Bar Baz", "container.xhtml"),
             segments[0],
         )
     }
@@ -172,8 +172,8 @@ class RailSegmentGeneratorTest {
 
         assertEquals(
             listOf(
-                RailSegment("Chapter 1", "real-ch1.xhtml", groupIndex = 0),
-                RailSegment("Appendix", "appendix.xhtml", groupIndex = 1),
+                RailSegment("Chapter 1", "real-ch1.xhtml"),
+                RailSegment("Appendix", "appendix.xhtml"),
             ),
             buildRailSegments(toc, bookTitle = "Some Other Book"),
         )
@@ -197,7 +197,7 @@ class RailSegmentGeneratorTest {
         val ch1 = TocEntry("Ch 1", "ch1.xhtml")
         val blank = TocEntry("", "container.xhtml", listOf(ch1))
         assertEquals(
-            listOf(RailSegment("Ch 1", "ch1.xhtml", groupIndex = 0)),
+            listOf(RailSegment("Ch 1", "ch1.xhtml")),
             buildRailSegments(listOf(blank), bookTitle = "Some Book"),
         )
     }
@@ -210,7 +210,7 @@ class RailSegmentGeneratorTest {
         val inner = TocEntry("My Book", "inner.xhtml", listOf(leaf))
         val outer = TocEntry("My Book", "outer.xhtml", listOf(inner))
         assertEquals(
-            listOf(RailSegment("Leaf", "leaf.xhtml", groupIndex = 0)),
+            listOf(RailSegment("Leaf", "leaf.xhtml")),
             buildRailSegments(listOf(outer), bookTitle = "My Book"),
         )
     }
@@ -276,8 +276,10 @@ class RailSegmentGeneratorTest {
             )
         }
 
+        // Collapsed chapters are single-segment groups; coloring them would be a 21-color
+        // rainbow with no grouping information, so the rail also falls back to flat mode.
         assertEquals(
-            (1..21).map { RailSegment("Chapter $it", "ch$it.xhtml", groupIndex = it - 1) },
+            (1..21).map { RailSegment("Chapter $it", "ch$it.xhtml") },
             buildRailSegments(toc),
         )
     }
@@ -298,7 +300,7 @@ class RailSegmentGeneratorTest {
         val segments = buildRailSegments(heavy + light)
 
         assertEquals(21, segments.size)
-        assertEquals(RailSegment("Epilogue", "epilogue.xhtml", groupIndex = 20), segments.last())
+        assertEquals(RailSegment("Epilogue", "epilogue.xhtml"), segments.last())
     }
 
     @Test
@@ -375,7 +377,7 @@ class RailSegmentGeneratorTest {
         val ch20 = TocEntry("Chapter 20", "chapter20.xhtml", listOf(sol376, sol380))
 
         assertEquals(
-            listOf(RailSegment("Chapter 20", "chapter20.xhtml", groupIndex = 0)),
+            listOf(RailSegment("Chapter 20", "chapter20.xhtml")),
             buildRailSegments(listOf(ch20)),
         )
     }
@@ -430,7 +432,7 @@ class RailSegmentGeneratorTest {
         val positionCounts = listOf(15, 3, 3, 3)
 
         assertEquals(
-            listOf(RailSegment("Chapter 4", "chapter4.xhtml", groupIndex = 0)),
+            listOf(RailSegment("Chapter 4", "chapter4.xhtml")),
             buildRailSegments(listOf(ch4), spineHrefs = spineHrefs, positionCounts = positionCounts),
         )
     }
@@ -670,7 +672,6 @@ class RailSegmentGeneratorTest {
                 RailSegment(
                     "Четвърта глава. Детето съдия",
                     "chapter-78.xhtml",
-                    groupIndex = 0,
                 ),
             ),
             buildRailSegments(listOf(parent), spineHrefs = spineHrefs, positionCounts = positionCounts),
@@ -690,7 +691,7 @@ class RailSegmentGeneratorTest {
         val positionCounts = listOf(1, 2, 3, 1)
 
         assertEquals(
-            listOf(RailSegment("Трета глава", "chapter-102.xhtml", groupIndex = 0)),
+            listOf(RailSegment("Трета глава", "chapter-102.xhtml")),
             buildRailSegments(listOf(parent), spineHrefs = spineHrefs, positionCounts = positionCounts),
         )
     }
@@ -720,7 +721,7 @@ class RailSegmentGeneratorTest {
         val positionCounts = listOf(2, 2, 2, 2, 2, 5, 2)
 
         assertEquals(
-            listOf(RailSegment("Първа глава", "chapter-91.xhtml", groupIndex = 0)),
+            listOf(RailSegment("Първа глава", "chapter-91.xhtml")),
             buildRailSegments(listOf(parent), spineHrefs = spineHrefs, positionCounts = positionCounts),
         )
     }
@@ -736,7 +737,7 @@ class RailSegmentGeneratorTest {
         val positionCounts = listOf(1, 20, 0)
 
         assertEquals(
-            listOf(RailSegment("Part", "part.xhtml", groupIndex = 0)),
+            listOf(RailSegment("Part", "part.xhtml")),
             buildRailSegments(listOf(parent), spineHrefs = spineHrefs, positionCounts = positionCounts),
         )
     }
@@ -749,7 +750,7 @@ class RailSegmentGeneratorTest {
         val sol2 = TocEntry("LOG 2", "sol2.xhtml")
         val ch = TocEntry("Chapter 20", "chapter20.xhtml", listOf(sol1, sol2))
         assertEquals(
-            listOf(RailSegment("Chapter 20", "chapter20.xhtml", groupIndex = 0)),
+            listOf(RailSegment("Chapter 20", "chapter20.xhtml")),
             buildRailSegments(listOf(ch)),
         )
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentGeneratorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentGeneratorTest.kt
@@ -262,10 +262,50 @@ class RailSegmentGeneratorTest {
     }
 
     @Test
+    fun `section-heavy book collapses same-file sections back to chapter segments`() {
+        // "A Philosophy of Software Design" / "Monolith to Microservices" report: ~21 chapters,
+        // each carrying several same-file section anchors, explode into 100+ rail segments. The
+        // rail punches 2.5dp gaps between segments, so at that count the map is mostly gaps and
+        // unreadable. Above the readability cap, same-file sections must collapse so the rail
+        // shows one segment per chapter again.
+        val toc = (1..21).map { ch ->
+            TocEntry(
+                "Chapter $ch",
+                "ch$ch.xhtml",
+                (1..5).map { s -> TocEntry("$ch.$s", "ch$ch.xhtml#s$s") },
+            )
+        }
+
+        assertEquals(
+            (1..21).map { RailSegment("Chapter $it", "ch$it.xhtml", groupIndex = it - 1) },
+            buildRailSegments(toc),
+        )
+    }
+
+    @Test
+    fun `section-count cap is all-or-nothing across the book`() {
+        // One section-light chapter in an otherwise section-heavy book must not stay exploded
+        // while its siblings collapse — granularity is a whole-book decision.
+        val heavy = (1..20).map { ch ->
+            TocEntry(
+                "Chapter $ch",
+                "ch$ch.xhtml",
+                (1..5).map { s -> TocEntry("$ch.$s", "ch$ch.xhtml#s$s") },
+            )
+        }
+        val light = TocEntry("Epilogue", "epilogue.xhtml", listOf(TocEntry("Notes", "epilogue.xhtml#notes")))
+
+        val segments = buildRailSegments(heavy + light)
+
+        assertEquals(21, segments.size)
+        assertEquals(RailSegment("Epilogue", "epilogue.xhtml", groupIndex = 20), segments.last())
+    }
+
+    @Test
     fun `chapter groups color their exposed same-file sections`() {
-        // "A Philosophy of Software Design" shape from the reported regression:
-        // top-level chapters own indented same-file section anchors. Each section becomes a rail
-        // segment and inherits its top-level chapter's group color.
+        // Section-sparse Chapter → same-file-anchor shape: with the whole book under the
+        // readability cap, each section becomes a rail segment and inherits its top-level
+        // chapter's group color.
         val chapter1 = TocEntry(
             "1: Introduction",
             "ch01.html",

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentInvariantTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/RailSegmentInvariantTest.kt
@@ -1,0 +1,83 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.models.TocEntry
+import kotlin.random.Random
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Property test for the rail's global readability invariant. Unlike the fixture tests, this is
+ * not tied to any expected segment list, so it cannot be "updated to match" a behavior change —
+ * weakening it requires editing this claim itself:
+ *
+ * Same-file section segments (several rail segments sharing one spine resource) may only appear
+ * when the whole book stays within [MAX_SEGMENTS_WITH_SAME_FILE_SECTIONS]. Beyond that the rail's
+ * 2.5dp inter-segment gaps dominate and the chapter map degenerates — the section-flood bug
+ * reported on "A Philosophy of Software Design" / "Monolith to Microservices". Flat TOCs are
+ * exempt: one segment per spine resource mirrors the book's real granularity at any count.
+ */
+class RailSegmentInvariantTest {
+
+    @Test
+    fun `same-file sections are never exposed beyond the readability cap`() {
+        val rng = Random(42)
+        repeat(500) { iteration ->
+            val toc = randomToc(rng)
+            val spine = toc.map { it.href.substringBefore('#') }
+            val segments = if (rng.nextBoolean()) {
+                buildRailSegments(toc)
+            } else {
+                buildRailSegments(
+                    toc,
+                    bookTitle = "Property Book",
+                    spineHrefs = spine,
+                    positionCounts = spine.map { rng.nextInt(0, 40) },
+                )
+            }
+            val hasSameFileSections = segments
+                .groupBy { it.href.substringBefore('#') }
+                .any { it.value.size > 1 }
+            if (hasSameFileSections) {
+                assertTrue(
+                    "iteration $iteration: ${segments.size} segments while same-file sections " +
+                        "are exposed (cap $MAX_SEGMENTS_WITH_SAME_FILE_SECTIONS)",
+                    segments.size <= MAX_SEGMENTS_WITH_SAME_FILE_SECTIONS,
+                )
+            }
+        }
+    }
+
+    /**
+     * Random book shapes spanning the generator's decision space: flat leaves, chapters with
+     * same-file section anchors, cross-file part containers with chapter children, and the
+     * occasional blank-titled wrapper.
+     */
+    private fun randomToc(rng: Random): List<TocEntry> {
+        val topLevelCount = rng.nextInt(1, 41)
+        return List(topLevelCount) { i ->
+            val href = "ch$i.xhtml"
+            when (rng.nextInt(4)) {
+                // Flat leaf chapter.
+                0 -> TocEntry("Chapter $i", href)
+                // Chapter with same-file section anchors.
+                1 -> TocEntry(
+                    "Chapter $i",
+                    href,
+                    List(rng.nextInt(1, 13)) { s -> TocEntry("$i.$s", "$href#s$s") },
+                )
+                // Cross-file part container with leaf chapter children.
+                2 -> TocEntry(
+                    "Part $i",
+                    href,
+                    List(rng.nextInt(1, 7)) { c -> TocEntry("Chapter $i.$c", "ch$i-$c.xhtml") },
+                )
+                // Blank-titled wrapper (always replaced by its children).
+                else -> TocEntry(
+                    if (rng.nextBoolean()) "" else "Chapter $i",
+                    href,
+                    List(rng.nextInt(1, 5)) { s -> TocEntry("$i.$s", "$href#s$s") },
+                )
+            }
+        }
+    }
+}

--- a/app/src/test/resources/railcorpus/a-philosophy-of-software-design.json
+++ b/app/src/test/resources/railcorpus/a-philosophy-of-software-design.json
@@ -1,0 +1,812 @@
+{
+  "book": "A Philosophy of Software Design",
+  "provenance": "TOC transcribed from the 1st-edition print contents (dandelon.com TOC scan, ISBN 9781732102200). Hrefs synthesized in the Calibre part-file convention observed in the user's real EPUB (philosophy_ch2.xhtml test fixture is titled 'part0006', i.e. chapter N = part(N+4)); section anchor ids are synthesized. Position counts approximated as one position per print page from the TOC page numbers. Re-extract toc/spine/anchors from the real EPUB when a media server is reachable; 'expected' captures the intended rail behavior and should only change with a deliberate rail-granularity decision.",
+  "toc": [
+    {
+      "title": "Preface",
+      "href": "text/part0004.html"
+    },
+    {
+      "title": "1 Introduction",
+      "href": "text/part0005.html",
+      "children": [
+        {
+          "title": "1.1 How to use this book",
+          "href": "text/part0005.html#s1-1"
+        }
+      ]
+    },
+    {
+      "title": "2 The Nature of Complexity",
+      "href": "text/part0006.html",
+      "children": [
+        {
+          "title": "2.1 Complexity defined",
+          "href": "text/part0006.html#s2-1"
+        },
+        {
+          "title": "2.2 Symptoms of complexity",
+          "href": "text/part0006.html#s2-2"
+        },
+        {
+          "title": "2.3 Causes of complexity",
+          "href": "text/part0006.html#s2-3"
+        },
+        {
+          "title": "2.4 Complexity is incremental",
+          "href": "text/part0006.html#s2-4"
+        },
+        {
+          "title": "2.5 Conclusion",
+          "href": "text/part0006.html#s2-5"
+        }
+      ]
+    },
+    {
+      "title": "3 Working Code Isn't Enough",
+      "href": "text/part0007.html",
+      "children": [
+        {
+          "title": "3.1 Tactical programming",
+          "href": "text/part0007.html#s3-1"
+        },
+        {
+          "title": "3.2 Strategic programming",
+          "href": "text/part0007.html#s3-2"
+        },
+        {
+          "title": "3.3 How much to invest?",
+          "href": "text/part0007.html#s3-3"
+        },
+        {
+          "title": "3.4 Startups and investment",
+          "href": "text/part0007.html#s3-4"
+        },
+        {
+          "title": "3.5 Conclusion",
+          "href": "text/part0007.html#s3-5"
+        }
+      ]
+    },
+    {
+      "title": "4 Modules Should Be Deep",
+      "href": "text/part0008.html",
+      "children": [
+        {
+          "title": "4.1 Modular design",
+          "href": "text/part0008.html#s4-1"
+        },
+        {
+          "title": "4.2 What's in an interface?",
+          "href": "text/part0008.html#s4-2"
+        },
+        {
+          "title": "4.3 Abstractions",
+          "href": "text/part0008.html#s4-3"
+        },
+        {
+          "title": "4.4 Deep modules",
+          "href": "text/part0008.html#s4-4"
+        },
+        {
+          "title": "4.5 Shallow modules",
+          "href": "text/part0008.html#s4-5"
+        },
+        {
+          "title": "4.6 Classitis",
+          "href": "text/part0008.html#s4-6"
+        },
+        {
+          "title": "4.7 Examples: Java and Unix I/O",
+          "href": "text/part0008.html#s4-7"
+        },
+        {
+          "title": "4.8 Conclusion",
+          "href": "text/part0008.html#s4-8"
+        }
+      ]
+    },
+    {
+      "title": "5 Information Hiding (and Leakage)",
+      "href": "text/part0009.html",
+      "children": [
+        {
+          "title": "5.1 Information hiding",
+          "href": "text/part0009.html#s5-1"
+        },
+        {
+          "title": "5.2 Information leakage",
+          "href": "text/part0009.html#s5-2"
+        },
+        {
+          "title": "5.3 Temporal decomposition",
+          "href": "text/part0009.html#s5-3"
+        },
+        {
+          "title": "5.4 Example: HTTP server",
+          "href": "text/part0009.html#s5-4"
+        },
+        {
+          "title": "5.5 Example: too many classes",
+          "href": "text/part0009.html#s5-5"
+        },
+        {
+          "title": "5.6 Example: HTTP parameter handling",
+          "href": "text/part0009.html#s5-6"
+        },
+        {
+          "title": "5.7 Example: defaults in HTTP responses",
+          "href": "text/part0009.html#s5-7"
+        },
+        {
+          "title": "5.8 Information hiding within a class",
+          "href": "text/part0009.html#s5-8"
+        },
+        {
+          "title": "5.9 Taking it too far",
+          "href": "text/part0009.html#s5-9"
+        },
+        {
+          "title": "5.10 Conclusion",
+          "href": "text/part0009.html#s5-10"
+        }
+      ]
+    },
+    {
+      "title": "6 General-Purpose Modules are Deeper",
+      "href": "text/part0010.html",
+      "children": [
+        {
+          "title": "6.1 Make classes somewhat general-purpose",
+          "href": "text/part0010.html#s6-1"
+        },
+        {
+          "title": "6.2 Example: storing text for an editor",
+          "href": "text/part0010.html#s6-2"
+        },
+        {
+          "title": "6.3 A more general-purpose API",
+          "href": "text/part0010.html#s6-3"
+        },
+        {
+          "title": "6.4 Generality leads to better information hiding",
+          "href": "text/part0010.html#s6-4"
+        },
+        {
+          "title": "6.5 Questions to ask yourself",
+          "href": "text/part0010.html#s6-5"
+        },
+        {
+          "title": "6.6 Conclusion",
+          "href": "text/part0010.html#s6-6"
+        }
+      ]
+    },
+    {
+      "title": "7 Different Layer, Different Abstraction",
+      "href": "text/part0011.html",
+      "children": [
+        {
+          "title": "7.1 Pass-through methods",
+          "href": "text/part0011.html#s7-1"
+        },
+        {
+          "title": "7.2 When is interface duplication OK?",
+          "href": "text/part0011.html#s7-2"
+        },
+        {
+          "title": "7.3 Decorators",
+          "href": "text/part0011.html#s7-3"
+        },
+        {
+          "title": "7.4 Interface versus implementation",
+          "href": "text/part0011.html#s7-4"
+        },
+        {
+          "title": "7.5 Pass-through variables",
+          "href": "text/part0011.html#s7-5"
+        },
+        {
+          "title": "7.6 Conclusion",
+          "href": "text/part0011.html#s7-6"
+        }
+      ]
+    },
+    {
+      "title": "8 Pull Complexity Downwards",
+      "href": "text/part0012.html",
+      "children": [
+        {
+          "title": "8.1 Example: editor text class",
+          "href": "text/part0012.html#s8-1"
+        },
+        {
+          "title": "8.2 Example: configuration parameters",
+          "href": "text/part0012.html#s8-2"
+        },
+        {
+          "title": "8.3 Taking it too far",
+          "href": "text/part0012.html#s8-3"
+        },
+        {
+          "title": "8.4 Conclusion",
+          "href": "text/part0012.html#s8-4"
+        }
+      ]
+    },
+    {
+      "title": "9 Better Together Or Better Apart?",
+      "href": "text/part0013.html",
+      "children": [
+        {
+          "title": "9.1 Bring together if information is shared",
+          "href": "text/part0013.html#s9-1"
+        },
+        {
+          "title": "9.2 Bring together if it will simplify the interface",
+          "href": "text/part0013.html#s9-2"
+        },
+        {
+          "title": "9.3 Bring together to eliminate duplication",
+          "href": "text/part0013.html#s9-3"
+        },
+        {
+          "title": "9.4 Separate general-purpose and special-purpose code",
+          "href": "text/part0013.html#s9-4"
+        },
+        {
+          "title": "9.5 Example: insertion cursor and selection",
+          "href": "text/part0013.html#s9-5"
+        },
+        {
+          "title": "9.6 Example: separate class for logging",
+          "href": "text/part0013.html#s9-6"
+        },
+        {
+          "title": "9.7 Example: editor undo mechanism",
+          "href": "text/part0013.html#s9-7"
+        },
+        {
+          "title": "9.8 Splitting and joining methods",
+          "href": "text/part0013.html#s9-8"
+        },
+        {
+          "title": "9.9 Conclusion",
+          "href": "text/part0013.html#s9-9"
+        }
+      ]
+    },
+    {
+      "title": "10 Define Errors Out Of Existence",
+      "href": "text/part0014.html",
+      "children": [
+        {
+          "title": "10.1 Why exceptions add complexity",
+          "href": "text/part0014.html#s10-1"
+        },
+        {
+          "title": "10.2 Too many exceptions",
+          "href": "text/part0014.html#s10-2"
+        },
+        {
+          "title": "10.3 Define errors out of existence",
+          "href": "text/part0014.html#s10-3"
+        },
+        {
+          "title": "10.4 Example: file deletion in Windows",
+          "href": "text/part0014.html#s10-4"
+        },
+        {
+          "title": "10.5 Example: Java substring method",
+          "href": "text/part0014.html#s10-5"
+        },
+        {
+          "title": "10.6 Mask exceptions",
+          "href": "text/part0014.html#s10-6"
+        },
+        {
+          "title": "10.7 Exception aggregation",
+          "href": "text/part0014.html#s10-7"
+        },
+        {
+          "title": "10.8 Just crash?",
+          "href": "text/part0014.html#s10-8"
+        },
+        {
+          "title": "10.9 Design special cases out of existence",
+          "href": "text/part0014.html#s10-9"
+        },
+        {
+          "title": "10.10 Taking it too far",
+          "href": "text/part0014.html#s10-10"
+        },
+        {
+          "title": "10.11 Conclusion",
+          "href": "text/part0014.html#s10-11"
+        }
+      ]
+    },
+    {
+      "title": "11 Design it Twice",
+      "href": "text/part0015.html"
+    },
+    {
+      "title": "12 Why Write Comments? The Four Excuses",
+      "href": "text/part0016.html",
+      "children": [
+        {
+          "title": "12.1 Good code is self-documenting",
+          "href": "text/part0016.html#s12-1"
+        },
+        {
+          "title": "12.2 I don't have time to write comments",
+          "href": "text/part0016.html#s12-2"
+        },
+        {
+          "title": "12.3 Comments get out of date and become misleading",
+          "href": "text/part0016.html#s12-3"
+        },
+        {
+          "title": "12.4 All the comments I have seen are worthless",
+          "href": "text/part0016.html#s12-4"
+        },
+        {
+          "title": "12.5 Benefits of well-written comments",
+          "href": "text/part0016.html#s12-5"
+        }
+      ]
+    },
+    {
+      "title": "13 Comments Should Describe Things that Aren't Obvious from the Code",
+      "href": "text/part0017.html",
+      "children": [
+        {
+          "title": "13.1 Pick conventions",
+          "href": "text/part0017.html#s13-1"
+        },
+        {
+          "title": "13.2 Don't repeat the code",
+          "href": "text/part0017.html#s13-2"
+        },
+        {
+          "title": "13.3 Lower-level comments add precision",
+          "href": "text/part0017.html#s13-3"
+        },
+        {
+          "title": "13.4 Higher-level comments enhance intuition",
+          "href": "text/part0017.html#s13-4"
+        },
+        {
+          "title": "13.5 Interface documentation",
+          "href": "text/part0017.html#s13-5"
+        },
+        {
+          "title": "13.6 Implementation comments: what and why, not how",
+          "href": "text/part0017.html#s13-6"
+        },
+        {
+          "title": "13.7 Cross-module design decisions",
+          "href": "text/part0017.html#s13-7"
+        },
+        {
+          "title": "13.8 Conclusion",
+          "href": "text/part0017.html#s13-8"
+        },
+        {
+          "title": "13.9 Answers to questions on page 113",
+          "href": "text/part0017.html#s13-9"
+        }
+      ]
+    },
+    {
+      "title": "14 Choosing Names",
+      "href": "text/part0018.html",
+      "children": [
+        {
+          "title": "14.1 Example: bad names cause bugs",
+          "href": "text/part0018.html#s14-1"
+        },
+        {
+          "title": "14.2 Create an image",
+          "href": "text/part0018.html#s14-2"
+        },
+        {
+          "title": "14.3 Names should be precise",
+          "href": "text/part0018.html#s14-3"
+        },
+        {
+          "title": "14.4 Use names consistently",
+          "href": "text/part0018.html#s14-4"
+        },
+        {
+          "title": "14.5 A different opinion: Go style guide",
+          "href": "text/part0018.html#s14-5"
+        },
+        {
+          "title": "14.6 Conclusion",
+          "href": "text/part0018.html#s14-6"
+        }
+      ]
+    },
+    {
+      "title": "15 Write The Comments First",
+      "href": "text/part0019.html",
+      "children": [
+        {
+          "title": "15.1 Delayed comments are bad comments",
+          "href": "text/part0019.html#s15-1"
+        },
+        {
+          "title": "15.2 Write the comments first",
+          "href": "text/part0019.html#s15-2"
+        },
+        {
+          "title": "15.3 Comments are a design tool",
+          "href": "text/part0019.html#s15-3"
+        },
+        {
+          "title": "15.4 Early comments are fun comments",
+          "href": "text/part0019.html#s15-4"
+        },
+        {
+          "title": "15.5 Are early comments expensive?",
+          "href": "text/part0019.html#s15-5"
+        },
+        {
+          "title": "15.6 Conclusion",
+          "href": "text/part0019.html#s15-6"
+        }
+      ]
+    },
+    {
+      "title": "16 Modifying Existing Code",
+      "href": "text/part0020.html",
+      "children": [
+        {
+          "title": "16.1 Stay strategic",
+          "href": "text/part0020.html#s16-1"
+        },
+        {
+          "title": "16.2 Maintaining comments: keep the comments near the code",
+          "href": "text/part0020.html#s16-2"
+        },
+        {
+          "title": "16.3 Comments belong in the code, not the commit log",
+          "href": "text/part0020.html#s16-3"
+        },
+        {
+          "title": "16.4 Maintaining comments: avoid duplication",
+          "href": "text/part0020.html#s16-4"
+        },
+        {
+          "title": "16.5 Maintaining comments: check the diffs",
+          "href": "text/part0020.html#s16-5"
+        },
+        {
+          "title": "16.6 Higher-level comments are easier to maintain",
+          "href": "text/part0020.html#s16-6"
+        }
+      ]
+    },
+    {
+      "title": "17 Consistency",
+      "href": "text/part0021.html",
+      "children": [
+        {
+          "title": "17.1 Examples of consistency",
+          "href": "text/part0021.html#s17-1"
+        },
+        {
+          "title": "17.2 Ensuring consistency",
+          "href": "text/part0021.html#s17-2"
+        },
+        {
+          "title": "17.3 Taking it too far",
+          "href": "text/part0021.html#s17-3"
+        },
+        {
+          "title": "17.4 Conclusion",
+          "href": "text/part0021.html#s17-4"
+        }
+      ]
+    },
+    {
+      "title": "18 Code Should be Obvious",
+      "href": "text/part0022.html",
+      "children": [
+        {
+          "title": "18.1 Things that make code more obvious",
+          "href": "text/part0022.html#s18-1"
+        },
+        {
+          "title": "18.2 Things that make code less obvious",
+          "href": "text/part0022.html#s18-2"
+        },
+        {
+          "title": "18.3 Conclusion",
+          "href": "text/part0022.html#s18-3"
+        }
+      ]
+    },
+    {
+      "title": "19 Software Trends",
+      "href": "text/part0023.html",
+      "children": [
+        {
+          "title": "19.1 Object-oriented programming and inheritance",
+          "href": "text/part0023.html#s19-1"
+        },
+        {
+          "title": "19.2 Agile development",
+          "href": "text/part0023.html#s19-2"
+        },
+        {
+          "title": "19.3 Unit tests",
+          "href": "text/part0023.html#s19-3"
+        },
+        {
+          "title": "19.4 Test-driven development",
+          "href": "text/part0023.html#s19-4"
+        },
+        {
+          "title": "19.5 Design patterns",
+          "href": "text/part0023.html#s19-5"
+        },
+        {
+          "title": "19.6 Getters and setters",
+          "href": "text/part0023.html#s19-6"
+        },
+        {
+          "title": "19.7 Conclusion",
+          "href": "text/part0023.html#s19-7"
+        }
+      ]
+    },
+    {
+      "title": "20 Designing for Performance",
+      "href": "text/part0024.html",
+      "children": [
+        {
+          "title": "20.1 How to think about performance",
+          "href": "text/part0024.html#s20-1"
+        },
+        {
+          "title": "20.2 Measure before modifying",
+          "href": "text/part0024.html#s20-2"
+        },
+        {
+          "title": "20.3 Design around the critical path",
+          "href": "text/part0024.html#s20-3"
+        },
+        {
+          "title": "20.4 An example: RAMCloud Buffers",
+          "href": "text/part0024.html#s20-4"
+        },
+        {
+          "title": "20.5 Conclusion",
+          "href": "text/part0024.html#s20-5"
+        }
+      ]
+    },
+    {
+      "title": "21 Conclusion",
+      "href": "text/part0025.html"
+    },
+    {
+      "title": "Index",
+      "href": "text/part0026.html"
+    },
+    {
+      "title": "Summary of Design Principles",
+      "href": "text/part0027.html"
+    },
+    {
+      "title": "Summary of Red Flags",
+      "href": "text/part0028.html"
+    }
+  ],
+  "spine": [
+    {
+      "href": "text/part0004.html",
+      "positions": 4
+    },
+    {
+      "href": "text/part0005.html",
+      "positions": 4
+    },
+    {
+      "href": "text/part0006.html",
+      "positions": 8
+    },
+    {
+      "href": "text/part0007.html",
+      "positions": 6
+    },
+    {
+      "href": "text/part0008.html",
+      "positions": 10
+    },
+    {
+      "href": "text/part0009.html",
+      "positions": 10
+    },
+    {
+      "href": "text/part0010.html",
+      "positions": 6
+    },
+    {
+      "href": "text/part0011.html",
+      "positions": 10
+    },
+    {
+      "href": "text/part0012.html",
+      "positions": 4
+    },
+    {
+      "href": "text/part0013.html",
+      "positions": 16
+    },
+    {
+      "href": "text/part0014.html",
+      "positions": 16
+    },
+    {
+      "href": "text/part0015.html",
+      "positions": 4
+    },
+    {
+      "href": "text/part0016.html",
+      "positions": 6
+    },
+    {
+      "href": "text/part0017.html",
+      "positions": 20
+    },
+    {
+      "href": "text/part0018.html",
+      "positions": 8
+    },
+    {
+      "href": "text/part0019.html",
+      "positions": 6
+    },
+    {
+      "href": "text/part0020.html",
+      "positions": 6
+    },
+    {
+      "href": "text/part0021.html",
+      "positions": 4
+    },
+    {
+      "href": "text/part0022.html",
+      "positions": 6
+    },
+    {
+      "href": "text/part0023.html",
+      "positions": 8
+    },
+    {
+      "href": "text/part0024.html",
+      "positions": 10
+    },
+    {
+      "href": "text/part0025.html",
+      "positions": 2
+    },
+    {
+      "href": "text/part0026.html",
+      "positions": 4
+    },
+    {
+      "href": "text/part0027.html",
+      "positions": 2
+    },
+    {
+      "href": "text/part0028.html",
+      "positions": 1
+    }
+  ],
+  "expected": [
+    {
+      "title": "Preface",
+      "href": "text/part0004.html"
+    },
+    {
+      "title": "1 Introduction",
+      "href": "text/part0005.html"
+    },
+    {
+      "title": "2 The Nature of Complexity",
+      "href": "text/part0006.html"
+    },
+    {
+      "title": "3 Working Code Isn't Enough",
+      "href": "text/part0007.html"
+    },
+    {
+      "title": "4 Modules Should Be Deep",
+      "href": "text/part0008.html"
+    },
+    {
+      "title": "5 Information Hiding (and Leakage)",
+      "href": "text/part0009.html"
+    },
+    {
+      "title": "6 General-Purpose Modules are Deeper",
+      "href": "text/part0010.html"
+    },
+    {
+      "title": "7 Different Layer, Different Abstraction",
+      "href": "text/part0011.html"
+    },
+    {
+      "title": "8 Pull Complexity Downwards",
+      "href": "text/part0012.html"
+    },
+    {
+      "title": "9 Better Together Or Better Apart?",
+      "href": "text/part0013.html"
+    },
+    {
+      "title": "10 Define Errors Out Of Existence",
+      "href": "text/part0014.html"
+    },
+    {
+      "title": "11 Design it Twice",
+      "href": "text/part0015.html"
+    },
+    {
+      "title": "12 Why Write Comments? The Four Excuses",
+      "href": "text/part0016.html"
+    },
+    {
+      "title": "13 Comments Should Describe Things that Aren't Obvious from the Code",
+      "href": "text/part0017.html"
+    },
+    {
+      "title": "14 Choosing Names",
+      "href": "text/part0018.html"
+    },
+    {
+      "title": "15 Write The Comments First",
+      "href": "text/part0019.html"
+    },
+    {
+      "title": "16 Modifying Existing Code",
+      "href": "text/part0020.html"
+    },
+    {
+      "title": "17 Consistency",
+      "href": "text/part0021.html"
+    },
+    {
+      "title": "18 Code Should be Obvious",
+      "href": "text/part0022.html"
+    },
+    {
+      "title": "19 Software Trends",
+      "href": "text/part0023.html"
+    },
+    {
+      "title": "20 Designing for Performance",
+      "href": "text/part0024.html"
+    },
+    {
+      "title": "21 Conclusion",
+      "href": "text/part0025.html"
+    },
+    {
+      "title": "Index",
+      "href": "text/part0026.html"
+    },
+    {
+      "title": "Summary of Design Principles",
+      "href": "text/part0027.html"
+    },
+    {
+      "title": "Summary of Red Flags",
+      "href": "text/part0028.html"
+    }
+  ]
+}

--- a/app/src/test/resources/railcorpus/monolith-to-microservices.json
+++ b/app/src/test/resources/railcorpus/monolith-to-microservices.json
@@ -1,0 +1,370 @@
+{
+  "book": "Monolith to Microservices",
+  "provenance": "RECONSTRUCTED (not extracted from the real EPUB — ABS/Storyteller were unreachable and oreilly.com blocks fetches): chapter/section structure from the book's published section listings (github.com/SaraLerma/Monolith-To-Microservices summary cross-checked against O'Reilly chapter pages indexed in search results), depth-2 only; O'Reilly-convention hrefs, synthesized anchors, positions approximated from print page spans (~270 pages total). The real O'Reilly nav is DEEPER than this (pattern subsections like 'How It Works'/'Where to Use It' at depth 3, which do not become rail segments) and may name a few depth-2 sections differently. Re-extract from the real EPUB when available. 'expected' captures the intended rail behavior: 57 same-file sections exceed the readability cap, so the rail collapses to chapter granularity.",
+  "toc": [
+    {
+      "title": "Preface",
+      "href": "preface01.html",
+      "children": [
+        {
+          "title": "What You Will Learn",
+          "href": "preface01.html#learn"
+        },
+        {
+          "title": "Conventions Used in This Book",
+          "href": "preface01.html#conventions"
+        },
+        {
+          "title": "O'Reilly Online Learning",
+          "href": "preface01.html#oreilly"
+        },
+        {
+          "title": "Acknowledgments",
+          "href": "preface01.html#acks"
+        }
+      ]
+    },
+    {
+      "title": "1. Just Enough Microservices",
+      "href": "ch01.html",
+      "children": [
+        {
+          "title": "What Are Microservices?",
+          "href": "ch01.html#what-are"
+        },
+        {
+          "title": "The Monolith",
+          "href": "ch01.html#monolith"
+        },
+        {
+          "title": "On Coupling and Cohesion",
+          "href": "ch01.html#coupling"
+        },
+        {
+          "title": "Just Enough Domain-Driven Design",
+          "href": "ch01.html#ddd"
+        },
+        {
+          "title": "Summary",
+          "href": "ch01.html#summary"
+        }
+      ]
+    },
+    {
+      "title": "2. Planning a Migration",
+      "href": "ch02.html",
+      "children": [
+        {
+          "title": "Understanding the Goal",
+          "href": "ch02.html#goal"
+        },
+        {
+          "title": "Why Might You Choose Microservices?",
+          "href": "ch02.html#why"
+        },
+        {
+          "title": "When Might Microservices Be a Bad Idea?",
+          "href": "ch02.html#bad-idea"
+        },
+        {
+          "title": "Trade-Offs",
+          "href": "ch02.html#tradeoffs"
+        },
+        {
+          "title": "Taking People on the Journey",
+          "href": "ch02.html#people"
+        },
+        {
+          "title": "Changing Organizations",
+          "href": "ch02.html#orgs"
+        },
+        {
+          "title": "Importance of Incremental Migration",
+          "href": "ch02.html#incremental"
+        },
+        {
+          "title": "Cost of Change",
+          "href": "ch02.html#cost"
+        },
+        {
+          "title": "Domain-Driven Design",
+          "href": "ch02.html#ddd"
+        },
+        {
+          "title": "Reorganizing Teams",
+          "href": "ch02.html#teams"
+        },
+        {
+          "title": "How Will You Know if the Transition Is Working?",
+          "href": "ch02.html#working"
+        },
+        {
+          "title": "Summary",
+          "href": "ch02.html#summary"
+        }
+      ]
+    },
+    {
+      "title": "3. Splitting the Monolith",
+      "href": "ch03.html",
+      "children": [
+        {
+          "title": "To Change the Monolith, or Not?",
+          "href": "ch03.html#change-or-not"
+        },
+        {
+          "title": "Migration Patterns",
+          "href": "ch03.html#patterns"
+        },
+        {
+          "title": "Pattern: Strangler Fig Application",
+          "href": "ch03.html#strangler"
+        },
+        {
+          "title": "Changing Behavior While Migrating Functionality",
+          "href": "ch03.html#behavior"
+        },
+        {
+          "title": "Pattern: UI Composition",
+          "href": "ch03.html#ui-composition"
+        },
+        {
+          "title": "Pattern: Branch by Abstraction",
+          "href": "ch03.html#branch-abstraction"
+        },
+        {
+          "title": "Pattern: Parallel Run",
+          "href": "ch03.html#parallel-run"
+        },
+        {
+          "title": "Pattern: Decorating Collaborator",
+          "href": "ch03.html#decorating"
+        },
+        {
+          "title": "Pattern: Change Data Capture",
+          "href": "ch03.html#cdc"
+        },
+        {
+          "title": "Summary",
+          "href": "ch03.html#summary"
+        }
+      ]
+    },
+    {
+      "title": "4. Decomposing the Database",
+      "href": "ch04.html",
+      "children": [
+        {
+          "title": "Pattern: The Shared Database",
+          "href": "ch04.html#shared-db"
+        },
+        {
+          "title": "But It Can't Be Done!",
+          "href": "ch04.html#cant-be-done"
+        },
+        {
+          "title": "Pattern: Database View",
+          "href": "ch04.html#db-view"
+        },
+        {
+          "title": "Pattern: Database Wrapping Service",
+          "href": "ch04.html#db-wrapping"
+        },
+        {
+          "title": "Pattern: Database-as-a-Service Interface",
+          "href": "ch04.html#dbaas"
+        },
+        {
+          "title": "Transferring Ownership",
+          "href": "ch04.html#ownership"
+        },
+        {
+          "title": "Data Synchronization",
+          "href": "ch04.html#data-sync"
+        },
+        {
+          "title": "Pattern: Synchronize Data in Application",
+          "href": "ch04.html#sync-in-app"
+        },
+        {
+          "title": "Pattern: Tracer Write",
+          "href": "ch04.html#tracer-write"
+        },
+        {
+          "title": "Splitting Apart the Database",
+          "href": "ch04.html#splitting"
+        },
+        {
+          "title": "Schema Separation Examples",
+          "href": "ch04.html#schema-examples"
+        },
+        {
+          "title": "Transactions",
+          "href": "ch04.html#transactions"
+        },
+        {
+          "title": "Sagas",
+          "href": "ch04.html#sagas"
+        },
+        {
+          "title": "Summary",
+          "href": "ch04.html#summary"
+        }
+      ]
+    },
+    {
+      "title": "5. Growing Pains",
+      "href": "ch05.html",
+      "children": [
+        {
+          "title": "More Services, More Pain",
+          "href": "ch05.html#more-pain"
+        },
+        {
+          "title": "Ownership at Scale",
+          "href": "ch05.html#ownership"
+        },
+        {
+          "title": "Breaking Changes",
+          "href": "ch05.html#breaking"
+        },
+        {
+          "title": "Reporting",
+          "href": "ch05.html#reporting"
+        },
+        {
+          "title": "Monitoring and Troubleshooting",
+          "href": "ch05.html#monitoring"
+        },
+        {
+          "title": "Local Developer Experience",
+          "href": "ch05.html#dev-experience"
+        },
+        {
+          "title": "Running Too Many Things",
+          "href": "ch05.html#too-many"
+        },
+        {
+          "title": "End-to-End Testing",
+          "href": "ch05.html#e2e"
+        },
+        {
+          "title": "Global Versus Local Optimization",
+          "href": "ch05.html#optimization"
+        },
+        {
+          "title": "Robustness and Resiliency",
+          "href": "ch05.html#robustness"
+        },
+        {
+          "title": "Orphaned Services",
+          "href": "ch05.html#orphaned"
+        },
+        {
+          "title": "Summary",
+          "href": "ch05.html#summary"
+        }
+      ]
+    },
+    {
+      "title": "6. Closing Words",
+      "href": "ch06.html"
+    },
+    {
+      "title": "A. Bibliography",
+      "href": "app01.html"
+    },
+    {
+      "title": "B. Pattern Index",
+      "href": "app02.html"
+    },
+    {
+      "title": "Index",
+      "href": "ix01.html"
+    }
+  ],
+  "spine": [
+    {
+      "href": "preface01.html",
+      "positions": 8
+    },
+    {
+      "href": "ch01.html",
+      "positions": 38
+    },
+    {
+      "href": "ch02.html",
+      "positions": 42
+    },
+    {
+      "href": "ch03.html",
+      "positions": 68
+    },
+    {
+      "href": "ch04.html",
+      "positions": 88
+    },
+    {
+      "href": "ch05.html",
+      "positions": 38
+    },
+    {
+      "href": "ch06.html",
+      "positions": 3
+    },
+    {
+      "href": "app01.html",
+      "positions": 2
+    },
+    {
+      "href": "app02.html",
+      "positions": 3
+    },
+    {
+      "href": "ix01.html",
+      "positions": 12
+    }
+  ],
+  "expected": [
+    {
+      "title": "Preface",
+      "href": "preface01.html"
+    },
+    {
+      "title": "1. Just Enough Microservices",
+      "href": "ch01.html"
+    },
+    {
+      "title": "2. Planning a Migration",
+      "href": "ch02.html"
+    },
+    {
+      "title": "3. Splitting the Monolith",
+      "href": "ch03.html"
+    },
+    {
+      "title": "4. Decomposing the Database",
+      "href": "ch04.html"
+    },
+    {
+      "title": "5. Growing Pains",
+      "href": "ch05.html"
+    },
+    {
+      "title": "6. Closing Words",
+      "href": "ch06.html"
+    },
+    {
+      "title": "A. Bibliography",
+      "href": "app01.html"
+    },
+    {
+      "title": "B. Pattern Index",
+      "href": "app02.html"
+    },
+    {
+      "title": "Index",
+      "href": "ix01.html"
+    }
+  ]
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import com.riffle.buildlogic.AndroidImportLint
 import com.riffle.buildlogic.OkHttpConfinementLint
 import com.riffle.buildlogic.RiffleLogTagLint
 import com.riffle.buildlogic.ServerReferenceLint
+import com.riffle.buildlogic.TestGuardrailLint
 
 plugins {
     alias(libs.plugins.android.application) apply false
@@ -97,6 +98,27 @@ tasks.register("checkRiffleInfraSeams") {
             // migrate once the reader layer routes through DispatcherProvider.
             "app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt",
             "app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt",
+            // ---- Grandfathered when CI enforcement of these lints was turned on (the custom
+            // checks were wired into `check`, which no CI job ran — drift below accumulated
+            // unenforced). Same sweep-follow-up rationale as the blocks above.
+            // DefaultDispatcherProvider moved main → jvmMain in the core carve-out (#576).
+            "core/domain/src/jvmMain/kotlin/com/riffle/core/domain/DefaultDispatcherProvider.kt",
+            // Catalog adapters: network/parse work pinned to Dispatchers.IO/Default.
+            "core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt",
+            "core/catalog-gutenberg/src/main/kotlin/com/riffle/core/catalog/gutenberg/GutenbergCatalog.kt",
+            "core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalog.kt",
+            // core:data — file I/O, connectivity callbacks, sync timestamps.
+            "core/data/src/main/kotlin/com/riffle/core/data/ConnectivityObserverImpl.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/absbookmark/AbsBookmarkAnnotationSyncTarget.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/localfiles/CopyCoverImageUseCase.kt",
+            "core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesScanner.kt",
+            // Reader/session/export layer — same reader-layer rationale as the CBZ entries.
+            "app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/reader/FigureZoomOverlay.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/source/localfiles/PdfiumPdfMetadataExtractor.kt",
         )
 
         val scanRoots = listOf(
@@ -154,10 +176,23 @@ tasks.register("checkRendererBridgeUsage") {
         val bridgePackageRoot = layout.projectDirectory.dir(
             "app/src/main/kotlin/com/riffle/app/feature/reader/renderer",
         ).asFile.absolutePath
-        // Continuous mode has its own custom WebViews — out of scope per the issue.
+        // Continuous mode has its own custom WebViews — out of scope per the issue. The last two
+        // entries are sanctioned non-continuous seams; anything new belongs in RendererBridge.
         val continuousAllowlist = setOf(
             "app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt",
             "app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt",
+            // Continuous-mode controllers/binder drive the same custom ChapterWebViews.
+            "app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousDecorationController.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebViewBinder.kt",
+            // Cadence's continuous chapter-load hook receives a ChapterWebView (issue #403).
+            "app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt",
+            // WebViewFiguresInRangeResolver is unwired scaffolding (DI binds the Noop); it must
+            // move behind RendererBridge when the WebView seam that wires it lands.
+            "app/src/main/kotlin/com/riffle/app/feature/reader/FiguresInRangeResolver.kt",
+            // ADR 0046: the presenter's typed suspend wrapper around the Readium navigator's
+            // evaluateJavascript IS the sanctioned seam for emphasis-span injection.
+            "app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt",
         )
         val scanRoots = listOf(
             layout.projectDirectory.dir("app/src/main").asFile,
@@ -271,6 +306,85 @@ tasks.register("checkNoAndroidImports") {
     }
 }
 
+// Treats every @Test function as a guardrail: a test that disappears relative to the merge base
+// with main — deleted or renamed — fails the build unless a commit message on the branch declares
+// it with a `Removed-test: <exact test name>` trailer. Tests pin behavioral claims; the chapter-map
+// section-flood regression shipped by renaming three pinning tests to assert the opposite inside a
+// large feature diff. The trailer doesn't bypass judgment — it forces the retired claim to be
+// visible in `git log` and the PR instead of buried in a test-file diff. Detection logic lives in
+// buildSrc/.../TestGuardrailLint.kt; see AGENTS.md "Don't blindly update tests".
+tasks.register("checkTestGuardrails") {
+    group = "verification"
+    description = "Fails if @Test functions disappeared vs origin/main without a Removed-test: commit trailer."
+    notCompatibleWithConfigurationCache("invokes git at execution time")
+
+    doLast {
+        val projectRoot = layout.projectDirectory.asFile
+        fun git(vararg args: String): String? {
+            val process = ProcessBuilder(listOf("git") + args)
+                .directory(projectRoot)
+                .start()
+            val stdout = process.inputStream.bufferedReader().readText()
+            process.errorStream.bufferedReader().readText()
+            return if (process.waitFor() == 0) stdout else null
+        }
+
+        val base = git("merge-base", "HEAD", "origin/main")?.trim()
+            ?: git("merge-base", "HEAD", "main")?.trim()
+        if (base == null) {
+            logger.warn("checkTestGuardrails: no merge base with origin/main (shallow clone or missing remote) — skipping.")
+            return@doLast
+        }
+        val head = git("rev-parse", "HEAD")?.trim()
+        if (head == null || base == head) return@doLast
+
+        val oldTests = mutableMapOf<String, Set<String>>()
+        val newTests = mutableMapOf<String, Set<String>>()
+        val nameStatus = git("diff", "--name-status", "-M", base, "HEAD") ?: return@doLast
+        for (line in nameStatus.lineSequence().filter { it.isNotBlank() }) {
+            val parts = line.split('\t')
+            val status = parts[0]
+            val oldPath = parts.getOrNull(1) ?: continue
+            val newPath = if (status.startsWith("R") || status.startsWith("C")) parts.getOrNull(2) else oldPath
+            if (!status.startsWith("A") && TestGuardrailLint.isTestSourceFile(oldPath)) {
+                git("show", "$base:$oldPath")?.let { oldTests[oldPath] = TestGuardrailLint.extractTestNames(it) }
+            }
+            if (!status.startsWith("D") && newPath != null && TestGuardrailLint.isTestSourceFile(newPath)) {
+                git("show", "$head:$newPath")?.let { newTests[newPath] = TestGuardrailLint.extractTestNames(it) }
+            }
+        }
+
+        val declared = TestGuardrailLint.parseDeclaredRemovals(git("log", "--format=%B", "$base..HEAD").orEmpty())
+        val offenders = TestGuardrailLint.findUndeclaredRemovals(oldTests, newTests, declared)
+        if (offenders.isNotEmpty()) {
+            throw GradleException(
+                "Tests are guardrails: these @Test functions exist at the merge base with main but not on this " +
+                    "branch. If retiring each behavioral claim is intentional, declare it with a commit-message " +
+                    "trailer line `Removed-test: <exact test name>` and justify the change in the commit body / " +
+                    "PR (see AGENTS.md \"Don't blindly update tests\"):\n" +
+                    offenders.joinToString("\n") { "  ${it.render()}" },
+            )
+        }
+    }
+}
+
+// Aggregate for CI: the six static lints plus the test-guardrail check. The CI Lint job runs this
+// explicitly — module `check` tasks (which also depend on these) are never invoked on CI, where
+// unit tests run via `./gradlew test`.
+tasks.register("riffleChecks") {
+    group = "verification"
+    description = "Runs all custom Riffle lint/guardrail checks."
+    dependsOn(
+        "checkRiffleLogTags",
+        "checkRiffleInfraSeams",
+        "checkRendererBridgeUsage",
+        "checkNoServerReferences",
+        "checkNoAndroidImports",
+        "checkNoOkHttpOutsideCoreNet",
+        "checkTestGuardrails",
+    )
+}
+
 // Make it part of the normal `./gradlew check` run.
 allprojects {
     tasks.matching { it.name == "check" }.configureEach {
@@ -280,5 +394,6 @@ allprojects {
         dependsOn(rootProject.tasks.named("checkNoServerReferences"))
         dependsOn(rootProject.tasks.named("checkNoAndroidImports"))
         dependsOn(rootProject.tasks.named("checkNoOkHttpOutsideCoreNet"))
+        dependsOn(rootProject.tasks.named("checkTestGuardrails"))
     }
 }

--- a/buildSrc/src/main/kotlin/com/riffle/buildlogic/TestGuardrailLint.kt
+++ b/buildSrc/src/main/kotlin/com/riffle/buildlogic/TestGuardrailLint.kt
@@ -1,0 +1,76 @@
+package com.riffle.buildlogic
+
+/**
+ * Pure detector for disappearing `@Test` functions. Analogue of `RiffleLogTagLint` —
+ * the gradle task `checkTestGuardrails` is a thin git-plumbing wrapper around these
+ * functions, keeping the logic JUnit-testable.
+ *
+ * Every test assertion is a behavioral claim someone once made; deleting or renaming a
+ * test silently retires that claim. The chapter-map section-flood regression shipped
+ * exactly this way: three tests pinning "same-file sections collapse to one chapter
+ * segment" were renamed to assert the opposite inside a 300-line feature diff, and the
+ * removal was invisible in review. This lint turns every disappearance of a test
+ * function (relative to the merge base with main) into an explicit, declared event: the
+ * branch must carry a `Removed-test: <exact test name>` line in a commit message, which
+ * surfaces the retired claim in `git log` and the PR conversation.
+ */
+object TestGuardrailLint {
+
+    /** Matches `@Test` (optionally fully qualified) but not e.g. `@TestOnly`. */
+    private val TEST_ANNOTATION = Regex("""@(?:org\.junit\.)?Test\b""")
+
+    /** The next function declaration after a `@Test` annotation, backticked or plain. */
+    private val FUN_NAME = Regex("""\bfun\s+(?:`([^`]+)`|(\w+))\s*\(""")
+
+    private val REMOVED_TEST_TRAILER = Regex("""^Removed-test:\s*(.+)$""", RegexOption.MULTILINE)
+
+    private val TEST_SOURCE_DIR = Regex("""(^|/)src/(test|androidTest|jvmTest|commonTest)/""")
+
+    /** Kotlin files under a test source set are subject to the guardrail. */
+    fun isTestSourceFile(path: String): Boolean =
+        path.endsWith(".kt") && TEST_SOURCE_DIR.containsMatchIn(path)
+
+    /** Names of all `@Test` functions declared in [source]. */
+    fun extractTestNames(source: String): Set<String> {
+        val names = mutableSetOf<String>()
+        var searchFrom = 0
+        while (true) {
+            val annotation = TEST_ANNOTATION.find(source, searchFrom) ?: break
+            val declaration = FUN_NAME.find(source, annotation.range.last) ?: break
+            names += declaration.groupValues[1].ifEmpty { declaration.groupValues[2] }
+            searchFrom = declaration.range.last
+        }
+        return names
+    }
+
+    /**
+     * Test names declared as intentionally removed via `Removed-test:` trailer lines in
+     * [commitMessages] (the concatenated bodies of every commit on the branch). Backticks
+     * around the name are tolerated so the trailer can be pasted from the test source.
+     */
+    fun parseDeclaredRemovals(commitMessages: String): Set<String> =
+        REMOVED_TEST_TRAILER.findAll(commitMessages)
+            .map { it.groupValues[1].trim().removeSurrounding("`") }
+            .toSet()
+
+    data class RemovedTest(val file: String, val name: String) {
+        fun render(): String = "$name  (was in $file)"
+    }
+
+    /**
+     * Test names present in the old tree but absent from the new one, minus [declared].
+     * Comparison is global across files, so moving a test between files is not flagged —
+     * only its disappearance from the branch is.
+     */
+    fun findUndeclaredRemovals(
+        oldTestsByFile: Map<String, Set<String>>,
+        newTestsByFile: Map<String, Set<String>>,
+        declared: Set<String>,
+    ): List<RemovedTest> {
+        val newNames = newTestsByFile.values.flatten().toSet()
+        return oldTestsByFile
+            .flatMap { (file, names) -> names.map { RemovedTest(file, it) } }
+            .filterNot { it.name in newNames || it.name in declared }
+            .sortedWith(compareBy({ it.file }, { it.name }))
+    }
+}

--- a/buildSrc/src/test/kotlin/com/riffle/buildlogic/TestGuardrailLintTest.kt
+++ b/buildSrc/src/test/kotlin/com/riffle/buildlogic/TestGuardrailLintTest.kt
@@ -1,0 +1,136 @@
+package com.riffle.buildlogic
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TestGuardrailLintTest {
+
+    // ── extractTestNames ──────────────────────────────────────────────────
+
+    @Test
+    fun `extracts plain and backticked test names`() {
+        val source = """
+            class FooTest {
+                @Test
+                fun plainName() {}
+
+                @Test
+                fun `backticked name with spaces`() {}
+            }
+        """.trimIndent()
+        assertEquals(
+            setOf("plainName", "backticked name with spaces"),
+            TestGuardrailLint.extractTestNames(source),
+        )
+    }
+
+    @Test
+    fun `tolerates annotations and modifiers between Test and fun`() {
+        val source = """
+            @Test
+            @TabletLayout
+            internal fun annotatedTest() {}
+        """.trimIndent()
+        assertEquals(setOf("annotatedTest"), TestGuardrailLint.extractTestNames(source))
+    }
+
+    @Test
+    fun `ignores non-test functions and TestOnly annotations`() {
+        val source = """
+            @TestOnly
+            fun helper() {}
+
+            fun alsoHelper() {}
+
+            @Test
+            fun realTest() {}
+        """.trimIndent()
+        assertEquals(setOf("realTest"), TestGuardrailLint.extractTestNames(source))
+    }
+
+    @Test
+    fun `matches fully qualified Test annotation`() {
+        val source = """
+            @org.junit.Test
+            fun qualified() {}
+        """.trimIndent()
+        assertEquals(setOf("qualified"), TestGuardrailLint.extractTestNames(source))
+    }
+
+    // ── isTestSourceFile ──────────────────────────────────────────────────
+
+    @Test
+    fun `recognizes test source sets`() {
+        assertTrue(TestGuardrailLint.isTestSourceFile("app/src/test/kotlin/FooTest.kt"))
+        assertTrue(TestGuardrailLint.isTestSourceFile("app/src/androidTest/kotlin/FooTest.kt"))
+        assertTrue(TestGuardrailLint.isTestSourceFile("core/domain/src/jvmTest/kotlin/FooTest.kt"))
+        assertFalse(TestGuardrailLint.isTestSourceFile("app/src/main/kotlin/Foo.kt"))
+        assertFalse(TestGuardrailLint.isTestSourceFile("app/src/test/resources/fixture.json"))
+    }
+
+    // ── parseDeclaredRemovals ─────────────────────────────────────────────
+
+    @Test
+    fun `parses Removed-test trailers with and without backticks`() {
+        val log = """
+            fix(reader): collapse sections
+
+            The old claim no longer holds because the user asked for X.
+
+            Removed-test: `old behavior is pinned`
+            Removed-test: plainOldTest
+        """.trimIndent()
+        assertEquals(
+            setOf("old behavior is pinned", "plainOldTest"),
+            TestGuardrailLint.parseDeclaredRemovals(log),
+        )
+    }
+
+    // ── findUndeclaredRemovals ────────────────────────────────────────────
+
+    @Test
+    fun `renamed test is flagged under its old name`() {
+        // The #656 motion: "subchapters are NOT promoted" renamed to assert the opposite.
+        val old = mapOf("FooTest.kt" to setOf("subchapters are NOT promoted"))
+        val new = mapOf("FooTest.kt" to setOf("subchapters are promoted"))
+        assertEquals(
+            listOf(TestGuardrailLint.RemovedTest("FooTest.kt", "subchapters are NOT promoted")),
+            TestGuardrailLint.findUndeclaredRemovals(old, new, declared = emptySet()),
+        )
+    }
+
+    @Test
+    fun `declared removal is not flagged`() {
+        val old = mapOf("FooTest.kt" to setOf("retired claim"))
+        val new = mapOf("FooTest.kt" to emptySet<String>())
+        assertEquals(
+            emptyList<TestGuardrailLint.RemovedTest>(),
+            TestGuardrailLint.findUndeclaredRemovals(old, new, declared = setOf("retired claim")),
+        )
+    }
+
+    @Test
+    fun `test moved between files is not flagged`() {
+        val old = mapOf("FooTest.kt" to setOf("stable claim"))
+        val new = mapOf("BarTest.kt" to setOf("stable claim"))
+        assertEquals(
+            emptyList<TestGuardrailLint.RemovedTest>(),
+            TestGuardrailLint.findUndeclaredRemovals(old, new, declared = emptySet()),
+        )
+    }
+
+    @Test
+    fun `deleted file flags every test it contained`() {
+        val old = mapOf("GoneTest.kt" to setOf("claim a", "claim b"))
+        val new = emptyMap<String, Set<String>>()
+        assertEquals(
+            listOf(
+                TestGuardrailLint.RemovedTest("GoneTest.kt", "claim a"),
+                TestGuardrailLint.RemovedTest("GoneTest.kt", "claim b"),
+            ),
+            TestGuardrailLint.findUndeclaredRemovals(old, new, declared = emptySet()),
+        )
+    }
+}

--- a/docs/2026-07-27-chapter-map-color-groups-bookmarks-design.md
+++ b/docs/2026-07-27-chapter-map-color-groups-bookmarks-design.md
@@ -185,6 +185,7 @@ No changes. `PdfTocEntry` is flat (no children field), so `buildPdfRailSegments`
 |---|---|
 | Flat TOC (all top-level = leaves) | Flat mode: current 4dp single-strip, no colors |
 | Chapter → same-file Sections | Every direct section is a distinct segment; all siblings share the chapter color |
+| Section-heavy book (same-file exposure would exceed 48 segments) | All same-file section groups collapse back to one segment per chapter (whole-book decision); chapters keep their group colors. Prevents the rail from degenerating into 2.5dp gaps on books like "A Philosophy of Software Design" (~21 chapters × ~5 sections) |
 | Single parent chapter | Its sections all get `groupIndex=0` and share one color at the normal 4dp height |
 | >8 groups | Colors cycle: `groupIndex % 8`. |
 | Bookmark in a spine resource with no TOC entry | `findActiveSegmentIndex` already handles this (falls back to last segment before the current spine position). Bookmark tick lands there. |

--- a/docs/2026-07-27-chapter-map-color-groups-bookmarks-design.md
+++ b/docs/2026-07-27-chapter-map-color-groups-bookmarks-design.md
@@ -185,7 +185,8 @@ No changes. `PdfTocEntry` is flat (no children field), so `buildPdfRailSegments`
 |---|---|
 | Flat TOC (all top-level = leaves) | Flat mode: current 4dp single-strip, no colors |
 | Chapter → same-file Sections | Every direct section is a distinct segment; all siblings share the chapter color |
-| Section-heavy book (same-file exposure would exceed 48 segments) | All same-file section groups collapse back to one segment per chapter (whole-book decision); chapters keep their group colors. Prevents the rail from degenerating into 2.5dp gaps on books like "A Philosophy of Software Design" (~21 chapters × ~5 sections) |
+| Section-heavy book (same-file exposure would exceed 48 segments) | All same-file section groups collapse back to one segment per chapter (whole-book decision). Prevents the rail from degenerating into 2.5dp gaps on books like "A Philosophy of Software Design" (~21 chapters × ~5 sections) |
+| Every group is a single segment (e.g. after a section-heavy collapse) | Rail renders in flat mode (`groupIndex = null`). Colors exist to show which segments belong together; a one-segment-per-color rainbow carries no grouping information |
 | Single parent chapter | Its sections all get `groupIndex=0` and share one color at the normal 4dp height |
 | >8 groups | Colors cycle: `groupIndex % 8`. |
 | Bookmark in a spine resource with no TOC entry | `findActiveSegmentIndex` already handles this (falls back to last segment before the current spine position). Bookmark tick lands there. |


### PR DESCRIPTION
## Summary

**Chapter-map fix** — reported on "A Philosophy of Software Design" and "Monolith to Microservices":

- PR #656 exposed every same-file section anchor as a rail segment unconditionally. Section-heavy books (~20 chapters × 5+ anchors) exploded into 100+ segments; with 2.5dp gaps punched between segments the map was mostly gaps and unreadable. Same-file section exposure is now capped at 48 total segments (`MAX_SEGMENTS_WITH_SAME_FILE_SECTIONS`, the legibility floor of the gap-punched rail on narrow phones); above it the whole book collapses to one segment per chapter.
- Group colors now render only when at least one group spans multiple segments. After the collapse these books produced a per-chapter rainbow (one color per single-segment group = no grouping information); they now render the classic flat rail. Existing test expectations whose fixtures produce only singleton groups were flipped to `groupIndex = null` accordingly — a deliberate, user-requested behavior change.

**Test guardrails, repo-wide** — the #656 regression shipped by renaming three pinning tests to assert the opposite inside a large feature diff:

- New `checkTestGuardrails` task: any `@Test` function present at the merge base with main but missing on the branch (deleted or renamed) fails the build unless a commit message carries a `Removed-test: <exact test name>` trailer. Logic in `buildSrc/.../TestGuardrailLint.kt` (unit-tested); rule documented in AGENTS.md.
- New `railcorpus` golden suite: real full-scale book TOCs pin the rendered segment list per book, so heuristic changes surface as reviewable per-book diffs instead of on-device surprises. APoSD is transcribed from the authoritative print TOC scan; M2M is reconstructed (provenance field flags it for re-extraction from the real EPUB).
- New seeded property test pins the readability-cap invariant over 500 random TOC shapes.

**CI gap fixed** — no CI job ever ran `./gradlew check`, so the six existing custom lints were silently unenforced (and two were failing on main). The Lint job now runs `riffleChecks` (all custom lints + guardrails) with `fetch-depth: 0` (the guardrail diffs against the merge base). Accumulated drift is grandfathered into the renderer-bridge and infra-seams allowlists with per-file justifications, per those lints' own sweep-follow-up convention.

## Tests

- `./gradlew test`, `./gradlew riffleChecks`, and buildSrc unit tests all green locally.
- Guardrail verified end-to-end: an undeclared test rename fails the build listing the old name; adding the `Removed-test:` trailer passes.
- Reverting the cap flips `section-heavy book collapses same-file sections back to chapter segments` red; reverting the flat-coloring rule flips the corpus goldens red.
- Not verified on-device (no build requested); worth opening both books after merge to confirm the flat chapter-granularity map.