### PR TITLE
fix(library): stop progress bar ping-pong between library refresh and detail pull

### DIFF
--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogProgress.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogProgress.kt
@@ -16,4 +16,24 @@ data class CatalogProgress(
     val isFinished: Boolean = false,
     val finishedAt: Long? = null,
     val lastUpdate: Long,
-)
+) {
+    /**
+     * The single "how far through this item" fraction that `library_items.readingProgress`
+     * stores (ADR 0029). Every writer of that column that consumes a [CatalogProgress] must
+     * derive through here — the bulk pull ([ProgressPeerCapability.pullAllProgress]) and the
+     * per-item pull ([ProgressPeerCapability.pullProgress]) hit different endpoints, and letting
+     * them derive differently makes the two writers ping-pong the library UI between two values.
+     *
+     * `isFinished` pins to 1f to cover "server marks finished but audioCurrentTime slightly
+     * under duration". A real (>0) ebook fraction wins over the audio position (ABS ships
+     * `ebookProgress = 0` on audio-only items). Returns null when the payload carries no
+     * meaningful progress at all (fresh item / audio-only book whose duration hasn't populated
+     * server-side yet) — writing 0 in that case would clobber a previously-adopted value.
+     */
+    fun unifiedLibraryFraction(): Float? = when {
+        isFinished -> 1f
+        ebookProgress > 0f -> ebookProgress.coerceIn(0f, 1f)
+        audioDuration > 0.0 -> (audioCurrentTime / audioDuration).toFloat().coerceIn(0f, 1f)
+        else -> null
+    }
+}

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
@@ -358,9 +358,9 @@ class AbsCatalog(
                     itemId = id,
                     ebookLocation = null,
                     ebookProgress = p.ebookProgress ?: 0f,
-                    audioCurrentTime = 0.0,
-                    audioDuration = 0.0,
-                    isFinished = p.finishedAt != null,
+                    audioCurrentTime = p.currentTime,
+                    audioDuration = p.duration,
+                    isFinished = p.isFinished || p.finishedAt != null,
                     finishedAt = p.finishedAt,
                     lastUpdate = p.lastUpdate ?: 0L,
                 )

--- a/core/catalog/src/test/kotlin/com/riffle/core/catalog/CatalogProgressTest.kt
+++ b/core/catalog/src/test/kotlin/com/riffle/core/catalog/CatalogProgressTest.kt
@@ -1,0 +1,46 @@
+package com.riffle.core.catalog
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CatalogProgressTest {
+
+    private fun progress(
+        ebookProgress: Float = 0f,
+        audioCurrentTime: Double = 0.0,
+        audioDuration: Double = 0.0,
+        isFinished: Boolean = false,
+    ) = CatalogProgress(
+        itemId = "item-1",
+        ebookProgress = ebookProgress,
+        audioCurrentTime = audioCurrentTime,
+        audioDuration = audioDuration,
+        isFinished = isFinished,
+        lastUpdate = 1_000L,
+    )
+
+    @Test fun `finished pins to 1 regardless of positions`() {
+        assertEquals(1f, progress(isFinished = true, audioCurrentTime = 1.0, audioDuration = 100.0).unifiedLibraryFraction())
+    }
+
+    @Test fun `ebook progress wins when present`() {
+        assertEquals(0.3f, progress(ebookProgress = 0.3f, audioCurrentTime = 59.0, audioDuration = 100.0).unifiedLibraryFraction())
+    }
+
+    @Test fun `audio fraction derived from currentTime over duration when ebook progress is absent`() {
+        assertEquals(0.59f, progress(audioCurrentTime = 59.0, audioDuration = 100.0).unifiedLibraryFraction()!!, 0.0001f)
+    }
+
+    @Test fun `audio fraction clamps to 1 when currentTime exceeds duration`() {
+        assertEquals(1f, progress(audioCurrentTime = 101.0, audioDuration = 100.0).unifiedLibraryFraction())
+    }
+
+    @Test fun `empty payload yields null so callers skip the write`() {
+        assertNull(progress().unifiedLibraryFraction())
+    }
+
+    @Test fun `audio position without a duration yields null`() {
+        assertNull(progress(audioCurrentTime = 42.0).unifiedLibraryFraction())
+    }
+}

--- a/core/catalog/src/test/kotlin/com/riffle/core/catalog/abs/AbsCatalogTest.kt
+++ b/core/catalog/src/test/kotlin/com/riffle/core/catalog/abs/AbsCatalogTest.kt
@@ -513,6 +513,27 @@ class AbsCatalogTest {
         assertEquals(true, result["b"]!!.isFinished)
     }
 
+    @Test fun `pullAllProgress carries audio position and isFinished instead of hardcoding zeros`() = runTest {
+        // Regression for the "progress bar jumps back and forth" bug: the bulk pull used to
+        // hardcode audioCurrentTime/audioDuration to 0.0, so the library refresh could never
+        // derive the same unified fraction as the per-item pullProgress and the two writers
+        // ping-ponged library_items.readingProgress.
+        libraryApi.userProgress = mapOf(
+            "a" to NetworkUserMediaProgress(
+                ebookProgress = null, lastUpdate = 100L,
+                currentTime = 59.0, duration = 100.0, isFinished = false,
+            ),
+            "b" to NetworkUserMediaProgress(ebookProgress = null, lastUpdate = 200L, isFinished = true),
+        )
+
+        val result = catalog.pullAllProgress().associateBy { it.itemId }
+
+        assertEquals(59.0, result["a"]!!.audioCurrentTime, 0.0001)
+        assertEquals(100.0, result["a"]!!.audioDuration, 0.0001)
+        assertEquals(false, result["a"]!!.isFinished)
+        assertEquals(true, result["b"]!!.isFinished)
+    }
+
     // endregion
 
     // region ReadingSessionsCapability

--- a/core/data/src/main/kotlin/com/riffle/core/data/CatalogProgressRemotes.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/CatalogProgressRemotes.kt
@@ -102,10 +102,10 @@ class CatalogAudioProgressRemote(
         // fraction=0, clobbering the ebook reconciler's just-written readingProgress. isFinished
         // is a separate signal — treat it as a real audio "done" event even without duration.
         if (!r.isFinished && r.audioDuration <= 0.0 && r.audioCurrentTime <= 0.0) return null
-        // Single-item ABS pullProgress leaves `ebookProgress` at 0 for audio-only items (unlike
-        // pullAllProgress which folds `progress` into it — ADR 0029); derive from currentTime/
-        // duration here so an audio-only book's library-grid % reflects the just-pulled listen
-        // fraction. `isFinished` overrides to 1f in case duration is 0/absent on server payload.
+        // ABS pullProgress leaves `ebookProgress` at 0 for audio-only items; derive from
+        // currentTime/duration here so an audio-only book's library-grid % reflects the
+        // just-pulled listen fraction (ADR 0029). `isFinished` overrides to 1f in case
+        // duration is 0/absent on server payload.
         val fraction = when {
             r.isFinished -> 1f
             r.audioDuration > 0.0 -> (r.audioCurrentTime / r.audioDuration).toFloat().coerceIn(0f, 1f)

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -233,14 +233,15 @@ class LibraryRepositoryImpl @Inject constructor(
                         title = item.title,
                         author = item.author,
                         coverUrl = item.coverUrl ?: "",
-                        // For an audiobook-only item the ABS user-progress fallback already maps
-                        // its listen fraction into `ebookProgress` (AbsApiClient: ebookProgress ?:
-                        // progress), so this single field is the unified "how far through this
-                        // item" value that surfaces audiobooks in In Progress too (ADR 0029).
+                        // The unified "how far through this item" fraction (ebook CFI progress,
+                        // else audio currentTime/duration) that surfaces audiobooks in In
+                        // Progress too (ADR 0029) — same derivation as refreshItemProgress so
+                        // the bulk and per-item pulls can never disagree.
                         // Note: for existing items the DAO's updateMetadata ignores this field and
                         // preserves the locally-tracked value. It is only used when inserting a
                         // new item for the first time.
-                        readingProgress = serverProgress?.ebookProgress ?: item.readingProgress ?: 0f,
+                        readingProgress = serverProgress?.unifiedLibraryFraction()
+                            ?: item.readingProgress ?: 0f,
                         ebookFileIno = item.ebookFileIno,
                         ebookFormat = item.ebookFormat.toEbookFormat().toStorageString(),
                         hasAudio = item.hasAudio,
@@ -286,7 +287,11 @@ class LibraryRepositoryImpl @Inject constructor(
             for (item in items) {
                 if (item.id in dirtyIds) continue
                 val sp = serverProgressMap[item.id] ?: continue
-                libraryItemDao.updateReadingProgress(source.id, item.id, sp.ebookProgress)
+                // Same derivation (and same empty-payload skip) as refreshItemProgress: the two
+                // pulls hit different endpoints, and deriving differently here is exactly what
+                // made the library card ping-pong against the detail screen's per-item pull.
+                val fraction = sp.unifiedLibraryFraction() ?: continue
+                libraryItemDao.updateReadingProgress(source.id, item.id, fraction)
             }
             val isUnsupported = entities.isNotEmpty() && entities.none { it.ebookFormat != EbookFormat.Unsupported.toStorageString() }
             libraryDao.setUnsupported(source.id, libraryId, isUnsupported)
@@ -312,22 +317,12 @@ class LibraryRepositoryImpl @Inject constructor(
             }
             return LibraryRefreshResult.NetworkError(t)
         } ?: return LibraryRefreshResult.Success
-        // Single-item pullProgress doesn't apply the "audio → ebookProgress" fallback that
-        // pullAllProgress does (ABS ships `progress` on audio-only items, `ebookProgress = 0`),
-        // so derive the unified library fraction here (ADR 0029). isFinished pins to 1f to cover
-        // "server marks finished but audioCurrentTime slightly under duration" boundary.
-        // Skip when the payload carries no meaningful progress at all (fresh item / audio-only
-        // book whose duration hasn't been populated server-side yet) — writing 0 in that case
-        // would clobber a previously-adopted non-zero value in library_items.readingProgress.
-        if (!sp.isFinished && sp.ebookProgress <= 0f && sp.audioDuration <= 0.0 && sp.audioCurrentTime <= 0.0) {
-            return LibraryRefreshResult.Success
-        }
-        val fraction = when {
-            sp.isFinished -> 1f
-            sp.ebookProgress > 0f -> sp.ebookProgress
-            sp.audioDuration > 0.0 -> (sp.audioCurrentTime / sp.audioDuration).toFloat().coerceIn(0f, 1f)
-            else -> 0f
-        }
+        // Derive the unified library fraction (ADR 0029) through the shared helper so this
+        // per-item pull can never disagree with refreshLibraryItems' bulk pull. A null fraction
+        // means the payload carries no meaningful progress at all (fresh item / audio-only book
+        // whose duration hasn't been populated server-side yet) — writing 0 in that case would
+        // clobber a previously-adopted non-zero value in library_items.readingProgress.
+        val fraction = sp.unifiedLibraryFraction() ?: return LibraryRefreshResult.Success
         val finishedAt = sp.finishedAt ?: sp.lastUpdate.takeIf { sp.isFinished }
         libraryItemDao.updateReadingProgress(source.id, itemId, fraction)
         libraryItemDao.updateFinishedAt(source.id, itemId, finishedAt)

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryRepositoryTest.kt
@@ -605,6 +605,111 @@ class LibraryRepositoryTest {
     }
 
     @Test
+    fun `refreshLibraryItems derives the audio fraction instead of clobbering with the stored scalar`() = runTest {
+        // Regression for the "progress bar jumps back and forth on detail open/close" bug: an
+        // audio-dimension item whose server record has ebookProgress=0 plus authoritative
+        // currentTime/duration (59/100). The detail screen's per-item refreshItemProgress derives
+        // 0.59 and writes it; the bulk library refresh on the home screen's ON_RESUME used to
+        // write back the collapsed stored scalar (or 0), ping-ponging the card between the two
+        // values on every navigation. Both writers must derive the same unified fraction.
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeLibraryItemDao()
+        dao.upsertAll(listOf(
+            LibraryItemEntity(
+                "s1", "item-1", "lib-1", "Book", "A", null, 0.59f,
+                lastOpenedAt = 10_000L, addedAt = 0L,
+            ),
+        ))
+        val api = object : AbsLibraryApi {
+            override suspend fun getUserProgress(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<Map<String, NetworkUserMediaProgress>> =
+                com.riffle.core.network.NetworkResult.Success(
+                    mapOf("item-1" to com.riffle.core.network.NetworkUserMediaProgress(
+                        ebookProgress = null, lastUpdate = 5_000L,
+                        currentTime = 59.0, duration = 100.0, isFinished = false,
+                    ))
+                )
+            override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkLibrary>> =
+                NetworkResult.Success(emptyList())
+            override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkLibraryItem>> =
+                NetworkResult.Success(listOf(
+                    NetworkLibraryItem("item-1", "lib-1", "Book", "A", 0f, ebookFormat = EbookFormat.Epub)
+                ))
+            override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkSeries>> =
+                NetworkResult.Success(emptyList())
+            override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkCollection>> =
+                NetworkResult.Success(emptyList())
+        }
+        makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
+        assertEquals(0.59f, dao.itemsFor("lib-1").first { it.id == "item-1" }.readingProgress, 0.001f)
+    }
+
+    @Test
+    fun `refreshLibraryItems keeps existing readingProgress when the payload carries no meaningful progress`() = runTest {
+        // A record whose every progress dimension is empty (fresh item, or an audio-only book
+        // whose duration hasn't populated server-side yet) must not clobber a previously-adopted
+        // non-zero value — same guard refreshItemProgress applies to the per-item pull.
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeLibraryItemDao()
+        dao.upsertAll(listOf(
+            LibraryItemEntity(
+                "s1", "item-1", "lib-1", "Book", "A", null, 0.59f,
+                lastOpenedAt = 10_000L, addedAt = 0L,
+            ),
+        ))
+        val api = object : AbsLibraryApi {
+            override suspend fun getUserProgress(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<Map<String, NetworkUserMediaProgress>> =
+                com.riffle.core.network.NetworkResult.Success(
+                    mapOf("item-1" to com.riffle.core.network.NetworkUserMediaProgress(ebookProgress = null, lastUpdate = 5_000L))
+                )
+            override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkLibrary>> =
+                NetworkResult.Success(emptyList())
+            override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkLibraryItem>> =
+                NetworkResult.Success(listOf(
+                    NetworkLibraryItem("item-1", "lib-1", "Book", "A", 0f, ebookFormat = EbookFormat.Epub)
+                ))
+            override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkSeries>> =
+                NetworkResult.Success(emptyList())
+            override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkCollection>> =
+                NetworkResult.Success(emptyList())
+        }
+        makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
+        assertEquals(0.59f, dao.itemsFor("lib-1").first { it.id == "item-1" }.readingProgress, 0.001f)
+    }
+
+    @Test
+    fun `refreshLibraryItems seeds a newly inserted audiobook row from the audio position`() = runTest {
+        // ADR 0029: audiobook-only items must surface in "In Progress" too. The bulk /api/me
+        // mapping no longer folds the stored scalar into ebookProgress when audio position data
+        // is present, so the insert seed must derive the fraction from currentTime/duration.
+        fakeServerRepository.activeServer = activeServer()
+        fakeTokenStorage.tokens["s1"] = "tok"
+        val dao = FakeLibraryItemDao() // no pre-existing items
+        val api = object : AbsLibraryApi {
+            override suspend fun getUserProgress(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<Map<String, NetworkUserMediaProgress>> =
+                com.riffle.core.network.NetworkResult.Success(
+                    mapOf("item-1" to com.riffle.core.network.NetworkUserMediaProgress(
+                        ebookProgress = null, lastUpdate = 1_000L,
+                        currentTime = 25.0, duration = 100.0, isFinished = false,
+                    ))
+                )
+            override suspend fun getLibraries(baseUrl: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkLibrary>> =
+                NetworkResult.Success(emptyList())
+            override suspend fun getLibraryItems(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkLibraryItem>> =
+                NetworkResult.Success(listOf(
+                    NetworkLibraryItem("item-1", "lib-1", "My Book", "Author A", 0f, ebookFormat = EbookFormat.Epub)
+                ))
+            override suspend fun getSeries(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkSeries>> =
+                NetworkResult.Success(emptyList())
+            override suspend fun getCollections(baseUrl: String, libraryId: String, token: String, insecureAllowed: Boolean): NetworkResult<List<NetworkCollection>> =
+                NetworkResult.Success(emptyList())
+        }
+        makeRepo(libraryItemDao = dao, api = api).refreshLibraryItems("lib-1")
+        assertEquals(0.25f, dao.itemsFor("lib-1").first { it.id == "item-1" }.readingProgress, 0.001f)
+    }
+
+    @Test
     fun `refreshLibraryItems uses source readingProgress when no local record exists`() = runTest {
         fakeServerRepository.activeServer = activeServer()
         fakeTokenStorage.tokens["s1"] = "tok"

--- a/core/net/src/commonMain/kotlin/com/riffle/core/network/AbsApiClient.kt
+++ b/core/net/src/commonMain/kotlin/com/riffle/core/network/AbsApiClient.kt
@@ -99,10 +99,19 @@ class AbsApiClient(
                 it.libraryItemId to NetworkUserMediaProgress(
                     // ABS reports completion in two fields: an ebook carries a precise
                     // `ebookProgress` (CFI-based, can exceed `progress`); an audiobook carries
-                    // `progress` (currentTime/duration) with `ebookProgress` 0/absent. Prefer a
-                    // real (>0) `ebookProgress`, else fall back to `progress` — so a 0
-                    // `ebookProgress` no longer shadows a real audiobook position (ADR 0029).
-                    ebookProgress = it.ebookProgress?.takeIf { p -> p > 0f } ?: it.progress,
+                    // `currentTime`/`duration` with `ebookProgress` 0/absent. Surface a real
+                    // (>0) `ebookProgress` and the raw audio position so callers derive one
+                    // unified fraction (ADR 0029). Do NOT fold the stored `progress` scalar in
+                    // when audio position data exists — that scalar can be stale (a client once
+                    // pushed it computed against the wrong duration) and folding it made the
+                    // bulk pull disagree with the per-item pull, ping-ponging the library UI.
+                    // Only when the entry carries no duration at all is `progress` the sole
+                    // signal left, so keep it as the last-resort fallback there.
+                    ebookProgress = it.ebookProgress?.takeIf { p -> p > 0f }
+                        ?: it.progress.takeIf { _ -> it.duration <= 0.0 },
+                    currentTime = it.currentTime,
+                    duration = it.duration,
+                    isFinished = it.isFinished,
                     lastUpdate = it.lastUpdate,
                     finishedAt = it.finishedAt,
                 )

--- a/core/net/src/commonMain/kotlin/com/riffle/core/network/AbsLibraryApi.kt
+++ b/core/net/src/commonMain/kotlin/com/riffle/core/network/AbsLibraryApi.kt
@@ -7,6 +7,9 @@ data class NetworkUserMediaProgress(
     val ebookProgress: Float?,
     val lastUpdate: Long?,
     val finishedAt: Long? = null,
+    val currentTime: Double = 0.0,
+    val duration: Double = 0.0,
+    val isFinished: Boolean = false,
 )
 
 interface AbsLibraryApi {

--- a/core/net/src/commonMain/kotlin/com/riffle/core/network/model/AbsMeResponse.kt
+++ b/core/net/src/commonMain/kotlin/com/riffle/core/network/model/AbsMeResponse.kt
@@ -12,6 +12,9 @@ internal data class AbsMeResponse(
         val libraryItemId: String = "",
         val ebookProgress: Float? = null,
         val progress: Float = 0f,
+        val currentTime: Double = 0.0,
+        val duration: Double = 0.0,
+        val isFinished: Boolean = false,
         val lastUpdate: Long? = null,
         val finishedAt: Long? = null,
     )

--- a/core/net/src/jvmTest/kotlin/com/riffle/core/network/AbsApiClientLibraryTest.kt
+++ b/core/net/src/jvmTest/kotlin/com/riffle/core/network/AbsApiClientLibraryTest.kt
@@ -294,6 +294,54 @@ class AbsApiClientLibraryTest {
     }
 
     @Test
+    fun `getUserProgress passes audio position through instead of collapsing to the stored scalar`() = runTest {
+        // Regression for the "progress bar jumps back and forth" bug: ABS's stored `progress`
+        // scalar can be stale (a client once PATCHed it computed against the wrong duration)
+        // while `currentTime`/`duration` remain authoritative. When audio position data is
+        // present, the mapping must surface it raw and must NOT fold the scalar into
+        // ebookProgress — otherwise the bulk library refresh writes the stale scalar over the
+        // audio-derived fraction the per-item pull just wrote.
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                    """{"mediaProgress":[
+                        {"libraryItemId":"audio-1","mediaItemType":"book",
+                         "progress":0.05,"ebookProgress":0.0,"currentTime":148.3,"duration":251.4,
+                         "isFinished":false,"lastUpdate":1780170049396}
+                    ]}""".trimIndent()
+                )
+        )
+
+        val result = client.getUserProgress(server.url("/").toString().trimEnd('/'), "tok", false)
+
+        val entry = (result as NetworkResult.Success).value["audio-1"]!!
+        assertEquals(148.3, entry.currentTime, 0.0001)
+        assertEquals(251.4, entry.duration, 0.0001)
+        assertEquals(false, entry.isFinished)
+        assertNull(entry.ebookProgress)
+    }
+
+    @Test
+    fun `getUserProgress parses isFinished from mediaProgress entries`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .addHeader("Content-Type", "application/json")
+                .setBody(
+                    """{"mediaProgress":[
+                        {"libraryItemId":"item-1","progress":1.0,"isFinished":true,"lastUpdate":100}
+                    ]}""".trimIndent()
+                )
+        )
+
+        val result = client.getUserProgress(server.url("/").toString().trimEnd('/'), "tok", false)
+
+        assertEquals(true, (result as NetworkResult.Success).value["item-1"]?.isFinished)
+    }
+
+    @Test
     fun `getUserProgress yields null lastUpdate when field is absent`() = runTest {
         server.enqueue(
             MockResponse()


### PR DESCRIPTION
## Problem

The library card and the item detail screen both read `library_items.readingProgress`, but the two writers of that column derived it differently:

- **Per-item pull** (`refreshItemProgress`, detail screen ON_RESUME → `GET /api/me/progress/{id}`) derives the fraction from `currentTime/duration` when `ebookProgress` is 0.
- **Bulk pull** (`refreshLibraryItems`, library ON_RESUME → `GET /api/me`) hardcoded `audioCurrentTime`/`audioDuration` to 0.0 in `AbsCatalog.pullAllProgress` and instead folded ABS's stored `progress` scalar into `ebookProgress`.

The stored scalar is write-through, not derived — ABS keeps whatever triple the last client PATCHed, and Riffle computes `progress = currentTime / localDuration` at push time. A single past push with a wrong local duration leaves a record where the scalar (5%) disagrees with the authoritative `currentTime/duration` (59%) forever. On such a record every detail open/close ping-pongs the library bar: detail writes 59%, home-screen resume writes 5% back, repeat.

Present since #589 (v2.31.0); data-dependent, so it only shows on books with a poisoned record.

## Fix

- `/api/me` mapping (`AbsApiClient.getUserProgress`) carries `currentTime`/`duration`/`isFinished` raw and no longer folds the stored scalar in when audio position data exists (kept as last-resort fallback only for records with no duration).
- `AbsCatalog.pullAllProgress` maps the real audio fields instead of hardcoded zeros.
- New shared helper `CatalogProgress.unifiedLibraryFraction()` (finished → 1f, ebook fraction if > 0, else `currentTime/duration`, null on empty payload) is the single derivation used by both `refreshLibraryItems` (adoption loop + insert seed) and `refreshItemProgress` — the two pulls structurally can't disagree anymore. The bulk adoption also inherits the per-item pull's empty-payload skip, so an all-zero record can no longer clobber a previously-adopted value.

## Hypothesis trail

Diagnosed from frame-extracted screen recording (library 5% → detail 5%→59% → library 59%→5%); confirmed by tracing both writers to their endpoints. The winning hypothesis: divergent fraction derivation between bulk and per-item pulls over the same column, triggered by a stale server-side `progress` scalar.

## Tests

All watched fail red before the fix:
- `LibraryRepositoryTest`: the exact 5↔59 scenario (audio fraction not clobbered by the scalar), empty-payload keep, audiobook insert seed (protects ADR 0029).
- `AbsCatalogTest`: `pullAllProgress` carries audio position + `isFinished`.
- `AbsApiClientLibraryTest`: raw audio passthrough, no scalar collapse when duration present, `isFinished` parsing.
- New `CatalogProgressTest`: helper derivation matrix.

Full `./gradlew test` green.