### PR TITLE
fix(reader): stop reader font pref from pinning the elided view's face

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -63,9 +63,11 @@ import com.riffle.core.domain.resolveEpubHref
 import com.riffle.core.database.AnnotationDao
 import com.riffle.core.database.AnnotationEntity
 import com.riffle.app.feature.reader.highlights.ChapterElision
+import com.riffle.app.feature.reader.highlights.GENERIC_CSS_FONT_KEYWORDS
 import com.riffle.app.feature.reader.highlights.HighlightsPdfExporter
 import com.riffle.app.feature.reader.highlights.HighlightsPublicationFactory
 import com.riffle.app.feature.reader.highlights.ReaderSource
+import com.riffle.app.feature.reader.highlights.realCapturedFontOrNull
 import com.riffle.app.feature.reader.highlights.toFormattingScope
 import com.riffle.core.logging.LogChannel
 import com.riffle.core.logging.Logger
@@ -128,8 +130,7 @@ private const val FALLBACK_ORIGIN_FONT_FAMILY =
  *  by lazy backfill yet, OR when the stored value is the [FALLBACK_ORIGIN_FONT_FAMILY] sentinel
  *  (which is not a real captured font and must not propagate through merges). */
 private fun entityFontFamily(annotation: Annotation): String? =
-    annotation.originFontFamily
-        ?.takeIf { it.isNotBlank() && it != FALLBACK_ORIGIN_FONT_FAMILY }
+    realCapturedFontOrNull(annotation.originFontFamily)
 
 /** Plurality (mode) `originFontFamily` across every annotation in [chapters], skipping blanks
  *  AND the [FALLBACK_ORIGIN_FONT_FAMILY] sentinel — a book whose annotations were all created
@@ -156,13 +157,41 @@ internal fun combineDraftEmphasisStyles(
     else -> preset + tapped
 }
 
+/**
+ * Heals every row whose stored `originFontFamily` is a bare generic CSS keyword — not only the
+ * `serif` sentinel — to the probed real face [fontFamily]. Rows written as `sans-serif` (etc.)
+ * by captures made while a reader Font pref was active are equally "no real captured value" and
+ * must converge to the publisher's face once the book is next opened in Original mode
+ * (elided-view-always-sans regression, *Taking Charge of ADHD*). The caller guarantees
+ * [fontFamily] is itself never a generic ([noteBookBodyFontFamily]'s refusal guard), so this
+ * can't churn sync on a book whose CSS legitimately computes to a bare generic. Top-level so a
+ * JVM test can exercise the loop against [AnnotationStore] without standing up the ViewModel
+ * (Readium's `Url` needs the real `android.net.Uri`).
+ */
+internal suspend fun healGenericOriginFonts(
+    annotationStore: com.riffle.core.domain.AnnotationStore,
+    sourceId: String,
+    itemId: String,
+    fontFamily: String,
+): Int = GENERIC_CSS_FONT_KEYWORDS.sumOf { generic ->
+    runCatching {
+        annotationStore.healSentinelOriginFontFamily(
+            sourceId = sourceId,
+            itemId = itemId,
+            sentinel = generic,
+            fontFamily = fontFamily,
+        )
+    }.getOrElse { 0 }
+}
+
 internal fun pluralityOriginFont(chapters: List<ChapterElision>): String? =
     chapters.asSequence()
         .flatMap { it.highlights.asSequence() }
         .mapNotNull {
-            it.originFontFamily?.takeIf { f ->
-                f.isNotBlank() && f != FALLBACK_ORIGIN_FONT_FAMILY
-            }
+            // Skip bare generic keywords, not just the sentinel — a row stamped `sans-serif`
+            // (captured while a reader font pref was active) must not win the vote and pin the
+            // whole book's elided view to the pref face (elided-view-always-sans regression).
+            realCapturedFontOrNull(it.originFontFamily)
         }
         .groupingBy { it }
         .eachCount()
@@ -1242,8 +1271,9 @@ class EpubReaderViewModel @Inject constructor(
             // in-memory probe unknown) means "emit no `font-family`, ReadiumCSS default wins" —
             // pre-issue-484 behaviour and the pre-regression rendering for chapter titles.
             elidedBodyFontFamily = pluralityOriginFont(chapters)
-                ?: bookBodyFontFamilyReported.get()
-                    .takeIf { it.isNotBlank() && it != FALLBACK_ORIGIN_FONT_FAMILY }
+                ?: realCapturedFontOrNull(
+                    bookBodyFontFamilyReported.get(),
+                )
             // Serve figure bytes from the source EPUB (if it's been downloaded) so annotated
             // figures render as their real image in the elided view instead of the "[figure
             // image not captured]" placeholder. Highlights mode never runs the normal
@@ -1912,7 +1942,12 @@ class EpubReaderViewModel @Inject constructor(
         // default), and skipping leaves the atomic empty so a later chapter whose computed
         // font is a REAL face (e.g. `Nimbusromno9l, serif` on a chapter that mounts a font
         // stack, not the generic keyword) can still fill it in.
-        if (trimmed == FALLBACK_ORIGIN_FONT_FAMILY) return
+        // Same reasoning for every bare generic keyword, not just the `serif` sentinel: a probe
+        // that computed to bare `sans-serif`/`monospace`/… is the ReadiumCSS user-font override
+        // (Font pref ≠ Original) leaking through, never a real publisher face — latching it
+        // would backfill/heal every row on the book to the pref face and pin the elided view
+        // to it permanently (elided-view-always-sans regression, *Taking Charge of ADHD*).
+        if (realCapturedFontOrNull(trimmed) == null) return
         // Set-once per (VM lifecycle, book). AtomicReference.compareAndSet returns false when
         // we've already stored a non-blank font — cheap no-op on the many repeat reports the
         // JS tracker fires as chapters install across a reading session.
@@ -1929,14 +1964,7 @@ class EpubReaderViewModel @Inject constructor(
             // the elided view even after the user opens the source book. The store no-ops
             // when [trimmed] equals the sentinel, so a book whose CSS legitimately sets
             // `body { font-family: serif }` doesn't churn sync.
-            val healed = runCatching {
-                annotationStore.healSentinelOriginFontFamily(
-                    sourceId = sourceId,
-                    itemId = itemId,
-                    sentinel = FALLBACK_ORIGIN_FONT_FAMILY,
-                    fontFamily = trimmed,
-                )
-            }.getOrElse { 0 }
+            val healed = healGenericOriginFonts(annotationStore, sourceId, itemId, trimmed)
             val updated = backfilled + healed
             if (updated > 0) {
                 logger.d(LogChannel.HighlightMerge) {
@@ -2065,7 +2093,7 @@ class EpubReaderViewModel @Inject constructor(
             // [FALLBACK_ORIGIN_FONT_FAMILY] sentinel. Preferring (a) means the elided view's
             // per-excerpt `<p>` still renders in the publisher's face for annotations created in
             // rare-race sessions, avoiding the pre-fix "elided body forced to browser serif" bug.
-            val originFont = SelectionFontStash.consume().takeIf { it.isNotBlank() }
+            val originFont = realCapturedFontOrNull(SelectionFontStash.consume())
                 ?: bookBodyFontFamilyReported.get().takeIf { it.isNotBlank() }
                 ?: FALLBACK_ORIGIN_FONT_FAMILY
             // Inline-formatted excerpt HTML (issue: elided view drops italics). Empty string means
@@ -2663,7 +2691,7 @@ class EpubReaderViewModel @Inject constructor(
                 // the entire book was bookmark-only). Only if both are unknown do we stamp the
                 // [FALLBACK_ORIGIN_FONT_FAMILY] sentinel; the sentinel is filtered at render time
                 // and healed by the next full-book open. Issue #484.
-                val bookmarkFont = SelectionFontStash.consume().takeIf { it.isNotBlank() }
+                val bookmarkFont = realCapturedFontOrNull(SelectionFontStash.consume())
                     ?: bookBodyFontFamilyReported.get().takeIf { it.isNotBlank() }
                     ?: FALLBACK_ORIGIN_FONT_FAMILY
                 annotationStore.createBookmark(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -173,15 +173,26 @@ internal suspend fun healGenericOriginFonts(
     sourceId: String,
     itemId: String,
     fontFamily: String,
-): Int = GENERIC_CSS_FONT_KEYWORDS.sumOf { generic ->
-    runCatching {
-        annotationStore.healSentinelOriginFontFamily(
-            sourceId = sourceId,
-            itemId = itemId,
-            sentinel = generic,
-            fontFamily = fontFamily,
-        )
-    }.getOrElse { 0 }
+): Int {
+    // The store heal is an exact-match UPDATE, so enumerate every concrete form a polluted
+    // capture can take: the bare keyword (paginated mode — Readium serializes generics
+    // unquoted) plus single/double-quoted variants (continuous mode's
+    // [ContinuousStyleInjector.buildHtmlStyleAttr] quotes every stack entry, and Chromium's
+    // computed value preserves the quoting). Cased variants can't be produced by either
+    // injector; render-side [realCapturedFontOrNull] still filters them defensively.
+    val sentinels = GENERIC_CSS_FONT_KEYWORDS.flatMap { generic ->
+        listOf(generic, "\"$generic\"", "'$generic'")
+    }
+    return sentinels.sumOf { sentinel ->
+        runCatching {
+            annotationStore.healSentinelOriginFontFamily(
+                sourceId = sourceId,
+                itemId = itemId,
+                sentinel = sentinel,
+                fontFamily = fontFamily,
+            )
+        }.getOrElse { 0 }
+    }
 }
 
 internal fun pluralityOriginFont(chapters: List<ChapterElision>): String? =
@@ -2974,7 +2985,11 @@ class EpubReaderViewModel @Inject constructor(
                     }
                     next
                 } else {
-                    val originFont = highlight.originFontFamily?.takeIf { it.isNotBlank() }
+                    // realCapturedFontOrNull, not a bare isNotBlank(): copying a polluted
+                    // generic (`sans-serif` captured under a font pref) from the source
+                    // highlight into a NEW emphasis row would re-spread the very value the
+                    // heal path is trying to retire (elided-view-always-sans regression).
+                    val originFont = realCapturedFontOrNull(highlight.originFontFamily)
                         ?: FALLBACK_ORIGIN_FONT_FAMILY
                     annotationStore.createEmphasis(
                         sourceId = sourceId,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -202,6 +202,21 @@ internal fun readiumDecorationTemplatesRegisterJs(): String {
 // on selectionchange, because the live DOM selection is gone by the time the action-mode menu handler
 // runs. getClientRects()[0] is the rect of the selection's first glyph (its start).
 /**
+ * JS boolean expression: true when a ReadiumCSS user-font override is active in this document.
+ * Both reader stacks mark an active Font pref the same way — `--USER__fontOverride:
+ * readium-font-on` inside the inline `style` attribute on `<html>` (paginated/vertical via
+ * Readium's `EpubSettings`/`UserProperties.toCss()`, continuous via
+ * [ContinuousStyleInjector.buildHtmlStyleAttr]) — so a plain substring check on the attribute
+ * covers all three modes. While the override is on, every `getComputedStyle().fontFamily` in the
+ * document reports the USER's pref stack (e.g. bare `sans-serif`), not the publisher's face, so
+ * the font probes below must not capture it (elided-view-always-sans regression: a highlight
+ * created under the Sans pref stamped `sans-serif` on the row and pinned the whole book's elided
+ * view to sans).
+ */
+internal const val FONT_OVERRIDE_ACTIVE_JS =
+    "((document.documentElement.getAttribute('style') || '').indexOf('readium-font-on') !== -1)"
+
+/**
  * Reads the current text selection for the continuous-mode action-mode menu handlers ("Highlight",
  * "Copy", "Share", "Play from here"). Returns a JSON payload with `text`, within-chapter
  * progression `p`, the range's viewport rect (`l`/`t`/`r`/`b`, CSS px), and 60-char before/after
@@ -257,12 +272,18 @@ internal val CONTINUOUS_SELECTION_READ_JS = """
                     aft = afterR.toString().slice(0, 60);
                 } catch (e) { aft = ''; }
             }
+            // Skip the capture entirely while a user font override is active — the computed
+            // style is the Font pref's stack, not the publisher's face (see
+            // [FONT_OVERRIDE_ACTIVE_JS]). Empty ff falls back to the body probe / sentinel
+            // machinery on the Kotlin side.
             try {
-                var startEl = range.startContainer;
-                if (startEl && startEl.nodeType === 3) startEl = startEl.parentElement;
-                if (startEl && startEl.nodeType === 1) {
-                    var cs = window.getComputedStyle(startEl);
-                    if (cs) ff = cs.fontFamily || '';
+                if (!$FONT_OVERRIDE_ACTIVE_JS) {
+                    var startEl = range.startContainer;
+                    if (startEl && startEl.nodeType === 3) startEl = startEl.parentElement;
+                    if (startEl && startEl.nodeType === 1) {
+                        var cs = window.getComputedStyle(startEl);
+                        if (cs) ff = cs.fontFamily || '';
+                    }
                 }
             } catch (e) { ff = ''; }
         }
@@ -289,8 +310,16 @@ internal val SELECTION_SPAN_TRACKER_JS = """
       // whole "elided view inherits the origin's font" contract (elided-view-serif-font-
       // regression). `<body>` remains the final fallback for chapter shells that don't yet
       // have inner content (the tracker re-fires on the next install once content mounts).
+      //
+      // Skipped entirely while a user font override is active (Font pref ≠ Original): every
+      // computed font-family in the document is then the USER's pref stack, not the publisher's
+      // face, and capturing it would backfill/heal the pref face onto every annotation on the
+      // book (elided-view-always-sans regression). Leaving __riffleBookBodyFont empty is the
+      // same as the "chapter shell with no content" case — the Kotlin side falls back to the
+      // sentinel machinery, and a later session in Original mode fills the real value in.
       try {
         var probeEl = null;
+        if ($FONT_OVERRIDE_ACTIVE_JS) throw 'font-override-active';
         // Prefer real body-text elements over chapter-header wrappers. `<p>` and `<li>` are the
         // canonical body-text carriers publisher CSS styles; the earlier version fell straight
         // through to `<div>`/`<span>` and picked up leading `<div class="chapternum">7</div>`
@@ -499,7 +528,9 @@ internal val SELECTION_SPAN_TRACKER_JS = """
             // no content yet) do we fall through to the start-element style — better than
             // recording nothing.
             var ff = window.__riffleBookBodyFont || '';
-            if (!ff) {
+            // Same font-override guard as the body probe: under an active Font pref the
+            // start-element's computed style is the pref stack, not the publisher face.
+            if (!ff && !$FONT_OVERRIDE_ACTIVE_JS) {
               try {
                 var startEl = rng.startContainer;
                 if (startEl && startEl.nodeType === 3) startEl = startEl.parentElement;

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporter.kt
@@ -238,7 +238,7 @@ internal fun buildCombinedHtml(
 
     val bodyFontRule = run {
         val safe = sanitizeCssFontFamily(
-            bookBodyFontFamily?.takeIf { it != FALLBACK_ORIGIN_FONT_FAMILY },
+            realCapturedFontOrNull(bookBodyFontFamily),
         ) ?: return@run ""
         "body,h1,h2,h3,h4,h5,h6{font-family:$safe;}"
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -37,6 +37,34 @@ import org.readium.r2.shared.util.resource.Resource
 internal const val FALLBACK_ORIGIN_FONT_FAMILY = "serif"
 
 /**
+ * Bare CSS generic font keywords that can never be trusted as a *captured publisher face*.
+ * A `getComputedStyle().fontFamily` equal to one of these is almost always the ReadiumCSS
+ * user-font override leaking into the probe (elided-view-always-sans regression: a highlight
+ * created while the reader Font pref was Sans stored `sans-serif`, which then won
+ * [pluralityOriginFont] and pinned the whole elided view to sans for that book — *Taking
+ * Charge of ADHD*). The trade-off is the same one [FALLBACK_ORIGIN_FONT_FAMILY] already made
+ * for bare `serif`: a publisher whose CSS legitimately computes to a bare generic falls back
+ * to ReadiumCSS's default face instead — never worse than rendering every book annotated
+ * under a font pref in that pref's face forever.
+ */
+internal val GENERIC_CSS_FONT_KEYWORDS: Set<String> = setOf(
+    "serif", "sans-serif", "monospace", "cursive", "fantasy", "system-ui",
+)
+
+/**
+ * Returns [value] trimmed when it is a plausible *captured publisher face*: non-blank and not a
+ * bare generic CSS font keyword (quoted or not, any case) — else null. A comma-separated stack
+ * (`Nimbusromno9l, serif`) passes: the leading entry is a real face and the generics are only
+ * its fallbacks. Subsumes the [FALLBACK_ORIGIN_FONT_FAMILY] sentinel check (`serif` is in
+ * [GENERIC_CSS_FONT_KEYWORDS]).
+ */
+internal fun realCapturedFontOrNull(value: String?): String? {
+    val trimmed = value?.trim().takeUnless { it.isNullOrEmpty() } ?: return null
+    val bare = trimmed.trim('"', '\'').trim().lowercase()
+    return trimmed.takeUnless { bare in GENERIC_CSS_FONT_KEYWORDS }
+}
+
+/**
  * One chapter's worth of highlights to be rendered into the elided reader (ADR 0041).
  *
  * [highlights] must already be sorted by (spineIndex, progression, createdAt) — the factory
@@ -315,7 +343,7 @@ class HighlightsPublicationFactory @Inject constructor() {
         // font-pref rule (which uses `!important` in Serif/Sans/publisher-typography modes)
         // now cleanly wins over ours for the whole document — body AND heading — so the toggle
         // finally does what the user expects.
-        val realBodyFont = bookBodyFontFamily?.takeIf { it != FALLBACK_ORIGIN_FONT_FAMILY }
+        val realBodyFont = realCapturedFontOrNull(bookBodyFontFamily)
         val safeBodyFont = sanitizeCssFontFamily(realBodyFont)
         val bodyFontStyleBlock = if (safeBodyFont != null) {
             val escaped = safeBodyFont.xmlEscape()
@@ -630,10 +658,8 @@ private fun appendOriginFontFamilyStyle(
     // book. Elided-view excerpts are always body paragraphs, so the book body font is right
     // for every row. Falls back to the annotation's own captured value only when the caller
     // has no body-font hint (fresh Highlights VM whose DB rows all lack a real captured value).
-    val body = bookBodyFontFamily
-        ?.takeIf { it.isNotBlank() && it != FALLBACK_ORIGIN_FONT_FAMILY }
-    val ownFont = originFontFamily
-        ?.takeIf { it.isNotBlank() && it != FALLBACK_ORIGIN_FONT_FAMILY }
+    val body = realCapturedFontOrNull(bookBodyFontFamily)
+    val ownFont = realCapturedFontOrNull(originFontFamily)
     val raw = body ?: ownFont
     val safe = sanitizeCssFontFamily(raw) ?: return
     // No `!important` (elided-view-serif-font-regression follow-up): with it, the captured

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/HealGenericOriginFontsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/HealGenericOriginFontsTest.kt
@@ -124,6 +124,8 @@ class HealGenericOriginFontsTest {
         val store = RecordingStore(
             mutableMapOf(
                 "polluted-sans" to "sans-serif",
+                "polluted-sans-quoted" to "\"sans-serif\"",
+                "polluted-serif-squoted" to "'serif'",
                 "legacy-sentinel" to "serif",
                 "polluted-mono" to "monospace",
                 "real-face" to "Minion",
@@ -134,11 +136,21 @@ class HealGenericOriginFontsTest {
 
         val healed = healGenericOriginFonts(store, "S1", "B1", "Minion Pro")
 
-        assertEquals("all three generic-stamped rows must be healed", 3, healed)
+        assertEquals("all five generic-stamped rows must be healed", 5, healed)
         assertEquals(
             "the sans-serif row (elided-view-always-sans regression) converges to the probed face",
             "Minion Pro",
             store.fonts["polluted-sans"],
+        )
+        assertEquals(
+            "continuous mode quotes stack entries — the double-quoted variant heals too",
+            "Minion Pro",
+            store.fonts["polluted-sans-quoted"],
+        )
+        assertEquals(
+            "single-quoted variant heals too",
+            "Minion Pro",
+            store.fonts["polluted-serif-squoted"],
         )
         assertEquals("the serif sentinel row still heals", "Minion Pro", store.fonts["legacy-sentinel"])
         assertEquals("monospace pollution heals too", "Minion Pro", store.fonts["polluted-mono"])

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/HealGenericOriginFontsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/HealGenericOriginFontsTest.kt
@@ -1,0 +1,153 @@
+package com.riffle.app.feature.reader
+
+import com.riffle.core.domain.AnnotationStore
+import com.riffle.core.models.Annotation
+import com.riffle.core.models.EmbeddedFigure
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the heal loop [EpubReaderViewModel.noteBookBodyFontFamily] runs on the first real
+ * body-font report per book: EVERY bare-generic-stamped row must converge to the probed
+ * publisher face, not only rows carrying the legacy `serif` sentinel.
+ *
+ * Regression: elided-view-always-sans (*Taking Charge of ADHD*). A highlight created while the
+ * reader Font pref was Sans stored `sans-serif`; the pre-fix heal only targeted the `serif`
+ * sentinel, so the polluted row survived every subsequent Original-mode open and kept winning
+ * the plurality vote — the book's elided view stayed pinned to sans-serif forever.
+ */
+class HealGenericOriginFontsTest {
+
+    /** id → originFontFamily, healed with the same exact-match semantics as the Room query. */
+    private class RecordingStore(
+        val fonts: MutableMap<String, String?>,
+    ) : AnnotationStore {
+        val healedSentinels = mutableListOf<String>()
+
+        override suspend fun healSentinelOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            sentinel: String,
+            fontFamily: String,
+        ): Int {
+            if (fontFamily.isBlank() || sentinel.isBlank() || fontFamily == sentinel) return 0
+            healedSentinels += sentinel
+            var changed = 0
+            for ((id, font) in fonts) {
+                if (font == sentinel) {
+                    fonts[id] = fontFamily
+                    changed++
+                }
+            }
+            return changed
+        }
+
+        override fun observeHighlights(sourceId: String, itemId: String): Flow<List<Annotation>> = error("unused")
+        override fun observeBookmarks(sourceId: String, itemId: String): Flow<List<Annotation>> = error("unused")
+        override fun observeAnnotations(sourceId: String, itemId: String): Flow<List<Annotation>> = error("unused")
+        override fun observeAnnotationsForSource(sourceId: String): Flow<List<Annotation>> = error("unused")
+        override suspend fun createHighlight(
+            sourceId: String,
+            itemId: String,
+            cfi: String,
+            textSnippet: String,
+            chapterHref: String,
+            textBefore: String,
+            textAfter: String,
+            color: String,
+            spineIndex: Int,
+            progression: Double,
+            embeddedFigures: List<EmbeddedFigure>?,
+            originFontFamily: String,
+            textSnippetHtml: String?,
+        ): Annotation = error("unused")
+        override suspend fun createBookmark(
+            sourceId: String,
+            itemId: String,
+            cfi: String,
+            textSnippet: String,
+            chapterHref: String,
+            spineIndex: Int,
+            progression: Double,
+            bookmarkTitle: String,
+            originFontFamily: String,
+        ): Annotation = error("unused")
+        override suspend fun createImageAnnotation(
+            sourceId: String,
+            itemId: String,
+            cfi: String,
+            textSnippet: String,
+            chapterHref: String,
+            spineIndex: Int,
+            progression: Double,
+            imageHref: String?,
+            imageSvg: String?,
+            imageBytes: String?,
+            color: String,
+        ): Annotation = error("unused")
+        override suspend fun backfillNullOriginFontFamily(
+            sourceId: String,
+            itemId: String,
+            fontFamily: String,
+        ): Int = error("unused")
+        override suspend fun upgradeImageToCaptionHighlight(
+            id: String,
+            cfi: String,
+            textSnippet: String,
+            textBefore: String,
+            textAfter: String,
+            figure: EmbeddedFigure,
+        ): Annotation? = error("unused")
+        override suspend fun mergeFiguresIntoHighlight(
+            id: String,
+            newFigures: List<EmbeddedFigure>,
+        ): Annotation? = error("unused")
+        override suspend fun delete(id: String) = error("unused")
+        override suspend fun recolor(id: String, color: String) = error("unused")
+        override suspend fun updateNote(id: String, note: String?) = error("unused")
+        override suspend fun renameBookmark(id: String, title: String) = error("unused")
+        override suspend fun findByItemAndCfi(sourceId: String, itemId: String, cfi: String): Annotation? =
+            error("unused")
+        override suspend fun findImageAnnotationForFigure(
+            sourceId: String,
+            itemId: String,
+            chapterHref: String,
+            imageHref: String?,
+            imageSvg: String?,
+        ): Annotation? = error("unused")
+    }
+
+    @Test
+    fun healsEveryBareGenericKeywordNotJustTheSerifSentinel() = runTest {
+        val store = RecordingStore(
+            mutableMapOf(
+                "polluted-sans" to "sans-serif",
+                "legacy-sentinel" to "serif",
+                "polluted-mono" to "monospace",
+                "real-face" to "Minion",
+                "stack" to "Nimbusromno9l, serif",
+                "unprobed" to null,
+            ),
+        )
+
+        val healed = healGenericOriginFonts(store, "S1", "B1", "Minion Pro")
+
+        assertEquals("all three generic-stamped rows must be healed", 3, healed)
+        assertEquals(
+            "the sans-serif row (elided-view-always-sans regression) converges to the probed face",
+            "Minion Pro",
+            store.fonts["polluted-sans"],
+        )
+        assertEquals("the serif sentinel row still heals", "Minion Pro", store.fonts["legacy-sentinel"])
+        assertEquals("monospace pollution heals too", "Minion Pro", store.fonts["polluted-mono"])
+        assertEquals("a real captured face is never rewritten", "Minion", store.fonts["real-face"])
+        assertEquals(
+            "a stack with a generic fallback is a real face and is never rewritten",
+            "Nimbusromno9l, serif",
+            store.fonts["stack"],
+        )
+        assertEquals("null rows are the backfill path's job, not heal's", null, store.fonts["unprobed"])
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/PluralityOriginFontTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/PluralityOriginFontTest.kt
@@ -80,6 +80,61 @@ class PluralityOriginFontTest {
         assertNull(pluralityOriginFont(chapters))
     }
 
+    // Regression: elided-view-always-sans (*Taking Charge of ADHD*). A highlight created while
+    // the reader Font pref was Sans captured the ReadiumCSS override (`sans-serif`) instead of
+    // the publisher's face; plurality elected it and pinned the book's whole elided view to
+    // sans-serif regardless of reading mode or pref. Bare generic CSS keywords are never a
+    // captured publisher face — plurality must skip every one of them, not just the `serif`
+    // sentinel.
+    @Test
+    fun pluralityIgnoresBareGenericKeywords() {
+        val chapters = listOf(
+            chapter(
+                "ch0",
+                hl("h1", originFontFamily = "sans-serif"),
+                hl("h2", originFontFamily = "sans-serif"),
+                hl("h3", originFontFamily = "monospace"),
+                hl("h4", originFontFamily = "Minion"),
+            ),
+        )
+        assertEquals(
+            "generic-keyword rows outnumber the real face, but plurality must still pick the real one",
+            "Minion",
+            pluralityOriginFont(chapters),
+        )
+    }
+
+    @Test
+    fun pluralityReturnsNullWhenOnlyGenericKeywordRowsExist() {
+        val chapters = listOf(
+            chapter(
+                "ch0",
+                hl("h1", originFontFamily = "sans-serif"),
+                hl("h2", originFontFamily = "\"sans-serif\""),
+                hl("h3", originFontFamily = "Sans-Serif"),
+            ),
+        )
+        assertNull(
+            "quoted/cased variants of a bare generic keyword must be skipped too",
+            pluralityOriginFont(chapters),
+        )
+    }
+
+    @Test
+    fun pluralityKeepsStacksWhoseFallbackIsGeneric() {
+        val chapters = listOf(
+            chapter(
+                "ch0",
+                hl("h1", originFontFamily = "Nimbusromno9l, serif"),
+            ),
+        )
+        assertEquals(
+            "a real face with a generic fallback in its stack is a captured publisher font",
+            "Nimbusromno9l, serif",
+            pluralityOriginFont(chapters),
+        )
+    }
+
     private fun chapter(href: String, vararg highlights: AnnotationEntity) =
         ChapterElision(href = href, title = "T", highlights = highlights.toList())
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -342,6 +342,37 @@ class ReaderWebViewScriptsTest {
         assertTrue("returns before/after context (bef/aft)", js.contains("bef: stash.bef") && js.contains("aft: stash.aft"))
     }
 
+    // Regression pin (elided-view-always-sans, *Taking Charge of ADHD*): while a ReadiumCSS
+    // user-font override is active (Font pref ≠ Original), every getComputedStyle().fontFamily
+    // in the chapter document reports the USER's pref stack (e.g. bare `sans-serif`), not the
+    // publisher's face. All three capture paths — the one-shot body-font probe, the
+    // selectionchange stash's start-element fallback, and the continuous live-read fallback —
+    // must therefore skip the capture when the `readium-font-on` flag is present in the inline
+    // `style` attribute on `<html>` (how BOTH reader stacks mark an active Font pref). Without
+    // the guard, one highlight created under the Sans pref stamps `sans-serif` on the row, the
+    // plurality vote elects it, and the book's entire elided view is pinned to sans forever.
+    @Test
+    fun `font probes skip capture while a user font override is active`() {
+        assertTrue(
+            "override detector checks the readium-font-on flag on <html>",
+            FONT_OVERRIDE_ACTIVE_JS.contains("readium-font-on"),
+        )
+        val tracker = SELECTION_SPAN_TRACKER_JS
+        // Both the body probe and the stash's start-element fallback carry the guard.
+        assertTrue(
+            "body-font probe bails out under an active font override",
+            tracker.contains("if ($FONT_OVERRIDE_ACTIVE_JS) throw 'font-override-active'"),
+        )
+        assertTrue(
+            "selectionchange ff fallback is gated on the override being off",
+            tracker.contains("if (!ff && !$FONT_OVERRIDE_ACTIVE_JS)"),
+        )
+        assertTrue(
+            "continuous live-read ff fallback is gated on the override being off",
+            CONTINUOUS_SELECTION_READ_JS.contains("if (!$FONT_OVERRIDE_ACTIVE_JS)"),
+        )
+    }
+
     // Regression pin: the figure walker inside SELECTION_SPAN_TRACKER_JS must scan the range's scope
     // with querySelectorAll + range.intersectsNode, NOT document.createTreeWalker + an acceptNode
     // callback. The TreeWalker form never yielded any enclosed <img> in Chromium's paginated Readium

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPdfExporterTest.kt
@@ -48,6 +48,46 @@ class HighlightsPdfExporterTest {
         assertTrue("Chapter Two h1", html.contains("<h1>Chapter Two</h1>"))
     }
 
+    // Regression (elided-view-always-sans, *Taking Charge of ADHD*): the PDF export must apply
+    // the same "bare generic keyword = no captured value" filter as the elided view — a book
+    // whose plurality font was polluted to `sans-serif` by a capture made under an active Font
+    // pref must not export with a sans-serif body rule.
+    @Test
+    fun combinedHtml_dropsBareGenericBookBodyFont() {
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(
+                ChapterElision("ch1.xhtml", "Chapter One", listOf(highlight("h1", "text"))),
+            ),
+            bookTitle = "My Book",
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = "",
+            bookBodyFontFamily = "sans-serif",
+        )
+        assertTrue(
+            "generic keyword must not emit a body font rule; html was: $html",
+            !html.contains("font-family:sans-serif"),
+        )
+    }
+
+    @Test
+    fun combinedHtml_keepsRealBookBodyFont() {
+        val html = buildCombinedHtml(
+            factory = factory,
+            chapters = listOf(
+                ChapterElision("ch1.xhtml", "Chapter One", listOf(highlight("h1", "text"))),
+            ),
+            bookTitle = "My Book",
+            figureBytesByHref = emptyMap(),
+            publisherFontFaceCss = "",
+            bookBodyFontFamily = "Minion",
+        )
+        assertTrue(
+            "real face still exports as the body rule; html was: $html",
+            html.contains("body,h1,h2,h3,h4,h5,h6{font-family:Minion;}"),
+        )
+    }
+
     @Test
     fun combinedHtml_hasNoReadiumAssetLink() {
         val html = buildCombinedHtml(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
@@ -442,6 +442,55 @@ class HighlightsPublicationFactoryTest {
         )
     }
 
+    // Regression (elided-view-always-sans, *Taking Charge of ADHD*): a highlight created while
+    // the reader Font pref was Sans captured the ReadiumCSS override — the bare generic
+    // `sans-serif` — instead of the publisher's face. That value then flowed in as both the
+    // per-row [originFontFamily] and (via the plurality vote) the book-wide
+    // [bookBodyFontFamily], pinning the whole elided view to sans-serif regardless of mode or
+    // pref. Bare generic CSS keywords are "no captured value", exactly like the sentinel: no
+    // font-family declaration may be emitted for them.
+    @Test
+    fun bareGenericKeyword_doesNotForceSansOnBodyOrExcerpts() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "Chapter Title Here",
+                    listOf(hl("h1", "excerpt", originFontFamily = "sans-serif")),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+            bookBodyFontFamily = "sans-serif",
+        )
+        val html = readChapterHtml(pub, index = 0)
+        assertTrue(
+            "bare generic keyword must NOT emit any font-family declaration; html was: $html",
+            !html.contains("font-family:"),
+        )
+    }
+
+    // Same regression, mixed inputs: a real book-body face must still be emitted even when the
+    // annotation's own captured value is a polluted generic keyword.
+    @Test
+    fun realBookFontWinsOverGenericKeywordAnnotationCapture() {
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "One",
+                    listOf(hl("h1", "excerpt", originFontFamily = "sans-serif")),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+            bookBodyFontFamily = "Minion",
+        )
+        val html = readChapterHtml(pub, index = 0)
+        assertTrue(
+            "excerpt <p> must render in the real book face, not the polluted generic; html was: $html",
+            html.contains("font-family: Minion;") && !html.contains("sans-serif"),
+        )
+    }
+
     // Same regression, per-excerpt path: an annotation whose stored [originFontFamily] is the
     // sentinel must render its `<p>` without a `font-family` override, deferring to whatever
     // real fallback the caller passes (or ReadiumCSS default when both are absent).
@@ -890,6 +939,34 @@ class HighlightsPublicationFactoryTest {
         val result = joinEmphasisStylesToHighlights(listOf(highlight))
         val joinedHighlight = result.first { it.id == "h1" }
         assertNull("emphasisStyles stays null when no emphasis rows", joinedHighlight.emphasisStyles)
+    }
+
+    // [realCapturedFontOrNull] is the single filter every consumer of a captured font goes
+    // through (plurality vote, per-<p> emitter, body-font style block, PDF export, body-font
+    // latch). Pinning its edge cases here pins them for all of those sites at once.
+    @Test
+    fun realCapturedFontOrNullFiltersBareGenericsInAnyDressing() {
+        assertNull(realCapturedFontOrNull(null))
+        assertNull(realCapturedFontOrNull("   "))
+        assertNull(realCapturedFontOrNull(FALLBACK_ORIGIN_FONT_FAMILY))
+        assertNull("the elided-view-always-sans capture", realCapturedFontOrNull("sans-serif"))
+        assertNull("case-insensitive", realCapturedFontOrNull("Sans-Serif"))
+        assertNull("double-quoted override stacks", realCapturedFontOrNull("\"sans-serif\""))
+        assertNull("single-quoted override stacks", realCapturedFontOrNull("'monospace'"))
+        assertNull("whitespace-padded", realCapturedFontOrNull("  serif  "))
+        assertNull(realCapturedFontOrNull("system-ui"))
+    }
+
+    @Test
+    fun realCapturedFontOrNullKeepsRealFacesAndStacks() {
+        assertEquals("Minion", realCapturedFontOrNull("Minion"))
+        assertEquals("trims but preserves", "Georgia, serif", realCapturedFontOrNull(" Georgia, serif "))
+        assertEquals("\"Fira Sans\", sans-serif", realCapturedFontOrNull("\"Fira Sans\", sans-serif"))
+        assertEquals(
+            "a real face whose stack ends in a generic is a captured publisher font",
+            "Nimbusromno9l, serif",
+            realCapturedFontOrNull("Nimbusromno9l, serif"),
+        )
     }
 
     private fun readChapterHtml(pub: Publication, index: Int): String {


### PR DESCRIPTION
## Problem

Some books' annotations rendered in the correct publisher face in the elided view regardless of reading mode or font preference.

## Root cause

Highlight creation captures `getComputedStyle().fontFamily` as the row's `originFontFamily`. While a reader Font preference override is active (ReadiumCSS `readium-font-on`), the computed style is the **user's pref stack** (e.g. bare `sans-serif`), not the publisher's face. The existing filter only special-cased the bare `serif` sentinel, so the polluted `sans-serif` value passed as a real captured font, won the `pluralityOriginFont` vote, and pinned the book's entire elided view (and PDF export) to sans. Verified against the real data: the broken book's single highlight row stores `sans-serif` while sitting in a paragraph whose publisher CSS computes to `Minion`.

## Fix

1. **`realCapturedFontOrNull()`** — bare generic CSS keywords (`serif`, `sans-serif`, `monospace`, `cursive`, `fantasy`, `system-ui`; quoted/cased variants included) are treated as "no captured value" at every consumer: plurality vote, per-excerpt emitter, body-font style block, PDF export, body-font latch, stamp-site fallbacks, and emphasis-row creation. Real stacks (`Nimbusromno9l, serif`) still pass.
2. **JS capture guard** — all three font probes (one-shot body probe, selectionchange stash fallback, continuous live-read fallback) skip capture while `readium-font-on` is present on `<html>`'s style attribute, which is how both reader stacks mark an active Font pref — covers paginated, vertical, and continuous modes.
3. **Heal** — the first real body-font report per book now heals rows stamped with any bare generic keyword (bare and single/double-quoted forms), not only the legacy `serif` sentinel, so polluted rows converge to the publisher face on the next Original-mode open and the fix propagates via annotation sync.

## Known residuals (deliberate)

- A book whose publisher CSS *legitimately* computes to a bare generic now falls back to the ReadiumCSS default face in the elided view — same trade-off the original `serif` sentinel made.
- Pre-fix captures made under a *named* font pref (e.g. `Literata`) are indistinguishable from a legitimate publisher face and are neither filtered nor healed; the JS guard prevents new ones.

## Tests

- `PluralityOriginFontTest` — generic keywords (quoted/cased) never win the vote; real stacks with generic fallbacks do.
- `HighlightsPublicationFactoryTest` — no `font-family` emitted for generic captures; real book face wins over a polluted per-row capture; `realCapturedFontOrNull` edge cases.
- `HighlightsPdfExporterTest` — PDF export applies the same filter.
- `ReaderWebViewScriptsTest` — pins the override guard in all three probes.
- `HealGenericOriginFontsTest` (new) — heal converges every generic form (bare/quoted), never rewrites real faces or null rows.