### PR TITLE
fix(reader): anchor annotation jumps to decoration Range and clamp note glyphs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,10 @@ When finalizing, `git status` is almost never empty — the user routinely piggy
 
 When the work originated from a GitHub Issue (e.g. the user asked you to "do #123"), the PR body must include a `Closes #N` line so the merge auto-closes the issue. One line per issue if the PR spans several. Put it near the top of the body, above the change summary.
 
+## No real book titles in commits or PRs
+
+Never include real book titles in commit messages, PR titles, or PR descriptions. If you need to refer to a specific book, use the book's library ID instead. This avoids leaking the user's reading list in public repository history.
+
 ## Tests are required before opening a PR
 
 Do not open a PR without tests that cover the fix or new functionality. Every bug fix needs a regression test that fails before the change and passes after; every new feature needs unit and/or integration coverage for its behaviour. "Manually verified" is not a substitute for an automated test.

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/NoteGlyphMarginWebViewTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/NoteGlyphMarginWebViewTest.kt
@@ -1,0 +1,81 @@
+package com.riffle.app.feature.reader
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Real-WebView regression coverage for note glyphs at the minimum reader margin. */
+@RunWith(AndroidJUnit4::class)
+class NoteGlyphMarginWebViewTest {
+
+    @Test
+    fun paginatedGlyphKeepsReadableViewportInsetWhenSelectionStartsNearPageEdge() {
+        val stylesheet = noteGlyphTemplate().stylesheet.orEmpty()
+        val html = """
+            <!doctype html>
+            <html>
+              <head><style>$stylesheet</style></head>
+              <body style="margin:0">
+                <div id="selection" style="position:absolute;left:8px;top:40px;width:160px;height:24px">
+                  $NOTE_GLYPH_ELEMENT_HTML
+                </div>
+                <div id="next-selection" style="position:absolute;left:408px;top:40px;width:160px;height:24px">
+                  $NOTE_GLYPH_ELEMENT_HTML
+                </div>
+              </body>
+            </html>
+        """.trimIndent()
+
+        withSizedWebViewFixture(html, widthPx = 400, heightPx = 600) { webView ->
+            webView.evalSync(noteGlyphViewportClampAfterApplyJs())
+            val lefts = webView.evalSync(
+                "JSON.stringify(Array.prototype.map.call(" +
+                    "document.querySelectorAll('.$NOTE_GLYPH_ICON_CLASS')," +
+                    "function(e){return e.getBoundingClientRect().left;}))"
+            ).trim('"').removePrefix("[").removeSuffix("]").split(',').map(String::toDouble)
+
+            assertTrue(
+                "visible-spread glyph must stay at least ${NOTE_GLYPH_VIEWPORT_INSET_PX}px inside; lefts=$lefts",
+                lefts[0] >= NOTE_GLYPH_VIEWPORT_INSET_PX,
+            )
+            assertTrue(
+                "adjacent-spread glyph must stay on its own spread; lefts=$lefts",
+                lefts[1] >= 400 + NOTE_GLYPH_VIEWPORT_INSET_PX,
+            )
+        }
+    }
+
+    @Test
+    fun continuousGlyphKeepsReadableViewportInsetWhenTextStartsNearPageEdge() {
+        val html = """
+            <!doctype html>
+            <html>
+              <head><style>html,body,p{margin:0} p{padding-left:8px}</style></head>
+              <body><p>Narrow margin note glyph fixture text.</p></body>
+            </html>
+        """.trimIndent()
+
+        withSizedWebViewFixture(html, widthPx = 400, heightPx = 600) { webView ->
+            val annotationId = "narrow-note"
+            val annotation = AnnotationHighlight(
+                id = annotationId,
+                text = "Narrow margin",
+                cssColor = "rgba(33,150,243,0.45)",
+                hasNote = true,
+                before = "",
+                after = " note",
+            )
+            webView.evalSync(ContinuousStyleInjector.applyAnnotationHighlightsJs(listOf(annotation)))
+            val left = webView.evalSync(
+                "document.querySelector('[data-riffle-note-glyph=\"$annotationId\"]')" +
+                    ".getBoundingClientRect().left.toString()"
+            ).trim('"').toDouble()
+
+            assertTrue(
+                "continuous glyph must stay at least ${NOTE_GLYPH_VIEWPORT_INSET_PX}px inside; left=$left",
+                left >= NOTE_GLYPH_VIEWPORT_INSET_PX,
+            )
+        }
+    }
+}

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/NoteGlyphRenderHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/NoteGlyphRenderHarnessTest.kt
@@ -1,0 +1,290 @@
+package com.riffle.app.feature.reader
+
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebView
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.riffle.app.MainActivity
+import com.riffle.app.harness.ReaderSemanticMatchers
+import com.riffle.app.harness.StubAbsServer
+import com.riffle.core.data.di.EpubCacheStore
+import com.riffle.core.database.RiffleDatabase
+import com.riffle.core.domain.AnnotationStore
+import com.riffle.core.domain.FormattingPreferencesStore
+import com.riffle.core.domain.LocalStore
+import com.riffle.core.domain.ReaderOrientation
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.jsoup.Jsoup
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * End-to-end regression loop for noted-highlight glyphs. Unlike the renderer unit tests, this
+ * opens the real EPUB in Readium and inspects the live chapter WebView after navigation/reflow.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class NoteGlyphRenderHarnessTest {
+
+    private companion object {
+        const val NARROW_MARGINS = 0.2f
+        const val GLYPH_VIEWPORT_INSET_PX = 12.0
+    }
+
+    @get:Rule(order = 0) val hiltRule = HiltAndroidRule(this)
+    @get:Rule(order = 1) val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Inject lateinit var database: RiffleDatabase
+    @EpubCacheStore @Inject lateinit var epubCacheStore: LocalStore
+    @Inject lateinit var annotationStore: AnnotationStore
+    @Inject lateinit var formattingPreferencesStore: FormattingPreferencesStore
+
+    private val stubServer = StubAbsServer()
+    private val targetPhrase = "Section 1.3: Development"
+
+    @Before
+    fun setUp() {
+        stubServer.start()
+        hiltRule.inject()
+        database.clearAllTables()
+        epubCacheStore.clear()
+        runBlocking {
+            val prefs = formattingPreferencesStore.preferences.first()
+            formattingPreferencesStore.update(prefs.copy(orientation = ReaderOrientation.Horizontal))
+        }
+    }
+
+    @After
+    fun tearDown() {
+        stubServer.shutdown()
+        composeTestRule.activityRule.scenario.close()
+        Runtime.getRuntime().gc()
+        Thread.sleep(400)
+        database.clearAllTables()
+    }
+
+    @Test
+    fun paginatedNotedHighlightRendersVisibleGlyph() {
+        runModeTest(ReaderOrientation.Horizontal)
+    }
+
+    @Test
+    fun verticalNotedHighlightRendersVisibleGlyph() {
+        runModeTest(ReaderOrientation.Vertical)
+    }
+
+    @Test
+    fun continuousNotedHighlightRendersVisibleGlyph() {
+        runModeTest(ReaderOrientation.Continuous)
+    }
+
+    private fun runModeTest(orientation: ReaderOrientation) {
+        runBlocking {
+            val prefs = formattingPreferencesStore.preferences.first()
+            formattingPreferencesStore.update(
+                prefs.copy(orientation = orientation, margins = NARROW_MARGINS),
+            )
+        }
+        addServerAndBrowseLibrary()
+        seedDeepNotedHighlight()
+        searchAndTapAnnotation()
+        composeTestRule.waitUntil(timeoutMillis = 20_000) {
+            composeTestRule.onAllNodesWithTag(ReaderSemanticMatchers.TAG_READER_READY)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        val deadline = System.currentTimeMillis() + 20_000
+        var lastDetails = "no WebView"
+        val glyphSelector = if (orientation == ReaderOrientation.Continuous) {
+            "[data-riffle-note-glyph]"
+        } else {
+            ".riffle-note-glyph-icon"
+        }
+        while (System.currentTimeMillis() < deadline) {
+            val details = visibleWebViews().map { webView ->
+                evalJs(
+                    webView,
+                    """
+                    (function () {
+                      var e = document.querySelector('$glyphSelector');
+                      if (!e) return 'missing';
+                      var r = e.getBoundingClientRect();
+                      var s = getComputedStyle(e);
+                      var se = document.scrollingElement || document.documentElement;
+                      var g = window.readium && window.readium.getDecorations
+                        ? window.readium.getDecorations('$NOTE_GLYPH_DECORATION_GROUP') : null;
+                      var item = g && g.items && g.items[0];
+                      var rr = item && item.range ? item.range.getBoundingClientRect() : null;
+                      return [
+                        'left=' + r.left, 'top=' + r.top, 'right=' + r.right,
+                        'bottom=' + r.bottom, 'iw=' + innerWidth, 'ih=' + innerHeight,
+                        'scrollLeft=' + (se ? se.scrollLeft : -1),
+                        'items=' + (g && g.items ? g.items.length : -1),
+                        'itemId=' + (item && item.decoration ? item.decoration.id : ''),
+                        'focus=' + (window.$NOTE_GLYPH_FOCUS_ID_JS_KEY || ''),
+                        'rangeLeft=' + (rr ? rr.left : -1),
+                        'rangeTop=' + (rr ? rr.top : -1),
+                        'mask=' + s.webkitMaskImage, 'bg=' + s.backgroundColor,
+                        'opacity=' + s.opacity
+                      ].join('|');
+                    })()
+                    """.trimIndent(),
+                ).trim('"')
+            }
+            lastDetails = details.joinToString()
+            if (details.any { detail ->
+                    detail != "missing" &&
+                        evalGlyphVisible(detail)
+                }
+            ) return
+            Thread.sleep(250)
+        }
+        assertTrue("$orientation noted highlight glyph never became visible: $lastDetails", false)
+    }
+
+    private fun evalGlyphVisible(detail: String): Boolean {
+        val fields = detail.split('|').associate { field ->
+            field.substringBefore('=') to field.substringAfter('=')
+        }
+        val left = fields["left"]?.toDoubleOrNull() ?: return false
+        val top = fields["top"]?.toDoubleOrNull() ?: return false
+        val right = fields["right"]?.toDoubleOrNull() ?: return false
+        val bottom = fields["bottom"]?.toDoubleOrNull() ?: return false
+        val width = fields["iw"]?.toDoubleOrNull() ?: return false
+        val height = fields["ih"]?.toDoubleOrNull() ?: return false
+        return left >= GLYPH_VIEWPORT_INSET_PX && right <= width &&
+            bottom > 0 && top < height &&
+            fields["mask"]?.let { it.isNotBlank() && it != "none" } == true &&
+            fields["bg"] != "rgba(0, 0, 0, 0)" &&
+            (fields["opacity"]?.toDoubleOrNull() ?: 0.0) > 0.0
+    }
+
+    private fun seedDeepNotedHighlight() = runBlocking {
+        val source = database.sourceDao().getActive()
+            ?: error("no active source registered after browsing library")
+        val html = chapter1Html()
+        val progression = phraseProgression(html, targetPhrase)
+        val cfi = buildHighlightCfiRangeForSelection(
+            spineStep = 2,
+            html = html,
+            startProgression = progression,
+            selectedText = targetPhrase,
+        ) ?: error("failed to build highlight CFI for '$targetPhrase'")
+        val highlight = annotationStore.createHighlight(
+            sourceId = source.id,
+            itemId = StubAbsServer.TEST_STANDALONE_ITEM_ID,
+            cfi = cfi,
+            textSnippet = targetPhrase,
+            chapterHref = "chapter1.xhtml",
+            originFontFamily = "Georgia, serif",
+        )
+        annotationStore.updateNote(highlight.id, "This note must produce a visible margin glyph.")
+    }
+
+    private fun chapter1Html(): String {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        java.util.zip.ZipInputStream(context.assets.open("test.epub")).use { zip ->
+            var entry = zip.nextEntry
+            while (entry != null) {
+                if (entry.name.endsWith("chapter1.xhtml")) return zip.readBytes().decodeToString()
+                entry = zip.nextEntry
+            }
+        }
+        error("chapter1.xhtml not found in test.epub")
+    }
+
+    private fun phraseProgression(html: String, phrase: String): Double {
+        val body = Jsoup.parse(html).body().text()
+        val index = body.indexOf(phrase)
+        require(index >= 0) { "phrase '$phrase' not found in chapter body" }
+        return index.toDouble() / body.length.toDouble()
+    }
+
+    private fun addServerAndBrowseLibrary() {
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Audiobookshelf").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Audiobookshelf").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Connect").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNode(hasSetTextAction() and hasText("Source URL"))
+            .performTextReplacement(stubServer.baseUrl)
+        composeTestRule.onNode(hasSetTextAction() and hasText("Username"))
+            .performTextReplacement("testuser")
+        composeTestRule.onNode(hasSetTextAction() and hasText("Password"))
+            .performTextReplacement("testpass")
+        composeTestRule.onNodeWithText("Connect").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 15_000) {
+            composeTestRule.onAllNodesWithText("Connect anyway").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Connect anyway").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            composeTestRule.onAllNodesWithContentDescription("All Books")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithContentDescription("All Books").performClick()
+    }
+
+    private fun searchAndTapAnnotation() {
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            composeTestRule.onAllNodesWithText("Search").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Search").performTextReplacement("Section 1.3")
+        composeTestRule.waitUntil(timeoutMillis = 8_000) {
+            composeTestRule.onAllNodesWithText(targetPhrase).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(targetPhrase).performClick()
+    }
+
+    private fun visibleWebViews(): List<WebView> {
+        val latch = CountDownLatch(1)
+        val result = mutableListOf<WebView>()
+        composeTestRule.activityRule.scenario.onActivity { activity ->
+            fun collect(view: View) {
+                if (view is WebView && view.visibility == View.VISIBLE) result += view
+                if (view is ViewGroup) {
+                    for (index in 0 until view.childCount) collect(view.getChildAt(index))
+                }
+            }
+            collect(activity.window.decorView)
+            latch.countDown()
+        }
+        latch.await(5, TimeUnit.SECONDS)
+        return result
+    }
+
+    private fun evalJs(webView: WebView, script: String): String {
+        val latch = CountDownLatch(1)
+        val result = arrayOfNulls<String>(1)
+        composeTestRule.activityRule.scenario.onActivity {
+            webView.evaluateJavascript(script) { value ->
+                result[0] = value
+                latch.countDown()
+            }
+        }
+        if (!latch.await(5, TimeUnit.SECONDS)) return "NO_WEBVIEW"
+        return result[0] ?: "null"
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -505,6 +505,7 @@ internal object ColumnSnap {
         locatorProgression: Double? = null,
         locatorJson: String? = null,
         snapProgressionToNearestColumn: Boolean = false,
+        focusAnnotationId: String? = null,
     ): String {
         val idLiteral = if (fragmentId.isNullOrEmpty()) "null" else JSONObject.quote(fragmentId)
         val locatorLiteral = locatorJson
@@ -518,6 +519,11 @@ internal object ColumnSnap {
             locatorProgression != null -> "se.scrollLeft=Math.floor($locatorProgression*se.scrollWidth/iw)*iw;"
             else -> "se.scrollLeft=Math.round(se.scrollLeft/iw)*iw;"
         }
+        val noteGroupLiteral = JSONObject.quote(NOTE_GLYPH_DECORATION_GROUP)
+        val focusAnnotationLiteral = focusAnnotationId
+            ?.takeIf { it.isNotBlank() }
+            ?.let(JSONObject::quote)
+            ?: "null"
         // For annotation focus (landAtStartWhenNoTarget=false with a progression), skip the
         // vertical smooth-tail block entirely. The snap JS runs immediately after go(locator),
         // before Readium has applied CSS multicol. At that moment scrollHeight > innerHeight (the
@@ -532,6 +538,8 @@ internal object ColumnSnap {
         val skipVertical = !landAtStartWhenNoTarget && locatorProgression != null
         return "(function(){var id=$idLiteral;" +
             "var loc=$locatorLiteral;" +
+            "var focusAnnotationId=$focusAnnotationLiteral;" +
+            "window.$NOTE_GLYPH_FOCUS_ID_JS_KEY=focusAnnotationId;" +
             "var se=document.scrollingElement;" +
             "var _skipV=$skipVertical;" +
             // Vertical (scroll-mode) smooth tail. Readium's `go(locator)` already teleported us to
@@ -564,8 +572,31 @@ internal object ColumnSnap {
             VERTICAL_SMOOTH_TAIL_JS +
             "return;}" +
             "var gen=(window.__riffleSnapGen=(window.__riffleSnapGen||0)+1);" +
-            "var lastW=-1,stable=0,frames=0;" +
+            "var lastW=-1,stable=0,frames=0,rangeMatched=false,rangeStable=0;" +
             "function snap(){var iw=window.innerWidth;" +
+            // On older WebViews Readium's scrollToLocator(TextQuote) can settle exactly one
+            // column after the quote. Once the note decoration exists, Readium has already
+            // resolved that same quote to a live Range. Prefer its first client rect: this is
+            // both more direct and uses the same geometry the glyph itself follows. The group
+            // may not exist on early ticks, so the normal locator/progression fallbacks remain.
+            "if((focusAnnotationId||(loc&&loc.text&&loc.text.highlight))&&se.scrollWidth>iw+4&&" +
+            "window.readium&&typeof window.readium.getDecorations==='function'){" +
+            "try{var notes=window.readium.getDecorations($noteGroupLiteral);" +
+            "var items=notes&&notes.items?notes.items:[];" +
+            "for(var ni=0;ni<items.length;ni++){" +
+            "var item=items[ni],dl=item.decoration&&item.decoration.locator;" +
+            "if(focusAnnotationId){" +
+            "if(!item.decoration||item.decoration.id!==focusAnnotationId)continue;" +
+            "}else{" +
+            "if(!dl||!dl.text||dl.text.highlight!==loc.text.highlight)continue;" +
+            "if(loc.text.before&&dl.text.before&&dl.text.before!==loc.text.before)continue;" +
+            "if(loc.text.after&&dl.text.after&&dl.text.after!==loc.text.after)continue;}" +
+            "var rects=item.range.getClientRects();" +
+            "var nr=rects&&rects.length?rects[0]:item.range.getBoundingClientRect();" +
+            "if(nr){var noteColumn=Math.floor((nr.left+se.scrollLeft)/iw)*iw;" +
+            "if(Math.abs(se.scrollLeft-noteColumn)>1)rangeStable=0;else rangeStable++;" +
+            "se.scrollLeft=noteColumn;rangeMatched=true;return;}" +
+            "}}catch(e){}}" +
             // Readium's own locator resolver uses text.highlight + before/after to reconstruct
             // the exact DOM Range. Re-run it on every tracked frame so a typography reflow
             // cannot reset the landing to column 0. This is strictly more precise than mapping
@@ -580,7 +611,16 @@ internal object ColumnSnap {
             "function tick(){if(gen!==window.__riffleSnapGen)return;" + // a newer jump superseded us
             "var w=se.scrollWidth;if(w===lastW)stable++;else{stable=0;lastW=w;}" +
             "snap();" +
-            "if((stable>=3&&frames>=2)||frames++>72){snap();return;}" + // settled, or ~1.2s safety cap
+            // A note Range can resolve before Readium's final API-25 layout write. Keep pinning it
+            // for a full second of correct frames; consuming focus on the first match lets that
+            // later write restore the stale one-column-ahead position. Focused jumps also wait
+            // longer for a late decoration publication, while ordinary navigation keeps the
+            // existing short settle cap.
+            "var rangeDone=rangeMatched&&rangeStable>=60;" +
+            "var ordinaryDone=!focusAnnotationId&&!rangeMatched&&stable>=3&&frames>=2;" +
+            "var cap=focusAnnotationId?600:72;" +
+            "if(rangeDone||ordinaryDone||frames++>cap){" +
+            "snap();window.$NOTE_GLYPH_FOCUS_ID_JS_KEY=null;return;}" +
             "requestAnimationFrame(tick);}" +
             "tick();})()"
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -517,7 +517,10 @@ internal object ContinuousStyleInjector {
                     var relTop = Math.max(0, markRect.top - blockRect.top + 2);
                     // Mirror paged-mode NoteGlyphStyle: position 28px to the LEFT of the mark's
                     // first-line left edge (not the block's left edge, which is the page margin).
-                    var relLeft = markRect.left - blockRect.left - 28;
+                    var relLeft = Math.max(
+                        markRect.left - blockRect.left - 28,
+                        $NOTE_GLYPH_VIEWPORT_INSET_PX - blockRect.left
+                    );
                     var s = document.createElement('span');
                     s.setAttribute('data-riffle-note-glyph', id);
                     s.style.cssText = 'position:absolute;left:' + relLeft + 'px;top:' + relTop + 'px;' +

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1329,11 +1329,15 @@ internal fun readaloudLocatorJson(ref: String, quote: SentenceQuote?): JSONObjec
  * `<= eps` check keeps the indicator lit on arrival regardless of where in the saved viewport
  * the anchor sat.
  */
-internal fun annotationNavigationOptions(isBookmark: Boolean): NavigationOptions =
+internal fun annotationNavigationOptions(
+    isBookmark: Boolean,
+    annotationId: String? = null,
+): NavigationOptions =
     NavigationOptions(
         landAtStartWhenNoTarget = false,
         snapProgressionToNearestColumn = isBookmark,
         alignToTop = isBookmark,
+        focusAnnotationId = annotationId,
     )
 
 @OptIn(ExperimentalReadiumApi::class)
@@ -2318,7 +2322,12 @@ private fun EpubNavigatorView(
     // Continuous has no equivalent seam — the paragraph anchor is only ~correct, so we look up the
     // actual `<mark data-riffle-ann>` device-Y and centre on it. Cannot live behind ReaderPresenter
     // without leaking Readium/Continuous internals up the stack.
-    LaunchedEffect(annotationNavigationEvents, isContinuous) {
+    LaunchedEffect(
+        annotationNavigationEvents,
+        isContinuous,
+        readerPresenter,
+        formattingPrefs.orientation,
+    ) {
         annotationNavigationEvents.collect { event ->
             val view = continuousViewRef.value
             if (isContinuous && !event.isBookmark && event.annotationId != null && view != null) {
@@ -2335,7 +2344,12 @@ private fun EpubNavigatorView(
             } else {
                 navigateWithCover(
                     NavigationTarget.ToLocatorJson(event.locator.toJSON().toString()),
-                    annotationNavigationOptions(isBookmark = event.isBookmark),
+                    annotationNavigationOptions(
+                        isBookmark = event.isBookmark,
+                        annotationId = event.annotationId.takeIf {
+                            formattingPrefs.orientation == ReaderOrientation.Horizontal
+                        },
+                    ),
                     event.locator.href.toString(),
                 )
             }
@@ -2475,7 +2489,7 @@ private fun EpubNavigatorView(
         val fragment = fragmentRef.value as? DecorableNavigator
         val listener = object : DecorableNavigator.Listener {
             override fun onDecorationActivated(event: DecorableNavigator.OnActivatedEvent): Boolean {
-                if (event.group != "annotation-notes") return false
+                if (event.group != NOTE_GLYPH_DECORATION_GROUP) return false
                 val container = containerRef.value ?: return false
                 val rawRect = event.rect ?: return false
                 val rect = rawRect.toWindowIntRect(container)
@@ -2483,7 +2497,7 @@ private fun EpubNavigatorView(
                 return true
             }
         }
-        fragment?.addDecorationListener("annotation-notes", listener)
+        fragment?.addDecorationListener(NOTE_GLYPH_DECORATION_GROUP, listener)
         onDispose { fragment?.removeDecorationListener(listener) }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -459,6 +459,9 @@ class EpubReaderViewModel @Inject constructor(
     // When opened from a library annotation search result, jump to this CFI instead of the saved
     // reading position. Null/blank for a normal open. EPUB-only (annotations anchor on ABS-EPUB CFI).
     private val openAtCfi: String? = savedStateHandle.get<String>("openAtCfi")
+    // Stable identity for an annotation-open route. Older/deep-linked routes may omit this, in
+    // which case ReaderSessionLifecycle falls back to resolving the row from the CFI.
+    private val openAnnotationId: String? = savedStateHandle.get<String>("openAnnotationId")
 
     // TOC entry to open immediately on launch — navigated once the publication is ready, using the same
     // _navigationEvents channel as the TOC panel's tap handler (see navigateToEntry).
@@ -1370,6 +1373,7 @@ class EpubReaderViewModel @Inject constructor(
             com.riffle.app.feature.reader.session.ReaderSessionLifecycle.OpenParams(
                 itemId = itemId,
                 openAtCfi = openAtCfi,
+                openAnnotationId = openAnnotationId,
                 startTocHref = startTocHref,
             ),
         )
@@ -1583,7 +1587,10 @@ class EpubReaderViewModel @Inject constructor(
         if (o.openAtLocator != null &&
             formatting.effectiveFormattingPreferences.value.orientation == ReaderOrientation.Horizontal
         ) {
-            annotationSession.emitAnnotationNavigation(o.openAtLocator)
+            annotationSession.emitAnnotationNavigation(
+                locator = o.openAtLocator,
+                annotationId = o.initialFocusAnnotationId,
+            )
         }
 
         // Audiobook→readaloud handoff: opened by swiping the audiobook player down. Auto-start
@@ -3349,6 +3356,7 @@ class EpubReaderViewModel @Inject constructor(
                     sourceId = row.sourceId,
                     itemId = row.itemId,
                     cfi = row.cfi,
+                    annotationId = row.id,
                 ),
             )
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt
@@ -7,6 +7,105 @@ import android.os.Parcelable
 import org.readium.r2.navigator.Decoration
 import org.readium.r2.navigator.html.HtmlDecorationTemplate
 
+internal const val NOTE_GLYPH_DECORATION_GROUP = "annotation-notes"
+internal const val NOTE_GLYPH_FOCUS_ID_JS_KEY = "__riffleFocusAnnotationId"
+internal const val NOTE_GLYPH_VIEWPORT_INSET_PX = 12
+
+/**
+ * Completes an annotation jump when the column tracker ran before Readium published the note
+ * decoration Range. Readium applies decoration diffs on its own animation frame, so this queues
+ * behind that work and consumes the one-shot focus id left by [ColumnSnap.snapToTargetColumnJs].
+ */
+internal fun noteGlyphFocusAfterApplyJs(): String {
+    val group = org.json.JSONObject.quote(NOTE_GLYPH_DECORATION_GROUP)
+    return """
+        (function(){
+          var frames = 0;
+          var matchedFrames = 0;
+          function tick(){
+            try {
+              var focusId = window.$NOTE_GLYPH_FOCUS_ID_JS_KEY;
+              if (!focusId || !window.readium ||
+                  typeof window.readium.getDecorations !== 'function') return;
+              var se = document.scrollingElement || document.documentElement;
+              var iw = window.innerWidth;
+              if (se && iw > 0 && se.scrollWidth > iw + 4) {
+                var notes = window.readium.getDecorations($group);
+                var items = notes && notes.items ? notes.items : [];
+                for (var i = 0; i < items.length; i++) {
+                  var item = items[i];
+                  if (!item.decoration || item.decoration.id !== focusId) continue;
+                  var rects = item.range.getClientRects();
+                  var rect = rects && rects.length
+                    ? rects[0]
+                    : item.range.getBoundingClientRect();
+                  if (!rect) return;
+                  var target = Math.floor((rect.left + se.scrollLeft) / iw) * iw;
+                  if (Math.abs(se.scrollLeft - target) > 1) matchedFrames = 0;
+                  else matchedFrames++;
+                  se.scrollLeft = target;
+                  if (matchedFrames >= 60) {
+                    window.$NOTE_GLYPH_FOCUS_ID_JS_KEY = null;
+                    return;
+                  }
+                }
+              }
+            } catch (e) {}
+            if (frames++ < 600) requestAnimationFrame(tick);
+            else window.$NOTE_GLYPH_FOCUS_ID_JS_KEY = null;
+          }
+          requestAnimationFrame(tick);
+        })()
+    """.trimIndent()
+}
+
+/**
+ * Keeps each margin glyph inside the left edge of its paginated spread (or the viewport in scroll
+ * mode). The decoration remains 28px left of its text whenever the page margin has room; only the
+ * portion that would cross the page edge is shifted inward.
+ *
+ * Readium publishes decoration DOM asynchronously, so retry for a bounded number of frames. Using
+ * the decoration parent to identify the spread is important: clamping every offscreen glyph to the
+ * current viewport would pull notes from adjacent columns onto the visible page.
+ */
+internal fun noteGlyphViewportClampAfterApplyJs(): String = """
+    (function(){
+      var frames = 0;
+      var seenFrames = 0;
+      function clamp(){
+        try {
+          var se = document.scrollingElement || document.documentElement;
+          var iw = window.innerWidth;
+          if (!se || iw <= 0) return;
+          var icons = document.querySelectorAll('.$NOTE_GLYPH_ICON_CLASS');
+          for (var i = 0; i < icons.length; i++) {
+            var icon = icons[i];
+            var bounds = icon.parentElement;
+            if (!bounds) continue;
+            icon.style.webkitTransform = '';
+            icon.style.transform = '';
+            var boundsRect = bounds.getBoundingClientRect();
+            var iconRect = icon.getBoundingClientRect();
+            var boundsDocumentLeft = boundsRect.left + se.scrollLeft;
+            var spreadLeft = Math.floor(Math.max(0, boundsDocumentLeft) / iw) * iw;
+            var iconDocumentLeft = iconRect.left + se.scrollLeft;
+            var shift = Math.max(0, spreadLeft + $NOTE_GLYPH_VIEWPORT_INSET_PX - iconDocumentLeft);
+            if (shift > 0) {
+              var transform = 'translateX(' + shift + 'px)';
+              icon.style.webkitTransform = transform;
+              icon.style.transform = transform;
+            }
+          }
+          if (icons.length > 0) seenFrames++;
+        } catch (e) {}
+        if ((seenFrames < 4 || seenFrames === 0) && frames++ < 72) {
+          requestAnimationFrame(clamp);
+        }
+      }
+      clamp();
+    })()
+""".trimIndent()
+
 // SVG path from Icons.Outlined.NoteAlt (Apache 2.0): document page with ruled lines.
 // Percent-encoded so it can be embedded directly in a CSS url() without base64.
 // %3C/%3E = < / >
@@ -17,8 +116,8 @@ internal const val NOTE_GLYPH_SVG_DATA_URI =
     "M16,4l4,4h-4V4ZM13,18H7v-2h6V18ZM17,14H7v-2h10V14ZM17,10H7V8h10V10Z'/%3E" +
     "%3C/svg%3E"
 
-private const val NOTE_GLYPH_CLASS = "riffle-note-glyph"
-private const val NOTE_GLYPH_ICON_CLASS = "riffle-note-glyph-icon"
+internal const val NOTE_GLYPH_CLASS = "riffle-note-glyph"
+internal const val NOTE_GLYPH_ICON_CLASS = "riffle-note-glyph-icon"
 
 // data-activable="1" tells Readium to use THIS element's rect for hit-testing rather than
 // falling back to D.children (the outer BOUNDS div, which only covers the text selection).
@@ -52,7 +151,7 @@ class NoteGlyphStyle : Decoration.Style, Parcelable {
 
 /**
  * Decoration template for [NoteGlyphStyle]. A transparent BOUNDS div covers the selection;
- * an inner div child is absolutely positioned 24px to the left of the selection's left edge,
+ * an inner div child is absolutely positioned 28px to the left of the selection's left edge,
  * landing in the left gutter. Using a real DOM child (not ::before) means tap events bubble
  * up through the inner div → outer div → Readium's decoration listener, so glyph taps are
  * reliably detected. Uses CSS masking so the icon inherits `currentColor` — readable on

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/NoteGlyphDecoration.kt
@@ -98,7 +98,7 @@ internal fun noteGlyphViewportClampAfterApplyJs(): String = """
           }
           if (icons.length > 0) seenFrames++;
         } catch (e) {}
-        if ((seenFrames < 4 || seenFrames === 0) && frames++ < 72) {
+        if (seenFrames < 4 && frames++ < 72) {
           requestAnimationFrame(clamp);
         }
       }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderNavEvent.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderNavEvent.kt
@@ -8,7 +8,12 @@ import android.net.Uri
  * real source book (ADR 0041, Task 9).
  */
 sealed interface ReaderNavEvent {
-    data class OpenInSourceBook(val sourceId: String, val itemId: String, val cfi: String) : ReaderNavEvent
+    data class OpenInSourceBook(
+        val sourceId: String,
+        val itemId: String,
+        val cfi: String,
+        val annotationId: String,
+    ) : ReaderNavEvent
 
     /**
      * Highlights-mode reader has no highlights left (user deleted the last one). The synthesised

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRenderer.kt
@@ -141,14 +141,16 @@ internal class ReadiumHighlightRenderer(
         val noted = renders.filter { it.note != null && !it.useAccentBarStyle }
         if (noted.isEmpty()) {
             if (!hasNoteGlyphDecorations) return
-            applyDecorationsBlock(emptyList(), "annotation-notes")
+            applyDecorationsBlock(emptyList(), NOTE_GLYPH_DECORATION_GROUP)
             hasNoteGlyphDecorations = false
             return
         }
         val noteDecorations = noted.map { h ->
             Decoration(id = h.id, locator = h.locator, style = NoteGlyphStyle())
         }
-        applyDecorationsWithClear(noteDecorations, "annotation-notes")
+        applyDecorationsWithClear(noteDecorations, NOTE_GLYPH_DECORATION_GROUP)
+        evaluateJavascript?.invoke(noteGlyphViewportClampAfterApplyJs())
+        evaluateJavascript?.invoke(noteGlyphFocusAfterApplyJs())
         hasNoteGlyphDecorations = true
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReaderPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReaderPresenter.kt
@@ -249,7 +249,7 @@ internal sealed class AnnotationTapEvent {
  *
  * Honoured by:
  * - [ReadiumPresenter]: [snap], [landAtStartWhenNoTarget], [snapProgressionToNearestColumn],
- *   [animated]. [alignToTop] is irrelevant (Readium handles column alignment internally).
+ *   [animated], and [focusAnnotationId]. [alignToTop] is irrelevant (Readium handles column alignment internally).
  * - [ContinuousPresenter]: [alignToTop]. The other flags do not apply (no column grid, no
  *   Readium-go animation control).
  */
@@ -279,6 +279,8 @@ internal data class NavigationOptions(
      * Readium (it handles column alignment internally).
      */
     val alignToTop: Boolean = false,
+    /** Annotation id whose already-resolved decoration Range should anchor a Readium jump. */
+    val focusAnnotationId: String? = null,
 )
 
 internal sealed class NavigationTarget {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReadiumPresenter.kt
@@ -173,9 +173,10 @@ internal class ReadiumPresenter(
         val locator = target.toLocator(publication) ?: return
         if (options.snap) {
             bridge.snapAfterGoTo(
-                locator,
-                options.landAtStartWhenNoTarget,
-                options.snapProgressionToNearestColumn,
+                locator = locator,
+                landAtStartWhenNoTarget = options.landAtStartWhenNoTarget,
+                snapProgressionToNearestColumn = options.snapProgressionToNearestColumn,
+                focusAnnotationId = options.focusAnnotationId,
             )
         } else {
             fragment.go(locator, animated = options.animated)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
@@ -90,6 +90,7 @@ internal class DefaultRendererBridge(
         locator: Locator,
         landAtStartWhenNoTarget: Boolean,
         snapProgressionToNearestColumn: Boolean,
+        focusAnnotationId: String?,
     ) {
         val frag = fragment ?: return
         // For TOC/search/resume navigation (landAtStartWhenNoTarget=true), use the fragment id
@@ -135,6 +136,7 @@ internal class DefaultRendererBridge(
                 locatorProgression = progression,
                 locatorJson = exactLocatorJson,
                 snapProgressionToNearestColumn = snapProgressionToNearestColumn,
+                focusAnnotationId = focusAnnotationId,
             ),
         )
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererBridge.kt
@@ -82,11 +82,13 @@ internal interface RendererBridge {
      * the no-DOM-fragment landing (chapter top vs. progression for a within-chapter jump).
      * [snapProgressionToNearestColumn] distinguishes exact bookmark page boundaries from
      * arbitrary progressions which must floor to their containing page.
+     * [focusAnnotationId] selects an already-resolved note decoration Range when available.
      */
     suspend fun snapAfterGoTo(
         locator: Locator,
         landAtStartWhenNoTarget: Boolean = true,
         snapProgressionToNearestColumn: Boolean = false,
+        focusAnnotationId: String? = null,
     )
 
     /** Re-pin the current page to its LAST column through a backward cross-resource turn's reflow. */

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationSession.kt
@@ -656,12 +656,20 @@ class AnnotationSession @AssistedInject constructor(
      * Emit a locator directly to the annotation navigation channel. Used by the VM's
      * openBook() path to snap to the initial annotation-nav target (openAtCfi) using the same
      * channel that [navigateToAnnotation] uses — so the screen only needs one subscriber.
+     * [annotationId] lets paginated navigation use Readium's already-resolved decoration Range
+     * and lets continuous navigation centre the matching mark.
      * The openAtCfi path is highlight/note-shaped (text anchor), so we send `isBookmark = false`
      * to reflect the annotation type on the event. Continuous-mode landing is uniform midpoint
      * for both types; the flag no longer affects alignment.
      */
-    fun emitAnnotationNavigation(locator: Locator) {
-        _annotationNavigationChannel.trySend(AnnotationNavigationEvent(locator, isBookmark = false))
+    fun emitAnnotationNavigation(locator: Locator, annotationId: String?) {
+        _annotationNavigationChannel.trySend(
+            AnnotationNavigationEvent(
+                locator = locator,
+                isBookmark = false,
+                annotationId = annotationId,
+            ),
+        )
     }
 
     /**
@@ -772,9 +780,8 @@ class AnnotationSession @AssistedInject constructor(
                 AnnotationNavigationEvent(
                     locator = locator,
                     isBookmark = annotation.type == AnnotationEntity.TYPE_BOOKMARK,
-                    // Carry the id so continuous mode can look up the actual mark and centre on
-                    // it (see AnnotationNavigationEvent doc). Paginated / vertical don't need it —
-                    // they rely on Readium's own fragment-based landing.
+                    // Carry the id so continuous mode can centre the actual mark and paginated
+                    // mode can snap to Readium's already-resolved decoration Range.
                     annotationId = id,
                 ),
             )

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
@@ -208,13 +208,19 @@ class ReaderSessionLifecycle @AssistedInject constructor(
             resolvedReaderServerId != null
         ) {
             runCatching {
-                annotationStore.findByItemAndCfi(resolvedReaderServerId, params.itemId, openAtCfiNonBlank)
+                annotationStore.findByItemAndCfi(
+                    resolvedReaderServerId,
+                    params.itemId,
+                    openAtCfiNonBlank,
+                )
             }.getOrNull()
         } else {
             null
         }
         val openAtLocator = resolvedOpenAtLocator?.withAnnotationNavigationAnchor(openAtAnnotation)
-        val initialFocusAnnotationId = openAtAnnotation?.id
+        // New routes carry the stable annotation id directly. Keep the exact-CFI lookup as a
+        // compatibility fallback for old deep links and use it independently to enrich TextQuote.
+        val initialFocusAnnotationId = params.openAnnotationId ?: openAtAnnotation?.id
 
         // Stored lastPosition is Readium Locator JSON. Rows written before ADR 0030's translation
         // fix may still hold a raw ABS `epubcfi(...)` — heal those on open so legacy progress
@@ -316,6 +322,7 @@ class ReaderSessionLifecycle @AssistedInject constructor(
         val itemId: String,
         val openAtCfi: String?,
         val startTocHref: String?,
+        val openAnnotationId: String? = null,
     )
 
     sealed interface OpenOutcome {

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -95,7 +95,7 @@ private const val FILTERED_BOOKS = "filtered_books/{libraryId}/{facetType}/{face
 private const val LIBRARY_ITEM_DETAIL = "library_item_detail/{itemId}"
 private const val PLAYLIST_DETAIL = "playlist_detail/{libraryId}/{playlistId}/{playlistName}"
 private const val EPUB_READER =
-    "epub_reader/{itemId}?startReadaloudAtSec={startReadaloudAtSec}&openAtCfi={openAtCfi}&startTocHref={startTocHref}&source={source}&sourceId={sourceId}"
+    "epub_reader/{itemId}?startReadaloudAtSec={startReadaloudAtSec}&openAtCfi={openAtCfi}&openAnnotationId={openAnnotationId}&startTocHref={startTocHref}&source={source}&sourceId={sourceId}"
 private const val PDF_READER = "pdf_reader/{itemId}"
 private const val CBZ_READER = "cbz_reader/{itemId}"
 private const val ANNOTATION_SEARCH = "annotation_search/{libraryId}?query={query}"
@@ -594,7 +594,10 @@ fun MainScreen(
                     onAnnotationSelected = { result ->
                         val encodedId = URLEncoder.encode(result.annotation.itemId, "UTF-8")
                         val encodedCfi = URLEncoder.encode(result.annotation.cfi, "UTF-8")
-                        navController.navigate("epub_reader/$encodedId?openAtCfi=$encodedCfi")
+                        val encodedAnnotationId = URLEncoder.encode(result.annotation.id, "UTF-8")
+                        navController.navigate(
+                            "epub_reader/$encodedId?openAtCfi=$encodedCfi&openAnnotationId=$encodedAnnotationId"
+                        )
                     },
                     onAudiobookBookmarkSelected = { result ->
                         val encodedId = URLEncoder.encode(result.bookmark.itemId, "UTF-8")
@@ -780,6 +783,11 @@ fun MainScreen(
                         nullable = true
                         defaultValue = null
                     },
+                    navArgument("openAnnotationId") {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    },
                     navArgument("startTocHref") {
                         type = NavType.StringType
                         nullable = true
@@ -809,8 +817,11 @@ fun MainScreen(
                             is com.riffle.app.feature.reader.ReaderNavEvent.OpenInSourceBook -> {
                                 val encodedId = URLEncoder.encode(event.itemId, "UTF-8")
                                 val encodedCfi = URLEncoder.encode(event.cfi, "UTF-8")
+                                val encodedAnnotationId = URLEncoder.encode(event.annotationId, "UTF-8")
                                 navController.popBackStack()
-                                navController.navigate("epub_reader/$encodedId?openAtCfi=$encodedCfi")
+                                navController.navigate(
+                                    "epub_reader/$encodedId?openAtCfi=$encodedCfi&openAnnotationId=$encodedAnnotationId"
+                                )
                             }
                             com.riffle.app.feature.reader.ReaderNavEvent.CloseEmptyHighlights -> {
                                 navController.popBackStack()
@@ -856,7 +867,10 @@ fun MainScreen(
                     onAnnotationSelected = { result ->
                         val encodedId = URLEncoder.encode(result.annotation.itemId, "UTF-8")
                         val encodedCfi = URLEncoder.encode(result.annotation.cfi, "UTF-8")
-                        navController.navigate("epub_reader/$encodedId?openAtCfi=$encodedCfi")
+                        val encodedAnnotationId = URLEncoder.encode(result.annotation.id, "UTF-8")
+                        navController.navigate(
+                            "epub_reader/$encodedId?openAtCfi=$encodedCfi&openAnnotationId=$encodedAnnotationId"
+                        )
                     },
                     onAudiobookBookmarkSelected = { result ->
                         val encodedId = URLEncoder.encode(result.bookmark.itemId, "UTF-8")

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -657,6 +657,16 @@ class ContinuousStyleInjectorTest {
     }
 
     @Test
+    fun `note glyph position is clamped to readable viewport inset`() {
+        val js = ContinuousStyleInjector.applyAnnotationHighlightsJs(
+            listOf(AnnotationHighlight("a1", "text", "red", true, "", "")),
+        )
+
+        assertTrue(js.contains("$NOTE_GLYPH_VIEWPORT_INSET_PX - blockRect.left"))
+        assertTrue(js.contains("var relLeft = Math.max("))
+    }
+
+    @Test
     fun `existing marks are updated in-place via cssText rewrite`() {
         val js = applyJs(AnnotationHighlight("ann1", "text", "#abc"))
         // Multi-paragraph annotations produce one <mark> per block — the in-place update path

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -1330,13 +1330,17 @@ class AnnotationNavigationOptionsTest {
     fun `highlights land at viewport midpoint (alignToTop=false)`() {
         // Highlights are text-anchored — centring on the mark preserves reading context above
         // the anchor. Kept at midpoint by design.
-        val opts = annotationNavigationOptions(isBookmark = false)
+        val opts = annotationNavigationOptions(
+            isBookmark = false,
+            annotationId = "annotation-42",
+        )
         assertFalse(opts.alignToTop)
         assertFalse(
             "highlight progression is only an arbitrary fallback and must stay on its " +
                 "containing page",
             opts.snapProgressionToNearestColumn,
         )
+        assertEquals("annotation-42", opts.focusAnnotationId)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/NoteGlyphDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/NoteGlyphDecorationTest.kt
@@ -51,6 +51,16 @@ class NoteGlyphDecorationTest {
     }
 
     @Test
+    fun `viewport clamp preserves inset without pulling adjacent spread glyphs into view`() {
+        val js = noteGlyphViewportClampAfterApplyJs()
+
+        assertTrue(js.contains("document.querySelectorAll('.$NOTE_GLYPH_ICON_CLASS')"))
+        assertTrue(js.contains("boundsRect.left + se.scrollLeft"))
+        assertTrue(js.contains("spreadLeft + $NOTE_GLYPH_VIEWPORT_INSET_PX"))
+        assertTrue(js.contains("translateX("))
+    }
+
+    @Test
     fun `noteGlyphTemplate stylesheet uses mask-image for theme-aware colouring`() {
         val stylesheet = noteGlyphTemplate().stylesheet ?: ""
         assertTrue("stylesheet must use -webkit-mask-image so glyph inherits currentColor",

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -196,7 +196,7 @@ class ReaderWebViewScriptsTest {
         assertTrue("reads the live column pitch", js.contains("window.innerWidth"))
         assertTrue("re-applies across frames", js.contains("requestAnimationFrame"))
         assertTrue("waits for scrollWidth to hold steady", js.contains("scrollWidth"))
-        assertTrue("bounded by a safety cap", js.contains("frames++>72"))
+        assertTrue("bounded by a safety cap", js.contains("focusAnnotationId?600:72"))
         assertTrue("a newer jump supersedes it", js.contains("__riffleSnapGen"))
     }
 
@@ -295,6 +295,55 @@ class ReaderWebViewScriptsTest {
             "exact range resolution runs before progression fallback",
             js.indexOf("window.readium.scrollToLocator(loc)") <
                 js.indexOf("Math.floor(0.42*se.scrollWidth/iw)"),
+        )
+    }
+
+    // Readium's scrollToLocator can land one column after a TextQuote on older WebViews. Once the
+    // note decoration has resolved that same quote to a live DOM Range, its geometry is the
+    // authoritative target and avoids repeating the faulty locator scroll.
+    @Test
+    fun `snapToTargetColumnJs prefers the resolved note range over locator navigation`() {
+        val locatorJson =
+            """{"href":"chapter1.xhtml","type":"application/xhtml+xml","locations":{"progression":0.42},"text":{"highlight":"target"}}"""
+        val js = ColumnSnap.snapToTargetColumnJs(
+            fragmentId = null,
+            landAtStartWhenNoTarget = false,
+            locatorProgression = 0.42,
+            locatorJson = locatorJson,
+        )
+
+        val rangeSnap = js.indexOf("notes.items")
+        val locatorSnap = js.indexOf("window.readium.scrollToLocator(loc)")
+        assertTrue("looks up Readium's resolved note items", rangeSnap >= 0)
+        assertTrue("reads the live decoration Range", js.contains("range.getBoundingClientRect()"))
+        assertTrue(
+            "uses the resolved decoration Range before the locator fallback",
+            locatorSnap >= 0 && rangeSnap < locatorSnap,
+        )
+    }
+
+    @Test
+    fun `snapToTargetColumnJs selects the focused note decoration by annotation id`() {
+        val js = ColumnSnap.snapToTargetColumnJs(
+            fragmentId = null,
+            landAtStartWhenNoTarget = false,
+            locatorProgression = 0.42,
+            focusAnnotationId = "annotation-42",
+        )
+
+        assertTrue("embeds the focus id safely", js.contains("var focusAnnotationId=\"annotation-42\""))
+        assertTrue(
+            "matches the resolved decoration by its persisted annotation id",
+            js.contains("item.decoration.id!==focusAnnotationId"),
+        )
+        assertTrue("uses the matched decoration Range", js.contains("item.range.getClientRects()"))
+        assertTrue(
+            "leaves the focus pending for a later decoration apply",
+            js.contains("window.$NOTE_GLYPH_FOCUS_ID_JS_KEY=focusAnnotationId"),
+        )
+        assertTrue(
+            "holds the resolved Range through the final layout-settle window",
+            js.contains("rangeMatched&&rangeStable>=60"),
         )
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReadiumHighlightRendererTest.kt
@@ -219,9 +219,49 @@ class ReadiumHighlightRendererTest {
         )
         renderer.applyNoteGlyphs(renders)
         val decorationCall = applied.last()
-        assertEquals("annotation-notes", decorationCall.second)
+        assertEquals(NOTE_GLYPH_DECORATION_GROUP, decorationCall.second)
         assertEquals(1, decorationCall.first.size)
         assertEquals("h1", decorationCall.first[0].id)
+    }
+
+    @Test
+    fun `applyNoteGlyphs completes a pending focus after Readium adds the range`() = runTest {
+        val callOrder = mutableListOf<String>()
+        val rendererWithJavascript = ReadiumHighlightRenderer(
+            applyDecorationsBlock = { _, group -> callOrder += "decorate:$group" },
+            fragmentLocator = { ref, _ ->
+                if (ref.isNotBlank()) minimalLocator(ref.substringBefore('#')) else null
+            },
+            evaluateJavascript = { script -> callOrder += "javascript:$script" },
+        )
+
+        rendererWithJavascript.applyNoteGlyphs(
+            listOf(makeRender("h1", "c.xhtml", note = "My note")),
+        )
+
+        val finalDecoration = callOrder.indexOfLast { it == "decorate:$NOTE_GLYPH_DECORATION_GROUP" }
+        val viewportClamp = callOrder.indexOfFirst {
+            it.startsWith("javascript:") &&
+                it.contains(".$NOTE_GLYPH_ICON_CLASS") &&
+                it.contains("spreadLeft + $NOTE_GLYPH_VIEWPORT_INSET_PX")
+        }
+        val focusCompletion = callOrder.indexOfFirst {
+                it.startsWith("javascript:") &&
+                it.contains("window.$NOTE_GLYPH_FOCUS_ID_JS_KEY") &&
+                it.contains("item.range.getClientRects()") &&
+                it.contains("se.scrollLeft = target") &&
+                it.contains("matchedFrames >= 60") &&
+                it.contains("frames++ < 600")
+        }
+        assertTrue("note group is applied", finalDecoration >= 0)
+        assertTrue(
+            "viewport clamp is queued after the note DOM is applied: $callOrder",
+            viewportClamp > finalDecoration,
+        )
+        assertTrue(
+            "focus completion is queued after the note Range is applied: $callOrder",
+            focusCompletion > viewportClamp,
+        )
     }
 
     @Test
@@ -233,7 +273,7 @@ class ReadiumHighlightRendererTest {
         renderer.applyNoteGlyphs(listOf(makeRender("h2", "c.xhtml", note = null)))
         assertEquals(1, applied.size)
         assertEquals(emptyList<Decoration>(), applied[0].first)
-        assertEquals("annotation-notes", applied[0].second)
+        assertEquals(NOTE_GLYPH_DECORATION_GROUP, applied[0].second)
     }
 
     // ---- applySearch ---------------------------------------------------------

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/FakeRendererBridge.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/FakeRendererBridge.kt
@@ -61,6 +61,7 @@ internal class FakeRendererBridge(
         locator: Locator,
         landAtStartWhenNoTarget: Boolean,
         snapProgressionToNearestColumn: Boolean,
+        focusAnnotationId: String?,
     ) {
         calls += "snapAfterGoTo(locator=${locator.href}, landAtStart=$landAtStartWhenNoTarget, " +
             "nearest=$snapProgressionToNearestColumn)"

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/FakeRendererBridge.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/FakeRendererBridge.kt
@@ -64,7 +64,7 @@ internal class FakeRendererBridge(
         focusAnnotationId: String?,
     ) {
         calls += "snapAfterGoTo(locator=${locator.href}, landAtStart=$landAtStartWhenNoTarget, " +
-            "nearest=$snapProgressionToNearestColumn)"
+            "nearest=$snapProgressionToNearestColumn, focusAnnotationId=$focusAnnotationId)"
     }
 
     override suspend fun snapToEnd() {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -297,8 +297,14 @@ class ReaderSessionLifecycleTest {
     private fun params(
         itemId: String = "item-1",
         openAtCfi: String? = null,
+        openAnnotationId: String? = null,
         startTocHref: String? = null,
-    ) = ReaderSessionLifecycle.OpenParams(itemId, openAtCfi, startTocHref)
+    ) = ReaderSessionLifecycle.OpenParams(
+        itemId = itemId,
+        openAtCfi = openAtCfi,
+        openAnnotationId = openAnnotationId,
+        startTocHref = startTocHref,
+    )
 
     // ── Tests ────────────────────────────────────────────────────────────────────────────
 
@@ -522,6 +528,26 @@ class ReaderSessionLifecycleTest {
             0.000001,
         )
         assertNull(outcome.openAtLocator!!.text.highlight)
+        assertSame(outcome.openAtLocator, outcome.initialLocator)
+    }
+
+    @Test
+    fun `open carries route annotation id when exact CFI lookup misses`() = runTest {
+        val cfi = "epubcfi(/6/2!/4/2)"
+        val resolvedLocator = Locator(
+            href = mockk(relaxed = true),
+            mediaType = org.readium.r2.shared.util.mediatype.MediaType.XHTML,
+            locations = Locator.Locations(progression = 0.7),
+        )
+        val (lifecycle, _) = makeLifecycle(
+            cfiResolver = { candidate -> if (candidate == cfi) resolvedLocator else null },
+        )
+
+        val outcome = lifecycle.open(
+            params(openAtCfi = cfi, openAnnotationId = "ann-from-route"),
+        ) as ReaderSessionLifecycle.OpenOutcome.Ready
+
+        assertEquals("ann-from-route", outcome.initialFocusAnnotationId)
         assertSame(outcome.openAtLocator, outcome.initialLocator)
     }
 


### PR DESCRIPTION
## Summary

- Thread `focusAnnotationId` through the full navigation stack (nav route → SavedStateHandle → OpenParams → AnnotationSession → NavigationOptions → RendererBridge → ColumnSnap JS) so paginated annotation jumps snap to Readium's already-resolved decoration Range instead of the text-quote re-resolution that can land one column ahead on API-25 WebViews.
- Clamp note glyph icons to the visible page edge — paginated mode uses a CSS transform shift keyed to the decoration's spread, continuous mode uses `Math.max` against a 12px viewport inset constant.
- Wire `openAnnotationId` through the nav route so the stable annotation id survives the reader open path end-to-end (with CFI-based fallback for old deep links).
- Replace all `"annotation-notes"` literals with `NOTE_GLYPH_DECORATION_GROUP` constant.

Also includes an unrelated AGENTS.md policy addition forbidding real book titles in commits/PRs.

## Test plan

- [ ] JVM: `ReaderWebViewScriptsTest` — verifies snap JS includes `focusAnnotationId` variable, note-group lookup, and range-based column snap
- [ ] JVM: `ReadiumHighlightRendererTest` — verifies viewport clamp and focus-after-apply JS are injected after note decoration apply
- [ ] JVM: `NoteGlyphDecorationTest` — verifies clamp JS references the icon class and viewport inset constant
- [ ] JVM: `ContinuousStyleInjectorTest` — verifies continuous-mode glyph left uses `Math.max` with viewport inset
- [ ] JVM: `EpubReaderViewModelTest` — verifies annotation navigation options carry `focusAnnotationId`
- [ ] JVM: `ReaderSessionLifecycleTest` — verifies route annotation id is preferred over CFI-resolved id
- [ ] Harness: `NoteGlyphMarginWebViewTest` — real WebView geometry test for glyph clamping
- [ ] Harness: `NoteGlyphRenderHarnessTest` — full reader harness for note glyph rendering across modes