### PR TITLE
fix(reader): land bookmark navigation on the exact bookmarked page

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AnnotationFocusHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/AnnotationFocusHarnessTest.kt
@@ -3,6 +3,8 @@ package com.riffle.app.feature.reader
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebView
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
@@ -10,9 +12,12 @@ import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.click
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.riffle.app.MainActivity
@@ -29,6 +34,7 @@ import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.jsoup.Jsoup
 import org.junit.After
 import org.junit.Assert.assertTrue
@@ -87,6 +93,75 @@ class AnnotationFocusHarnessTest {
     @Test
     fun paginatedMode_annotationTap_focusesAnnotationOnScreen() {
         runModeTest(ReaderOrientation.Horizontal)
+    }
+
+    @Test
+    fun paginatedMode_bookmarkTap_focusesBookmarkedPage() {
+        runBookmarkModeTest(ReaderOrientation.Horizontal)
+    }
+
+    @Test
+    fun verticalMode_bookmarkTap_focusesBookmarkedPosition() {
+        runBookmarkModeTest(ReaderOrientation.Vertical)
+    }
+
+    @Test
+    fun continuousMode_bookmarkTap_focusesBookmarkedPosition() {
+        runBookmarkModeTest(ReaderOrientation.Continuous)
+    }
+
+    private fun runBookmarkModeTest(orientation: ReaderOrientation) {
+        runBlocking {
+            val prefs = formattingPreferencesStore.preferences.first()
+            formattingPreferencesStore.update(prefs.copy(orientation = orientation))
+        }
+        addServerAndBrowseLibrary()
+        composeTestRule.waitUntil(timeoutMillis = 15_000) {
+            composeTestRule.onAllNodesWithText(StubAbsServer.TEST_STANDALONE_ITEM_TITLE)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(StubAbsServer.TEST_STANDALONE_ITEM_TITLE).performClick()
+        composeTestRule.tapReadInDetailScreen()
+        waitForReaderReady()
+
+        // Create the bookmark through the production path. This is important: toggleBookmark()
+        // stores Readium's live page-boundary progression alongside a lossy character-count CFI.
+        navigateWithSearch(targetPhrase)
+        assertTrue(
+            "search did not reach the bookmark target",
+            waitForPhraseOnScreen(orientation, 15_000, targetPhrase).onScreen,
+        )
+        closeSearch()
+        showTopAppBar()
+        composeTestRule.onNodeWithContentDescription("Bookmark this page").performClick()
+        val bookmark = runBlocking {
+            withTimeout(10_000) {
+                annotationStore.observeBookmarks(
+                    database.sourceDao().getActive()?.id ?: error("no active source"),
+                    StubAbsServer.TEST_STANDALONE_ITEM_ID,
+                ).first { it.isNotEmpty() }.single()
+            }
+        }
+
+        // Leave the bookmarked page, then return through the actual Annotations panel navigation.
+        navigateWithSearch("Section 1.1: Origins")
+        closeSearch()
+        showTopAppBar()
+        composeTestRule.onNodeWithContentDescription("Annotations").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 8_000) {
+            composeTestRule.onAllNodesWithText(bookmark.bookmarkTitle).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(bookmark.bookmarkTitle).performClick()
+
+        val result = waitForPhraseOnScreen(
+            orientation,
+            timeoutMs = 15_000,
+            phrase = targetPhrase,
+        )
+        assertTrue(
+            "$orientation bookmark navigation did not land on the bookmarked position. $result",
+            result.onScreen,
+        )
     }
 
     @Test
@@ -168,11 +243,15 @@ class AnnotationFocusHarnessTest {
         override fun toString() = detail
     }
 
-    private fun waitForPhraseOnScreen(orientation: ReaderOrientation, timeoutMs: Long): FocusResult {
+    private fun waitForPhraseOnScreen(
+        orientation: ReaderOrientation,
+        timeoutMs: Long,
+        phrase: String = targetPhrase,
+    ): FocusResult {
         val deadline = System.currentTimeMillis() + timeoutMs
         var last = FocusResult(false, "phrase never located")
         while (System.currentTimeMillis() < deadline) {
-            last = phraseOnScreen(orientation)
+            last = phraseOnScreen(orientation, phrase)
             if (last.onScreen) return last
             Thread.sleep(150)
         }
@@ -191,12 +270,12 @@ class AnnotationFocusHarnessTest {
      * runs on the UI thread — so we register the eval inside onActivity and await OUTSIDE it (never
      * block the UI thread waiting on its own callback).
      */
-    private fun phraseOnScreen(orientation: ReaderOrientation): FocusResult {
+    private fun phraseOnScreen(orientation: ReaderOrientation, phrase: String): FocusResult {
         val webViews = visibleWebViews()
         if (webViews.isEmpty()) return FocusResult(false, "no visible WebView")
         // Find the WebView whose phrase rect resolves, and read its rect + viewport.
         for (wv in webViews) {
-            val raw = evalJs(wv, phraseRectJs(targetPhrase))
+            val raw = evalJs(wv, phraseRectJs(phrase))
             val parts = raw.takeIf { it != "null" && it != "NO_WEBVIEW" && it.isNotBlank() }?.split(',')
             if (parts == null || parts.size < 4) continue
             val left = parts[0].toDoubleOrNull() ?: continue
@@ -351,5 +430,52 @@ class AnnotationFocusHarnessTest {
             composeTestRule.onAllNodesWithContentDescription("All Books").fetchSemanticsNodes().isNotEmpty()
         }
         composeTestRule.onNodeWithContentDescription("All Books").performClick()
+    }
+
+    private fun waitForReaderReady() {
+        composeTestRule.waitUntil(timeoutMillis = 20_000) {
+            composeTestRule.onAllNodesWithTag(ReaderSemanticMatchers.TAG_READER_READY)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun navigateWithSearch(phrase: String) {
+        showTopAppBar()
+        composeTestRule.onNodeWithContentDescription("Search").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithTag(SearchTopBarTags.FIELD).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithTag(SearchTopBarTags.FIELD).performTextReplacement(phrase)
+        composeTestRule.waitUntil(timeoutMillis = 30_000) {
+            composeTestRule.onAllNodesWithTag(SearchTopBarTags.COUNT).fetchSemanticsNodes()
+                .any { node ->
+                    runCatching { node.config[SemanticsProperties.Text] }.getOrElse { emptyList() }
+                        .any { it.text.contains(" of ") }
+                }
+        }
+    }
+
+    private fun closeSearch() {
+        composeTestRule.onNodeWithContentDescription("Close search").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithTag(SearchTopBarTags.FIELD).fetchSemanticsNodes().isEmpty()
+        }
+    }
+
+    private fun showTopAppBar() {
+        repeat(3) {
+            composeTestRule
+                .onNodeWithTag(ReaderSemanticMatchers.TAG_READER_READY)
+                .performTouchInput { click(Offset(width * 0.5f, height * 0.3f)) }
+            try {
+                composeTestRule.waitUntil(timeoutMillis = 2_000) {
+                    composeTestRule.onAllNodesWithContentDescription("Back").fetchSemanticsNodes().isNotEmpty()
+                }
+                return
+            } catch (_: androidx.compose.ui.test.ComposeTimeoutException) {
+                // A dismiss-overlay race can re-hide the bar; retry the reader tap.
+            }
+        }
+        throw AssertionError("showTopAppBar: Back button not visible after 3 tap attempts")
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -504,6 +504,7 @@ internal object ColumnSnap {
         landAtStartWhenNoTarget: Boolean = true,
         locatorProgression: Double? = null,
         locatorJson: String? = null,
+        snapProgressionToNearestColumn: Boolean = false,
     ): String {
         val idLiteral = if (fragmentId.isNullOrEmpty()) "null" else JSONObject.quote(fragmentId)
         val locatorLiteral = locatorJson
@@ -512,6 +513,8 @@ internal object ColumnSnap {
             ?: "null"
         val noTargetSnap = when {
             landAtStartWhenNoTarget -> "se.scrollLeft=0;"
+            locatorProgression != null && snapProgressionToNearestColumn ->
+                "se.scrollLeft=Math.round($locatorProgression*se.scrollWidth/iw)*iw;"
             locatorProgression != null -> "se.scrollLeft=Math.floor($locatorProgression*se.scrollWidth/iw)*iw;"
             else -> "se.scrollLeft=Math.round(se.scrollLeft/iw)*iw;"
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1330,7 +1330,11 @@ internal fun readaloudLocatorJson(ref: String, quote: SentenceQuote?): JSONObjec
  * the anchor sat.
  */
 internal fun annotationNavigationOptions(isBookmark: Boolean): NavigationOptions =
-    NavigationOptions(landAtStartWhenNoTarget = false, alignToTop = isBookmark)
+    NavigationOptions(
+        landAtStartWhenNoTarget = false,
+        snapProgressionToNearestColumn = isBookmark,
+        alignToTop = isBookmark,
+    )
 
 @OptIn(ExperimentalReadiumApi::class)
 @Composable

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReaderPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReaderPresenter.kt
@@ -240,14 +240,16 @@ internal sealed class AnnotationTapEvent {
  *
  * - **Source-progress resume / annotation jump**: [landAtStartWhenNoTarget] = `false` — don't yank
  *   to the chapter top; honour the locator's progression.
+ * - **Bookmark jump**: [snapProgressionToNearestColumn] = `true` — its persisted progression is
+ *   an exact page boundary, so floating-point underflow must not floor it to the previous page.
  * - **Readaloud `play-from-here`**: [snap] = `false`, [animated] = `false` — the locator already
  *   names the precise sentence column; snap would round it off.
  * - **Annotation jump in continuous mode**: [alignToTop] = `true` — bookmark progressions are
  *   content-top-relative, not viewport-midpoint (the inverse [locatorAt] uses).
  *
  * Honoured by:
- * - [ReadiumPresenter]: [snap], [landAtStartWhenNoTarget], [animated]. [alignToTop] is irrelevant
- *   (Readium handles column alignment internally).
+ * - [ReadiumPresenter]: [snap], [landAtStartWhenNoTarget], [snapProgressionToNearestColumn],
+ *   [animated]. [alignToTop] is irrelevant (Readium handles column alignment internally).
  * - [ContinuousPresenter]: [alignToTop]. The other flags do not apply (no column grid, no
  *   Readium-go animation control).
  */
@@ -260,6 +262,12 @@ internal data class NavigationOptions(
      * (continuous always honours the explicit progression).
      */
     val landAtStartWhenNoTarget: Boolean = true,
+    /**
+     * Readium-only. Round a progression target to the nearest column instead of flooring it.
+     * Enable only for bookmarks whose progression was captured at a paginated page boundary;
+     * arbitrary progressions (sync and legacy fallbacks) still floor to their containing page.
+     */
+    val snapProgressionToNearestColumn: Boolean = false,
     /**
      * Readium-only. Whether the page-turn animates. Only consulted on the non-snap branch — the
      * snap branch's animation is owned by [ColumnSnap.goAndSnap].

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
@@ -172,7 +172,11 @@ internal class ReadiumPresenter(
         val fragment = fragment ?: return
         val locator = target.toLocator(publication) ?: return
         if (options.snap) {
-            bridge.snapAfterGoTo(locator, options.landAtStartWhenNoTarget)
+            bridge.snapAfterGoTo(
+                locator,
+                options.landAtStartWhenNoTarget,
+                options.snapProgressionToNearestColumn,
+            )
         } else {
             fragment.go(locator, animated = options.animated)
         }
@@ -224,12 +228,13 @@ internal class ReadiumPresenter(
     suspend fun navigateToLocator(
         locator: Locator,
         landAtStartWhenNoTarget: Boolean = true,
+        snapProgressionToNearestColumn: Boolean = false,
         snap: Boolean = true,
         animated: Boolean = true,
     ) {
         val fragment = fragment ?: return
         if (snap) {
-            bridge.snapAfterGoTo(locator, landAtStartWhenNoTarget)
+            bridge.snapAfterGoTo(locator, landAtStartWhenNoTarget, snapProgressionToNearestColumn)
         } else {
             fragment.go(locator, animated = animated)
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
@@ -86,7 +86,11 @@ internal class DefaultRendererBridge(
         frag.evaluateJavascript(ColumnSnap.snapToTargetColumnJs(navTargetFragmentId(link.href.toString())))
     }
 
-    override suspend fun snapAfterGoTo(locator: Locator, landAtStartWhenNoTarget: Boolean) {
+    override suspend fun snapAfterGoTo(
+        locator: Locator,
+        landAtStartWhenNoTarget: Boolean,
+        snapProgressionToNearestColumn: Boolean,
+    ) {
         val frag = fragment ?: return
         // For TOC/search/resume navigation (landAtStartWhenNoTarget=true), use the fragment id
         // from locations.fragments or the href anchor to snap the JS to the exact target element.
@@ -96,9 +100,9 @@ internal class DefaultRendererBridge(
         // highlighted text node — typically a <section id="ch01"> or <div id="main"> that spans
         // the entire chapter. Snapping to that element always resolves to column 0 (page 1)
         // because getBoundingClientRect().left for a section that starts at the chapter top is 0.
-        // The locator's TextQuote is the precise target: Readium resolves it to the highlighted
-        // DOM Range on every rAF tick. Character-count progression remains the fallback for a
-        // missing/stale quote; unlike a range it can be a column off when block density varies.
+        // A highlight locator's TextQuote is the precise DOM target. A bookmark has no text range:
+        // its persisted live-reader progression is the precise page boundary. Character-count
+        // progression remains only a fallback for missing/stale highlight quotes.
         val fragmentId = if (landAtStartWhenNoTarget) {
             locator.locations.fragments.firstOrNull()
                 ?: navTargetFragmentId(locator.href.toString())
@@ -110,9 +114,9 @@ internal class DefaultRendererBridge(
         } else {
             null
         }
-        // A TextQuote locator lets Readium resolve the exact highlighted DOM range. Pass the
-        // complete locator into the reflow tracker so it can repeat that exact resolution after
-        // each scrollWidth change; progression is only a fallback when the quote is absent/stale.
+        // A TextQuote locator lets Readium resolve the exact DOM range. Pass the complete locator
+        // into the reflow tracker so it can repeat that exact resolution after each scrollWidth
+        // change; progression is only a fallback when the quote is absent/stale.
         val exactLocatorJson = locator.text.highlight
             ?.takeIf { it.isNotBlank() }
             ?.let { locator.toJSON().toString() }
@@ -130,6 +134,7 @@ internal class DefaultRendererBridge(
                 landAtStartWhenNoTarget = landAtStartWhenNoTarget,
                 locatorProgression = progression,
                 locatorJson = exactLocatorJson,
+                snapProgressionToNearestColumn = snapProgressionToNearestColumn,
             ),
         )
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererBridge.kt
@@ -79,9 +79,15 @@ internal interface RendererBridge {
 
     /**
      * Navigate to [locator] then snap onto the target's column. [landAtStartWhenNoTarget] picks
-     * the no-DOM-fragment landing (chapter top vs. round-to-grid for a within-chapter sync).
+     * the no-DOM-fragment landing (chapter top vs. progression for a within-chapter jump).
+     * [snapProgressionToNearestColumn] distinguishes exact bookmark page boundaries from
+     * arbitrary progressions which must floor to their containing page.
      */
-    suspend fun snapAfterGoTo(locator: Locator, landAtStartWhenNoTarget: Boolean = true)
+    suspend fun snapAfterGoTo(
+        locator: Locator,
+        landAtStartWhenNoTarget: Boolean = true,
+        snapProgressionToNearestColumn: Boolean = false,
+    )
 
     /** Re-pin the current page to its LAST column through a backward cross-resource turn's reflow. */
     suspend fun snapToEnd()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationNavigationLocator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationNavigationLocator.kt
@@ -5,25 +5,30 @@ import com.riffle.core.models.Annotation
 import org.readium.r2.shared.publication.Locator
 
 /**
- * Adds the persisted TextQuote to a resolved highlight locator.
+ * Restores the annotation-owned navigation anchor after resolving its translated CFI.
  *
- * CFI resolution reconstructs chapter/progression/fragment without access to the annotation row.
- * Readium needs highlight/before/after to resolve the exact DOM Range, so every annotation entry
- * path enriches its locator once the matching row is available. Progression stays intact as the
- * fallback when a legacy or stale quote no longer matches the publication.
+ * The translated CFI's character-count progression is approximate: it does not preserve the
+ * exact Readium page boundary captured when a bookmark was created. Bookmarks therefore restore
+ * the live-reader progression persisted in their row. Highlights instead attach their persisted
+ * TextQuote so Readium can resolve the exact DOM range, retaining CFI progression as a fallback.
  */
-internal fun Locator.withAnnotationTextQuote(annotation: Annotation?): Locator {
-    if (
-        annotation?.type != AnnotationEntity.TYPE_HIGHLIGHT ||
-        annotation.textSnippet.isBlank()
-    ) {
-        return this
+internal fun Locator.withAnnotationNavigationAnchor(annotation: Annotation?): Locator =
+    when {
+        annotation?.type == AnnotationEntity.TYPE_BOOKMARK -> {
+            // Migration 9→10 and pre-extension W3C imports defaulted an unknown progression to
+            // 0.0. Keep the CFI-derived fallback for those legacy rows when the CFI clearly points
+            // later in the resource; a real first-page bookmark resolves to 0.0 as well.
+            val persistedProgression = annotation.progression.takeIf {
+                it > 0.0 || locations.progression == null
+            }
+            copy(locations = locations.copy(progression = persistedProgression ?: locations.progression))
+        }
+        annotation?.type == AnnotationEntity.TYPE_HIGHLIGHT && annotation.textSnippet.isNotBlank() -> copy(
+            text = Locator.Text(
+                before = annotation.textBefore,
+                highlight = annotation.textSnippet,
+                after = annotation.textAfter,
+            ),
+        )
+        else -> this
     }
-    return copy(
-        text = Locator.Text(
-            before = annotation.textBefore,
-            highlight = annotation.textSnippet,
-            after = annotation.textAfter,
-        ),
-    )
-}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
@@ -150,10 +150,9 @@ class AnnotationSession @AssistedInject constructor(
      */
     /**
      * A "navigate to this annotation" event. [locator] resolves to (chapter, progression,
-     * fragment) and, for text highlights, carries the persisted TextQuote
-     * (highlight/before/after). Readium uses the quote to resolve the exact DOM range; the
-     * fragment remains the range's START paragraph id (see [extractAnchorFromCfi]) and the
-     * progression is the fallback for legacy rows whose quote no longer matches.
+     * fragment). Highlights carry their persisted TextQuote so Readium can resolve the exact DOM
+     * range. Bookmarks carry the original live-reader progression persisted when they were
+     * created, rather than the approximate progression reconstructed from their translated CFI.
      *
      * Continuous mode uses [annotationId] to look up the actual `<mark data-riffle-ann="…">`
      * element in the DOM and centre the viewport on IT, not just on the enclosing paragraph.
@@ -758,15 +757,14 @@ class AnnotationSession @AssistedInject constructor(
             val annotation = _annotations.value.firstOrNull { it.id == id } ?: return@launch
             val resolver = cfiLocatorResolverFn ?: return@launch
             val resolvedLocator = resolver(annotation.cfi) ?: return@launch
-            // The CFI resolver reconstructs chapter/progression/fragment but does not have the
-            // annotation row, so it cannot attach the TextQuote that Readium's scrollToLocator
-            // needs for exact range resolution. Enrich highlight locators here, where the
-            // persisted snippet and both disambiguating context strings are available.
+            // The CFI resolver reconstructs chapter/progression/fragment without the annotation
+            // row. Restore the exact live-reader progression for bookmarks; for highlights,
+            // attach the persisted quote and its disambiguating context strings.
             //
             // Character progression remains on the locator as a fallback for legacy/stale
             // quotes. It is not precise enough to be the primary paginated target: block
             // elements and variable line density mean progression can map one column away.
-            val locator = resolvedLocator.withAnnotationTextQuote(annotation)
+            val locator = resolvedLocator.withAnnotationNavigationAnchor(annotation)
             // Annotation.type uses the database-layer constants from AnnotationEntity. A typo
             // matching a lowercased literal here silently flipped every annotation to
             // isBookmark=false, which inverted the continuous-mode landing.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
@@ -200,8 +200,9 @@ class ReaderSessionLifecycle @AssistedInject constructor(
         // (set above) — cfiStringToLocator resolves against it.
         val resolvedOpenAtLocator = openAtCfiNonBlank?.let { cfiStringToLocator(it) }
         // openAtCfiNonBlank is non-null whenever resolvedOpenAtLocator is (the locator is derived
-        // from it). Fetch the matching row once: its id drives Continuous mark focus and its
-        // TextQuote makes Readium's paginated/vertical locator exact.
+        // from it). Fetch the matching row once: its id drives Continuous mark focus, its
+        // TextQuote makes highlight locators exact, and its persisted progression restores a
+        // bookmark's original live-reader page boundary.
         val openAtAnnotation = if (
             resolvedOpenAtLocator != null &&
             resolvedReaderServerId != null
@@ -212,7 +213,7 @@ class ReaderSessionLifecycle @AssistedInject constructor(
         } else {
             null
         }
-        val openAtLocator = resolvedOpenAtLocator?.withAnnotationTextQuote(openAtAnnotation)
+        val openAtLocator = resolvedOpenAtLocator?.withAnnotationNavigationAnchor(openAtAnnotation)
         val initialFocusAnnotationId = openAtAnnotation?.id
 
         // Stored lastPosition is Readium Locator JSON. Rows written before ADR 0030's translation

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -1319,6 +1319,11 @@ class AnnotationNavigationOptionsTest {
                 "annotationNavigationOptions and the #399 eps analysis in its doc",
             opts.alignToTop,
         )
+        assertTrue(
+            "paginated bookmark navigation must round its saved page-boundary progression; " +
+                "flooring a slightly-underflowed boundary lands on the previous page",
+            opts.snapProgressionToNearestColumn,
+        )
     }
 
     @Test
@@ -1327,6 +1332,11 @@ class AnnotationNavigationOptionsTest {
         // the anchor. Kept at midpoint by design.
         val opts = annotationNavigationOptions(isBookmark = false)
         assertFalse(opts.alignToTop)
+        assertFalse(
+            "highlight progression is only an arbitrary fallback and must stay on its " +
+                "containing page",
+            opts.snapProgressionToNearestColumn,
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -243,6 +243,30 @@ class ReaderWebViewScriptsTest {
         assertTrue("does NOT yank to column 0", !js.contains("se.scrollLeft=0;"))
     }
 
+    @Test
+    fun `snapToTargetColumnJs rounds a persisted bookmark page boundary instead of landing one page early`() {
+        val progressionWithFloatingUnderflow = 0.4285714285714285
+        val js = ColumnSnap.snapToTargetColumnJs(
+            fragmentId = null,
+            landAtStartWhenNoTarget = false,
+            locatorProgression = progressionWithFloatingUnderflow,
+            snapProgressionToNearestColumn = true,
+        )
+
+        assertTrue(
+            "the exact page-boundary progression saved by toggleBookmark must round back to its " +
+                "column; Math.floor would turn 2.999999999999999 into the previous page",
+            js.contains(
+                "else{se.scrollLeft=Math.round(" +
+                    "$progressionWithFloatingUnderflow*se.scrollWidth/iw)*iw;}",
+            ),
+        )
+        assertTrue(
+            "bookmark page boundaries must not use the arbitrary-progression floor path",
+            !js.contains("Math.floor($progressionWithFloatingUnderflow*se.scrollWidth/iw)"),
+        )
+    }
+
     // Annotation navigation carries a TextQuote locator. Readium's own resolver can reconstruct
     // the exact DOM Range from highlight + before/after, which avoids the one-column error of
     // estimating a visual page from character progression. The rAF tracker must repeat that

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/FakeRendererBridge.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/FakeRendererBridge.kt
@@ -57,8 +57,13 @@ internal class FakeRendererBridge(
         calls += "snapAfterGoTo(link=${link.href})"
     }
 
-    override suspend fun snapAfterGoTo(locator: Locator, landAtStartWhenNoTarget: Boolean) {
-        calls += "snapAfterGoTo(locator=${locator.href}, landAtStart=$landAtStartWhenNoTarget)"
+    override suspend fun snapAfterGoTo(
+        locator: Locator,
+        landAtStartWhenNoTarget: Boolean,
+        snapProgressionToNearestColumn: Boolean,
+    ) {
+        calls += "snapAfterGoTo(locator=${locator.href}, landAtStart=$landAtStartWhenNoTarget, " +
+            "nearest=$snapProgressionToNearestColumn)"
     }
 
     override suspend fun snapToEnd() {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -1035,7 +1035,7 @@ class AnnotationSessionTest {
         val sessionScope = CoroutineScope(dispatcher)
         val store = FakeAnnotationStore()
         val syncOps = FakeSyncOps()
-        val targetLocator = buildLocator()
+        val targetLocator = buildLocator(progression = 0.71)
         val anno = fakeAnnotation(id = "b1", type = com.riffle.core.database.AnnotationEntity.TYPE_BOOKMARK, cfi = "epubcfi(/6/4!/4/2)")
         store.allAnnotations.value = listOf(anno)
         val session = makeSession(store = store, syncOps = syncOps, scope = sessionScope)
@@ -1056,12 +1056,58 @@ class AnnotationSessionTest {
 
         assertEquals(1, received.size)
         assertTrue(received[0].isBookmark)
-        assertSame(
+        assertEquals(
+            "bookmark navigation must restore the original live-reader progression persisted on " +
+                "the annotation, not the lossy progression reconstructed from its translated CFI",
+            anno.progression,
+            received[0].locator.locations.progression!!,
+            0.000001,
+        )
+        assertEquals(targetLocator.href, received[0].locator.href)
+        assertEquals(targetLocator.mediaType, received[0].locator.mediaType)
+        assertNull(
             "bookmarks are point locators and must not receive a highlight TextQuote",
-            targetLocator,
-            received[0].locator,
+            received[0].locator.text.highlight,
         )
 
+        collectJob.cancel()
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
+
+    @Test
+    fun `navigateToAnnotation retains CFI progression for legacy bookmark with unknown zero progression`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val store = FakeAnnotationStore()
+        val syncOps = FakeSyncOps()
+        val targetLocator = buildLocator(progression = 0.71)
+        val legacyBookmark = fakeAnnotation(
+            id = "legacy-bookmark",
+            type = AnnotationEntity.TYPE_BOOKMARK,
+            cfi = "epubcfi(/6/4!/4/2)",
+        ).copy(progression = 0.0)
+        store.allAnnotations.value = listOf(legacyBookmark)
+        val session = makeSession(store = store, syncOps = syncOps, scope = sessionScope)
+        session.bind(
+            sourceId = "srv1",
+            namespace = "ns1",
+            itemId = "item1",
+            highlightRenderResolver = { emptyList() },
+            cfiLocatorResolver = { targetLocator },
+        )
+        val received = mutableListOf<AnnotationSession.AnnotationNavigationEvent>()
+        val collectJob = sessionScope.launch {
+            session.annotationNavigationEvents.collect { received.add(it) }
+        }
+
+        session.navigateToAnnotation(legacyBookmark.id)
+
+        assertEquals(
+            "a legacy zero means unknown when its translated CFI points later in the chapter",
+            targetLocator.locations.progression!!,
+            received.single().locator.locations.progression!!,
+            0.000001,
+        )
         collectJob.cancel()
         sessionScope.coroutineContext[Job]?.cancel()
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -2,6 +2,7 @@ package com.riffle.app.feature.reader.session
 
 import com.riffle.core.sync.OpenReconcileTargets
 import com.riffle.core.models.Annotation
+import com.riffle.core.database.AnnotationEntity
 import com.riffle.core.domain.AnnotationStore
 import com.riffle.core.models.AudioIdentity
 import com.riffle.core.domain.AudioIdentityResolver
@@ -490,6 +491,38 @@ class ReaderSessionLifecycleTest {
         assertEquals("ann-99", outcome.initialFocusAnnotationId)
         assertSame(outcome.openAtLocator, outcome.initialLocator)
         assertSame(outcome.openAtLocator, outcome.effectiveInitialLocator)
+    }
+
+    @Test
+    fun `open at bookmark restores persisted live-reader progression instead of translated CFI approximation`() = runTest {
+        val cfi = "epubcfi(/6/2!/4/2)"
+        val cfiApproximation = Locator(
+            href = mockk(relaxed = true),
+            mediaType = org.readium.r2.shared.util.mediatype.MediaType.XHTML,
+            locations = Locator.Locations(progression = 0.7),
+        )
+        val bookmark = AnnotationSessionTest.makeAnnotation(
+            id = "bookmark-99",
+            type = AnnotationEntity.TYPE_BOOKMARK,
+            cfi = cfi,
+        )
+        val (lifecycle, _) = makeLifecycle(
+            annotationStore = FakeAnnotationStore(
+                byCfi = mapOf(Triple("srv-abs", "item-1", cfi) to bookmark),
+            ),
+            cfiResolver = { c -> if (c == cfi) cfiApproximation else null },
+        )
+
+        val outcome = lifecycle.open(params(openAtCfi = cfi)) as ReaderSessionLifecycle.OpenOutcome.Ready
+
+        assertEquals(
+            "cold-open bookmark navigation must use the original page boundary saved on the row",
+            bookmark.progression,
+            outcome.openAtLocator!!.locations.progression!!,
+            0.000001,
+        )
+        assertNull(outcome.openAtLocator!!.text.highlight)
+        assertSame(outcome.openAtLocator, outcome.initialLocator)
     }
 
     @Test


### PR DESCRIPTION
## Problem

Navigating to a bookmark in paginated mode could land one page off from where the bookmark was created.

## Causes and fixes

1. **Lossy progression from CFI translation.** The CFI resolver reconstructs a character-count progression that does not preserve the exact Readium page boundary captured when the bookmark was made. Bookmark navigation (both in-reader taps and cold-open via `openAtCfi`) now restores the live-reader progression persisted on the annotation row. `withAnnotationTextQuote` became `withAnnotationNavigationAnchor`: highlights still attach their persisted TextQuote; bookmarks restore their persisted progression, keeping the CFI-derived value as a fallback for legacy rows whose progression defaulted to 0.0.
2. **Floor vs round in the column snap.** The JS column snap floored `progression * scrollWidth / iw`, so floating-point underflow at an exact page boundary (e.g. 2.999999999999999 columns) dropped to the previous page. A new `snapProgressionToNearestColumn` option — enabled only for bookmarks, whose progression is an exact page boundary — rounds instead. Arbitrary progressions (sync, stale-quote fallbacks) still floor to their containing page.

## Tests

- JVM: JS rounding path in `ReaderWebViewScriptsTest`, option wiring in `EpubReaderViewModelTest`, progression restore + legacy-0.0 fallback in `AnnotationSessionTest`, cold-open restore in `ReaderSessionLifecycleTest`.
- Harness: new `AnnotationFocusHarnessTest` bookmark round-trip tests in all three reader modes (paginated / vertical / continuous), creating the bookmark through the production toolbar path and returning via the Annotations panel.

Note: one existing assertion in `AnnotationSessionTest` changed semantically (`assertSame` on the pass-through locator → `assertEquals` on restored progression) because bookmark locators are now intentionally enriched; the original "bookmarks get no TextQuote" claim is still asserted.