### PR TITLE
fix(reader): element-anchored bookmark navigation + 10s page-override fix

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -641,7 +641,7 @@ internal object ColumnSnap {
     fun capturePageFragmentAnchorJs(): String =
         "(function(){" +
             "var se=document.scrollingElement;" +
-            "if(!se||se.scrollHeight<=window.innerHeight+4)return null;" +
+            "if(!se||se.scrollHeight>window.innerHeight+4)return null;" +
             "var iw=window.innerWidth;" +
             "var sel=['p[id]','h1[id]','h2[id]','h3[id]','h4[id]','h5[id]','h6[id]'," +
             "'li[id]','blockquote[id]','div[id]','section[id]','article[id]'];" +

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -524,18 +524,18 @@ internal object ColumnSnap {
             ?.takeIf { it.isNotBlank() }
             ?.let(JSONObject::quote)
             ?: "null"
-        // For annotation focus (landAtStartWhenNoTarget=false with a progression), skip the
-        // vertical smooth-tail block entirely. The snap JS runs immediately after go(locator),
-        // before Readium has applied CSS multicol. At that moment scrollHeight > innerHeight (the
-        // natural page height), so the vertical check fires and returns early — the paginated rAF
-        // loop never runs. Then Readium applies multicol and resets scrollLeft to 0, always landing
-        // on page 1. By setting _skipV=true we fall straight into the rAF loop, which tracks
+        // For all annotation navigation (landAtStartWhenNoTarget=false), skip the vertical
+        // smooth-tail block entirely. The snap JS runs immediately after go(locator), before
+        // Readium has applied CSS multicol. At that moment scrollHeight > innerHeight (the natural
+        // page height), so the vertical check fires and returns early — the paginated rAF loop
+        // never runs. Then Readium applies multicol and resets scrollLeft to 0, always landing on
+        // page 1. By setting _skipV=true we fall straight into the rAF loop, which tracks
         // scrollWidth each frame: it starts at innerWidth (pre-multicol → snap() is a near-no-op),
-        // then grows when multicol is applied, and on each subsequent frame the loop recomputes
-        // progression*scrollWidth/iw and snaps scrollLeft to the correct column. The loop exits
-        // only once scrollWidth has held steady for ≥3 frames, so typography-injection reflows
-        // (which transiently reset scrollLeft to 0) are automatically absorbed.
-        val skipVertical = !landAtStartWhenNoTarget && locatorProgression != null
+        // then grows when multicol is applied, and on each subsequent frame the loop either follows
+        // the element id (new-style bookmark) or recomputes progression*scrollWidth/iw (legacy).
+        // The loop exits only once scrollWidth has held steady for ≥3 frames, so
+        // typography-injection reflows (which transiently reset scrollLeft to 0) are absorbed.
+        val skipVertical = !landAtStartWhenNoTarget
         return "(function(){var id=$idLiteral;" +
             "var loc=$locatorLiteral;" +
             "var focusAnnotationId=$focusAnnotationLiteral;" +

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -626,6 +626,33 @@ internal object ColumnSnap {
     }
 
     /**
+     * JS expression that finds the first paragraph-level element with an `id` attribute that is
+     * visible in the current paginated column (viewport). Returns a JSON-encoded string (the id)
+     * or `null` when not in paginated mode or no named element is visible.
+     *
+     * Element types are queried in priority order: block-text types (p, h1–h6, li, blockquote)
+     * before generic containers (div, section, article). The first match in the current viewport
+     * wins. `getBoundingClientRect().left` in [0, innerWidth) means the element starts in the
+     * current column.
+     *
+     * The result is wrapped by `evaluateJavascript` in outer JSON quotes, so the caller must
+     * call `raw.trim('"')` and then check for the literal string `"null"` before using.
+     */
+    fun capturePageFragmentAnchorJs(): String =
+        "(function(){" +
+            "var se=document.scrollingElement;" +
+            "if(!se||se.scrollHeight<=window.innerHeight+4)return null;" +
+            "var iw=window.innerWidth;" +
+            "var sel=['p[id]','h1[id]','h2[id]','h3[id]','h4[id]','h5[id]','h6[id]'," +
+            "'li[id]','blockquote[id]','div[id]','section[id]','article[id]'];" +
+            "for(var s=0;s<sel.length;s++){" +
+            "var els=document.querySelectorAll(sel[s]);" +
+            "for(var i=0;i<els.length;i++){" +
+            "var r=els[i].getBoundingClientRect();" +
+            "if(r.height>0&&r.left>=0&&r.left<iw)return els[i].id;}}" +
+            "return null;})()"
+
+    /**
      * Parse the raw string [measureNarratedColumnsJs] returned through `evaluateJavascript`.
      * `evaluateJavascript` wraps a returned string in JSON quotes (the inner JSON number array
      * has no quotes to escape) and returns `null` when the page is gone. Protocol:

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ColumnSnap.kt
@@ -630,26 +630,27 @@ internal object ColumnSnap {
      * visible in the current paginated column (viewport). Returns a JSON-encoded string (the id)
      * or `null` when not in paginated mode or no named element is visible.
      *
-     * Element types are queried in priority order: block-text types (p, h1–h6, li, blockquote)
-     * before generic containers (div, section, article). The first match in the current viewport
-     * wins. `getBoundingClientRect().left` in [0, innerWidth) means the element starts in the
-     * current column.
+     * A single `querySelectorAll` with a priority-ordered selector list is used so the DOM is
+     * traversed once. Block-text types (p, h1–h6, li, blockquote) appear before generic containers
+     * (div, section, article) so paragraph-level ids are preferred over section wrappers. The first
+     * match in the current viewport wins. `getBoundingClientRect().left` in [0, innerWidth) means
+     * the element starts in the current column.
      *
      * The result is wrapped by `evaluateJavascript` in outer JSON quotes, so the caller must
      * call `raw.trim('"')` and then check for the literal string `"null"` before using.
+     *
+     * This expression is constant — evaluated once and reused across all bookmark-creation calls.
      */
-    fun capturePageFragmentAnchorJs(): String =
+    val CAPTURE_PAGE_FRAGMENT_ANCHOR_JS: String =
         "(function(){" +
             "var se=document.scrollingElement;" +
             "if(!se||se.scrollHeight>window.innerHeight+4)return null;" +
             "var iw=window.innerWidth;" +
-            "var sel=['p[id]','h1[id]','h2[id]','h3[id]','h4[id]','h5[id]','h6[id]'," +
-            "'li[id]','blockquote[id]','div[id]','section[id]','article[id]'];" +
-            "for(var s=0;s<sel.length;s++){" +
-            "var els=document.querySelectorAll(sel[s]);" +
+            "var els=document.querySelectorAll(" +
+            "'p[id],h1[id],h2[id],h3[id],h4[id],h5[id],h6[id],li[id],blockquote[id],div[id],section[id],article[id]');" +
             "for(var i=0;i<els.length;i++){" +
             "var r=els[i].getBoundingClientRect();" +
-            "if(r.height>0&&r.left>=0&&r.left<iw)return els[i].id;}}" +
+            "if(r.height>0&&r.left>=0&&r.left<iw)return els[i].id;}" +
             "return null;})()"
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -59,6 +59,8 @@ import com.riffle.app.feature.reader.presenter.NavigationTarget
 import com.riffle.app.feature.reader.presenter.PageDirection
 import com.riffle.app.feature.reader.presenter.ReaderPresenter
 import com.riffle.app.feature.reader.presenter.ReadiumPresenter
+import com.riffle.app.feature.reader.renderer.DefaultRendererBridge
+import com.riffle.app.feature.reader.renderer.RendererBridge
 import com.riffle.app.feature.reader.sentence.SentencePlaybackController
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
@@ -407,7 +409,7 @@ fun EpubReaderScreen(
                     // composables (e.g. CornerBookmarkIndicator) can invoke bridge methods
                     // without being placed inside EpubNavigatorView itself.
                     val rendererBridgeRef = remember {
-                        mutableStateOf<com.riffle.app.feature.reader.renderer.RendererBridge?>(null)
+                        mutableStateOf<RendererBridge?>(null)
                     }
                     LaunchedEffect(tocVisible, showFormattingPanel) {
                         if (tocVisible || showFormattingPanel) viewModel.closeSearch()
@@ -1474,7 +1476,7 @@ private fun EpubNavigatorView(
     /** Notified once per publication with the [RendererBridge] that was just created. Callers that
      *  need to capture the bridge for use outside this composable (e.g. the `CornerBookmarkIndicator`
      *  sibling in `EpubReaderScreen`) can stash it in a `mutableStateOf`. */
-    onRendererBridgeCreated: (com.riffle.app.feature.reader.renderer.RendererBridge) -> Unit = {},
+    onRendererBridgeCreated: (RendererBridge) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -1499,12 +1501,12 @@ private fun EpubNavigatorView(
     // current value at install time).
     val currentReadaloudReservePxState = remember { mutableStateOf(readaloudReservePx) }
     currentReadaloudReservePxState.value = readaloudReservePx
-    val rendererBridge: com.riffle.app.feature.reader.renderer.RendererBridge =
+    val rendererBridge: RendererBridge =
         remember(state.publication, coroutineScope) {
             // Shared across modes: the bridge short-circuits to a no-op when `fragmentProvider`
             // returns null (continuous mode keeps the fragment parked at height=0), so it is safe
             // to construct once per publication and not key on isContinuous.
-            com.riffle.app.feature.reader.renderer.DefaultRendererBridge(
+            DefaultRendererBridge(
                 fragmentProvider = { fragmentRef.value },
                 readaloudReserveProvider = { currentReadaloudReservePxState.value },
             )

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -1337,7 +1337,10 @@ internal fun annotationNavigationOptions(
         landAtStartWhenNoTarget = false,
         snapProgressionToNearestColumn = isBookmark,
         alignToTop = isBookmark,
-        focusAnnotationId = annotationId,
+        // Bookmarks have no note-glyph decoration in the WebView ("annotation-notes" group).
+        // Passing focusAnnotationId for a bookmark makes the rAF tracker wait 600 frames (~10s)
+        // for a decoration that never arrives, overriding page turns the whole time.
+        focusAnnotationId = annotationId.takeIf { !isBookmark },
     )
 
 @OptIn(ExperimentalReadiumApi::class)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -403,6 +403,12 @@ fun EpubReaderScreen(
                 } else {
                     val locatorHref by viewModel.currentLocatorHref.collectAsState()
                     val tocEntries by viewModel.tocEntries.collectAsState()
+                    // Holds the RendererBridge created inside EpubNavigatorView so sibling
+                    // composables (e.g. CornerBookmarkIndicator) can invoke bridge methods
+                    // without being placed inside EpubNavigatorView itself.
+                    val rendererBridgeRef = remember {
+                        mutableStateOf<com.riffle.app.feature.reader.renderer.RendererBridge?>(null)
+                    }
                     LaunchedEffect(tocVisible, showFormattingPanel) {
                         if (tocVisible || showFormattingPanel) viewModel.closeSearch()
                         viewModel.onPanelStateChanged(tocVisible || showFormattingPanel)
@@ -624,6 +630,7 @@ fun EpubReaderScreen(
                         onBookBodyFontFamily = viewModel::noteBookBodyFontFamily,
                         dispatchers = viewModel.dispatchers,
                         logger = viewModel.logger,
+                        onRendererBridgeCreated = { rendererBridgeRef.value = it },
                         modifier = Modifier
                             .fillMaxSize()
                             .testTag("reader_ready")
@@ -673,7 +680,15 @@ fun EpubReaderScreen(
                     CornerBookmarkIndicator(
                         isBookmarked = isCurrentPageBookmarked,
                         isVisible = annotationsAvailable,
-                        onToggle = viewModel::toggleBookmark,
+                        onToggle = {
+                            viewModel.toggleBookmark {
+                                // capturePageFragmentAnchor is a paginated/vertical JS probe;
+                                // skip it in Continuous mode which has no rendererBridge JS seam.
+                                rendererBridgeRef.value
+                                    ?.takeIf { formattingPrefs.orientation != ReaderOrientation.Continuous }
+                                    ?.capturePageFragmentAnchor()
+                            }
+                        },
                         modifier = Modifier
                             .align(Alignment.TopEnd)
                             .padding(end = 12.dp)
@@ -1454,6 +1469,10 @@ private fun EpubNavigatorView(
      *  its memory-capped configuration. */
     isElidedContinuous: Boolean = false,
     onScrollStart: () -> Unit = {},
+    /** Notified once per publication with the [RendererBridge] that was just created. Callers that
+     *  need to capture the bridge for use outside this composable (e.g. the `CornerBookmarkIndicator`
+     *  sibling in `EpubReaderScreen`) can stash it in a `mutableStateOf`. */
+    onRendererBridgeCreated: (com.riffle.app.feature.reader.renderer.RendererBridge) -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
@@ -1488,6 +1507,7 @@ private fun EpubNavigatorView(
                 readaloudReserveProvider = { currentReadaloudReservePxState.value },
             )
         }
+    LaunchedEffect(rendererBridge) { onRendererBridgeCreated(rendererBridge) }
     val readiumPresenter: ReadiumPresenter? = remember(state.publication, isContinuous, coroutineScope) {
         if (isContinuous) null else ReadiumPresenter(coroutineScope, state.publication, rendererBridge, dispatchers.main)
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -682,8 +682,10 @@ fun EpubReaderScreen(
                         isVisible = annotationsAvailable,
                         onToggle = {
                             viewModel.toggleBookmark {
-                                // capturePageFragmentAnchor is a paginated/vertical JS probe;
-                                // skip it in Continuous mode which has no rendererBridge JS seam.
+                                // MODE-FORK: capturePageFragmentAnchor is a paginated/vertical JS
+                                // probe; skip it in Continuous mode which has no rendererBridge JS
+                                // seam. Tracked by ReaderModeForkGuardTest — bump MAX_MODE_BRANCHES
+                                // if you add another fork nearby.
                                 rendererBridgeRef.value
                                     ?.takeIf { formattingPrefs.orientation != ReaderOrientation.Continuous }
                                     ?.capturePageFragmentAnchor()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -2668,7 +2668,7 @@ class EpubReaderViewModel @Inject constructor(
      * removes it; otherwise creates a new bookmark anchored to the top-of-viewport CFI with the
      * surrounding text as snippet.
      */
-    fun toggleBookmark() {
+    fun toggleBookmark(fragmentAnchorProvider: suspend () -> String? = { null }) {
         if (source == ReaderSource.Highlights) return
         val sourceId = annotationServerId ?: return
         viewModelScope.launch {
@@ -2712,6 +2712,7 @@ class EpubReaderViewModel @Inject constructor(
                 val bookmarkFont = realCapturedFontOrNull(SelectionFontStash.consume())
                     ?: bookBodyFontFamilyReported.get().takeIf { it.isNotBlank() }
                     ?: FALLBACK_ORIGIN_FONT_FAMILY
+                val fragmentAnchor = fragmentAnchorProvider()
                 annotationStore.createBookmark(
                     sourceId = sourceId,
                     itemId = itemId,
@@ -2722,6 +2723,7 @@ class EpubReaderViewModel @Inject constructor(
                     progression = prog,
                     bookmarkTitle = title,
                     originFontFamily = bookmarkFont,
+                    fragmentAnchor = fragmentAnchor,
                 )
                 scheduleAnnotationSync()
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
@@ -112,11 +112,14 @@ internal class DefaultRendererBridge(
                 locator.locations.fragments.firstOrNull()
             else -> null
         }
-        val progression = if (!landAtStartWhenNoTarget && fragmentId == null) {
-            locator.locations.progression
-        } else {
-            null
-        }
+        // Always pass progression for annotation navigation (landAtStartWhenNoTarget=false) so
+        // that if getElementById fails (e.g. element id changed in a revised EPUB), the JS
+        // fallback can still snap to the right column using the persisted progression ratio.
+        // With Fix 2 ensuring legacy bookmarks have cleared fragments, new-style bookmarks have
+        // both fragments AND progression set; the JS tries element first, falls back to progression.
+        // For TOC/resume navigation (landAtStartWhenNoTarget=true) we don't provide progression
+        // because those jumps always land at the chapter start or a specific element anchor.
+        val progression = if (!landAtStartWhenNoTarget) locator.locations.progression else null
         // A TextQuote locator lets Readium resolve the exact DOM range. Pass the complete locator
         // into the reflow tracker so it can repeat that exact resolution after each scrollWidth
         // change; progression is only a fallback when the quote is absent/stale.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
@@ -107,10 +107,10 @@ internal class DefaultRendererBridge(
             landAtStartWhenNoTarget ->
                 locator.locations.fragments.firstOrNull()
                     ?: navTargetFragmentId(locator.href.toString())
-            locator.locations.fragments.isNotEmpty() ->
+            else ->
                 // New-style bookmark: a paragraph-level element id was captured at creation time.
+                // firstOrNull() already returns null for an empty list, so no isNotEmpty() guard needed.
                 locator.locations.fragments.firstOrNull()
-            else -> null
         }
         // Always pass progression for annotation navigation (landAtStartWhenNoTarget=false) so
         // that if getElementById fails (e.g. element id changed in a revised EPUB), the JS
@@ -236,7 +236,7 @@ internal class DefaultRendererBridge(
     }
 
     override suspend fun capturePageFragmentAnchor(): String? {
-        val raw = fragment?.evaluateJavascript(ColumnSnap.capturePageFragmentAnchorJs()) ?: return null
+        val raw = fragment?.evaluateJavascript(ColumnSnap.CAPTURE_PAGE_FRAGMENT_ANCHOR_JS) ?: return null
         val trimmed = raw.trim('"')
         return if (trimmed == "null" || trimmed.isBlank()) null else trimmed
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
@@ -96,14 +96,13 @@ internal class DefaultRendererBridge(
         // For TOC/search/resume navigation (landAtStartWhenNoTarget=true), use the fragment id
         // from locations.fragments or the href anchor to snap the JS to the exact target element.
         //
-        // For annotation navigation (landAtStartWhenNoTarget=false), SKIP the fragment id even if
-        // one is present. extractAnchorFromCfi stores the innermost NAMED ancestor of the
-        // highlighted text node — typically a <section id="ch01"> or <div id="main"> that spans
-        // the entire chapter. Snapping to that element always resolves to column 0 (page 1)
-        // because getBoundingClientRect().left for a section that starts at the chapter top is 0.
-        // A highlight locator's TextQuote is the precise DOM target. A bookmark has no text range:
-        // its persisted live-reader progression is the precise page boundary. Character-count
-        // progression remains only a fallback for missing/stale highlight quotes.
+        // For annotation navigation (landAtStartWhenNoTarget=false), skip CFI-derived section-level
+        // fragments (the extractAnchorFromCfi ancestor is typically a <section id="ch01"> spanning
+        // the whole chapter; getBoundingClientRect().left is 0 for it → always column 0). Instead,
+        // use fragments only when withAnnotationNavigationAnchor placed a paragraph-level id there
+        // (i.e. a bookmark with a fragmentAnchor captured at creation time from the live page). For
+        // highlights the TextQuote is the precise DOM target; for legacy bookmarks the persisted
+        // live-reader progression is used as fallback via the else branch below.
         val fragmentId = when {
             landAtStartWhenNoTarget ->
                 locator.locations.fragments.firstOrNull()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
@@ -104,13 +104,16 @@ internal class DefaultRendererBridge(
         // A highlight locator's TextQuote is the precise DOM target. A bookmark has no text range:
         // its persisted live-reader progression is the precise page boundary. Character-count
         // progression remains only a fallback for missing/stale highlight quotes.
-        val fragmentId = if (landAtStartWhenNoTarget) {
-            locator.locations.fragments.firstOrNull()
-                ?: navTargetFragmentId(locator.href.toString())
-        } else {
-            null
+        val fragmentId = when {
+            landAtStartWhenNoTarget ->
+                locator.locations.fragments.firstOrNull()
+                    ?: navTargetFragmentId(locator.href.toString())
+            locator.locations.fragments.isNotEmpty() ->
+                // New-style bookmark: a paragraph-level element id was captured at creation time.
+                locator.locations.fragments.firstOrNull()
+            else -> null
         }
-        val progression = if (!landAtStartWhenNoTarget) {
+        val progression = if (!landAtStartWhenNoTarget && fragmentId == null) {
             locator.locations.progression
         } else {
             null

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/DefaultRendererBridge.kt
@@ -230,6 +230,12 @@ internal class DefaultRendererBridge(
         fragment?.evaluateJavascript(js)
     }
 
+    override suspend fun capturePageFragmentAnchor(): String? {
+        val raw = fragment?.evaluateJavascript(ColumnSnap.capturePageFragmentAnchorJs()) ?: return null
+        val trimmed = raw.trim('"')
+        return if (trimmed == "null" || trimmed.isBlank()) null else trimmed
+    }
+
     override suspend fun evaluateCadenceFeatureDetect(): String? =
         fragment?.evaluateJavascript(
             com.riffle.app.feature.reader.cadence.CadenceDomScript.FEATURE_DETECT_JS,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererBridge.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/renderer/RendererBridge.kt
@@ -208,6 +208,13 @@ internal interface RendererBridge {
     // ── Cadence (issue #403) ───────────────────────────────────────────────────────────────────
 
     /**
+     * Evaluates JS to find the first named paragraph-level element visible in the current
+     * paginated column. Returns its `id` attribute, or null if not in paginated mode or no
+     * named element is visible on the current page.
+     */
+    suspend fun capturePageFragmentAnchor(): String?
+
+    /**
      * Probe the paged/vertical WebView for `Intl.Segmenter`. Returns `"true"` / `"false"` (raw
      * JSON), or null when the fragment is gone. The reader screen uses this to gate the Cadence
      * top-bar toggle: no `Intl.Segmenter` → toggle hidden, feature disabled.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationNavigationLocator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationNavigationLocator.kt
@@ -17,21 +17,28 @@ internal fun Locator.withAnnotationNavigationAnchor(annotation: Annotation?): Lo
         annotation?.type == AnnotationEntity.TYPE_BOOKMARK -> {
             val anchor = annotation.fragmentAnchor
             if (anchor != null) {
-                // New bookmark: element-anchored navigation. Put the captured paragraph id
-                // into locations.fragments so DefaultRendererBridge uses it as fragmentId
-                // rather than the container id from extractAnchorFromCfi.
-                copy(locations = locations.copy(fragments = listOf(anchor)))
+                // New-style bookmark: element-anchored. Also restore progression as JS fallback
+                // if getElementById misses the element (e.g. element id changed in a revised EPUB).
+                val persistedProgression = annotation.progression.takeIf { it > 0.0 }
+                copy(locations = locations.copy(
+                    fragments = listOf(anchor),
+                    progression = persistedProgression ?: locations.progression,
+                ))
             } else {
-                // Legacy bookmark: no captured element id; restore the live-reader progression
-                // so the progression-ratio fallback in snapToTargetColumnJs lands correctly.
-                // Migration 9→10 and pre-extension W3C imports defaulted an unknown progression
-                // to 0.0. Keep the CFI-derived fallback for those legacy rows when the CFI
-                // clearly points later in the resource; a real first-page bookmark resolves to
-                // 0.0 as well.
+                // Legacy bookmark: no captured element id. Clear any CFI-derived container fragments
+                // (section-level, always resolve to column 0) and use stored progression instead.
+                // The production cfiLocatorResolver (EpubReaderViewModel.cfiStringToLocator) calls
+                // extractAnchorFromCfi and puts the result into locations.fragments — so even a
+                // legacy bookmark arrives here with a container-level id like "section#ch01" in
+                // fragments. If we don't clear it, snapAfterGoTo sees a non-empty fragments list,
+                // takes the element-snap path, and always lands at column 0 (the container's left).
                 val persistedProgression = annotation.progression.takeIf {
                     it > 0.0 || locations.progression == null
                 }
-                copy(locations = locations.copy(progression = persistedProgression ?: locations.progression))
+                copy(locations = locations.copy(
+                    fragments = emptyList(),
+                    progression = persistedProgression ?: locations.progression,
+                ))
             }
         }
         annotation?.type == AnnotationEntity.TYPE_HIGHLIGHT && annotation.textSnippet.isNotBlank() -> copy(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationNavigationLocator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationNavigationLocator.kt
@@ -17,12 +17,13 @@ internal fun Locator.withAnnotationNavigationAnchor(annotation: Annotation?): Lo
         annotation?.type == AnnotationEntity.TYPE_BOOKMARK -> {
             val anchor = annotation.fragmentAnchor
             if (anchor != null) {
-                // New-style bookmark: element-anchored. Also restore progression as JS fallback
-                // if getElementById misses the element (e.g. element id changed in a revised EPUB).
-                val persistedProgression = annotation.progression.takeIf { it > 0.0 }
+                // New-style bookmark: element-anchored. Progression was captured precisely at
+                // creation time (live-reader column ratio), so trust it unconditionally — no >0.0
+                // guard. The JS tries getElementById first; progression is the fallback if the
+                // element id disappears in a revised EPUB, including the 0.0 case (first column).
                 copy(locations = locations.copy(
                     fragments = listOf(anchor),
-                    progression = persistedProgression ?: locations.progression,
+                    progression = annotation.progression,
                 ))
             } else {
                 // Legacy bookmark: no captured element id. Clear any CFI-derived container fragments

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationNavigationLocator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/AnnotationNavigationLocator.kt
@@ -15,13 +15,24 @@ import org.readium.r2.shared.publication.Locator
 internal fun Locator.withAnnotationNavigationAnchor(annotation: Annotation?): Locator =
     when {
         annotation?.type == AnnotationEntity.TYPE_BOOKMARK -> {
-            // Migration 9→10 and pre-extension W3C imports defaulted an unknown progression to
-            // 0.0. Keep the CFI-derived fallback for those legacy rows when the CFI clearly points
-            // later in the resource; a real first-page bookmark resolves to 0.0 as well.
-            val persistedProgression = annotation.progression.takeIf {
-                it > 0.0 || locations.progression == null
+            val anchor = annotation.fragmentAnchor
+            if (anchor != null) {
+                // New bookmark: element-anchored navigation. Put the captured paragraph id
+                // into locations.fragments so DefaultRendererBridge uses it as fragmentId
+                // rather than the container id from extractAnchorFromCfi.
+                copy(locations = locations.copy(fragments = listOf(anchor)))
+            } else {
+                // Legacy bookmark: no captured element id; restore the live-reader progression
+                // so the progression-ratio fallback in snapToTargetColumnJs lands correctly.
+                // Migration 9→10 and pre-extension W3C imports defaulted an unknown progression
+                // to 0.0. Keep the CFI-derived fallback for those legacy rows when the CFI
+                // clearly points later in the resource; a real first-page bookmark resolves to
+                // 0.0 as well.
+                val persistedProgression = annotation.progression.takeIf {
+                    it > 0.0 || locations.progression == null
+                }
+                copy(locations = locations.copy(progression = persistedProgression ?: locations.progression))
             }
-            copy(locations = locations.copy(progression = persistedProgression ?: locations.progression))
         }
         annotation?.type == AnnotationEntity.TYPE_HIGHLIGHT && annotation.textSnippet.isNotBlank() -> copy(
             text = Locator.Text(

--- a/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModelTest.kt
@@ -73,7 +73,7 @@ class AnnotationSearchViewModelTest {
         override fun observeAnnotationsForSource(sourceId: String) =
             annotationsFlow.map { all -> all.filter { it.sourceId == sourceId } }
         override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.models.EmbeddedFigure>?, originFontFamily: String, textSnippetHtml: String?) = error("unused")
-        override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String, originFontFamily: String) = error("unused")
+        override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String, originFontFamily: String, fragmentAnchor: String?) = error("unused")
         override suspend fun createImageAnnotation(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, imageHref: String?, imageSvg: String?, imageBytes: String?, color: String) = error("unused")
         override suspend fun upgradeImageToCaptionHighlight(
             id: String, cfi: String, textSnippet: String, textBefore: String, textAfter: String,

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
@@ -82,7 +82,7 @@ class LibraryFilterEngineTest {
         override fun observeAnnotationsForSource(sourceId: String) =
             annotationsFlow.map { all -> all.filter { it.sourceId == sourceId } }
         override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.models.EmbeddedFigure>?, originFontFamily: String, textSnippetHtml: String?) = error("unused")
-        override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String, originFontFamily: String) = error("unused")
+        override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String, originFontFamily: String, fragmentAnchor: String?) = error("unused")
         override suspend fun createImageAnnotation(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, imageHref: String?, imageSvg: String?, imageBytes: String?, color: String) = error("unused")
         override suspend fun upgradeImageToCaptionHighlight(
             id: String, cfi: String, textSnippet: String, textBefore: String, textAfter: String,

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -85,7 +85,7 @@ class LibraryItemsViewModelTest {
             override fun observeAnnotationsForSource(sourceId: String) =
                 annotationsFlow.map { all -> all.filter { it.sourceId == sourceId } }
             override suspend fun createHighlight(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, textBefore: String, textAfter: String, color: String, spineIndex: Int, progression: Double, embeddedFigures: List<com.riffle.core.models.EmbeddedFigure>?, originFontFamily: String, textSnippetHtml: String?) = error("unused")
-            override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String, originFontFamily: String) = error("unused")
+            override suspend fun createBookmark(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String, originFontFamily: String, fragmentAnchor: String?) = error("unused")
             override suspend fun createImageAnnotation(sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String, spineIndex: Int, progression: Double, imageHref: String?, imageSvg: String?, imageBytes: String?, color: String) = error("unused")
             override suspend fun upgradeImageToCaptionHighlight(
                 id: String, cfi: String, textSnippet: String, textBefore: String, textAfter: String,

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelTest.kt
@@ -1350,6 +1350,17 @@ class AnnotationNavigationOptionsTest {
         assertFalse(annotationNavigationOptions(isBookmark = true).landAtStartWhenNoTarget)
         assertFalse(annotationNavigationOptions(isBookmark = false).landAtStartWhenNoTarget)
     }
+
+    @Test
+    fun `bookmark navigation never sets focusAnnotationId`() {
+        // Bookmarks have no note-glyph decoration in the WebView ("annotation-notes" group).
+        // Setting focusAnnotationId for a bookmark makes the rAF tracker run for 600 frames
+        // (~10s) instead of exiting after scrollWidth stabilises (~4 frames), overriding every
+        // page turn the user makes during that window.
+        assertNull(
+            annotationNavigationOptions(isBookmark = true, annotationId = "bookmark-id").focusAnnotationId,
+        )
+    }
 }
 
 /**

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/HealGenericOriginFontsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/HealGenericOriginFontsTest.kt
@@ -73,6 +73,7 @@ class HealGenericOriginFontsTest {
             progression: Double,
             bookmarkTitle: String,
             originFontFamily: String,
+            fragmentAnchor: String?,
         ): Annotation = error("unused")
         override suspend fun createImageAnnotation(
             sourceId: String,

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -646,14 +646,13 @@ class ReaderWebViewScriptsTest {
     }
 
     // DefaultRendererBridge.capturePageFragmentAnchor parses the raw evaluateJavascript result —
-    // a JS null comes back as the string "null" (no outer quotes), and a JS string like "para-ch03"
-    // comes back as "\"para-ch03\"" (JSON-encoded). The trim('"') + "null" check must handle both.
+    // a JS null comes back as the 4-char string "null" (no outer quotes), and a JS string like
+    // "para-ch03" comes back as "\"para-ch03\"" (JSON-encoded). The trim('"') + "null" check
+    // handles both: trim is a no-op for "null" and strips quotes for JSON strings.
     @Test
     fun `capturePageFragmentAnchor returns null for JS null result`() {
-        // The evaluateJavascript wrapper returns "null" (quoted) for a JS null.
-        // Verify the trimming logic handles all null variants.
-        // We test the parsing logic by constructing the expected raw strings.
-        val nullJson = "\"null\""   // what evaluateJavascript returns for JS null
+        // evaluateJavascript returns the 4-char string "null" (no outer quotes) for a JS null.
+        val nullJson = "null"   // what evaluateJavascript returns for JS null
         val trimmed = nullJson.trim('"')
         assertNull(
             "null JSON string must parse to null",

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -585,6 +585,39 @@ class ReaderWebViewScriptsTest {
         )
     }
 
+    // capturePageFragmentAnchorJs must bail early in non-paginated (scroll/continuous) mode so we
+    // never return a stale id from a chapter where the document is taller than the viewport in
+    // the normal (non-column) sense. The guard is scrollHeight <= innerHeight + 4.
+    @Test
+    fun `capturePageFragmentAnchorJs returns null when not in paginated mode`() {
+        val js = ColumnSnap.capturePageFragmentAnchorJs()
+        assertTrue(
+            "must guard against non-paginated mode",
+            js.contains("scrollHeight") && js.contains("innerHeight"),
+        )
+    }
+
+    // Paragraph-type selectors (p, h1–h6, li, blockquote) must appear before generic container
+    // selectors (div, section, article) so the most semantically precise named element wins.
+    @Test
+    fun `capturePageFragmentAnchorJs prefers paragraph elements over section containers`() {
+        val js = ColumnSnap.capturePageFragmentAnchorJs()
+        val pIdx = js.indexOf("p[id]")
+        val sectionIdx = js.indexOf("section[id]")
+        assertTrue("p[id] must be queried before section[id]", pIdx in 0 until sectionIdx)
+    }
+
+    // Visibility is determined by getBoundingClientRect — the element must have non-zero height
+    // and its left edge must fall in [0, innerWidth).
+    @Test
+    fun `capturePageFragmentAnchorJs checks getBoundingClientRect for column visibility`() {
+        val js = ColumnSnap.capturePageFragmentAnchorJs()
+        assertTrue("uses getBoundingClientRect for visibility", js.contains("getBoundingClientRect()"))
+        assertTrue("checks height > 0", js.contains("r.height>0"))
+        assertTrue("checks left >= 0", js.contains("r.left>=0"))
+        assertTrue("checks left < innerWidth", js.contains("r.left<iw"))
+    }
+
     @Test
     fun `measureNarratedColumnsJs guards createTreeWalker against a null document body (issue 428)`() {
         // measureNarratedColumnsJs inlines narratedColumnsPreludeJs (private), so this exercises the

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -604,15 +604,23 @@ class ReaderWebViewScriptsTest {
         )
     }
 
-    // capturePageFragmentAnchorJs must bail early in non-paginated (scroll/continuous) mode so we
-    // never return a stale id from a chapter where the document is taller than the viewport in
-    // the normal (non-column) sense. The guard is scrollHeight <= innerHeight + 4.
+    // capturePageFragmentAnchorJs must bail early in vertical/continuous (non-paginated) mode so
+    // we never return a stale id from a chapter where the document overflows vertically. In
+    // paginated mode, scrollHeight == innerHeight (no vertical overflow) so the guard must return
+    // null when scrollHeight > innerHeight+4 (i.e. vertical overflow = not paginated).
+    // The inverted guard (<=) was the original bug: it returned null exactly in paginated mode,
+    // making the feature a no-op there while running in vertical/continuous where it should not.
     @Test
     fun `capturePageFragmentAnchorJs returns null when not in paginated mode`() {
         val js = ColumnSnap.capturePageFragmentAnchorJs()
+        // Must return null when the page has vertical overflow (non-paginated), not when it doesn't.
         assertTrue(
-            "must guard against non-paginated mode",
-            js.contains("scrollHeight") && js.contains("innerHeight"),
+            "guard must return null when scrollHeight > innerHeight (non-paginated), NOT when <=",
+            js.contains("scrollHeight>window.innerHeight"),
+        )
+        assertFalse(
+            "guard must NOT use <= (that would make the feature a no-op in paginated mode)",
+            js.contains("scrollHeight<=window.innerHeight"),
         )
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -1,6 +1,7 @@
 package com.riffle.app.feature.reader
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -243,6 +244,22 @@ class ReaderWebViewScriptsTest {
         // column, not the next one — Math.round(2.7) = 3 (wrong page), Math.floor(2.7) = 2 (right page).
         assertTrue("floors to the column boundary using progression * scrollWidth", js.contains("else{se.scrollLeft=Math.floor(0.42*se.scrollWidth/iw)*iw;}"))
         assertTrue("does NOT yank to column 0", !js.contains("se.scrollLeft=0;"))
+    }
+
+    @Test
+    fun `snapToTargetColumnJs with bookmark fragmentId uses getBoundingClientRect path not progression`() {
+        val js = ColumnSnap.snapToTargetColumnJs(
+            fragmentId = "para-ch03",
+            landAtStartWhenNoTarget = false,
+            locatorProgression = null,
+            snapProgressionToNearestColumn = false,
+        )
+        assertTrue("must set the id variable to the captured fragment",
+            js.contains("\"para-ch03\""))
+        assertTrue("must use getBoundingClientRect for the element",
+            js.contains("getBoundingClientRect"))
+        assertFalse("must not reference Math.round(…*scrollWidth…) when no progression supplied",
+            js.contains("scrollWidth/iw)*iw"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.app.feature.reader
 
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -616,6 +618,34 @@ class ReaderWebViewScriptsTest {
         assertTrue("checks height > 0", js.contains("r.height>0"))
         assertTrue("checks left >= 0", js.contains("r.left>=0"))
         assertTrue("checks left < innerWidth", js.contains("r.left<iw"))
+    }
+
+    // DefaultRendererBridge.capturePageFragmentAnchor parses the raw evaluateJavascript result —
+    // a JS null comes back as the string "null" (no outer quotes), and a JS string like "para-ch03"
+    // comes back as "\"para-ch03\"" (JSON-encoded). The trim('"') + "null" check must handle both.
+    @Test
+    fun `capturePageFragmentAnchor returns null for JS null result`() {
+        // The evaluateJavascript wrapper returns "null" (quoted) for a JS null.
+        // Verify the trimming logic handles all null variants.
+        // We test the parsing logic by constructing the expected raw strings.
+        val nullJson = "\"null\""   // what evaluateJavascript returns for JS null
+        val trimmed = nullJson.trim('"')
+        assertNull(
+            "null JSON string must parse to null",
+            if (trimmed == "null" || trimmed.isBlank()) null else trimmed,
+        )
+    }
+
+    @Test
+    fun `capturePageFragmentAnchor returns element id for non-null JS result`() {
+        // The JS returns a string, which evaluateJavascript JSON-encodes → "\"para-ch03\""
+        val raw = "\"para-ch03\""
+        val trimmed = raw.trim('"')
+        assertEquals(
+            "element id must be extracted from JSON-quoted string",
+            "para-ch03",
+            if (trimmed == "null" || trimmed.isBlank()) null else trimmed,
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -612,7 +612,7 @@ class ReaderWebViewScriptsTest {
     // making the feature a no-op there while running in vertical/continuous where it should not.
     @Test
     fun `capturePageFragmentAnchorJs returns null when not in paginated mode`() {
-        val js = ColumnSnap.capturePageFragmentAnchorJs()
+        val js = ColumnSnap.CAPTURE_PAGE_FRAGMENT_ANCHOR_JS
         // Must return null when the page has vertical overflow (non-paginated), not when it doesn't.
         assertTrue(
             "guard must return null when scrollHeight > innerHeight (non-paginated), NOT when <=",
@@ -628,7 +628,7 @@ class ReaderWebViewScriptsTest {
     // selectors (div, section, article) so the most semantically precise named element wins.
     @Test
     fun `capturePageFragmentAnchorJs prefers paragraph elements over section containers`() {
-        val js = ColumnSnap.capturePageFragmentAnchorJs()
+        val js = ColumnSnap.CAPTURE_PAGE_FRAGMENT_ANCHOR_JS
         val pIdx = js.indexOf("p[id]")
         val sectionIdx = js.indexOf("section[id]")
         assertTrue("p[id] must be queried before section[id]", pIdx in 0 until sectionIdx)
@@ -638,7 +638,7 @@ class ReaderWebViewScriptsTest {
     // and its left edge must fall in [0, innerWidth).
     @Test
     fun `capturePageFragmentAnchorJs checks getBoundingClientRect for column visibility`() {
-        val js = ColumnSnap.capturePageFragmentAnchorJs()
+        val js = ColumnSnap.CAPTURE_PAGE_FRAGMENT_ANCHOR_JS
         assertTrue("uses getBoundingClientRect for visibility", js.contains("getBoundingClientRect()"))
         assertTrue("checks height > 0", js.contains("r.height>0"))
         assertTrue("checks left >= 0", js.contains("r.left>=0"))

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/controllers/BookmarksControllerTest.kt
@@ -61,7 +61,7 @@ class BookmarksControllerTest {
         override suspend fun createBookmark(
             sourceId: String, itemId: String, cfi: String, textSnippet: String,
             chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String,
-            originFontFamily: String,
+            originFontFamily: String, fragmentAnchor: String?,
         ): Annotation {
             val a = Annotation(
                 id = "bm-${created.size}",

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/FakeRendererBridge.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/FakeRendererBridge.kt
@@ -143,7 +143,10 @@ internal class FakeRendererBridge(
         return viewportFractionResult
     }
 
-    override suspend fun capturePageFragmentAnchor(): String? = null
+    override suspend fun capturePageFragmentAnchor(): String? {
+        calls += "capturePageFragmentAnchor"
+        return null
+    }
 
     override suspend fun evaluateCadenceFeatureDetect(): String? {
         calls += "evaluateCadenceFeatureDetect"

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/FakeRendererBridge.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/renderer/FakeRendererBridge.kt
@@ -143,6 +143,8 @@ internal class FakeRendererBridge(
         return viewportFractionResult
     }
 
+    override suspend fun capturePageFragmentAnchor(): String? = null
+
     override suspend fun evaluateCadenceFeatureDetect(): String? {
         calls += "evaluateCadenceFeatureDetect"
         return cadenceFeatureDetectResult

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -1112,6 +1112,80 @@ class AnnotationSessionTest {
         sessionScope.coroutineContext[Job]?.cancel()
     }
 
+    @Test
+    fun `navigateToAnnotation sets locations fragments from fragmentAnchor on new bookmarks`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val store = FakeAnnotationStore()
+        val syncOps = FakeSyncOps()
+        val targetLocator = buildLocator(progression = 0.43)
+        val bookmark = fakeAnnotation(
+            id = "bm-new",
+            type = AnnotationEntity.TYPE_BOOKMARK,
+            cfi = "epubcfi(/6/4!/4/2)",
+        ).copy(progression = 0.43, fragmentAnchor = "para-ch03")
+        store.allAnnotations.value = listOf(bookmark)
+        val session = makeSession(store = store, syncOps = syncOps, scope = sessionScope)
+        session.bind(
+            sourceId = "srv1",
+            namespace = "ns1",
+            itemId = "item1",
+            highlightRenderResolver = { emptyList() },
+            cfiLocatorResolver = { targetLocator },
+        )
+        val received = mutableListOf<AnnotationSession.AnnotationNavigationEvent>()
+        val collectJob = sessionScope.launch {
+            session.annotationNavigationEvents.collect { received.add(it) }
+        }
+
+        session.navigateToAnnotation(bookmark.id)
+
+        assertEquals(1, received.size)
+        assertTrue(received[0].isBookmark)
+        assertEquals(
+            "bookmark with fragmentAnchor must populate locations.fragments for element-anchored snap",
+            listOf("para-ch03"),
+            received[0].locator.locations.fragments,
+        )
+        collectJob.cancel()
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
+
+    @Test
+    fun `navigateToAnnotation retains progression path for legacy bookmarks without fragmentAnchor`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val store = FakeAnnotationStore()
+        val syncOps = FakeSyncOps()
+        val targetLocator = buildLocator(progression = 0.43)
+        val legacyBookmark = fakeAnnotation(
+            id = "bm-legacy",
+            type = AnnotationEntity.TYPE_BOOKMARK,
+            cfi = "epubcfi(/6/4!/4/2)",
+        ).copy(progression = 0.43, fragmentAnchor = null)
+        store.allAnnotations.value = listOf(legacyBookmark)
+        val session = makeSession(store = store, syncOps = syncOps, scope = sessionScope)
+        session.bind(
+            sourceId = "srv1", namespace = "ns1", itemId = "item1",
+            highlightRenderResolver = { emptyList() },
+            cfiLocatorResolver = { targetLocator },
+        )
+        val received = mutableListOf<AnnotationSession.AnnotationNavigationEvent>()
+        val collectJob = sessionScope.launch {
+            session.annotationNavigationEvents.collect { received.add(it) }
+        }
+
+        session.navigateToAnnotation(legacyBookmark.id)
+
+        assertEquals(1, received.size)
+        assertTrue(received[0].isBookmark)
+        assertTrue("legacy bookmark must have empty fragments (uses progression fallback)",
+            received[0].locator.locations.fragments.isEmpty())
+        assertEquals(legacyBookmark.progression, received[0].locator.locations.progression!!, 0.000001)
+        collectJob.cancel()
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
+
     /**
      * Test 5: syncBanner reflects annotationStatusStore states (Syncing/Synced/Failed)
      */

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -84,7 +84,7 @@ class AnnotationSessionTest {
         override suspend fun createBookmark(
             sourceId: String, itemId: String, cfi: String, textSnippet: String,
             chapterHref: String, spineIndex: Int, progression: Double, bookmarkTitle: String,
-            originFontFamily: String,
+            originFontFamily: String, fragmentAnchor: String?,
         ): Annotation = makeAnnotation(id = "b1", type = "bookmark", cfi = cfi)
         override suspend fun createImageAnnotation(
             sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String,

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -1157,7 +1157,19 @@ class AnnotationSessionTest {
         val sessionScope = CoroutineScope(dispatcher)
         val store = FakeAnnotationStore()
         val syncOps = FakeSyncOps()
-        val targetLocator = buildLocator(progression = 0.43)
+        // Simulate the production cfiLocatorResolver output: it calls extractAnchorFromCfi and
+        // puts the container-level section id into locations.fragments. A legacy bookmark arrives
+        // at withAnnotationNavigationAnchor with fragments = ["section-ch01"], not empty. Without
+        // Fix 2, snapAfterGoTo sees a non-empty fragments list and takes the element-snap path,
+        // which always resolves to column 0 (the section container's left edge).
+        val locatorWithContainerFragment = Locator(
+            href = buildLocator().href,
+            mediaType = org.readium.r2.shared.util.mediatype.MediaType.XHTML,
+            locations = Locator.Locations(
+                progression = 0.43,
+                fragments = listOf("section-ch01"), // container-level CFI artifact
+            ),
+        )
         val legacyBookmark = fakeAnnotation(
             id = "bm-legacy",
             type = AnnotationEntity.TYPE_BOOKMARK,
@@ -1168,7 +1180,7 @@ class AnnotationSessionTest {
         session.bind(
             sourceId = "srv1", namespace = "ns1", itemId = "item1",
             highlightRenderResolver = { emptyList() },
-            cfiLocatorResolver = { targetLocator },
+            cfiLocatorResolver = { locatorWithContainerFragment },
         )
         val received = mutableListOf<AnnotationSession.AnnotationNavigationEvent>()
         val collectJob = sessionScope.launch {
@@ -1179,8 +1191,11 @@ class AnnotationSessionTest {
 
         assertEquals(1, received.size)
         assertTrue(received[0].isBookmark)
-        assertTrue("legacy bookmark must have empty fragments (uses progression fallback)",
-            received[0].locator.locations.fragments.isEmpty())
+        assertTrue(
+            "legacy bookmark must clear CFI-derived container fragments so snapAfterGoTo uses " +
+                "progression fallback instead of always snapping to column 0",
+            received[0].locator.locations.fragments.isEmpty(),
+        )
         assertEquals(legacyBookmark.progression, received[0].locator.locations.progression!!, 0.000001)
         collectJob.cancel()
         sessionScope.coroutineContext[Job]?.cancel()

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/AnnotationSessionTest.kt
@@ -1152,6 +1152,47 @@ class AnnotationSessionTest {
     }
 
     @Test
+    fun `navigateToAnnotation preserves zero progression for new-style bookmark on first column`() = runTest {
+        // Regression: annotation.progression.takeIf { it > 0.0 } dropped 0.0, falling back to
+        // the CFI-derived progression (0.71 here). A new-style bookmark on the first column of a
+        // chapter has progression=0.0, which is a legitimate value. If getElementById misses the
+        // element (revised EPUB), the JS fallback must use 0.0, not the CFI approximation.
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val sessionScope = CoroutineScope(dispatcher)
+        val store = FakeAnnotationStore()
+        val syncOps = FakeSyncOps()
+        val cfiFallbackLocator = buildLocator(progression = 0.71)
+        val bookmark = fakeAnnotation(
+            id = "bm-first-col",
+            type = AnnotationEntity.TYPE_BOOKMARK,
+            cfi = "epubcfi(/6/4!/4/2)",
+        ).copy(progression = 0.0, fragmentAnchor = "para-intro")
+        store.allAnnotations.value = listOf(bookmark)
+        val session = makeSession(store = store, syncOps = syncOps, scope = sessionScope)
+        session.bind(
+            sourceId = "srv1", namespace = "ns1", itemId = "item1",
+            highlightRenderResolver = { emptyList() },
+            cfiLocatorResolver = { cfiFallbackLocator },
+        )
+        val received = mutableListOf<AnnotationSession.AnnotationNavigationEvent>()
+        val collectJob = sessionScope.launch {
+            session.annotationNavigationEvents.collect { received.add(it) }
+        }
+
+        session.navigateToAnnotation(bookmark.id)
+
+        assertEquals(1, received.size)
+        assertEquals(
+            "new-style bookmark at progression=0.0 must NOT fall back to the CFI progression (0.71)",
+            0.0,
+            received[0].locator.locations.progression!!,
+            0.000001,
+        )
+        collectJob.cancel()
+        sessionScope.coroutineContext[Job]?.cancel()
+    }
+
+    @Test
     fun `navigateToAnnotation retains progression path for legacy bookmarks without fragmentAnchor`() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val sessionScope = CoroutineScope(dispatcher)

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -532,6 +532,36 @@ class ReaderSessionLifecycleTest {
     }
 
     @Test
+    fun `open at new-style bookmark puts fragmentAnchor in locations fragments`() = runTest {
+        val cfi = "epubcfi(/6/2!/4/2)"
+        val cfiApproximation = Locator(
+            href = mockk(relaxed = true),
+            mediaType = org.readium.r2.shared.util.mediatype.MediaType.XHTML,
+            locations = Locator.Locations(progression = 0.43),
+        )
+        val bookmark = AnnotationSessionTest.makeAnnotation(
+            id = "bm-new",
+            type = AnnotationEntity.TYPE_BOOKMARK,
+            cfi = cfi,
+        ).copy(fragmentAnchor = "para-ch03")
+        val (lifecycle, _) = makeLifecycle(
+            annotationStore = FakeAnnotationStore(
+                byCfi = mapOf(Triple("srv-abs", "item-1", cfi) to bookmark),
+            ),
+            cfiResolver = { c -> if (c == cfi) cfiApproximation else null },
+        )
+
+        val outcome = lifecycle.open(params(openAtCfi = cfi)) as ReaderSessionLifecycle.OpenOutcome.Ready
+
+        assertEquals(
+            "cold-open new-style bookmark must put fragmentAnchor into locations.fragments",
+            listOf("para-ch03"),
+            outcome.openAtLocator!!.locations.fragments,
+        )
+        assertNull(outcome.openAtLocator!!.text.highlight)
+    }
+
+    @Test
     fun `open carries route annotation id when exact CFI lookup misses`() = runTest {
         val cfi = "epubcfi(/6/2!/4/2)"
         val resolvedLocator = Locator(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -162,7 +162,7 @@ class ReaderSessionLifecycleTest {
         override suspend fun createBookmark(
             sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String,
             spineIndex: Int, progression: Double, bookmarkTitle: String,
-            originFontFamily: String,
+            originFontFamily: String, fragmentAnchor: String?,
         ): Annotation = error("not needed")
         override suspend fun createImageAnnotation(
             sourceId: String, itemId: String, cfi: String, textSnippet: String, chapterHref: String,

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationMergeOrchestrator.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationMergeOrchestrator.kt
@@ -172,6 +172,12 @@ internal class AnnotationMergeOrchestrator(
                     // sync round-trips don't flatten the excerpt back to plaintext and drop the
                     // publisher's inline formatting (<em>, <b>, <sup>, …) from the elided view.
                     textSnippetHtml = existing?.textSnippetHtml,
+                    // fragmentAnchor is not on the W3C wire format — preserve the local value so
+                    // a WebDAV round-trip doesn't drop the captured paragraph-level element id that
+                    // new-style bookmarks use for exact column-snap navigation. Without this,
+                    // every merge resets fragmentAnchor to null, silently regressing new-style
+                    // bookmarks to the legacy progression-only path.
+                    fragmentAnchor = existing?.fragmentAnchor,
                 )
             }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AnnotationStoreImpl.kt
@@ -109,6 +109,7 @@ class AnnotationStoreImpl(
         progression: Double,
         bookmarkTitle: String,
         originFontFamily: String,
+        fragmentAnchor: String?,
     ): Annotation {
         require(originFontFamily.isNotBlank()) {
             "originFontFamily must be non-blank for locally-created bookmarks (issue #484)"
@@ -134,6 +135,7 @@ class AnnotationStoreImpl(
             lastModifiedByDeviceId = deviceId,
             deleted = false,
             originFontFamily = originFontFamily,
+            fragmentAnchor = fragmentAnchor,
         )
         dao.upsert(entity)
         return entity.toDomain()
@@ -456,6 +458,7 @@ internal fun Annotation.toEntity() = AnnotationEntity(
     originFontFamily = originFontFamily,
     emphasisStyles = EmphasisStyle.encode(emphasisStyles.orEmpty()),
     textSnippetHtml = textSnippetHtml,
+    fragmentAnchor = fragmentAnchor,
 )
 
 internal fun AnnotationEntity.toDomain() = Annotation(
@@ -482,4 +485,5 @@ internal fun AnnotationEntity.toDomain() = Annotation(
     originFontFamily = originFontFamily,
     emphasisStyles = EmphasisStyle.decode(emphasisStyles),
     textSnippetHtml = textSnippetHtml,
+    fragmentAnchor = fragmentAnchor,
 )

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -105,6 +105,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_60_61,
                 RiffleDatabase.MIGRATION_61_62,
                 RiffleDatabase.MIGRATION_62_63,
+                RiffleDatabase.MIGRATION_63_64,
             )
             .build()
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationMappingTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationMappingTest.kt
@@ -100,4 +100,22 @@ class AnnotationMappingTest {
         assertNull(back.imageHref)
         assertNull(back.imageSvg)
     }
+
+    @Test
+    fun `toDomain maps fragmentAnchor through to Annotation`() {
+        val entity = baseAnnotation().toEntity().copy(
+            type = AnnotationEntity.TYPE_BOOKMARK,
+            fragmentAnchor = "para-42",
+        )
+        assertEquals("para-42", entity.toDomain().fragmentAnchor)
+    }
+
+    @Test
+    fun `toDomain maps null fragmentAnchor for legacy bookmarks`() {
+        val entity = baseAnnotation().toEntity().copy(
+            type = AnnotationEntity.TYPE_BOOKMARK,
+            fragmentAnchor = null,
+        )
+        assertNull(entity.toDomain().fragmentAnchor)
+    }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AnnotationSyncControllerLifecycleTest.kt
@@ -924,6 +924,34 @@ class AnnotationSyncControllerLifecycleTest {
         )
     }
 
+    // ===== Fix 6: syncOnOpen preserves fragmentAnchor on existing bookmark rows =====
+
+    @Test
+    fun `syncOnOpen preserves fragmentAnchor on existing bookmark rows`() = runTest {
+        // Seed Room with a bookmark that has a captured paragraph-level element id. The W3C
+        // wire format does NOT carry fragmentAnchor, so a naive entity rebuild from the parsed
+        // W3CAnnotation drops the value — every sync round-trip resets it to null and silently
+        // regresses new-style bookmarks to the legacy progression-only navigation path.
+        // Regression: fragmentAnchor must survive the sync round-trip.
+        val anchor = "para-ch03"
+        val local = highlightEntity("uuid-anchor-preserve", updatedAt = 1000L)
+            .copy(type = AnnotationEntity.TYPE_BOOKMARK, fragmentAnchor = anchor)
+        dao.localAnnotations += local
+
+        target.files["annotations-own.jsonld"] = jsonArrayOf(
+            w3c("uuid-anchor-preserve", updatedAt = 1000L, deviceId = DEVICE_ID),
+        )
+
+        newController().syncOnOpen(SRV, NS, ITEM)
+
+        val upserted = dao.upserts.single { it.id == "uuid-anchor-preserve" }
+        assertEquals(
+            "fragmentAnchor must survive the sync round-trip",
+            anchor,
+            upserted.fragmentAnchor,
+        )
+    }
+
     // ===== stamp + report + enqueue-on-failure =====
 
     @Test

--- a/core/database-api/src/main/kotlin/com/riffle/core/database/AnnotationEntity.kt
+++ b/core/database-api/src/main/kotlin/com/riffle/core/database/AnnotationEntity.kt
@@ -91,6 +91,13 @@ data class AnnotationEntity(
      * back to the plain-text render path in [HighlightsPublicationFactory].
      */
     val textSnippetHtml: String? = null,
+    /**
+     * Paragraph-level DOM element `id` captured at bookmark-creation time in paginated mode.
+     * Used as `locations.fragments` during navigation so the column snap can use
+     * `getBoundingClientRect()` rather than progression math. Null for bookmarks created before
+     * this column existed and for all non-bookmark annotation types.
+     */
+    val fragmentAnchor: String? = null,
 ) {
     companion object {
         const val TYPE_HIGHLIGHT = "HIGHLIGHT"

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/64.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/64.json
@@ -1,0 +1,2062 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 64,
+    "identityHash": "e7f167533f70de948734d4dfaa29c10e",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER NOT NULL, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, `pageCount` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesSequence",
+            "columnName": "seriesSequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `coloredChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coloredChapterMap",
+            "columnName": "coloredChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "scope"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, `originFontFamily` TEXT, `emphasisStyles` TEXT, `textSnippetHtml` TEXT, `fragmentAnchor` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedFigures",
+            "columnName": "embeddedFigures",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageHref",
+            "columnName": "imageHref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageSvg",
+            "columnName": "imageSvg",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBytes",
+            "columnName": "imageBytes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originFontFamily",
+            "columnName": "originFontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "emphasisStyles",
+            "columnName": "emphasisStyles",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippetHtml",
+            "columnName": "textSnippetHtml",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fragmentAnchor",
+            "columnName": "fragmentAnchor",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "local_files_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `treeUri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `addedAtEpochMs` INTEGER NOT NULL, `libraryId` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `treeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtEpochMs",
+            "columnName": "addedAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "treeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `originalUri` TEXT NOT NULL, `copiedPath` TEXT NOT NULL, `coverPath` TEXT, `format` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `mtimeEpochMs` INTEGER NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, `displayName` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUri",
+            "columnName": "originalUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "copiedPath",
+            "columnName": "copiedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtimeEpochMs",
+            "columnName": "mtimeEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_files_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_file_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `folderTreeUri` TEXT NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`, `folderTreeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderTreeUri",
+            "columnName": "folderTreeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId",
+            "folderTreeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_file_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_local_files_file_folders_sourceId_folderTreeUri",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "folderTreeUri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId_folderTreeUri` ON `${TABLE_NAME}` (`sourceId`, `folderTreeUri`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_file_metadata_overrides",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `title` TEXT, `author` TEXT, `seriesName` TEXT, `seriesIndex` REAL, `coverUrl` TEXT, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "seriesIndex",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_file_metadata_overrides_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_file_metadata_overrides_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_item_freshness",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `lastFetchedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFetchedAt",
+            "columnName": "lastFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `rootId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootId",
+            "columnName": "rootId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_playlists_rootId",
+            "unique": false,
+            "columnNames": [
+              "rootId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_rootId` ON `${TABLE_NAME}` (`rootId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `orderIndex` INTEGER NOT NULL, PRIMARY KEY(`playlistId`, `sourceId`, `itemId`), FOREIGN KEY(`sourceId`, `playlistId`) REFERENCES `playlists`(`sourceId`, `id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "orderIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId",
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_items_sourceId_playlistId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_items_sourceId_playlistId` ON `${TABLE_NAME}` (`sourceId`, `playlistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId",
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "sourceId",
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "publication_metrics_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `totalPositions` INTEGER, `pageCount` INTEGER, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPositions",
+            "columnName": "totalPositions",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_publication_metrics_cache_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_publication_metrics_cache_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e7f167533f70de948734d4dfaa29c10e')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1919,7 +1919,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 63, true,
+            TEST_DB, 64, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -1982,6 +1982,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_60_61,
             RiffleDatabase.MIGRATION_61_62,
             RiffleDatabase.MIGRATION_62_63,
+            RiffleDatabase.MIGRATION_63_64,
         )
 
         db.query("SELECT url, username, serverType, absUserId, type FROM sources WHERE id = 's1'").use { cursor ->
@@ -2934,5 +2935,28 @@ class MigrationTest {
             assertTrue("legacy override follows the global color preference", cursor.isNull(4))
         }
         db.close()
+    }
+
+    @Test
+    fun migration63To64_addsFragmentAnchorToAnnotations() {
+        helper.createDatabase(TEST_DB, 63).use { db ->
+            db.execSQL(
+                """INSERT INTO annotations (id, sourceId, itemId, type, cfi, color, textSnippet,
+               textBefore, textAfter, chapterHref, spineIndex, progression, bookmarkTitle,
+               createdAt, updatedAt, originDeviceId, lastModifiedByDeviceId, deleted, lastSyncedAt)
+               VALUES ('bm-1', 'srv-1', 'item-1', 'BOOKMARK', 'epubcfi(/6/4!/4/2)',
+               '', 'before text', '', '', 'ch01.xhtml', 0, 0.5, 'Test Bookmark',
+               1000, 1000, 'dev-1', 'dev-1', 0, 0)"""
+            )
+        }
+        helper.runMigrationsAndValidate(TEST_DB, 64, true, RiffleDatabase.MIGRATION_63_64).use { db ->
+            val cursor = db.query("SELECT fragmentAnchor FROM annotations WHERE id='bm-1'")
+            cursor.moveToFirst()
+            assertNull(
+                "pre-existing bookmark must have null fragmentAnchor after migration",
+                cursor.getString(cursor.getColumnIndexOrThrow("fragmentAnchor")),
+            )
+            cursor.close()
+        }
     }
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -36,7 +36,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         PlaylistItemEntity::class,
         PublicationMetricsCacheEntity::class,
     ],
-    version = 63,
+    version = 64,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -1688,6 +1688,15 @@ abstract class RiffleDatabase : RoomDatabase() {
                     "ALTER TABLE `book_formatting_preferences` " +
                         "ADD COLUMN `coloredChapterMap` INTEGER"
                 )
+            }
+        }
+
+        // Paragraph-level DOM anchor captured at bookmark creation time (paginated mode). Used to
+        // snap the reader column to the exact element instead of relying on progression math.
+        // NULL for all pre-existing bookmarks and every non-BOOKMARK annotation type.
+        val MIGRATION_63_64 = object : Migration(63, 64) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `annotations` ADD COLUMN `fragmentAnchor` TEXT")
             }
         }
 

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -1691,15 +1691,6 @@ abstract class RiffleDatabase : RoomDatabase() {
             }
         }
 
-        // Paragraph-level DOM anchor captured at bookmark creation time (paginated mode). Used to
-        // snap the reader column to the exact element instead of relying on progression math.
-        // NULL for all pre-existing bookmarks and every non-BOOKMARK annotation type.
-        val MIGRATION_63_64 = object : Migration(63, 64) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL("ALTER TABLE `annotations` ADD COLUMN `fragmentAnchor` TEXT")
-            }
-        }
-
         // Readium-derived publication facts used by the item-detail screen. EPUB position count
         // drives the personalized total/remaining reading-time estimate; PDF page count drives
         // the discrete page label. Both are keyed by ebookFileIno and TTL'd by the repository so
@@ -1722,6 +1713,15 @@ abstract class RiffleDatabase : RoomDatabase() {
                     "CREATE INDEX IF NOT EXISTS `index_publication_metrics_cache_sourceId` " +
                         "ON `publication_metrics_cache` (`sourceId`)"
                 )
+            }
+        }
+
+        // Paragraph-level DOM anchor captured at bookmark creation time (paginated mode). Used to
+        // snap the reader column to the exact element instead of relying on progression math.
+        // NULL for all pre-existing bookmarks and every non-BOOKMARK annotation type.
+        val MIGRATION_63_64 = object : Migration(63, 64) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `annotations` ADD COLUMN `fragmentAnchor` TEXT")
             }
         }
     }

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/AnnotationStore.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/AnnotationStore.kt
@@ -66,6 +66,7 @@ interface AnnotationStore {
         /** Computed `font-family` at the bookmark's anchor element. Same non-null contract as
          *  [createHighlight]. */
         originFontFamily: String,
+        fragmentAnchor: String? = null,
     ): Annotation
 
     /**

--- a/core/models/src/commonMain/kotlin/com/riffle/core/models/Annotation.kt
+++ b/core/models/src/commonMain/kotlin/com/riffle/core/models/Annotation.kt
@@ -41,6 +41,7 @@ data class Annotation(
      * reader. Nullable — legacy rows and rows received via W3C sync fall back to plaintext.
      */
     val textSnippetHtml: String? = null,
+    val fragmentAnchor: String? = null,
 )
 
 /**

--- a/core/models/src/commonMain/kotlin/com/riffle/core/models/Annotation.kt
+++ b/core/models/src/commonMain/kotlin/com/riffle/core/models/Annotation.kt
@@ -41,6 +41,7 @@ data class Annotation(
      * reader. Nullable — legacy rows and rows received via W3C sync fall back to plaintext.
      */
     val textSnippetHtml: String? = null,
+    /** Paragraph-level DOM element `id` captured at bookmark creation time in paginated mode. Null for legacy bookmarks and all non-bookmark types. */
     val fragmentAnchor: String? = null,
 )
 


### PR DESCRIPTION
## Summary

- **Immediate fix**: Bookmark navigation was overriding page turns for ~10 seconds because `focusAnnotationId` was incorrectly set to the bookmark's annotation ID. `NOTE_GLYPH_DECORATION_GROUP` only decorates highlights with notes — never bookmarks — so the rAF snap tracker waited the full 600-frame (~10s) cap for a decoration that would never appear. Fix: `focusAnnotationId = annotationId.takeIf { !isBookmark }`.

- **Structural fix**: Replaces the imprecise progression-ratio column snap for bookmark navigation with element-anchored navigation — the same mechanism used for TOC entries. At bookmark creation time, `capturePageFragmentAnchorJs` probes the live paginated WebView for the first paragraph-level element visible in the current column and stores its DOM `id` as `fragmentAnchor` in the DB. At navigation time, `withAnnotationNavigationAnchor` places `fragmentAnchor` into `locations.fragments`; `snapAfterGoTo` then snaps `scrollLeft` to that element's column via `getElementById`. If the element disappears in a revised EPUB, the precisely captured progression ratio is the fallback.

- **DB migration 63 → 64**: Adds `fragmentAnchor TEXT` column to `annotations`. Legacy bookmarks have `NULL`; they continue to navigate via stored progression (CFI-derived container fragments are now explicitly cleared to prevent always landing at column 0).

## Notable design decisions

- Continuous mode deliberately skips `capturePageFragmentAnchor` — it has no `RendererBridge` JS seam; the `takeIf { orientation != Continuous }` guard in `EpubReaderScreen` handles this.
- `AnnotationMergeOrchestrator` preserves `fragmentAnchor = existing?.fragmentAnchor` so the field survives sync round-trips (W3C wire format doesn't carry it).
- New-style bookmarks use `annotation.progression` unconditionally (no `> 0.0` guard) since it was captured precisely from the live reader — 0.0 is a valid first-column value and must not be dropped in favour of the lossy CFI approximation.

## Tests

- `EpubReaderViewModelTest`: bookmark navigation never sets `focusAnnotationId`
- `ReaderWebViewScriptsTest`: JS guard inverted-direction regression (paginated vs. vertical), element selector correctness, `capturePageFragmentAnchor` null/non-null parsing
- `AnnotationSessionTest`: new-style bookmark sets `locations.fragments`, legacy bookmark clears CFI container fragments, new-style bookmark at progression=0.0 preserves 0.0 (not CFI fallback)
- `ReaderSessionLifecycleTest`: cold-open new-style bookmark produces correct `locations.fragments`
- `AnnotationMappingTest`: `fragmentAnchor` maps through to domain model / null for legacy
- `AnnotationSyncControllerLifecycleTest`: `fragmentAnchor` survives sync round-trip
- `MigrationTest`: migration 63→64 adds column; full-chain migration verified

Note: `capturePageFragmentAnchor` touches the WebView JS layer. JVM tests cover the JS string structure and parsing; live-WebView execution requires a harness test that is tracked as a follow-up.