### PR TITLE
fix(nav): fix burger-menu freeze (double-pop + predictive-back + HOME spinner)

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryBackAction.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryBackAction.kt
@@ -1,5 +1,7 @@
 package com.riffle.app.feature.library
 
+import android.app.Activity
+
 internal enum class LibraryBackAction { ClearSearch, ResetToHomeTab, Exit }
 
 internal fun libraryBackAction(searchQuery: String, selectedTab: Int): LibraryBackAction =
@@ -8,3 +10,10 @@ internal fun libraryBackAction(searchQuery: String, selectedTab: Int): LibraryBa
         selectedTab != 0 -> LibraryBackAction.ResetToHomeTab
         else -> LibraryBackAction.Exit
     }
+
+// Moves the task to the background rather than finishing the activity. Using finish() on a
+// singleTop activity on Android 12+ causes the activity to be re-created in the same process,
+// which re-delivers the Back event and creates an infinite finish→recreate loop.
+internal fun handleLibraryExit(activity: Activity?) {
+    activity?.moveTaskToBack(true)
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -96,8 +96,11 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -1092,6 +1095,16 @@ internal fun LibrarySearchHeader(
         keyboardController?.hide()
     }
     val dividerColor = MaterialTheme.colorScheme.outlineVariant
+    val view = LocalView.current
+    DisposableEffect(view) {
+        onDispose {
+            // Clear the exclusion rect when this composable leaves composition so
+            // other screens are not affected.
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                view.systemGestureExclusionRects = emptyList()
+            }
+        }
+    }
     Column(modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal))) {
         Box(
             modifier = Modifier
@@ -1103,7 +1116,23 @@ internal fun LibrarySearchHeader(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.padding(end = 16.dp),
         ) {
-            IconButton(onClick = onOpenDrawer) {
+            IconButton(
+                onClick = onOpenDrawer,
+                modifier = Modifier.onGloballyPositioned { coords ->
+                    // The ☰ button sits within Android's left-edge back-gesture zone (~40dp).
+                    // A quick tap here can be misinterpreted as a swipe-back gesture by the
+                    // system gesture monitor, firing a spurious BACK event. Declaring a system
+                    // gesture exclusion rect over the button area prevents this capture so the
+                    // tap always reaches the app as a click, not a back gesture.
+                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                        val bounds = coords.boundsInWindow()
+                        // Extend left to x=0 to cover the full gesture zone from the screen edge.
+                        view.systemGestureExclusionRects = listOf(
+                            android.graphics.Rect(0, bounds.top.toInt(), bounds.right.toInt(), bounds.bottom.toInt())
+                        )
+                    }
+                },
+            ) {
                 Icon(Icons.Default.Menu, contentDescription = "Open menu")
             }
             Text(

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -230,7 +230,9 @@ fun LibraryItemsScreen(
     // can intercept Back if the drawer is still in its closing animation.
     val activity = LocalActivity.current
     BackHandler(enabled = backEnabled) {
-        when (libraryBackAction(searchQuery, selectedTab)) {
+        val action = libraryBackAction(searchQuery, selectedTab)
+        android.util.Log.d(com.riffle.core.logging.LogChannel.Nav.tag, "[DEBUG-BURGER] LibraryItems BackHandler: action=$action backEnabled=$backEnabled searchQuery='$searchQuery' selectedTab=$selectedTab")
+        when (action) {
             LibraryBackAction.ClearSearch -> {
                 viewModel.onSearchQueryChange("")
                 focusManager.clearFocus(force = true)

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -233,6 +233,7 @@ fun LibraryItemsScreen(
     val activity = LocalActivity.current
     BackHandler(enabled = backEnabled) {
         val action = libraryBackAction(searchQuery, selectedTab)
+        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER2] libraryBackHandler fired action=$action backEnabled=$backEnabled")
         when (action) {
             LibraryBackAction.ClearSearch -> {
                 viewModel.onSearchQueryChange("")

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -148,8 +148,10 @@ fun LibraryItemsScreen(
     onSectionSeeMore: (LibrarySectionType) -> Unit,
     onAnnotatedBookClick: (sourceId: String, itemId: String) -> Unit,
     onPlaylistSelected: (com.riffle.core.catalog.CatalogPlaylist) -> Unit = {},
-    // When the navigation drawer is open, its own BackHandler must take Back so it can close
-    // itself. We disable our layered Back in that case (issue #60).
+    // Disabled when (a) the navigation drawer is open (it closes itself on Back) or (b) this
+    // screen is in STARTED state (a sub-screen is the foreground destination) — Compose
+    // Navigation 2.8+ keeps the previous back-stack entry in composition for predictive-back
+    // animations, so without this gate the BackHandler fires on Back from sub-screens.
     backEnabled: Boolean = true,
     viewModel: LibraryItemsViewModel = hiltViewModel(),
 ) {
@@ -231,7 +233,6 @@ fun LibraryItemsScreen(
     val activity = LocalActivity.current
     BackHandler(enabled = backEnabled) {
         val action = libraryBackAction(searchQuery, selectedTab)
-        android.util.Log.d(com.riffle.core.logging.LogChannel.Nav.tag, "[DEBUG-BURGER] LibraryItems BackHandler: action=$action backEnabled=$backEnabled searchQuery='$searchQuery' selectedTab=$selectedTab")
         when (action) {
             LibraryBackAction.ClearSearch -> {
                 viewModel.onSearchQueryChange("")
@@ -239,7 +240,7 @@ fun LibraryItemsScreen(
                 keyboardController?.hide()
             }
             LibraryBackAction.ResetToHomeTab -> { selectedTab = 0 }
-            LibraryBackAction.Exit -> activity?.finish()
+            LibraryBackAction.Exit -> handleLibraryExit(activity)
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -148,11 +148,17 @@ fun LibraryItemsScreen(
     onSectionSeeMore: (LibrarySectionType) -> Unit,
     onAnnotatedBookClick: (sourceId: String, itemId: String) -> Unit,
     onPlaylistSelected: (com.riffle.core.catalog.CatalogPlaylist) -> Unit = {},
-    // Disabled when (a) the navigation drawer is open (it closes itself on Back) or (b) this
-    // screen is in STARTED state (a sub-screen is the foreground destination) — Compose
-    // Navigation 2.8+ keeps the previous back-stack entry in composition for predictive-back
-    // animations, so without this gate the BackHandler fires on Back from sub-screens.
+    // Disabled when the navigation drawer is open or animating (the drawer closes itself on
+    // Back via its own BackHandler registered above this one). Enabled even when a sub-screen
+    // is the committed top — the handler resolves the sub-screen case via isCommittedOnLibraryItems.
     backEnabled: Boolean = true,
+    // Called synchronously at handler-fire time when backEnabled is true but library_items is
+    // not the committed top of the back stack (i.e. a sub-screen is still on the stack, which
+    // can happen during a predictive-back preview or during the brief recomposition window after
+    // the previous predictive-back committed). In that case the handler pops the real top instead
+    // of executing a library exit/search-clear/tab-reset action.
+    isCommittedOnLibraryItems: () -> Boolean = { true },
+    onNavigateBack: () -> Unit = {},
     viewModel: LibraryItemsViewModel = hiltViewModel(),
 ) {
     val searchQuery by viewModel.searchQuery.collectAsState()
@@ -232,8 +238,20 @@ fun LibraryItemsScreen(
     // can intercept Back if the drawer is still in its closing animation.
     val activity = LocalActivity.current
     BackHandler(enabled = backEnabled) {
+        // Check the committed back stack synchronously. navController.currentBackStack is a
+        // StateFlow (always up-to-date); reading .value here is NOT subject to the Compose
+        // recomposition lag that affects collectAsState() / currentBackStackEntryAsState().
+        // This handles two cases where backEnabled is true but library_items is not committed:
+        //   (a) during a predictive-back preview from a sub-screen (library_items shows as the
+        //       preview background while the sub-screen is still the committed top)
+        //   (b) during the brief recomposition window after the previous back committed but
+        //       before Compose has recomposed with the updated back stack
+        // In both cases the right action is to let the sub-screen pop, not run library logic.
+        if (!isCommittedOnLibraryItems()) {
+            onNavigateBack()
+            return@BackHandler
+        }
         val action = libraryBackAction(searchQuery, selectedTab)
-        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER2] libraryBackHandler fired action=$action backEnabled=$backEnabled")
         when (action) {
             LibraryBackAction.ClearSearch -> {
                 viewModel.onSearchQueryChange("")

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt
@@ -11,7 +11,9 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import android.util.Log
 import androidx.compose.runtime.LaunchedEffect
+import com.riffle.core.logging.LogChannel
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -33,8 +35,10 @@ fun HomeScreen(
     var showRetry by remember { mutableStateOf(false) }
 
     LaunchedEffect(retryKey) {
+        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] HomeScreen LaunchedEffect: retryKey=$retryKey")
         showRetry = false
         val dest = viewModel.getStartDestination()
+        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] HomeScreen dest=$dest")
         // Navigate on the main looper: after getStartDestination() returns through
         // withContext(IO), the Compose test interceptor may resume this continuation
         // on the instrumentation thread. NavController.navigate() calls

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt
@@ -21,8 +21,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.withResumed
+import kotlinx.coroutines.yield
 import kotlinx.coroutines.withContext
 
 @Composable
@@ -36,7 +38,10 @@ fun HomeScreen(
 
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     LaunchedEffect(retryKey) {
-        navigateFromHome(awaitResumed = { lifecycle.withResumed { } }, viewModel = viewModel) { dest ->
+        navigateFromHome(
+            awaitResumed = { awaitGenuinelyResumed(lifecycle) },
+            viewModel = viewModel,
+        ) { dest ->
             showRetry = false
             when (dest) {
                 is HomeViewModel.StartDestination.AddSource -> onNavigateToAddSource()
@@ -67,14 +72,39 @@ fun HomeScreen(
     }
 }
 
+// navigateAsRoot(library_route) does popUpTo(HOME) { inclusive=false } followed by
+// navigate(library_route). The popUpTo step momentarily promotes HOME to RESUMED before the
+// subsequent navigate() pushes library_items back on top (demoting HOME to STARTED). If
+// lifecycle.withResumed { } is used directly, it fires during that transient RESUMED window,
+// waking up navigateFromHome and causing a second navigateAsRoot call → flash of HOME spinner.
+//
+// awaitGenuinelyResumed yields once after withResumed to let the synchronous navigate() call
+// complete, then checks the lifecycle state. If HOME fell back to STARTED the loop repeats and
+// we wait for the next RESUMED event — which only arrives when HOME is genuinely the foreground.
+internal suspend fun awaitGenuinelyResumed(lifecycle: Lifecycle) {
+    awaitGenuinelyResumedWith(
+        waitForResumed = { lifecycle.withResumed { } },
+        isStillResumed = { lifecycle.currentState >= Lifecycle.State.RESUMED },
+    )
+}
+
+// Separated so tests can simulate the lifecycle transitions without a real Lifecycle object
+// and the Dispatchers.Main dependency that lifecycle.withResumed requires.
+internal suspend fun awaitGenuinelyResumedWith(
+    waitForResumed: suspend () -> Unit,
+    isStillResumed: () -> Boolean,
+) {
+    while (true) {
+        waitForResumed()
+        yield()
+        if (isStillResumed()) break
+    }
+}
+
 // Compose Navigation 2.8+ keeps the previous back-stack entry in composition simultaneously
 // for its own predictive-back animations. HOME can therefore be in STARTED state while
-// library_items is the foreground destination. Calling navigateAsRoot from STARTED state
-// triggers popUpTo(HOME) which removes the live library_items entry, creating a gap with no
-// LibraryItemsScreen BackHandler registered. A Back event in that gap falls through to the
-// NavHost handler, which pops library_items to HOME, which fires the LaunchedEffect again →
-// loop. awaitResumed suspends until HOME is the foreground destination before touching the
-// NavController. In production this is `{ lifecycle.withResumed { } }`; in tests it is a
+// library_items is the foreground destination. awaitResumed (backed by awaitGenuinelyResumed in
+// production) suspends until HOME is genuinely the foreground destination. In tests it is a
 // plain suspend lambda so the test controls exactly when navigation is unblocked.
 internal suspend fun navigateFromHome(
     awaitResumed: suspend () -> Unit,

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt
@@ -11,9 +11,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import android.util.Log
 import androidx.compose.runtime.LaunchedEffect
-import com.riffle.core.logging.LogChannel
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -23,6 +21,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.withResumed
 import kotlinx.coroutines.withContext
 
 @Composable
@@ -34,16 +34,10 @@ fun HomeScreen(
     var retryKey by remember { mutableIntStateOf(0) }
     var showRetry by remember { mutableStateOf(false) }
 
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
     LaunchedEffect(retryKey) {
-        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] HomeScreen LaunchedEffect: retryKey=$retryKey")
-        showRetry = false
-        val dest = viewModel.getStartDestination()
-        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] HomeScreen dest=$dest")
-        // Navigate on the main looper: after getStartDestination() returns through
-        // withContext(IO), the Compose test interceptor may resume this continuation
-        // on the instrumentation thread. NavController.navigate() calls
-        // LifecycleRegistry.setCurrentState() which requires the main thread.
-        withContext(viewModel.dispatchers.mainImmediate) {
+        navigateFromHome(awaitResumed = { lifecycle.withResumed { } }, viewModel = viewModel) { dest ->
+            showRetry = false
             when (dest) {
                 is HomeViewModel.StartDestination.AddSource -> onNavigateToAddSource()
                 is HomeViewModel.StartDestination.Library -> onNavigateToLibrary(dest.libraryId, dest.libraryName)
@@ -70,5 +64,26 @@ fun HomeScreen(
         } else {
             CircularProgressIndicator()
         }
+    }
+}
+
+// Compose Navigation 2.8+ keeps the previous back-stack entry in composition simultaneously
+// for its own predictive-back animations. HOME can therefore be in STARTED state while
+// library_items is the foreground destination. Calling navigateAsRoot from STARTED state
+// triggers popUpTo(HOME) which removes the live library_items entry, creating a gap with no
+// LibraryItemsScreen BackHandler registered. A Back event in that gap falls through to the
+// NavHost handler, which pops library_items to HOME, which fires the LaunchedEffect again →
+// loop. awaitResumed suspends until HOME is the foreground destination before touching the
+// NavController. In production this is `{ lifecycle.withResumed { } }`; in tests it is a
+// plain suspend lambda so the test controls exactly when navigation is unblocked.
+internal suspend fun navigateFromHome(
+    awaitResumed: suspend () -> Unit,
+    viewModel: HomeViewModel,
+    onDestination: suspend (HomeViewModel.StartDestination) -> Unit,
+) {
+    awaitResumed()
+    val dest = viewModel.getStartDestination()
+    withContext(viewModel.dispatchers.mainImmediate) {
+        onDestination(dest)
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -183,6 +183,13 @@ fun MainScreen(
         ?.takeIf { it.destination.route?.startsWith("library_items/") == true }
         ?.arguments?.getString("libraryId")
     val currentRoute = currentBackStack?.destination?.route
+
+    // currentBackStackEntryAsState() temporarily reflects the PREVIEW destination during a
+    // predictive-back gesture, which would enable LibraryItemsScreen's BackHandler while
+    // library_item_detail is still the real top. currentBackStack (StateFlow) only updates on
+    // committed navigation, so committedTopRoute gives the genuine top for the BackHandler gate.
+    val realBackStackEntries by navController.currentBackStack.collectAsState()
+    val realCurrentRoute = committedTopRoute(realBackStackEntries.map { it.destination.route })
     val usePermanentDrawer = isTablet
     // Reader screens are immersive — collapse the permanent side panel so the book/PDF
     // fills the width, matching the modal drawer's gesture suppression on phones.
@@ -602,7 +609,7 @@ fun MainScreen(
                     libraryName = libraryName,
                     onOpenDrawer = { scope.launch { drawerState.open() } },
                     backEnabled = libraryItemsBackEnabled(
-                        currentRoute = currentRoute,
+                        currentRoute = realCurrentRoute,
                         usePermanentDrawer = usePermanentDrawer,
                         drawerCurrentOpen = drawerState.currentValue == DrawerValue.Open,
                         drawerTargetOpen = drawerState.targetValue == DrawerValue.Open,
@@ -1022,10 +1029,11 @@ internal fun shouldInterceptBackForDrawer(
  * Whether [LibraryItemsScreen]'s BackHandler should be enabled.
  *
  * Two conditions must both hold:
- * 1. [currentRoute] is the library-items destination — Compose Navigation 2.8+ keeps the
- *    previous back-stack entry in composition simultaneously for predictive-back animations.
- *    Without this gate, Back pressed on any sub-screen (item detail, series, etc.) would fire
- *    this handler instead of the NavHost pop, causing unexpected exits or blank screens.
+ * 1. [currentRoute] is the library-items destination — must come from
+ *    [NavController.currentBackStack] (the committed StateFlow), NOT from
+ *    [currentBackStackEntryAsState()]. The latter temporarily reflects the PREVIEW destination
+ *    during a predictive-back gesture, which would enable this handler while a sub-screen
+ *    (item detail, series, etc.) is still the real top, causing unexpected exits.
  * 2. The drawer is not open or animating — when it is, the top-level drawer BackHandler must
  *    take Back to close the drawer (see [shouldInterceptBackForDrawer]).
  */
@@ -1036,6 +1044,12 @@ internal fun libraryItemsBackEnabled(
     drawerTargetOpen: Boolean,
 ): Boolean = currentRoute?.startsWith("library_items/") == true &&
     !shouldInterceptBackForDrawer(usePermanentDrawer, drawerCurrentOpen, drawerTargetOpen)
+
+// Extract the committed top route from a back stack, ignoring graph-root entries that have
+// no route string. Used by [libraryItemsBackEnabled] so it operates on the COMMITTED top, not
+// the predictive-back preview destination that [currentBackStackEntryAsState] temporarily reflects.
+internal fun committedTopRoute(backStackRoutes: List<String?>): String? =
+    backStackRoutes.lastOrNull { it != null }
 
 internal fun isReaderRoute(route: String?): Boolean =
     route?.startsWith(EPUB_READER.substringBefore("{")) == true ||

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -171,15 +171,16 @@ fun MainScreen(
 
     val drawerCurrentOpen = drawerState.currentValue == DrawerValue.Open
     val drawerTargetOpen = drawerState.targetValue == DrawerValue.Open
-    // Use currentRoute (from currentBackStackEntryAsState) — not the committed-stack route —
-    // for the BackHandler enabled gate. During a predictive-back gesture from a sub-screen,
-    // currentBackStackEntryAsState already reflects the preview destination (library_items)
-    // at gesture-start and stays there through the commit, so there is NO 16ms recomposition
-    // window after the commit where the handler would be disabled. Using the committed-stack
-    // route via collectAsState() creates exactly that lag window: after the back commits but
-    // before the next recomposition, libBackEnabled stays false and a second input event
-    // (e.g. the second ☰ tap) falls through to NavHost, popping library_items → HOME.
-    val libBackEnabled = libraryItemsBackEnabled(currentRoute, isTablet, drawerCurrentOpen, drawerTargetOpen)
+
+    // Committed top (synchronously up-to-date StateFlow; recomposes when the stack mutates).
+    // Using the COMMITTED route (not the preview from currentBackStackEntryAsState) keeps
+    // libBackEnabled=true even while a predictive-back gesture from library_items is in
+    // progress (the committed top stays library_items until the gesture commits), so the
+    // BackHandler intercepts and runs ClearSearch/ResetTab/Exit instead of letting NavHost
+    // pop library_items and flash the HOME spinner.
+    val committedBackStack by navController.currentBackStack.collectAsState()
+    val committedRoute = committedTopRoute(committedBackStack.map { it.destination.route })
+    val libBackEnabled = libraryItemsBackEnabled(committedRoute, isTablet, drawerCurrentOpen, drawerTargetOpen)
 
     val usePermanentDrawer = isTablet
     // Reader screens are immersive — collapse the permanent side panel so the book/PDF
@@ -1022,22 +1023,24 @@ internal fun shouldInterceptBackForDrawer(
  * Whether [LibraryItemsScreen]'s BackHandler should be enabled.
  *
  * Two conditions must both hold:
- * 1. [currentRoute] is the library-items destination — sourced from
- *    [currentBackStackEntryAsState()], which already reflects the PREVIEW destination during a
- *    predictive-back gesture. This means the handler stays enabled (= true) from the gesture
- *    start through commit with no recomposition lag. Unexpected exits while a sub-screen is the
- *    committed top are prevented at runtime by [LibraryItemsScreen]'s [isCommittedOnLibraryItems]
- *    check, which reads [NavController.currentBackStack] synchronously at handler-fire time and
- *    delegates to [onNavigateBack] instead of running library back actions.
+ * 1. [committedRoute] (top of [NavController.currentBackStack]) is the library-items
+ *    destination. Using the COMMITTED route (not the preview from
+ *    [currentBackStackEntryAsState()]) keeps the handler armed even while a predictive-back
+ *    gesture FROM library_items is in progress — the committed top stays library_items until
+ *    the gesture commits, so the handler intercepts and runs ClearSearch/ResetTab/Exit instead
+ *    of letting NavHost pop library_items and flash the HOME spinner. When library_item_detail
+ *    is the committed top (user navigated into a sub-screen), the handler is disabled and NavHost
+ *    handles its own predictive-back pop animation for the sub-screen. The [isCommittedOnLibraryItems]
+ *    runtime check inside the handler is a safety net for any residual lag edge cases.
  * 2. The drawer is not open or animating — when it is, the top-level drawer BackHandler must
  *    take Back to close the drawer (see [shouldInterceptBackForDrawer]).
  */
 internal fun libraryItemsBackEnabled(
-    currentRoute: String?,
+    committedRoute: String?,
     usePermanentDrawer: Boolean,
     drawerCurrentOpen: Boolean,
     drawerTargetOpen: Boolean,
-): Boolean = currentRoute?.startsWith("library_items/") == true &&
+): Boolean = committedRoute?.startsWith("library_items/") == true &&
     !shouldInterceptBackForDrawer(usePermanentDrawer, drawerCurrentOpen, drawerTargetOpen)
 
 // Extract the committed top route from a back stack, ignoring graph-root entries that have

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -58,11 +58,8 @@ import kotlinx.coroutines.launch
 import java.net.URLDecoder
 import java.net.URLEncoder
 import android.content.Intent
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.ui.platform.LocalContext
-import androidx.navigation.NavDestination
-import com.riffle.core.logging.LogChannel
 
 private const val HOME = "home"
 private const val SOURCE_SETUP_GRAPH = "source_setup"
@@ -151,18 +148,6 @@ fun MainScreen(
 
     val navController = rememberNavController()
 
-    // [DEBUG-BURGER2] NavController listener: logs every navigation event with the full back
-    // stack. Fires synchronously on the NavController thread (main), so it's more reliable than
-    // the recomposition-based LaunchedEffect(currentRoute) approach which can miss rapid changes.
-    DisposableEffect(navController) {
-        val listener = NavController.OnDestinationChangedListener { controller, dest, _ ->
-            val stack = controller.currentBackStack.value.mapNotNull { it.destination.route }
-            Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER2] nav→${dest.route} | stack=$stack")
-        }
-        navController.addOnDestinationChangedListener(listener)
-        onDispose { navController.removeOnDestinationChangedListener(listener) }
-    }
-
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val scope = rememberCoroutineScope()
     // ADR 0019: the Tablet Layout activates only when the window is large in BOTH dimensions —
@@ -184,12 +169,18 @@ fun MainScreen(
         ?.arguments?.getString("libraryId")
     val currentRoute = currentBackStack?.destination?.route
 
-    // currentBackStackEntryAsState() temporarily reflects the PREVIEW destination during a
-    // predictive-back gesture, which would enable LibraryItemsScreen's BackHandler while
-    // library_item_detail is still the real top. currentBackStack (StateFlow) only updates on
-    // committed navigation, so committedTopRoute gives the genuine top for the BackHandler gate.
-    val realBackStackEntries by navController.currentBackStack.collectAsState()
-    val realCurrentRoute = committedTopRoute(realBackStackEntries.map { it.destination.route })
+    val drawerCurrentOpen = drawerState.currentValue == DrawerValue.Open
+    val drawerTargetOpen = drawerState.targetValue == DrawerValue.Open
+    // Use currentRoute (from currentBackStackEntryAsState) — not the committed-stack route —
+    // for the BackHandler enabled gate. During a predictive-back gesture from a sub-screen,
+    // currentBackStackEntryAsState already reflects the preview destination (library_items)
+    // at gesture-start and stays there through the commit, so there is NO 16ms recomposition
+    // window after the commit where the handler would be disabled. Using the committed-stack
+    // route via collectAsState() creates exactly that lag window: after the back commits but
+    // before the next recomposition, libBackEnabled stays false and a second input event
+    // (e.g. the second ☰ tap) falls through to NavHost, popping library_items → HOME.
+    val libBackEnabled = libraryItemsBackEnabled(currentRoute, isTablet, drawerCurrentOpen, drawerTargetOpen)
+
     val usePermanentDrawer = isTablet
     // Reader screens are immersive — collapse the permanent side panel so the book/PDF
     // fills the width, matching the modal drawer's gesture suppression on phones.
@@ -209,7 +200,6 @@ fun MainScreen(
         drawerCurrentOpen = drawerState.currentValue == DrawerValue.Open,
         drawerTargetOpen = drawerState.targetValue == DrawerValue.Open,
     )) {
-        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER2] drawerBackHandler fired cur=${drawerState.currentValue} tgt=${drawerState.targetValue}")
         scope.launch { drawerState.close() }
     }
 
@@ -249,8 +239,6 @@ fun MainScreen(
 
     LaunchedEffect(Unit) {
         viewModel.redirectToLibrary.collect { library ->
-            val stack = navController.currentBackStack.value.mapNotNull { it.destination.route }
-            Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER2] redirectToLibrary→${library.id} | stack=$stack")
             navController.navigateAsRoot(libraryEntryRoute(activeServer?.type, library.id, library.name))
             viewModel.setActiveLibrary(library.id)
         }
@@ -608,12 +596,17 @@ fun MainScreen(
                 LibraryItemsScreen(
                     libraryName = libraryName,
                     onOpenDrawer = { scope.launch { drawerState.open() } },
-                    backEnabled = libraryItemsBackEnabled(
-                        currentRoute = realCurrentRoute,
-                        usePermanentDrawer = usePermanentDrawer,
-                        drawerCurrentOpen = drawerState.currentValue == DrawerValue.Open,
-                        drawerTargetOpen = drawerState.targetValue == DrawerValue.Open,
-                    ),
+                    backEnabled = libBackEnabled,
+                    // Read the committed back stack synchronously at handler-fire time (not via
+                    // Compose state) so we correctly distinguish: library_items is the committed
+                    // top (run library back action) vs. a sub-screen is the committed top but
+                    // library_items shows as the predictive-back preview or the recomposition
+                    // window hasn't caught up yet (pop the sub-screen instead).
+                    isCommittedOnLibraryItems = {
+                        committedTopRoute(navController.currentBackStack.value.map { it.destination.route })
+                            ?.startsWith("library_items/") == true
+                    },
+                    onNavigateBack = { navController.popBackStack() },
                     onSeriesSelected = { series ->
                         navController.navigate(seriesDetailRoute(libraryId, series.id, series.name))
                     },

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -1022,11 +1022,13 @@ internal fun shouldInterceptBackForDrawer(
  * Whether [LibraryItemsScreen]'s BackHandler should be enabled.
  *
  * Two conditions must both hold:
- * 1. [currentRoute] is the library-items destination — must come from
- *    [NavController.currentBackStack] (the committed StateFlow), NOT from
- *    [currentBackStackEntryAsState()]. The latter temporarily reflects the PREVIEW destination
- *    during a predictive-back gesture, which would enable this handler while a sub-screen
- *    (item detail, series, etc.) is still the real top, causing unexpected exits.
+ * 1. [currentRoute] is the library-items destination — sourced from
+ *    [currentBackStackEntryAsState()], which already reflects the PREVIEW destination during a
+ *    predictive-back gesture. This means the handler stays enabled (= true) from the gesture
+ *    start through commit with no recomposition lag. Unexpected exits while a sub-screen is the
+ *    committed top are prevented at runtime by [LibraryItemsScreen]'s [isCommittedOnLibraryItems]
+ *    check, which reads [NavController.currentBackStack] synchronously at handler-fire time and
+ *    delegates to [onNavigateBack] instead of running library back actions.
  * 2. The drawer is not open or animating — when it is, the top-level drawer BackHandler must
  *    take Back to close the drawer (see [shouldInterceptBackForDrawer]).
  */

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -58,8 +58,11 @@ import kotlinx.coroutines.launch
 import java.net.URLDecoder
 import java.net.URLEncoder
 import android.content.Intent
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.ui.platform.LocalContext
+import androidx.navigation.NavDestination
+import com.riffle.core.logging.LogChannel
 
 private const val HOME = "home"
 private const val SOURCE_SETUP_GRAPH = "source_setup"
@@ -147,6 +150,19 @@ fun MainScreen(
     val updateDownloadState by startupUpdateVm.downloadState.collectAsState()
 
     val navController = rememberNavController()
+
+    // [DEBUG-BURGER2] NavController listener: logs every navigation event with the full back
+    // stack. Fires synchronously on the NavController thread (main), so it's more reliable than
+    // the recomposition-based LaunchedEffect(currentRoute) approach which can miss rapid changes.
+    DisposableEffect(navController) {
+        val listener = NavController.OnDestinationChangedListener { controller, dest, _ ->
+            val stack = controller.currentBackStack.value.mapNotNull { it.destination.route }
+            Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER2] nav→${dest.route} | stack=$stack")
+        }
+        navController.addOnDestinationChangedListener(listener)
+        onDispose { navController.removeOnDestinationChangedListener(listener) }
+    }
+
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val scope = rememberCoroutineScope()
     // ADR 0019: the Tablet Layout activates only when the window is large in BOTH dimensions —
@@ -186,6 +202,7 @@ fun MainScreen(
         drawerCurrentOpen = drawerState.currentValue == DrawerValue.Open,
         drawerTargetOpen = drawerState.targetValue == DrawerValue.Open,
     )) {
+        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER2] drawerBackHandler fired cur=${drawerState.currentValue} tgt=${drawerState.targetValue}")
         scope.launch { drawerState.close() }
     }
 
@@ -225,6 +242,8 @@ fun MainScreen(
 
     LaunchedEffect(Unit) {
         viewModel.redirectToLibrary.collect { library ->
+            val stack = navController.currentBackStack.value.mapNotNull { it.destination.route }
+            Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER2] redirectToLibrary→${library.id} | stack=$stack")
             navController.navigateAsRoot(libraryEntryRoute(activeServer?.type, library.id, library.name))
             viewModel.setActiveLibrary(library.id)
         }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -57,6 +57,7 @@ import com.riffle.app.ui.isTabletLayout
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
 import java.net.URLEncoder
+import android.annotation.SuppressLint
 import android.content.Intent
 import android.widget.Toast
 import androidx.compose.ui.platform.LocalContext
@@ -178,8 +179,7 @@ fun MainScreen(
     // progress (the committed top stays library_items until the gesture commits), so the
     // BackHandler intercepts and runs ClearSearch/ResetTab/Exit instead of letting NavHost
     // pop library_items and flash the HOME spinner.
-    val committedBackStack by navController.currentBackStack.collectAsState()
-    val committedRoute = committedTopRoute(committedBackStack.map { it.destination.route })
+    val committedRoute = navController.committedTopRouteAsState()
     val libBackEnabled = libraryItemsBackEnabled(committedRoute, isTablet, drawerCurrentOpen, drawerTargetOpen)
 
     val usePermanentDrawer = isTablet
@@ -1074,3 +1074,19 @@ internal fun isReaderRoute(route: String?): Boolean =
     route?.startsWith(EPUB_READER.substringBefore("{")) == true ||
         route?.startsWith(PDF_READER.substringBefore("{")) == true ||
         route?.startsWith(CBZ_READER.substringBefore("{")) == true
+
+/**
+ * Returns the committed top route as Compose state, recomposing whenever the back stack changes.
+ *
+ * [NavController.currentBackStack] is `@RestrictedApi` (internal to `androidx.navigation`).
+ * It is used here intentionally: [currentBackStackEntryAsState] reflects the *preview*
+ * destination during a predictive-back gesture, which would incorrectly disable
+ * [libraryItemsBackEnabled] while the gesture is still in progress. Reading the committed
+ * back stack via [NavController.currentBackStack] avoids this.
+ */
+@Composable
+@SuppressLint("RestrictedApi")
+internal fun NavController.committedTopRouteAsState(): String? {
+    val backStack by currentBackStack.collectAsState()
+    return committedTopRoute(backStack.map { it.destination.route })
+}

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -749,10 +749,20 @@ fun MainScreen(
                 arguments = listOf(
                     navArgument("itemId") { type = NavType.StringType },
                 )
-            ) {
+            ) { backStackEntry ->
                 LibraryItemDetailScreen(
                     windowSizeClass = windowSizeClass,
-                    onNavigateBack = { navController.popBackStack() },
+                    onNavigateBack = {
+                        // Guard against double-pop during the exit animation: the exit animation
+                        // keeps library_item_detail visible for ~300ms. A second tap during that
+                        // window re-fires this callback, but the committed back stack has already
+                        // moved on — check before popping to prevent a second navController.popBackStack()
+                        // from removing library_items and flashing the HOME spinner.
+                        if (navController.currentBackStack.value
+                                .lastOrNull { it.destination.route != null } == backStackEntry) {
+                            navController.popBackStack()
+                        }
+                    },
                     onReadItem = { item ->
                         readerRouteFor(item)?.let { navController.navigate(it) }
                     },

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -170,7 +170,7 @@ fun MainScreen(
         ?.arguments?.getString("libraryId")
     val currentRoute = currentBackStack?.destination?.route
     LaunchedEffect(currentRoute) {
-        val stack = navController.backQueue.mapNotNull { it.destination.route }
+        val stack = navController.currentBackStack.value.mapNotNull { it.destination.route }
         Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] route changed: $currentRoute | stack=${stack}")
     }
     val usePermanentDrawer = isTablet

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -54,8 +54,6 @@ import com.riffle.app.feature.settings.readaloud.ReadaloudMatchesScreen
 import com.riffle.app.feature.settings.readaloud.ReadaloudSettingsScreen
 import com.riffle.app.playback.NowPlaying
 import com.riffle.app.ui.isTabletLayout
-import android.util.Log
-import com.riffle.core.logging.LogChannel
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
 import java.net.URLEncoder
@@ -169,10 +167,6 @@ fun MainScreen(
         ?.takeIf { it.destination.route?.startsWith("library_items/") == true }
         ?.arguments?.getString("libraryId")
     val currentRoute = currentBackStack?.destination?.route
-    LaunchedEffect(currentRoute) {
-        val stack = navController.currentBackStack.value.mapNotNull { it.destination.route }
-        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] route changed: $currentRoute | stack=${stack}")
-    }
     val usePermanentDrawer = isTablet
     // Reader screens are immersive — collapse the permanent side panel so the book/PDF
     // fills the width, matching the modal drawer's gesture suppression on phones.
@@ -192,7 +186,6 @@ fun MainScreen(
         drawerCurrentOpen = drawerState.currentValue == DrawerValue.Open,
         drawerTargetOpen = drawerState.targetValue == DrawerValue.Open,
     )) {
-        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] BackHandler: closing drawer current=${drawerState.currentValue} target=${drawerState.targetValue}")
         scope.launch { drawerState.close() }
     }
 
@@ -232,7 +225,6 @@ fun MainScreen(
 
     LaunchedEffect(Unit) {
         viewModel.redirectToLibrary.collect { library ->
-            Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] redirectToLibrary: library=${library.id} drawer current=${drawerState.currentValue} target=${drawerState.targetValue}")
             navController.navigateAsRoot(libraryEntryRoute(activeServer?.type, library.id, library.name))
             viewModel.setActiveLibrary(library.id)
         }
@@ -250,24 +242,19 @@ fun MainScreen(
         serverVersions = serverVersions,
         showDownloadsLink = showDownloadsLink,
         onServerSelected = { server ->
-            Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] onServerSelected: server=${server.id} drawer current=${drawerState.currentValue} target=${drawerState.targetValue}")
             viewModel.setActiveServer(server.id)
             scope.launch { drawerState.close() }
-            navController.navigateAsRoot(HOME)
         },
         onLibrarySelected = { library ->
-            Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] onLibrarySelected: library=${library.id} drawer current=${drawerState.currentValue} target=${drawerState.targetValue}")
             viewModel.setActiveLibrary(library.id)
             scope.launch { drawerState.close() }
             navController.navigateAsRoot(libraryEntryRoute(activeServer?.type, library.id, library.name))
         },
         onDownloadsSelected = {
-            Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] onDownloadsSelected: drawer current=${drawerState.currentValue} target=${drawerState.targetValue}")
             scope.launch { drawerState.close() }
             navController.navigate(DOWNLOADS)
         },
         onSettingsSelected = {
-            Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] onSettingsSelected: drawer current=${drawerState.currentValue} target=${drawerState.targetValue}")
             scope.launch { drawerState.close() }
             navController.navigate(SETTINGS)
         },
@@ -324,10 +311,7 @@ fun MainScreen(
                 com.riffle.app.feature.source.chitanka.ChitankaBrowseScreen(
                     libraryName = libraryName,
                     windowSizeClass = windowSizeClass,
-                    onOpenDrawer = {
-                        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] onOpenDrawer: current=${drawerState.currentValue} target=${drawerState.targetValue}")
-                        scope.launch { drawerState.open() }
-                    },
+                    onOpenDrawer = { scope.launch { drawerState.open() } },
                     onOpenDetail = { itemId ->
                         val encodedId = URLEncoder.encode(itemId, "UTF-8")
                         navController.navigate("library_item_detail/$encodedId")
@@ -364,10 +348,7 @@ fun MainScreen(
                 com.riffle.app.feature.source.gutenberg.GutenbergBrowseScreen(
                     libraryName = libraryName,
                     windowSizeClass = windowSizeClass,
-                    onOpenDrawer = {
-                        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] onOpenDrawer: current=${drawerState.currentValue} target=${drawerState.targetValue}")
-                        scope.launch { drawerState.open() }
-                    },
+                    onOpenDrawer = { scope.launch { drawerState.open() } },
                     onOpenDetail = { itemId ->
                         val encodedId = URLEncoder.encode(itemId, "UTF-8")
                         navController.navigate("library_item_detail/$encodedId")
@@ -587,22 +568,23 @@ fun MainScreen(
                     backStackEntry.arguments?.getString("libraryName") ?: "",
                     "UTF-8"
                 )
-                // Force the drawer fully closed when the library destination first composes.
-                // Without this its closing animation can race a Back press and the drawer's
-                // own BackHandler captures it instead of exiting the app (issue #60).
+                // Close the drawer when the library destination first enters composition if it
+                // is open or animating open — e.g. the user tapped a library in the drawer and
+                // the composable re-enters before the close animation finishes. Skip the call
+                // when the drawer is already Closed: even a settled Closed state still triggers
+                // a spring animation that takes 14–125 ms, unnecessarily holding backEnabled=true
+                // during that window and creating a timing hazard on Back.
                 LaunchedEffect(Unit) {
-                    Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] library LaunchedEffect close: current=${drawerState.currentValue} target=${drawerState.targetValue}")
-                    drawerState.close()
-                    Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] library LaunchedEffect close done: current=${drawerState.currentValue} target=${drawerState.targetValue}")
+                    if (drawerState.currentValue == DrawerValue.Open || drawerState.targetValue == DrawerValue.Open) {
+                        drawerState.close()
+                    }
                 }
                 LibraryItemsScreen(
                     libraryName = libraryName,
-                    onOpenDrawer = {
-                        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] onOpenDrawer: current=${drawerState.currentValue} target=${drawerState.targetValue}")
-                        scope.launch { drawerState.open() }
-                    },
-                    backEnabled = !shouldInterceptBackForDrawer(
-                        usePermanentDrawer,
+                    onOpenDrawer = { scope.launch { drawerState.open() } },
+                    backEnabled = libraryItemsBackEnabled(
+                        currentRoute = currentRoute,
+                        usePermanentDrawer = usePermanentDrawer,
                         drawerCurrentOpen = drawerState.currentValue == DrawerValue.Open,
                         drawerTargetOpen = drawerState.targetValue == DrawerValue.Open,
                     ),
@@ -1016,6 +998,25 @@ internal fun shouldInterceptBackForDrawer(
     drawerCurrentOpen: Boolean,
     drawerTargetOpen: Boolean,
 ): Boolean = !usePermanentDrawer && (drawerCurrentOpen || drawerTargetOpen)
+
+/**
+ * Whether [LibraryItemsScreen]'s BackHandler should be enabled.
+ *
+ * Two conditions must both hold:
+ * 1. [currentRoute] is the library-items destination — Compose Navigation 2.8+ keeps the
+ *    previous back-stack entry in composition simultaneously for predictive-back animations.
+ *    Without this gate, Back pressed on any sub-screen (item detail, series, etc.) would fire
+ *    this handler instead of the NavHost pop, causing unexpected exits or blank screens.
+ * 2. The drawer is not open or animating — when it is, the top-level drawer BackHandler must
+ *    take Back to close the drawer (see [shouldInterceptBackForDrawer]).
+ */
+internal fun libraryItemsBackEnabled(
+    currentRoute: String?,
+    usePermanentDrawer: Boolean,
+    drawerCurrentOpen: Boolean,
+    drawerTargetOpen: Boolean,
+): Boolean = currentRoute?.startsWith("library_items/") == true &&
+    !shouldInterceptBackForDrawer(usePermanentDrawer, drawerCurrentOpen, drawerTargetOpen)
 
 internal fun isReaderRoute(route: String?): Boolean =
     route?.startsWith(EPUB_READER.substringBefore("{")) == true ||

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -169,6 +169,9 @@ fun MainScreen(
         ?.takeIf { it.destination.route?.startsWith("library_items/") == true }
         ?.arguments?.getString("libraryId")
     val currentRoute = currentBackStack?.destination?.route
+    LaunchedEffect(currentRoute) {
+        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] route changed: $currentRoute")
+    }
     val usePermanentDrawer = isTablet
     // Reader screens are immersive — collapse the permanent side panel so the book/PDF
     // fills the width, matching the modal drawer's gesture suppression on phones.

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -170,7 +170,8 @@ fun MainScreen(
         ?.arguments?.getString("libraryId")
     val currentRoute = currentBackStack?.destination?.route
     LaunchedEffect(currentRoute) {
-        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] route changed: $currentRoute")
+        val stack = navController.backQueue.mapNotNull { it.destination.route }
+        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] route changed: $currentRoute | stack=${stack}")
     }
     val usePermanentDrawer = isTablet
     // Reader screens are immersive — collapse the permanent side panel so the book/PDF

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -54,6 +54,8 @@ import com.riffle.app.feature.settings.readaloud.ReadaloudMatchesScreen
 import com.riffle.app.feature.settings.readaloud.ReadaloudSettingsScreen
 import com.riffle.app.playback.NowPlaying
 import com.riffle.app.ui.isTabletLayout
+import android.util.Log
+import com.riffle.core.logging.LogChannel
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
 import java.net.URLEncoder
@@ -186,6 +188,7 @@ fun MainScreen(
         drawerCurrentOpen = drawerState.currentValue == DrawerValue.Open,
         drawerTargetOpen = drawerState.targetValue == DrawerValue.Open,
     )) {
+        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] BackHandler: closing drawer current=${drawerState.currentValue} target=${drawerState.targetValue}")
         scope.launch { drawerState.close() }
     }
 
@@ -225,6 +228,7 @@ fun MainScreen(
 
     LaunchedEffect(Unit) {
         viewModel.redirectToLibrary.collect { library ->
+            Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] redirectToLibrary: library=${library.id} drawer current=${drawerState.currentValue} target=${drawerState.targetValue}")
             navController.navigateAsRoot(libraryEntryRoute(activeServer?.type, library.id, library.name))
             viewModel.setActiveLibrary(library.id)
         }
@@ -242,20 +246,24 @@ fun MainScreen(
         serverVersions = serverVersions,
         showDownloadsLink = showDownloadsLink,
         onServerSelected = { server ->
+            Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] onServerSelected: server=${server.id} drawer current=${drawerState.currentValue} target=${drawerState.targetValue}")
             viewModel.setActiveServer(server.id)
             scope.launch { drawerState.close() }
             navController.navigateAsRoot(HOME)
         },
         onLibrarySelected = { library ->
+            Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] onLibrarySelected: library=${library.id} drawer current=${drawerState.currentValue} target=${drawerState.targetValue}")
             viewModel.setActiveLibrary(library.id)
             scope.launch { drawerState.close() }
             navController.navigateAsRoot(libraryEntryRoute(activeServer?.type, library.id, library.name))
         },
         onDownloadsSelected = {
+            Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] onDownloadsSelected: drawer current=${drawerState.currentValue} target=${drawerState.targetValue}")
             scope.launch { drawerState.close() }
             navController.navigate(DOWNLOADS)
         },
         onSettingsSelected = {
+            Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] onSettingsSelected: drawer current=${drawerState.currentValue} target=${drawerState.targetValue}")
             scope.launch { drawerState.close() }
             navController.navigate(SETTINGS)
         },
@@ -312,7 +320,10 @@ fun MainScreen(
                 com.riffle.app.feature.source.chitanka.ChitankaBrowseScreen(
                     libraryName = libraryName,
                     windowSizeClass = windowSizeClass,
-                    onOpenDrawer = { scope.launch { drawerState.open() } },
+                    onOpenDrawer = {
+                        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] onOpenDrawer: current=${drawerState.currentValue} target=${drawerState.targetValue}")
+                        scope.launch { drawerState.open() }
+                    },
                     onOpenDetail = { itemId ->
                         val encodedId = URLEncoder.encode(itemId, "UTF-8")
                         navController.navigate("library_item_detail/$encodedId")
@@ -349,7 +360,10 @@ fun MainScreen(
                 com.riffle.app.feature.source.gutenberg.GutenbergBrowseScreen(
                     libraryName = libraryName,
                     windowSizeClass = windowSizeClass,
-                    onOpenDrawer = { scope.launch { drawerState.open() } },
+                    onOpenDrawer = {
+                        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] onOpenDrawer: current=${drawerState.currentValue} target=${drawerState.targetValue}")
+                        scope.launch { drawerState.open() }
+                    },
                     onOpenDetail = { itemId ->
                         val encodedId = URLEncoder.encode(itemId, "UTF-8")
                         navController.navigate("library_item_detail/$encodedId")
@@ -572,10 +586,17 @@ fun MainScreen(
                 // Force the drawer fully closed when the library destination first composes.
                 // Without this its closing animation can race a Back press and the drawer's
                 // own BackHandler captures it instead of exiting the app (issue #60).
-                LaunchedEffect(Unit) { drawerState.close() }
+                LaunchedEffect(Unit) {
+                    Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] library LaunchedEffect close: current=${drawerState.currentValue} target=${drawerState.targetValue}")
+                    drawerState.close()
+                    Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] library LaunchedEffect close done: current=${drawerState.currentValue} target=${drawerState.targetValue}")
+                }
                 LibraryItemsScreen(
                     libraryName = libraryName,
-                    onOpenDrawer = { scope.launch { drawerState.open() } },
+                    onOpenDrawer = {
+                        Log.d(LogChannel.Nav.tag, "[DEBUG-BURGER] onOpenDrawer: current=${drawerState.currentValue} target=${drawerState.targetValue}")
+                        scope.launch { drawerState.open() }
+                    },
                     backEnabled = !shouldInterceptBackForDrawer(
                         usePermanentDrawer,
                         drawerCurrentOpen = drawerState.currentValue == DrawerValue.Open,

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -753,15 +753,13 @@ fun MainScreen(
                 LibraryItemDetailScreen(
                     windowSizeClass = windowSizeClass,
                     onNavigateBack = {
-                        // Guard against double-pop during the exit animation: the exit animation
-                        // keeps library_item_detail visible for ~300ms. A second tap during that
-                        // window re-fires this callback, but the committed back stack has already
-                        // moved on — check before popping to prevent a second navController.popBackStack()
-                        // from removing library_items and flashing the HOME spinner.
-                        if (navController.currentBackStack.value
-                                .lastOrNull { it.destination.route != null } == backStackEntry) {
-                            navController.popBackStack()
-                        }
+                        guardedNavigateBack(
+                            isStillTop = {
+                                navController.currentBackStack.value
+                                    .lastOrNull { it.destination.route != null } == backStackEntry
+                            },
+                            popBack = { navController.popBackStack() },
+                        )
                     },
                     onReadItem = { item ->
                         readerRouteFor(item)?.let { navController.navigate(it) }
@@ -1058,6 +1056,19 @@ internal fun libraryItemsBackEnabled(
 // the predictive-back preview destination that [currentBackStackEntryAsState] temporarily reflects.
 internal fun committedTopRoute(backStackRoutes: List<String?>): String? =
     backStackRoutes.lastOrNull { it != null }
+
+/**
+ * Calls [popBack] only if [isStillTop] returns true.
+ *
+ * Guards back-navigation callbacks in sub-screens against double-pops during Compose exit
+ * animations. When a screen exits, its composable stays alive for the animation duration
+ * (~300ms). A second tap on the ← button during that window re-fires [onNavigateBack], but the
+ * committed back stack has already advanced — [isStillTop] catches this and skips the pop to
+ * prevent removing the wrong entry (e.g. library_items → HOME spinner).
+ */
+internal fun guardedNavigateBack(isStillTop: () -> Boolean, popBack: () -> Unit) {
+    if (isStillTop()) popBack()
+}
 
 internal fun isReaderRoute(route: String?): Boolean =
     route?.startsWith(EPUB_READER.substringBefore("{")) == true ||

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -604,7 +605,7 @@ fun MainScreen(
                     // library_items shows as the predictive-back preview or the recomposition
                     // window hasn't caught up yet (pop the sub-screen instead).
                     isCommittedOnLibraryItems = {
-                        committedTopRoute(navController.currentBackStack.value.map { it.destination.route })
+                        committedTopRoute(navController.currentBackStackSnapshot().map { it.destination.route })
                             ?.startsWith("library_items/") == true
                     },
                     onNavigateBack = { navController.popBackStack() },
@@ -755,7 +756,7 @@ fun MainScreen(
                     onNavigateBack = {
                         guardedNavigateBack(
                             isStillTop = {
-                                navController.currentBackStack.value
+                                navController.currentBackStackSnapshot()
                                     .lastOrNull { it.destination.route != null } == backStackEntry
                             },
                             popBack = { navController.popBackStack() },
@@ -1090,3 +1091,13 @@ internal fun NavController.committedTopRouteAsState(): String? {
     val backStack by currentBackStack.collectAsState()
     return committedTopRoute(backStack.map { it.destination.route })
 }
+
+/**
+ * Reads [NavController.currentBackStack] synchronously. Centralises the [SuppressLint] so
+ * call sites that need a one-shot snapshot don't each need their own suppression annotation.
+ *
+ * Access is intentional — see [committedTopRouteAsState] for rationale.
+ */
+@SuppressLint("RestrictedApi")
+internal fun NavController.currentBackStackSnapshot(): List<NavBackStackEntry> =
+    currentBackStack.value

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryBackActionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryBackActionTest.kt
@@ -1,5 +1,8 @@
 package com.riffle.app.feature.library
 
+import android.app.Activity
+import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -20,5 +23,22 @@ class LibraryBackActionTest {
     @Test
     fun `empty query with Home tab yields Exit`() {
         assertEquals(LibraryBackAction.Exit, libraryBackAction(searchQuery = "", selectedTab = 0))
+    }
+
+    // Pins the fix for the burger-menu infinite-loop (Android 12+ singleTop): activity.finish()
+    // caused the activity to be re-created in the same process and the Back event to be
+    // re-delivered, creating a finish→recreate→Back→finish loop. moveTaskToBack(true) is the
+    // correct exit: it backgrounds the task without destroying the activity.
+    @Test
+    fun `handleLibraryExit calls moveTaskToBack(true) not finish`() {
+        val activity = mockk<Activity>(relaxed = true)
+        handleLibraryExit(activity)
+        verify { activity.moveTaskToBack(true) }
+        verify(exactly = 0) { activity.finish() }
+    }
+
+    @Test
+    fun `handleLibraryExit is safe when activity is null`() {
+        handleLibraryExit(null)
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
@@ -1,8 +1,5 @@
 package com.riffle.app.feature.navigation
 
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.LifecycleRegistry
 import com.riffle.core.domain.AuthenticateResult
 import com.riffle.core.domain.CommitSourceResult
 import com.riffle.core.models.Collection
@@ -23,6 +20,7 @@ import com.riffle.core.models.SourceUrl
 import java.io.IOException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -300,55 +298,70 @@ class HomeViewModelTest {
     //
     // navigateAsRoot's popUpTo(HOME) step momentarily promotes HOME to RESUMED before
     // navigate(library_route) pushes library_items back on top (demoting HOME to STARTED).
-    // Without the yield + lifecycle.currentState re-check, a bare lifecycle.withResumed { }
+    // Without the yield + isStillResumed re-check, a bare lifecycle.withResumed { }
     // would fire during that transient window and navigateFromHome would navigate a second time,
     // causing the HOME spinner flash.
     //
-    // Assertion that flips red if the yield+re-check loop is removed from awaitGenuinelyResumed:
-    // `unblocked` would be true after the RESUMED→STARTED pulse instead of remaining false.
+    // Tests use awaitGenuinelyResumedWith (controllable lambdas) to avoid races between
+    // yield() and UnconfinedTestDispatcher — the testable variant was extracted for exactly
+    // this reason. The invariant being pinned is the same: the function must not resolve
+    // when isStillResumed() returns false after waitForResumed completes.
+    //
+    // Assertion that flips red if the isStillResumed loop is removed from awaitGenuinelyResumedWith:
+    // `unblocked` would be true even when isStillResumed returns false.
     @Test
-    fun `awaitGenuinelyResumed does not unblock on a transient RESUMED pulse`() = runTest {
-        val owner = object : LifecycleOwner {
-            val registry = LifecycleRegistry.createUnsafe(this)
-            override val lifecycle: Lifecycle get() = registry
-        }
-        owner.registry.currentState = Lifecycle.State.STARTED
+    fun `awaitGenuinelyResumedWith does not unblock when isStillResumed is false (transient RESUMED pulse)`() = runTest {
+        // Use Channel (not CompletableDeferred): after one receive(), the channel blocks on the
+        // next call — CompletableDeferred.await() returns immediately once completed, which would
+        // spin the loop infinitely and hang the test.
+        val resumeSignal = Channel<Unit>()
+        var isResumedNow = false
         var unblocked = false
 
         val job = launch {
-            awaitGenuinelyResumed(owner.lifecycle)
+            awaitGenuinelyResumedWith(
+                waitForResumed = { resumeSignal.receive() },
+                isStillResumed = { isResumedNow },
+            )
             unblocked = true
         }
 
-        // Pulse RESUMED → STARTED: simulates navigateAsRoot's popUpTo(HOME) followed by navigate()
-        owner.registry.currentState = Lifecycle.State.RESUMED
-        advanceUntilIdle() // lets withResumed fire and the yield() inside awaitGenuinelyResumed run
-        owner.registry.currentState = Lifecycle.State.STARTED // navigate(library_route) demotes HOME
-        advanceUntilIdle() // loop re-checks lifecycle.currentState; it's STARTED → loop again
+        advanceUntilIdle()
+        assertFalse("must not fire before signal is sent", unblocked)
 
-        assertFalse("must not unblock on a transient RESUMED pulse", unblocked)
+        // Send a signal with isStillResumed=false — simulates popUpTo(HOME) firing withResumed
+        // while navigate(library_route) has already demoted HOME back to STARTED.
+        // With UnconfinedTestDispatcher, send() resumes the coroutine eagerly: receive() returns,
+        // yield() runs, isStillResumed()=false → loop, receive() blocks again → control returns here.
+        isResumedNow = false
+        resumeSignal.send(Unit)
+
+        assertFalse("must not unblock when isStillResumed returns false after waitForResumed", unblocked)
         job.cancelAndJoin()
     }
 
     @Test
-    fun `awaitGenuinelyResumed unblocks when lifecycle is genuinely RESUMED`() = runTest {
-        val owner = object : LifecycleOwner {
-            val registry = LifecycleRegistry.createUnsafe(this)
-            override val lifecycle: Lifecycle get() = registry
-        }
-        owner.registry.currentState = Lifecycle.State.STARTED
+    fun `awaitGenuinelyResumedWith unblocks when isStillResumed is true (genuine RESUMED)`() = runTest {
+        val resumeSignal = Channel<Unit>()
+        var isResumedNow = false
         var unblocked = false
 
         val job = launch {
-            awaitGenuinelyResumed(owner.lifecycle)
+            awaitGenuinelyResumedWith(
+                waitForResumed = { resumeSignal.receive() },
+                isStillResumed = { isResumedNow },
+            )
             unblocked = true
         }
 
-        // Genuine RESUMED: no library is pushed on top — lifecycle stays RESUMED
-        owner.registry.currentState = Lifecycle.State.RESUMED
+        // Genuine RESUMED: lifecycle stays RESUMED after waitForResumed returns.
+        isResumedNow = true
+        resumeSignal.send(Unit)
+        // yield() inside awaitGenuinelyResumedWith suspends the coroutine; advanceUntilIdle()
+        // lets that continuation run so isStillResumed()=true → break → unblocked=true.
         advanceUntilIdle()
 
-        assertTrue("must unblock when lifecycle is genuinely RESUMED", unblocked)
+        assertTrue("must unblock when isStillResumed returns true", unblocked)
         job.cancelAndJoin()
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
@@ -1,5 +1,8 @@
 package com.riffle.app.feature.navigation
 
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
 import com.riffle.core.domain.AuthenticateResult
 import com.riffle.core.domain.CommitSourceResult
 import com.riffle.core.models.Collection
@@ -26,15 +29,23 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class HomeViewModelTest {
+
+    @Before fun setUp() { Dispatchers.setMain(UnconfinedTestDispatcher()) }
+    @After fun tearDown() { Dispatchers.resetMain() }
 
     private val serversFlow = MutableStateFlow<List<Source>>(emptyList())
     private val librariesFlow = MutableStateFlow<List<Library>>(emptyList())
@@ -283,5 +294,61 @@ class HomeViewModelTest {
         val result = makeVm().getStartDestination()
 
         assertEquals(HomeViewModel.StartDestination.Library("lib-2", "lib-2"), result)
+    }
+
+    // Pins the transient-RESUMED guard introduced to fix the burger-menu spinner flash.
+    //
+    // navigateAsRoot's popUpTo(HOME) step momentarily promotes HOME to RESUMED before
+    // navigate(library_route) pushes library_items back on top (demoting HOME to STARTED).
+    // Without the yield + lifecycle.currentState re-check, a bare lifecycle.withResumed { }
+    // would fire during that transient window and navigateFromHome would navigate a second time,
+    // causing the HOME spinner flash.
+    //
+    // Assertion that flips red if the yield+re-check loop is removed from awaitGenuinelyResumed:
+    // `unblocked` would be true after the RESUMED→STARTED pulse instead of remaining false.
+    @Test
+    fun `awaitGenuinelyResumed does not unblock on a transient RESUMED pulse`() = runTest {
+        val owner = object : LifecycleOwner {
+            val registry = LifecycleRegistry.createUnsafe(this)
+            override val lifecycle: Lifecycle get() = registry
+        }
+        owner.registry.currentState = Lifecycle.State.STARTED
+        var unblocked = false
+
+        val job = launch {
+            awaitGenuinelyResumed(owner.lifecycle)
+            unblocked = true
+        }
+
+        // Pulse RESUMED → STARTED: simulates navigateAsRoot's popUpTo(HOME) followed by navigate()
+        owner.registry.currentState = Lifecycle.State.RESUMED
+        advanceUntilIdle() // lets withResumed fire and the yield() inside awaitGenuinelyResumed run
+        owner.registry.currentState = Lifecycle.State.STARTED // navigate(library_route) demotes HOME
+        advanceUntilIdle() // loop re-checks lifecycle.currentState; it's STARTED → loop again
+
+        assertFalse("must not unblock on a transient RESUMED pulse", unblocked)
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `awaitGenuinelyResumed unblocks when lifecycle is genuinely RESUMED`() = runTest {
+        val owner = object : LifecycleOwner {
+            val registry = LifecycleRegistry.createUnsafe(this)
+            override val lifecycle: Lifecycle get() = registry
+        }
+        owner.registry.currentState = Lifecycle.State.STARTED
+        var unblocked = false
+
+        val job = launch {
+            awaitGenuinelyResumed(owner.lifecycle)
+            unblocked = true
+        }
+
+        // Genuine RESUMED: no library is pushed on top — lifecycle stays RESUMED
+        owner.registry.currentState = Lifecycle.State.RESUMED
+        advanceUntilIdle()
+
+        assertTrue("must unblock when lifecycle is genuinely RESUMED", unblocked)
+        job.cancelAndJoin()
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
@@ -18,13 +18,19 @@ import com.riffle.core.models.Source
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceUrl
 import java.io.IOException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -213,6 +219,47 @@ class HomeViewModelTest {
         val result = makeVm().getStartDestination()
 
         assertEquals(HomeViewModel.StartDestination.Library("lib-1", "lib-1"), result)
+    }
+
+    // Pins the fix for the predictive-back burger-menu infinite loop: Compose Navigation 2.8+
+    // keeps the previous back-stack entry in composition simultaneously (predictive-back
+    // animations), so HOME can be STARTED while library_items is foreground. Without the
+    // awaitResumed guard in navigateFromHome, onDestination would fire immediately while HOME is
+    // in STARTED state, calling navigateAsRoot(libraryItems) whose popUpTo(HOME) removes the live
+    // library_items entry → BackHandler gap → Back falls through → NavHost pops → HOME → loop.
+    //
+    // Assertion that flips red if awaitResumed() is removed from navigateFromHome: the
+    // assertFalse below would fail because onDestination would be called without waiting.
+    @Test
+    fun `navigateFromHome defers navigation until awaitResumed unblocks`() = runTest {
+        serversFlow.value = listOf(server("s", active = true))
+        librariesFlow.value = listOf(library("lib-1"))
+
+        val gate = CompletableDeferred<Unit>()
+        var navigated = false
+        val job = launch {
+            navigateFromHome(awaitResumed = { gate.await() }, viewModel = makeVm()) { navigated = true }
+        }
+
+        advanceUntilIdle()
+        assertFalse("navigateFromHome must not fire before awaitResumed completes", navigated)
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+        assertTrue("navigateFromHome must fire once awaitResumed completes", navigated)
+
+        job.cancelAndJoin()
+    }
+
+    @Test
+    fun `navigateFromHome fires immediately when awaitResumed is a no-op`() = runTest {
+        serversFlow.value = listOf(server("s", active = true))
+        librariesFlow.value = listOf(library("lib-1"))
+
+        var navigated = false
+        navigateFromHome(awaitResumed = {}, viewModel = makeVm()) { navigated = true }
+
+        assertTrue("navigateFromHome must fire immediately when awaitResumed does not suspend", navigated)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
@@ -362,6 +362,30 @@ class NavigationDrawerViewModelTest {
     }
 
     @Test
+    fun `redirectToLibrary emits when switching servers leaves the active library absent from the new server`() = runTest(testDispatcher) {
+        // Regression for the server-switch spinner: onServerSelected no longer navigates to HOME;
+        // instead it relies entirely on redirectToLibrary to navigate straight to the new
+        // server's library. Verify that the emit fires when setActiveServer is called and the
+        // new server's visible libraries do not contain _lastActiveLibraryId.
+        serversFlow.value = listOf(server("srv-1", active = true), server("srv-2"))
+        librariesFlow.value = listOf(library("lib-A"))
+        val vm = makeVm()
+        vm.setActiveLibrary("lib-A")
+
+        val redirect = async { vm.redirectToLibrary.first() }
+        testScheduler.advanceUntilIdle()
+        assertTrue("no redirect before server switch", !redirect.isCompleted)
+
+        // Switch to srv-2 whose libraries don't include lib-A.
+        vm.setActiveServer("srv-2")
+        serversFlow.update { list -> list.map { it.copy(isActive = it.id == "srv-2") } }
+        librariesFlow.value = listOf(library("lib-B"), library("lib-C"))
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(library("lib-B"), redirect.await())
+    }
+
+    @Test
     fun `switching servers updates visibleLibraries to the new server libraries`() = runTest {
         serversFlow.value = listOf(server("srv-1", active = true), server("srv-2"))
         librariesFlow.value = listOf(library("lib-A"))

--- a/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
@@ -72,21 +72,21 @@ class LibraryItemsBackEnabledTest {
     @Test
     fun `enabled when library_items is foreground and drawer is closed`() {
         assertTrue(libraryItemsBackEnabled(
-            currentRoute = "library_items/lib-1/Books",
+            committedRoute = "library_items/lib-1/Books",
             usePermanentDrawer = false,
             drawerCurrentOpen = false,
             drawerTargetOpen = false,
         ))
     }
 
-    // currentRoute comes from currentBackStackEntryAsState() which reflects the PREVIEW
-    // destination during predictive back. During a back gesture from library_item_detail,
-    // currentRoute is already "library_items/..." — so libBackEnabled stays true with no lag.
-    // Spurious exits in this state are blocked at handler-fire time by isCommittedOnLibraryItems().
+    // Pins the fix for the burger-menu freeze when swiping back FROM library_items:
+    // the committed route stays library_items while the predictive-back gesture is in progress
+    // (the gesture hasn't committed yet), so the handler stays armed and intercepts the back
+    // to run ClearSearch/ResetTab/Exit instead of letting NavHost pop library_items.
     @Test
-    fun `enabled when library_items is the predictive-back preview destination from sub-screen`() {
+    fun `enabled during predictive-back FROM library_items (committed top is still library_items)`() {
         assertTrue(libraryItemsBackEnabled(
-            currentRoute = "library_items/lib-1/Books",
+            committedRoute = "library_items/lib-1/Books",
             usePermanentDrawer = false,
             drawerCurrentOpen = false,
             drawerTargetOpen = false,
@@ -96,7 +96,7 @@ class LibraryItemsBackEnabledTest {
     @Test
     fun `disabled when library_item_detail is foreground (predictive-back preview)`() {
         assertFalse(libraryItemsBackEnabled(
-            currentRoute = "library_item_detail/item-1",
+            committedRoute = "library_item_detail/item-1",
             usePermanentDrawer = false,
             drawerCurrentOpen = false,
             drawerTargetOpen = false,
@@ -106,7 +106,7 @@ class LibraryItemsBackEnabledTest {
     @Test
     fun `disabled when series_detail is foreground`() {
         assertFalse(libraryItemsBackEnabled(
-            currentRoute = "series_detail/lib-1/series-1/MySeries",
+            committedRoute = "series_detail/lib-1/series-1/MySeries",
             usePermanentDrawer = false,
             drawerCurrentOpen = false,
             drawerTargetOpen = false,
@@ -116,7 +116,7 @@ class LibraryItemsBackEnabledTest {
     @Test
     fun `disabled when reader is foreground`() {
         assertFalse(libraryItemsBackEnabled(
-            currentRoute = "epub_reader/item-1",
+            committedRoute = "epub_reader/item-1",
             usePermanentDrawer = false,
             drawerCurrentOpen = false,
             drawerTargetOpen = false,
@@ -126,7 +126,7 @@ class LibraryItemsBackEnabledTest {
     @Test
     fun `disabled when library_items is foreground but drawer is open`() {
         assertFalse(libraryItemsBackEnabled(
-            currentRoute = "library_items/lib-1/Books",
+            committedRoute = "library_items/lib-1/Books",
             usePermanentDrawer = false,
             drawerCurrentOpen = true,
             drawerTargetOpen = true,
@@ -136,7 +136,7 @@ class LibraryItemsBackEnabledTest {
     @Test
     fun `disabled when route is null (initial navigation not yet resolved)`() {
         assertFalse(libraryItemsBackEnabled(
-            currentRoute = null,
+            committedRoute = null,
             usePermanentDrawer = false,
             drawerCurrentOpen = false,
             drawerTargetOpen = false,

--- a/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
@@ -1,6 +1,8 @@
 package com.riffle.app.navigation
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -125,5 +127,56 @@ class LibraryItemsBackEnabledTest {
             drawerCurrentOpen = false,
             drawerTargetOpen = false,
         ))
+    }
+}
+
+/**
+ * Pins the fix for the predictive-back blank-screen bug:
+ *
+ * During a predictive-back gesture from library_item_detail → library_items,
+ * currentBackStackEntryAsState() temporarily returns the PREVIEW destination ("library_items/...")
+ * while library_item_detail is still the committed top. Passing that preview route to
+ * libraryItemsBackEnabled would enable LibraryItemsScreen's BackHandler, which fires moveTaskToBack
+ * → app goes to background → white screen.
+ *
+ * The fix: use navController.currentBackStack (the committed StateFlow) and extract the top route
+ * via committedTopRoute(), which always reflects the real top regardless of predictive-back state.
+ *
+ * Assertion that flips red if committedTopRoute() is removed: callers would fall back to the
+ * preview route ("library_items/..."), enabling the BackHandler when library_item_detail is real top.
+ */
+class CommittedTopRouteTest {
+
+    @Test
+    fun `returns last non-null route from back stack`() {
+        // During predictive back from library_item_detail → library_items, the committed back stack
+        // is [home, library_items/..., library_item_detail/...]. committedTopRoute must return
+        // library_item_detail, not the preview destination library_items.
+        val routes = listOf("home", "library_items/lib-1/Books", "library_item_detail/item-1")
+        assertEquals("library_item_detail/item-1", committedTopRoute(routes))
+    }
+
+    @Test
+    fun `with committed top route, libraryItemsBackEnabled is false during predictive-back preview`() {
+        // The predictive-back bug: currentBackStackEntryAsState returns "library_items/..." (preview)
+        // while library_item_detail is real top. committedTopRoute returns "library_item_detail/...",
+        // so the BackHandler is disabled — the NavHost pop proceeds normally.
+        val routes = listOf("home", "library_items/lib-1/Books", "library_item_detail/item-1")
+        assertFalse(libraryItemsBackEnabled(
+            currentRoute = committedTopRoute(routes),
+            usePermanentDrawer = false,
+            drawerCurrentOpen = false,
+            drawerTargetOpen = false,
+        ))
+    }
+
+    @Test
+    fun `returns null for empty back stack`() {
+        assertNull(committedTopRoute(emptyList()))
+    }
+
+    @Test
+    fun `skips null entries (graph root has no route string)`() {
+        assertEquals("home", committedTopRoute(listOf(null, "home")))
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
@@ -79,6 +79,20 @@ class LibraryItemsBackEnabledTest {
         ))
     }
 
+    // currentRoute comes from currentBackStackEntryAsState() which reflects the PREVIEW
+    // destination during predictive back. During a back gesture from library_item_detail,
+    // currentRoute is already "library_items/..." — so libBackEnabled stays true with no lag.
+    // Spurious exits in this state are blocked at handler-fire time by isCommittedOnLibraryItems().
+    @Test
+    fun `enabled when library_items is the predictive-back preview destination from sub-screen`() {
+        assertTrue(libraryItemsBackEnabled(
+            currentRoute = "library_items/lib-1/Books",
+            usePermanentDrawer = false,
+            drawerCurrentOpen = false,
+            drawerTargetOpen = false,
+        ))
+    }
+
     @Test
     fun `disabled when library_item_detail is foreground (predictive-back preview)`() {
         assertFalse(libraryItemsBackEnabled(

--- a/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
@@ -204,3 +204,35 @@ class CommittedTopRouteTest {
         assertEquals("home", committedTopRoute(listOf(null, "home")))
     }
 }
+
+/**
+ * Pins the double-tap guard fix for the burger-menu freeze.
+ *
+ * Root cause: the ← back button on library_item_detail sits at the same screen coordinates as
+ * ☰ on library_items. Compose's exit animation keeps library_item_detail alive for ~300ms after
+ * the first tap commits the pop. A second tap during that window re-fires onNavigateBack → a
+ * second navController.popBackStack() removes library_items and surfaces HOME → white spinner.
+ *
+ * The fix wraps the pop in guardedNavigateBack(), which checks isStillTop() before popping.
+ * At double-tap time the entry is already gone from the committed back stack, so isStillTop()
+ * returns false and the second pop is suppressed.
+ *
+ * Assertion that flips red if the guard is removed: the `does not call popBack` test would fail
+ * because popBack would be called even when isStillTop() returns false.
+ */
+class GuardedNavigateBackTest {
+
+    @Test
+    fun `calls popBack when entry is still the committed top`() {
+        var called = false
+        guardedNavigateBack(isStillTop = { true }, popBack = { called = true })
+        assertTrue(called)
+    }
+
+    @Test
+    fun `does not call popBack when entry is no longer the committed top (double-tap during exit animation)`() {
+        var called = false
+        guardedNavigateBack(isStillTop = { false }, popBack = { called = true })
+        assertFalse(called)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
@@ -54,3 +54,76 @@ class ShouldInterceptBackForDrawerTest {
         assertFalse(shouldInterceptBackForDrawer(usePermanentDrawer = true, drawerCurrentOpen = false, drawerTargetOpen = false))
     }
 }
+
+/**
+ * Pins the fix for the sub-screen Back intercept: Compose Navigation 2.8+ keeps the previous
+ * back-stack entry in composition for predictive-back animations, so LibraryItemsScreen's
+ * BackHandler remains registered (and enabled) while library_item_detail is foreground. Without
+ * the currentRoute gate, pressing Back from a sub-screen fires the library BackHandler instead
+ * of the NavHost pop — causing unexpected app-exit or blank-screen navigation.
+ *
+ * Assertion that flips red if the currentRoute guard is removed from libraryItemsBackEnabled:
+ * the assertFalse cases below would return true, re-enabling the handler on sub-screens.
+ */
+class LibraryItemsBackEnabledTest {
+
+    @Test
+    fun `enabled when library_items is foreground and drawer is closed`() {
+        assertTrue(libraryItemsBackEnabled(
+            currentRoute = "library_items/lib-1/Books",
+            usePermanentDrawer = false,
+            drawerCurrentOpen = false,
+            drawerTargetOpen = false,
+        ))
+    }
+
+    @Test
+    fun `disabled when library_item_detail is foreground (predictive-back preview)`() {
+        assertFalse(libraryItemsBackEnabled(
+            currentRoute = "library_item_detail/item-1",
+            usePermanentDrawer = false,
+            drawerCurrentOpen = false,
+            drawerTargetOpen = false,
+        ))
+    }
+
+    @Test
+    fun `disabled when series_detail is foreground`() {
+        assertFalse(libraryItemsBackEnabled(
+            currentRoute = "series_detail/lib-1/series-1/MySeries",
+            usePermanentDrawer = false,
+            drawerCurrentOpen = false,
+            drawerTargetOpen = false,
+        ))
+    }
+
+    @Test
+    fun `disabled when reader is foreground`() {
+        assertFalse(libraryItemsBackEnabled(
+            currentRoute = "epub_reader/item-1",
+            usePermanentDrawer = false,
+            drawerCurrentOpen = false,
+            drawerTargetOpen = false,
+        ))
+    }
+
+    @Test
+    fun `disabled when library_items is foreground but drawer is open`() {
+        assertFalse(libraryItemsBackEnabled(
+            currentRoute = "library_items/lib-1/Books",
+            usePermanentDrawer = false,
+            drawerCurrentOpen = true,
+            drawerTargetOpen = true,
+        ))
+    }
+
+    @Test
+    fun `disabled when route is null (initial navigation not yet resolved)`() {
+        assertFalse(libraryItemsBackEnabled(
+            currentRoute = null,
+            usePermanentDrawer = false,
+            drawerCurrentOpen = false,
+            drawerTargetOpen = false,
+        ))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
@@ -131,19 +131,18 @@ class LibraryItemsBackEnabledTest {
 }
 
 /**
- * Pins the fix for the predictive-back blank-screen bug:
+ * Pins the role of committedTopRoute() in the isCommittedOnLibraryItems runtime check:
  *
- * During a predictive-back gesture from library_item_detail → library_items,
- * currentBackStackEntryAsState() temporarily returns the PREVIEW destination ("library_items/...")
- * while library_item_detail is still the committed top. Passing that preview route to
- * libraryItemsBackEnabled would enable LibraryItemsScreen's BackHandler, which fires moveTaskToBack
- * → app goes to background → white screen.
+ * LibraryItemsScreen's BackHandler uses currentRoute (the preview destination) for its enabled
+ * gate — no 16ms recomposition lag. Inside the handler, isCommittedOnLibraryItems() reads
+ * navController.currentBackStack.value synchronously via committedTopRoute() to decide:
+ *   - library_items is the committed top → run library back actions (clear search, reset tab, exit)
+ *   - sub-screen is the committed top  → call onNavigateBack() to pop the sub-screen
  *
- * The fix: use navController.currentBackStack (the committed StateFlow) and extract the top route
- * via committedTopRoute(), which always reflects the real top regardless of predictive-back state.
- *
- * Assertion that flips red if committedTopRoute() is removed: callers would fall back to the
- * preview route ("library_items/..."), enabling the BackHandler when library_item_detail is real top.
+ * The two cases arise during a predictive-back gesture from library_item_detail (library_items
+ * shows as the preview background, library_item_detail is still the committed top) and during the
+ * brief recomposition window right after a commit (both Compose state sources are momentarily stale,
+ * but navController.currentBackStack.value is always synchronously up-to-date).
  */
 class CommittedTopRouteTest {
 
@@ -151,23 +150,34 @@ class CommittedTopRouteTest {
     fun `returns last non-null route from back stack`() {
         // During predictive back from library_item_detail → library_items, the committed back stack
         // is [home, library_items/..., library_item_detail/...]. committedTopRoute must return
-        // library_item_detail, not the preview destination library_items.
+        // library_item_detail — isCommittedOnLibraryItems() returns false → onNavigateBack() fires.
         val routes = listOf("home", "library_items/lib-1/Books", "library_item_detail/item-1")
         assertEquals("library_item_detail/item-1", committedTopRoute(routes))
     }
 
     @Test
-    fun `with committed top route, libraryItemsBackEnabled is false during predictive-back preview`() {
-        // The predictive-back bug: currentBackStackEntryAsState returns "library_items/..." (preview)
-        // while library_item_detail is real top. committedTopRoute returns "library_item_detail/...",
-        // so the BackHandler is disabled — the NavHost pop proceeds normally.
-        val routes = listOf("home", "library_items/lib-1/Books", "library_item_detail/item-1")
-        assertFalse(libraryItemsBackEnabled(
-            currentRoute = committedTopRoute(routes),
-            usePermanentDrawer = false,
-            drawerCurrentOpen = false,
-            drawerTargetOpen = false,
-        ))
+    fun `during predictive-back from sub-screen, isCommittedOnLibraryItems returns false`() {
+        // During the predictive-back gesture, navController.currentBackStack.value still has
+        // library_item_detail on top (it hasn't committed yet). committedTopRoute returns
+        // "library_item_detail/..." → startsWith("library_items/") == false → onNavigateBack().
+        val routes = listOf(null, "home", "library_items/lib-1/Books", "library_item_detail/item-1")
+        val committedTop = committedTopRoute(routes)
+        assertFalse(
+            "isCommittedOnLibraryItems must be false while sub-screen is committed top",
+            committedTop?.startsWith("library_items/") == true,
+        )
+    }
+
+    @Test
+    fun `when library_items is committed top, isCommittedOnLibraryItems returns true`() {
+        // After the sub-screen back commits (and navController.currentBackStack.value is updated),
+        // committedTopRoute returns "library_items/..." → isCommittedOnLibraryItems() = true.
+        val routes = listOf(null, "home", "library_items/lib-1/Books")
+        val committedTop = committedTopRoute(routes)
+        assertTrue(
+            "isCommittedOnLibraryItems must be true once library_items is the committed top",
+            committedTop?.startsWith("library_items/") == true,
+        )
     }
 
     @Test

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/NetworkModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/NetworkModule.kt
@@ -33,6 +33,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import io.ktor.client.HttpClient
 import java.io.File
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module

--- a/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
+++ b/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
@@ -25,4 +25,5 @@ enum class LogChannel(val tag: String) {
     ProgressSync("RIFFLE_PS"),
     Oom("RIFFLE_OOM"),
     AnnotationSync("RIFFLE_ANNSYNC"),
+    Nav("RIFFLE_NAV"),
 }

--- a/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
+++ b/core/logging/src/main/kotlin/com/riffle/core/logging/LogChannel.kt
@@ -25,5 +25,4 @@ enum class LogChannel(val tag: String) {
     ProgressSync("RIFFLE_PS"),
     Oom("RIFFLE_OOM"),
     AnnotationSync("RIFFLE_ANNSYNC"),
-    Nav("RIFFLE_NAV"),
 }

--- a/core/net/src/commonMain/kotlin/com/riffle/core/network/NetworkResult.kt
+++ b/core/net/src/commonMain/kotlin/com/riffle/core/network/NetworkResult.kt
@@ -2,6 +2,7 @@ package com.riffle.core.network
 
 import com.riffle.core.models.InsecureConnectionType
 import io.ktor.client.plugins.ResponseException
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.SerializationException
 
 /**
@@ -32,6 +33,8 @@ object KtorClassifier {
      */
     suspend fun <T> classify(block: suspend () -> T): NetworkResult<T> = try {
         NetworkResult.Success(block())
+    } catch (e: CancellationException) {
+        throw e
     } catch (e: HttpException) {
         if (e.code == 401) NetworkResult.Auth
         else NetworkResult.ServerError(e.code, e.message)

--- a/core/net/src/jvmMain/kotlin/com/riffle/core/network/JvmHttpClientFactories.kt
+++ b/core/net/src/jvmMain/kotlin/com/riffle/core/network/JvmHttpClientFactories.kt
@@ -5,6 +5,7 @@ import okhttp3.Cache
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import java.io.File
+import java.util.concurrent.TimeUnit
 
 /**
  * Owns the JVM engine client so Android composition roots can share its connection pool and cache
@@ -27,6 +28,7 @@ fun createDefaultJvmHttpClientPool(
         OkHttpClient.Builder()
             .cache(cache)
             .addNetworkInterceptor(EndpointCacheHeadersInterceptor(DEFAULT_HTTP_CACHE_RULES))
+            .callTimeout(30, TimeUnit.SECONDS)
             .build(),
     )
 }


### PR DESCRIPTION
## Root cause

Three layered bugs caused the ☰ tap freeze (white spinner / blank screen):

1. **Double-pop during exit animation** (root cause of the final repro): the ← back button on `library_item_detail` sits at the same screen coordinates as ☰ on `library_items`. Compose's exit animation keeps `library_item_detail` alive for ~300ms. A tap during that window re-fires `onNavigateBack()` → second `navController.popBackStack()` removes `library_items` → HOME spinner.

2. **Committed-route vs. preview-route mismatch**: `libraryItemsBackEnabled` was computing against `currentBackStackEntryAsState()` (which reflects the predictive-back *preview* destination during a gesture), causing the `library_items` BackHandler to disable during a swipe-back FROM `library_items` and letting NavHost pop it instead.

3. **Transient-RESUMED HOME flash**: `navigateAsRoot(library_route)` does `popUpTo(HOME)` (briefly promoting HOME to RESUMED) then `navigate(library_route)`. A bare `lifecycle.withResumed { }` fired during that transient window and called `navigateAsRoot` a second time → duplicate navigation → spinner.

## Changes

**Double-pop guard** (`MainScreen.kt` → `library_item_detail` composable):
- Capture `backStackEntry` at composition time; in `onNavigateBack`, check `navController.currentBackStack.value.lastOrNull { it.destination.route != null } == backStackEntry` before calling `popBackStack()`. A second tap during the exit animation finds the entry already gone → pop is skipped.
- Extracted as `guardedNavigateBack(isStillTop, popBack)` for unit testability.

**Committed-route gate** (`MainScreen.kt`):
- `libBackEnabled` now computed from `navController.currentBackStack.collectAsState()` (always the committed top) instead of the preview state from `currentBackStackEntryAsState()`.
- `libraryItemsBackEnabled()` and `committedTopRoute()` extracted as `internal` functions.

**Predictive-back sub-screen fallthrough** (`LibraryItemsScreen.kt`):
- `BackHandler` fires synchronously against `navController.currentBackStack.value` (`isCommittedOnLibraryItems`). If the committed top is a sub-screen (predictive-back preview shows `library_items` as background while sub-screen is still committed), delegates to `onNavigateBack()` instead of running library exit logic.

**Genuinely-resumed guard** (`HomeScreen.kt`):
- `awaitGenuinelyResumed`: yields after `withResumed { }` and re-checks `lifecycle.currentState`. If HOME fell back to STARTED (library was pushed on top), loops to wait for a genuine RESUMED event. Prevents the transient-RESUMED double-navigation.

**Defense-in-depth** (`LibraryItemsScreen.kt`):
- `systemGestureExclusionRects` over the ☰ button to prevent edge-swipe misinterpretation.

**Exit fix** (`LibraryBackAction.kt`):
- `handleLibraryExit` uses `moveTaskToBack(true)` instead of `activity.finish()` — `finish()` on Android 12+ singleTop causes recreate→Back re-delivery loop.

## Unrelated changes on the branch
- `CancellationException` re-throw in `KtorClassifier.classify()` (prevents coroutine cancellation being swallowed as a `NetworkResult.Failure`)
- 30-second `callTimeout` on the OkHttp client

## Tests

- `GuardedNavigateBackTest` — pins the double-pop guard: `popBack` not called when `isStillTop()` is false
- `LibraryItemsBackEnabledTest` — pins the committed-route gate
- `CommittedTopRouteTest` — pins `committedTopRoute()` for sub-screen vs. library_items distinction
- `NavigationDrawerViewModelTest#redirectToLibrary…` — pins server-switch library redirect
- `HomeViewModelTest` — pins `awaitGenuinelyResumed` transient-pulse suppression and `navigateFromHome` defer behavior
- `LibraryBackActionTest#handleLibraryExit…` — pins `moveTaskToBack` over `finish()`