### PR TITLE
fix(reader): dismiss annotation popup on vertical drag to remove scroll resistance

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
@@ -1,8 +1,10 @@
 package com.riffle.app.feature.reader
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,7 +33,6 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -42,6 +43,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -227,6 +229,14 @@ fun HighlightActionsPopup(
             shape = RoundedCornerShape(12.dp),
             shadowElevation = 4.dp,
             tonalElevation = 0.dp,
+            // Dismiss when a vertical drag is detected on the popup surface. Without this, a scroll
+            // gesture that starts inside the popup bounds is absorbed by the popup window and the
+            // reader never sees it — the user experiences resistance until they lift and retry from
+            // outside the popup area. Dismissing on drag start clears the popup immediately so the
+            // user's next gesture scrolls the reader without friction.
+            modifier = Modifier.pointerInput(onDismiss) {
+                detectVerticalDragGestures(onDragStart = { onDismiss() }) { _, _ -> }
+            },
         ) {
             Column(modifier = Modifier.width(280.dp)) {
                 if (!noteOnly) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -225,6 +226,7 @@ fun HighlightActionsPopup(
         properties = PopupProperties(focusable = false),
     ) {
         BackHandler(enabled = true, onBack = onDismiss)
+        val currentOnDismiss by rememberUpdatedState(onDismiss)
         Surface(
             shape = RoundedCornerShape(12.dp),
             shadowElevation = 4.dp,
@@ -234,8 +236,10 @@ fun HighlightActionsPopup(
             // reader never sees it — the user experiences resistance until they lift and retry from
             // outside the popup area. Dismissing on drag start clears the popup immediately so the
             // user's next gesture scrolls the reader without friction.
-            modifier = Modifier.pointerInput(onDismiss) {
-                detectVerticalDragGestures(onDragStart = { onDismiss() }) { _, _ -> }
+            // Unit key keeps the detector stable for the popup's lifetime; rememberUpdatedState
+            // ensures the latest onDismiss is always called even if the lambda reference changes.
+            modifier = Modifier.pointerInput(Unit) {
+                detectVerticalDragGestures(onDragStart = { currentOnDismiss() }) { _, _ -> }
             },
         ) {
             Column(modifier = Modifier.width(280.dp)) {


### PR DESCRIPTION
When a scroll gesture starts inside the annotation popup's bounds, the Android
window system routes all subsequent events in that sequence to the popup window —
the reader never sees them. The popup's `Surface` had no gesture handler, so
those touches were silently absorbed and the user experienced scroll resistance
(the gesture did nothing; they had to lift and retry from outside the popup area).

## Changes

- Add `detectVerticalDragGestures` to `HighlightActionsPopup`'s `Surface`. As
  soon as a vertical drag is confirmed (standard touch slop), `onDismiss` is
  called. The popup clears on the next frame; the user's following gesture scrolls
  the reader without friction. Button taps inside the popup are unaffected —
  `detectVerticalDragGestures` only triggers for genuine drags.
- Use `Unit` as the `pointerInput` key with `rememberUpdatedState` so the gesture
  detector is never restarted by a lambda-reference change on recomposition (e.g.
  swatch pick, note-row expansion). The coroutine lives for the full popup lifetime
  and always calls the latest `onDismiss`.

## Context

This is the remaining resistance after #603 (which eliminated the ~1 s
draft-popup linger). The new fix covers the window-level touch-routing issue that
#603 did not address.