### PR TITLE
fix(audiobook): suppress ID3 title bleed-through in persistent notification

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -135,6 +135,7 @@ open class AudiobookController @Inject constructor(
         startAtSec: Double,
         localZipFile: File? = null,
         coverUri: String? = null,
+        bookTitle: String? = null,
     ) {
         logger.d(LogChannel.Handoff) { "AB.prepare start (controller already connected=${controller != null})" }
         val t0 = clock.nowMs()
@@ -153,6 +154,7 @@ open class AudiobookController @Inject constructor(
         lastRemainingMinuteBucket = (initialRemainingSec / 60.0).toLong()
         val metadata = androidx.media3.common.MediaMetadata.Builder()
             .apply { if (coverUri != null) setArtworkUri(android.net.Uri.parse(coverUri)) }
+            .apply { if (bookTitle != null) setTitle(bookTitle) }
             .setArtist(formatRemainingReadable(initialRemainingSec))
             .build()
         val items = trackUrls.map { url ->

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -224,6 +224,7 @@ class AudiobookPlayerViewModel @Inject constructor(
     // can await rather than drop when a swipe arrives before the ~1–2 s bundle-session fetch is done.
     private val sessionDeferred = CompletableDeferred<com.riffle.core.domain.AudiobookSession?>()
     private var resolvedCoverUri: String? = null
+    private var resolvedBookTitle: String? = null
     private var resolvedInitialSpeed: Float = 1f
 
     private val meta = MutableStateFlow(
@@ -487,6 +488,7 @@ class AudiobookPlayerViewModel @Inject constructor(
             resolvedSession = session
             sessionDeferred.complete(session)
             resolvedCoverUri = item.coverUrl
+            resolvedBookTitle = item.title
             resolvedInitialSpeed = initialSpeed
             logger.d(LogChannel.Handoff) { "AB.VM init: resolvedSession ready +${clock.nowMs() - t0}ms (startAtSec=$startAtSec)" }
 
@@ -506,6 +508,7 @@ class AudiobookPlayerViewModel @Inject constructor(
                     startAtSec = playbackStartSec,
                     localZipFile = session.localZipFile,
                     coverUri = item.coverUrl,
+                    bookTitle = item.title,
                 )
                 // Record the active session so a media-notification tap reopens this audiobook player.
                 nowPlayingStore.set(com.riffle.app.playback.NowPlaying.Audiobook(itemId))
@@ -817,6 +820,7 @@ class AudiobookPlayerViewModel @Inject constructor(
             startAtSec = finalSec,
             localZipFile = session.localZipFile,
             coverUri = resolvedCoverUri,
+            bookTitle = resolvedBookTitle,
         )
         logger.d(LogChannel.Handoff) { "AB.activateFromHandoff: prepare() done +${clock.nowMs() - t0}ms" }
         controller.setSpeed(resolvedInitialSpeed)

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -147,6 +147,7 @@ class AudiobookPlayerViewModelBookmarkTest {
         logger: RecordingLogger = RecordingLogger(),
         playlistsRepository: com.riffle.core.data.PlaylistsRepository = NoopPlaylistsRepository,
         savedState: Map<String, Any?> = mapOf("itemId" to itemId),
+        handoffState: AudiobookHandoffState = AudiobookHandoffState(),
     ): AudiobookPlayerViewModel {
         val session = AudiobookSession(
             trackUrls = listOf("http://x/track0"),
@@ -179,7 +180,7 @@ class AudiobookPlayerViewModelBookmarkTest {
             progressFlushScope = ProgressFlushScope(TestApplicationScope(CoroutineScope(testDispatcher))),
             bookmarkStore = bookmarkStore,
             connectivityObserver = connectivity,
-            audiobookHandoffState = AudiobookHandoffState(),
+            audiobookHandoffState = handoffState,
             followLoopOrchestrator = FollowLoopOrchestrator(
                 clock = object : Clock {
                     override fun nowMs(): Long = fixedNow
@@ -584,11 +585,36 @@ class AudiobookPlayerViewModelBookmarkTest {
 
     @Test
     fun `prepare is called with the catalog book title so ID3 tags cannot bleed into the notification`() = runTest(testDispatcher) {
-        // Regression: Gramofonche MP3s embed "Track /радио" in their ID3 TIT2 tag. If bookTitle is not
-        // set on the MediaItem's MediaMetadata, Media3 falls through to the ID3 value and shows the
-        // raw suffix in the persistent notification. The catalog title must win.
+        // Regression: some catalog MP3s embed raw source labels like "Track /радио" in their ID3
+        // TIT2 tag. If bookTitle is not set on the MediaItem's MediaMetadata, Media3 falls through
+        // to the ID3-extracted value and shows the suffix in the persistent notification.
         val ctrl = FakeController(position = 0.0)
         val vm = buildViewModel(ctrl, FakeBookmarkStore())
+        runCurrent()
+
+        // FakeLibraryRepository returns a LibraryItem with title = "Book".
+        assertEquals("Book", ctrl.preparedBookTitle)
+        vm.clearForTest()
+    }
+
+    @Test
+    fun `handoff-path prepare is called with the catalog book title so ID3 tags cannot bleed into the notification`() = runTest(testDispatcher) {
+        // Regression: the same ID3 bleed-through can happen via the readaloud→audiobook swipe-up
+        // handoff path (activateFromHandoff), which calls prepare() with resolvedBookTitle. If that
+        // field is not stored during init, it arrives as null and the ID3 title wins.
+        val handoffState = AudiobookHandoffState()
+        val ctrl = FakeController(position = 0.0)
+        // PREWARM_SENTINEL (-2f) defers prepare() during init; prepare() is called only on handoff.
+        val vm = buildViewModel(
+            ctrl,
+            FakeBookmarkStore(),
+            savedState = mapOf("itemId" to itemId, "startAtSec" to -2f),
+            handoffState = handoffState,
+        )
+        runCurrent()
+        assertNull(ctrl.preparedBookTitle) // no prepare() yet in prewarm mode
+
+        handoffState.signal(itemId, 0.0)
         runCurrent()
 
         // FakeLibraryRepository returns a LibraryItem with title = "Book".

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -69,6 +69,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -101,6 +101,7 @@ class AudiobookPlayerViewModelBookmarkTest {
     private class FakeController(var position: Double) : AudiobookController() {
         val seeks = mutableListOf<Double>()
         var preparedStartAtSec: Double? = null
+        var preparedBookTitle: String? = null
         var stopCount = 0
         override val state = MutableStateFlow(PlaybackState())
         private val ended = kotlinx.coroutines.flow.MutableSharedFlow<Unit>(extraBufferCapacity = 1)
@@ -113,7 +114,11 @@ class AudiobookPlayerViewModelBookmarkTest {
             startAtSec: Double,
             localZipFile: File?,
             coverUri: String?,
-        ) { preparedStartAtSec = startAtSec }
+            bookTitle: String?,
+        ) {
+            preparedStartAtSec = startAtSec
+            preparedBookTitle = bookTitle
+        }
         override fun play() {}
         override fun setSpeed(speed: Float) {}
         override fun currentAbsoluteSec(): Double = position
@@ -574,6 +579,20 @@ class AudiobookPlayerViewModelBookmarkTest {
         runCurrent()
 
         assertEquals(0.0, ctrl.preparedStartAtSec!!, 0.0001)
+        vm.clearForTest()
+    }
+
+    @Test
+    fun `prepare is called with the catalog book title so ID3 tags cannot bleed into the notification`() = runTest(testDispatcher) {
+        // Regression: Gramofonche MP3s embed "Track /радио" in their ID3 TIT2 tag. If bookTitle is not
+        // set on the MediaItem's MediaMetadata, Media3 falls through to the ID3 value and shows the
+        // raw suffix in the persistent notification. The catalog title must win.
+        val ctrl = FakeController(position = 0.0)
+        val vm = buildViewModel(ctrl, FakeBookmarkStore())
+        runCurrent()
+
+        // FakeLibraryRepository returns a LibraryItem with title = "Book".
+        assertEquals("Book", ctrl.preparedBookTitle)
         vm.clearForTest()
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -147,6 +147,7 @@ class SleepTimerTest {
             startAtSec: Double,
             localZipFile: File?,
             coverUri: String?,
+            bookTitle: String?,
         ) { /* no-op */ }
 
         override fun play() {}


### PR DESCRIPTION
## What

The persistent media notification was showing raw ID3 tag content — e.g. `"Сирачето /радио"` — as the track title for audiobooks from certain catalog sources. The `/радио` suffix is embedded in the `TIT2` ID3 tag of the audio files by whoever encoded the archive, marking the radio-broadcast origin.

## Why it happened

`AudiobookController.prepare()` never called `.setTitle()` on the `MediaMetadata.Builder`. Media3's `DefaultMediaNotificationProvider` then fell through to ExoPlayer's ID3-extracted value. App-set non-null `MediaMetadata` fields win over ID3 extraction — verified because the `artist` field already showed `"3h 12m left"` rather than the ID3 artist tag — but since `title` was `null`, the raw ID3 value surfaced.

## Fix

Pass `bookTitle` (the catalog item's title) through `AudiobookController.prepare()` and call `.setTitle(bookTitle)` on the builder. This pins the notification to the catalog title, matching the chapter list and all other in-app surfaces.

Both call sites are covered:
- Normal open path (`init` block)
- Readaloud→audiobook swipe-up handoff (`activateFromHandoff`), which reads a `resolvedBookTitle` field stored during init

## Tests

Two regression tests in `AudiobookPlayerViewModelBookmarkTest`:
1. **Init path**: asserts `ctrl.preparedBookTitle == "Book"` after normal open
2. **Handoff path**: uses `PREWARM_SENTINEL` to skip init-time `prepare()`, fires a `HandoffSignal`, then asserts `preparedBookTitle` is set — would have been null before this fix

`FakeController.prepare()` signature updated to include `bookTitle: String?`.