### PR TITLE
fix(reader): continuous scroll backward navigation fixes

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousChapterBoundaryHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousChapterBoundaryHarnessTest.kt
@@ -1,0 +1,780 @@
+package com.riffle.app.feature.reader
+
+import android.graphics.Bitmap
+import android.os.Handler
+import android.view.MotionEvent
+import android.view.PixelCopy
+import android.view.Surface
+import android.view.Window
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebView
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.riffle.app.MainActivity
+import com.riffle.app.harness.ReaderSemanticMatchers
+import com.riffle.app.harness.ReaderSemanticMatchers.assertNoErrorState
+import com.riffle.app.harness.ReaderSemanticMatchers.tapReadInDetailScreen
+import com.riffle.app.harness.StubAbsServer
+import com.riffle.core.data.di.EpubCacheStore
+import com.riffle.core.database.RiffleDatabase
+import com.riffle.core.domain.FormattingPreferencesStore
+import com.riffle.core.domain.LocalStore
+import com.riffle.core.domain.ReaderOrientation
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.zip.CRC32
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import javax.inject.Inject
+
+/**
+ * Device-level regression for the shape observed in "Taking Charge of ADHD": a long chapter,
+ * a tiny part-title resource, then another long chapter. Continuous mode used to oscillate the
+ * sliding window at that short middle resource, making the adjacent chapters unreachable by
+ * scrolling even though TOC navigation could open them directly.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class ContinuousChapterBoundaryHarnessTest {
+
+    @get:Rule(order = 0) val hiltRule = HiltAndroidRule(this)
+    @get:Rule(order = 1) val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Inject lateinit var database: RiffleDatabase
+    @EpubCacheStore @Inject lateinit var epubCacheStore: LocalStore
+    @Inject lateinit var formattingPreferencesStore: FormattingPreferencesStore
+
+    private val stubServer = StubAbsServer(epubBytesProvider = ::boundaryEpub)
+
+    @Before
+    fun setUp() {
+        stubServer.start()
+        hiltRule.inject()
+        database.clearAllTables()
+        epubCacheStore.clear()
+        runBlocking {
+            val prefs = formattingPreferencesStore.preferences.first()
+            formattingPreferencesStore.update(prefs.copy(orientation = ReaderOrientation.Continuous))
+        }
+    }
+
+    @After
+    fun tearDown() {
+        stubServer.shutdown()
+        composeTestRule.activityRule.scenario.close()
+        Runtime.getRuntime().gc()
+        Thread.sleep(400)
+        database.clearAllTables()
+        runBlocking {
+            val prefs = formattingPreferencesStore.preferences.first()
+            formattingPreferencesStore.update(prefs.copy(orientation = ReaderOrientation.Horizontal))
+        }
+    }
+
+    /**
+     * Regression for the "stuck title page" bug (book e866cd1d, "Free Excerpt" chapter).
+     *
+     * Chapters with large images get measured TWICE: once when the page loads (before the image
+     * decodes), and again when the image loads and triggers a second layout pass. The second
+     * measurement fires `reapplyLandingAfterFallback`, which queues a `port.post { postLandAt }`.
+     * If the user has touched between the image load and when that queued message runs,
+     * `onTouchDown` has already cleared `reapplyLandingAfterFallback` — but cannot cancel the
+     * already-posted message. Without the fix, that queued `postLandAt` re-arms `landingHoldTargetY`
+     * for 600 ms, and `tickLandingHold` reverts every scroll tick — the "stuck" symptom.
+     *
+     * The regression guard is `reapplyLandingSuperseded`: set on the first `onTouchDown` after
+     * any `openWindowAt`, checked inside the `port.post { postLandAt }` body. This test pins both
+     * transitions:
+     *   - false initially (fresh window) → true after a touch → false after next navigation
+     *
+     * The specific assertion that would fail if the fix were reverted: `isReapplyLandingSuperseded`
+     * stays false after a touch because the flag is never set in `onTouchDown`, so the re-apply
+     * guard inside `postLandAt` never fires and a late-image height change re-arms the hold.
+     */
+    @Test
+    fun reapplyLandingSupersededSetByTouchClearedByNavigation() {
+        addServerAndBrowseLibrary()
+        composeTestRule.waitUntil(timeoutMillis = 15_000) {
+            composeTestRule.onAllNodesWithText(StubAbsServer.TEST_STANDALONE_ITEM_TITLE)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(StubAbsServer.TEST_STANDALONE_ITEM_TITLE).performClick()
+        composeTestRule.tapReadInDetailScreen()
+        composeTestRule.waitUntil(timeoutMillis = 20_000) {
+            composeTestRule.onAllNodesWithTag(ReaderSemanticMatchers.TAG_READER_READY)
+                .fetchSemanticsNodes().isNotEmpty() ||
+                composeTestRule.onAllNodesWithTag(ReaderSemanticMatchers.TAG_ERROR_STATE)
+                    .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.assertNoErrorState()
+        composeTestRule.waitUntil(timeoutMillis = 15_000) {
+            findContinuousReader()?.isFirstLoadComplete?.value == true
+        }
+        val reader = requireNotNull(findContinuousReader()) { "continuous reader view was not mounted" }
+        dismissUpdateDialogIfPresent()
+
+        // 1. Fresh window: reapplyLandingSuperseded must start false so re-applies can fire to
+        //    correct the scroll position while the user hasn't yet touched (e.g. late image decode).
+        var superseded = true
+        composeTestRule.activityRule.scenario.onActivity { superseded = reader.isReapplyLandingSuperseded }
+        assertFalse("reapplyLandingSuperseded should be false on fresh window open", superseded)
+
+        // 2. After a touch: must flip to true so any already-queued postLandAt (from a
+        //    reapplyLandingAfterFallback triggered just before onTouchDown ran) bails out instead
+        //    of re-arming landingHoldTargetY and locking the reader for 600 ms.
+        dispatchSwipeUp(reader)
+        composeTestRule.waitForIdle()
+        composeTestRule.activityRule.scenario.onActivity { superseded = reader.isReapplyLandingSuperseded }
+        assertTrue("reapplyLandingSuperseded should be true after onTouchDown", superseded)
+
+        // 3. After cross-chapter navigation (openWindowAt): must reset to false so re-applies work
+        //    for the new target position before the user interacts with the new window.
+        composeTestRule.activityRule.scenario.onActivity {
+            reader.navigateTo("OEBPS/ch07.html", progression = 0f, alignToTop = true)
+        }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            isReaderInChapter(reader, "ch07.html")
+        }
+        composeTestRule.activityRule.scenario.onActivity { superseded = reader.isReapplyLandingSuperseded }
+        assertFalse("reapplyLandingSuperseded should be false after openWindowAt for cross-chapter nav", superseded)
+    }
+
+    /**
+     * Regression for 2026-08-06: [ContinuousWindowController.prependChapter] must arm
+     * [ContinuousWindowController.boundaryDetentArmed] so the backward-prepend scroll floor stays
+     * at the real chapter height even after the chapter measures (prependAwaitingMeasure=false).
+     * Without the detent, the floor drops to 0 at measurement time: any in-flight gesture or
+     * fling carries the user past the boundary and into the prepended chapter — field-reported as
+     * "abrupt jump navigating between specific chapters" (book e866cd1d, 2026-08-06).
+     *
+     * The specific assertion that fails if `boundaryDetentArmed = true` is removed from
+     * [ContinuousWindowController.prependChapter]: `isBoundaryDetentArmed` is `false` immediately
+     * after the backward swipe, so the floor is 0 and any residual scroll carries the user past
+     * the boundary.
+     */
+    @Test
+    fun boundaryDetentArmedAfterBackwardPrepend() {
+        addServerAndBrowseLibrary()
+        composeTestRule.waitUntil(timeoutMillis = 15_000) {
+            composeTestRule.onAllNodesWithText(StubAbsServer.TEST_STANDALONE_ITEM_TITLE)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(StubAbsServer.TEST_STANDALONE_ITEM_TITLE).performClick()
+        composeTestRule.tapReadInDetailScreen()
+        composeTestRule.waitUntil(timeoutMillis = 20_000) {
+            composeTestRule.onAllNodesWithTag(ReaderSemanticMatchers.TAG_READER_READY)
+                .fetchSemanticsNodes().isNotEmpty() ||
+                composeTestRule.onAllNodesWithTag(ReaderSemanticMatchers.TAG_ERROR_STATE)
+                    .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.assertNoErrorState()
+        composeTestRule.waitUntil(timeoutMillis = 15_000) {
+            findContinuousReader()?.isFirstLoadComplete?.value == true
+        }
+        val reader = requireNotNull(findContinuousReader()) { "continuous reader view was not mounted" }
+        dismissUpdateDialogIfPresent()
+
+        // Navigate to start of ch07 — immediately past the pt02 short-title boundary.
+        composeTestRule.activityRule.scenario.onActivity {
+            reader.navigateTo("OEBPS/ch07.html", progression = 0f, alignToTop = true)
+        }
+        composeTestRule.waitUntil(timeoutMillis = 20_000) {
+            isReaderInChapter(reader, "ch07.html")
+        }
+        composeTestRule.waitForIdle()
+        Thread.sleep(2_600) // let fallback flush pendingInitialScroll
+
+        // Dispatch a single backward swipe. The scroll crosses the ch07 top → triggers a backward
+        // prepend (either pt02 or ch06). After the gesture completes, boundaryDetentArmed must be
+        // true so the floor remains at the real chapter height until the next ACTION_DOWN.
+        dispatchSwipe(reader, forward = false)
+        composeTestRule.waitForIdle()
+        Thread.sleep(500) // give onHeightMeasured time to run and set prependAwaitingMeasure=false
+
+        var detentArmed = false
+        composeTestRule.activityRule.scenario.onActivity { detentArmed = reader.isBoundaryDetentArmed }
+        assertTrue(
+            "isBoundaryDetentArmed must be true after a backward prepend so the scroll floor " +
+                "remains at the real chapter height after measurement; without this the floor drops " +
+                "to 0 and any in-flight gesture carries the user past the boundary (abrupt jump)",
+            detentArmed,
+        )
+    }
+
+    @Test
+    fun scrollsAcrossBothLongChapterShortPartTitleBoundaries() {
+        addServerAndBrowseLibrary()
+        composeTestRule.waitUntil(timeoutMillis = 15_000) {
+            composeTestRule.onAllNodesWithText(StubAbsServer.TEST_STANDALONE_ITEM_TITLE)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(StubAbsServer.TEST_STANDALONE_ITEM_TITLE).performClick()
+        composeTestRule.tapReadInDetailScreen()
+        composeTestRule.waitUntil(timeoutMillis = 20_000) {
+            composeTestRule.onAllNodesWithTag(ReaderSemanticMatchers.TAG_READER_READY)
+                .fetchSemanticsNodes().isNotEmpty() ||
+                composeTestRule.onAllNodesWithTag(ReaderSemanticMatchers.TAG_ERROR_STATE)
+                    .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.assertNoErrorState()
+
+        // The synthetic publication begins at ch05 so reaching ch07 first forces the sliding
+        // window to evict ch06 and leave pt02 as the top buffer — the exact oscillation state.
+        // TOC navigation is a separate path and would mask this regression.
+        // At scrollY=0 NestedScrollView does not emit an onScrollChanged callback, so the public
+        // locator semantics are intentionally still empty here; wait on the real view's initial
+        // WebView measurement barrier instead.
+        composeTestRule.waitUntil(timeoutMillis = 15_000) {
+            findContinuousReader()?.isFirstLoadComplete?.value == true
+        }
+        val reader = requireNotNull(findContinuousReader()) {
+            "continuous reader view was not mounted"
+        }
+
+        dismissUpdateDialogIfPresent()
+        swipeFromNearEndInto(reader, fromHref = "OEBPS/ch06.html", toHref = "ch07.html")
+        swipeBackwardFromStartInto(reader, fromHref = "OEBPS/ch07.html", toHref = "ch06.html")
+        assertReaderViewportRendered(reader, "ch06.html")
+        flingBackwardLandsAtBoundary(
+            reader,
+            fromHref = "OEBPS/ch11.html",
+            prevHref = "ch10.html",
+            boundaryHref = "pt03.html",
+        )
+        swipeFromNearEndInto(reader, fromHref = "OEBPS/ch10.html", toHref = "ch11.html")
+        swipeBackwardFromStartInto(reader, fromHref = "OEBPS/ch11.html", toHref = "ch10.html")
+        assertReaderViewportRendered(reader, "ch10.html")
+        flingBackwardOverLoadedChapterStopsNearBoundary(reader)
+    }
+
+    /**
+     * Scenario A of the 2026-08-05 field repro: the previous chapter is ALREADY in the window
+     * (behind buffer / earlier crossing) so a backward fling triggers no prepend — none of the
+     * prepend gates apply — and an unconstrained ballistic fling teleported the reader ~4
+     * viewports deep into it. The backward-fling floor must cap the landing at one page past
+     * the folded pt03 boundary.
+     */
+    private fun flingBackwardOverLoadedChapterStopsNearBoundary(reader: ContinuousReaderView) {
+        composeTestRule.activityRule.scenario.onActivity {
+            reader.navigateTo("OEBPS/ch11.html", progression = 0f, alignToTop = true)
+        }
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            isReaderInChapter(reader, "ch11.html")
+        }
+        // ch10 must already be loaded and measured — that is the premise of this scenario.
+        var ch10Height = 0
+        composeTestRule.activityRule.scenario.onActivity {
+            ch10Height = loadedWebViews(reader)
+                .firstOrNull { it.url?.endsWith("ch10.html") == true }?.height ?: 0
+        }
+        assertTrue("premise broken: ch10 not loaded/measured before the fling", ch10Height > 10_000)
+        dispatchFlingSwipeBackward(reader)
+        composeTestRule.waitForIdle()
+        Thread.sleep(1_500)
+        var boundaryTop = -1
+        var scrollYNow = -1
+        var viewportH = 0
+        composeTestRule.activityRule.scenario.onActivity {
+            boundaryTop = loadedWebViews(reader)
+                .firstOrNull { it.url?.endsWith("pt03.html") == true }?.top ?: -1
+            scrollYNow = reader.scrollY
+            viewportH = reader.height
+        }
+        assertTrue("pt03 missing from window after fling", boundaryTop >= 0)
+        val overshoot = boundaryTop - scrollYNow
+        assertTrue(
+            "no-prepend backward fling overshot the pt03 boundary by $overshoot px " +
+                "(scrollY=$scrollYNow, boundaryTop=$boundaryTop, viewport=$viewportH) — " +
+                "the backward-fling floor must cap crossing flings at one page past the boundary",
+            overshoot <= viewportH,
+        )
+    }
+
+    private fun findContinuousReader(): ContinuousReaderView? {
+        var result: ContinuousReaderView? = null
+        composeTestRule.activityRule.scenario.onActivity { activity ->
+            fun walk(view: View) {
+                if (view is ContinuousReaderView) result = view
+                if (view is ViewGroup) {
+                    for (index in 0 until view.childCount) walk(view.getChildAt(index))
+                }
+            }
+            walk(activity.window.decorView)
+        }
+        return result
+    }
+
+    private fun loadedWebViews(reader: ContinuousReaderView): List<WebView> {
+        val container = reader.getChildAt(0) as? ViewGroup ?: return emptyList()
+        return (0 until container.childCount).mapNotNull { container.getChildAt(it) as? WebView }
+    }
+
+    private fun loadedChapterHrefs(reader: ContinuousReaderView): List<String> {
+        var result = emptyList<String>()
+        composeTestRule.activityRule.scenario.onActivity {
+            result = loadedWebViews(reader).mapNotNull { view ->
+                view.url?.substringAfter("https://readium_package/")
+            }
+        }
+        return result
+    }
+
+    private fun swipeFromNearEndInto(
+        reader: ContinuousReaderView,
+        fromHref: String,
+        toHref: String,
+    ) {
+        composeTestRule.activityRule.scenario.onActivity {
+            reader.navigateTo(fromHref, progression = 0.9f, alignToTop = true)
+        }
+        composeTestRule.waitUntil(timeoutMillis = 20_000) {
+            loadedChapterHrefs(reader).any { it.endsWith(fromHref) }
+        }
+        // Wait for the navigation itself to LAND before swiping: when the target chapter is
+        // already in the window the posted landing can run seconds later (main thread busy with
+        // measures), and if the reader incidentally already satisfies the destination check the
+        // swipe loop exits instantly — the late nav landing then legitimately moves the reader
+        // during the settle assertions and the leg fails as a phantom "yank".
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            isReaderInChapter(reader, fromHref)
+        }
+        for (attempt in 0 until 80) {
+            if (isReaderInChapter(reader, toHref)) break
+            dispatchSwipeUp(reader)
+            composeTestRule.waitForIdle()
+            Thread.sleep(100)
+        }
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            isReaderInChapter(reader, toHref)
+        }
+        repeat(8) {
+            composeTestRule.waitForIdle()
+            Thread.sleep(100)
+        }
+        if (!isReaderInChapter(reader, toHref)) {
+            var diag = ""
+            composeTestRule.activityRule.scenario.onActivity {
+                diag = loadedWebViews(reader).joinToString(prefix = "[", postfix = "]") {
+                    "${it.url?.substringAfterLast('/')}:h=${it.height}:top=${it.top}"
+                } + " scrollY=${reader.scrollY} vh=${reader.height}"
+            }
+            org.junit.Assert.fail("expected $toHref to remain reachable; window=$diag")
+        }
+    }
+
+    private fun swipeBackwardFromStartInto(
+        reader: ContinuousReaderView,
+        fromHref: String,
+        toHref: String,
+    ) {
+        composeTestRule.activityRule.scenario.onActivity {
+            reader.navigateTo(fromHref, progression = 0f, alignToTop = true)
+        }
+        composeTestRule.waitUntil(timeoutMillis = 20_000) {
+            loadedChapterHrefs(reader).any { it.endsWith(fromHref) }
+        }
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            isReaderInChapter(reader, fromHref)
+        }
+        for (attempt in 0 until 40) {
+            if (isReaderInChapter(reader, toHref)) break
+            dispatchSwipe(reader, forward = false)
+            composeTestRule.waitForIdle()
+            Thread.sleep(100)
+        }
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            isReaderInChapter(reader, toHref)
+        }
+        composeTestRule.waitForIdle()
+        assertFalse(
+            "one backward gesture must be consumed by one prepend; leaving it latched lets " +
+                "scroll compensation prepend every earlier resource until the screen is blank",
+            reader.hasPendingBackwardNavigationIntent,
+        )
+    }
+
+    /**
+     * Regression for the 2026-08-03 field repro (ch07 → ch06 in "Taking Charge of ADHD"): a
+     * backward FLING — not a slow drag — from the top of a chapter must land adjacent to the
+     * part-title boundary. On a device each MotionEvent is its own main-loop message, so the
+     * backward prepend fires MID-drag; NestedScrollView then still starts a ballistic fling from
+     * the release velocity at ACTION_UP, whose scroller deltas compose with the prepend's scroll
+     * compensation and carry the reader thousands of px past the boundary into the freshly
+     * revealed chapter. [ContinuousReaderView.fling] swallows that gesture's release fling.
+     * The gesture must be dispatched event-by-event ([dispatchFlingSwipeBackward]) — an atomic
+     * one-block dispatch defers the posted prepend until after ACTION_UP and never exercises the
+     * mid-gesture interleaving the fix targets.
+     */
+    private fun flingBackwardLandsAtBoundary(
+        reader: ContinuousReaderView,
+        fromHref: String,
+        prevHref: String,
+        boundaryHref: String,
+    ) {
+        composeTestRule.activityRule.scenario.onActivity {
+            reader.navigateTo(fromHref, progression = 0f, alignToTop = true)
+        }
+        composeTestRule.waitUntil(timeoutMillis = 20_000) {
+            loadedChapterHrefs(reader).any { it.endsWith(fromHref) }
+        }
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            isReaderInChapter(reader, fromHref)
+        }
+        // Let the rebuild's initial-scroll land fully: while pendingInitialScroll is set the
+        // controller ignores every shift decision (including the one this gesture triggers), so
+        // under machine load the prepend silently never fires and the leg flakes. The fallback
+        // fires at 2.5 s; wait just past it.
+        composeTestRule.waitForIdle()
+        Thread.sleep(2_600)
+        dispatchFlingSwipeBackward(reader)
+        // The prepended previous chapter must load AND measure past its screen-sized placeholder
+        // before the landing position is meaningful. Polled manually so a timeout can report the
+        // full window state instead of an opaque ComposeTimeoutException.
+        val measureDeadline = android.os.SystemClock.uptimeMillis() + 20_000
+        var prevMeasured = false
+        while (!prevMeasured && android.os.SystemClock.uptimeMillis() < measureDeadline) {
+            composeTestRule.waitForIdle()
+            composeTestRule.activityRule.scenario.onActivity {
+                prevMeasured = loadedWebViews(reader).any { wv ->
+                    wv.url?.endsWith(prevHref) == true && wv.height > reader.height * 3
+                }
+            }
+            if (!prevMeasured) Thread.sleep(200)
+        }
+        if (!prevMeasured) {
+            var diag = ""
+            composeTestRule.activityRule.scenario.onActivity {
+                diag = loadedWebViews(reader).joinToString(prefix = "[", postfix = "]") {
+                    "${it.url?.substringAfterLast('/')}:h=${it.height}:top=${it.top}"
+                } + " scrollY=${reader.scrollY} vh=${reader.height} " +
+                    "intent=${reader.hasPendingBackwardNavigationIntent}"
+            }
+            org.junit.Assert.fail("prepended $prevHref never measured after backward fling; window=$diag")
+        }
+        composeTestRule.waitForIdle()
+        Thread.sleep(1_000) // let any surviving scroller frames play out — that IS the regression
+        var boundaryTop = -1
+        var scrollYNow = -1
+        var viewportH = 0
+        composeTestRule.activityRule.scenario.onActivity {
+            boundaryTop = loadedWebViews(reader)
+                .firstOrNull { it.url?.endsWith(boundaryHref) == true }?.top ?: -1
+            scrollYNow = reader.scrollY
+            viewportH = reader.height
+        }
+        assertTrue("boundary resource $boundaryHref not in window after backward fling", boundaryTop >= 0)
+        val overshoot = boundaryTop - scrollYNow
+        assertTrue(
+            "backward fling overshot the $boundaryHref boundary by $overshoot px " +
+                "(scrollY=$scrollYNow, boundaryTop=$boundaryTop, viewport=$viewportH) — " +
+                "a crossing fling must land at most one page past the boundary (swallowed " +
+                "release fling after a mid-gesture prepend, or the backward-fling floor)",
+            overshoot <= viewportH,
+        )
+    }
+
+    private fun isReaderInChapter(reader: ContinuousReaderView, href: String): Boolean {
+        var currentHref: String? = null
+        composeTestRule.activityRule.scenario.onActivity {
+            val midpoint = reader.scrollY + reader.height / 2
+            currentHref = loadedWebViews(reader)
+                .firstOrNull { midpoint >= it.top && midpoint < it.bottom }
+                ?.url
+                ?.substringAfter("https://readium_package/")
+        }
+        return currentHref?.endsWith(href) == true
+    }
+
+    private fun assertReaderViewportRendered(reader: ContinuousReaderView, href: String) {
+        composeTestRule.waitForIdle()
+        Thread.sleep(1_500)
+        val screen = captureWindowToBitmap(composeTestRule.activity.window)
+        val location = IntArray(2)
+        composeTestRule.activityRule.scenario.onActivity { reader.getLocationOnScreen(location) }
+        val xStart = location[0].coerceAtLeast(0)
+        val xEnd = (location[0] + reader.width).coerceAtMost(screen.width)
+        val yStart = (location[1] + reader.height * 0.1f).toInt().coerceAtLeast(0)
+        val yEnd = (location[1] + reader.height * 0.85f).toInt().coerceAtMost(screen.height)
+        var inkPixels = 0
+        for (y in yStart until yEnd step 2) {
+            for (x in xStart until xEnd step 2) {
+                val pixel = screen.getPixel(x, y)
+                val red = (pixel shr 16) and 0xFF
+                val green = (pixel shr 8) and 0xFF
+                val blue = pixel and 0xFF
+                if (red + green + blue < 540) inkPixels++
+            }
+        }
+        assertTrue(
+            "expected rendered text after navigating backward into $href; " +
+                "only $inkPixels sampled ink pixels were visible",
+            inkPixels >= 500,
+        )
+    }
+
+    private fun captureWindowToBitmap(window: Window): Bitmap {
+        val decor = window.decorView
+        val viewRoot = decor.parent
+        val surfaceField = viewRoot.javaClass.getDeclaredField("mSurface").apply { isAccessible = true }
+        val surface = surfaceField.get(viewRoot) as Surface
+        val bitmap = Bitmap.createBitmap(decor.width, decor.height, Bitmap.Config.ARGB_8888)
+        val latch = CountDownLatch(1)
+        val result = intArrayOf(-1)
+        val handlerThread = android.os.HandlerThread("ContinuousBoundaryPixelCopy").apply { start() }
+        try {
+            PixelCopy.request(
+                surface,
+                bitmap,
+                { code ->
+                    result[0] = code
+                    latch.countDown()
+                },
+                Handler(handlerThread.looper),
+            )
+            assertTrue("PixelCopy timed out", latch.await(5, TimeUnit.SECONDS))
+            assertEquals("PixelCopy result was not SUCCESS", PixelCopy.SUCCESS, result[0])
+        } finally {
+            handlerThread.quitSafely()
+        }
+        return bitmap
+    }
+
+    private fun dispatchSwipeUp(reader: ContinuousReaderView) =
+        dispatchSwipe(reader, forward = true)
+
+    private fun dispatchSwipe(reader: ContinuousReaderView, forward: Boolean) {
+        composeTestRule.activityRule.scenario.onActivity {
+            val downTime = android.os.SystemClock.uptimeMillis()
+            val x = reader.width / 2f
+            val startY = reader.height * if (forward) 0.8f else 0.2f
+            // A slow pull is enough to reveal a previous chapter at the scrollY=0 clamp and
+            // avoids turning the regression assertion into a high-velocity fling test.
+            val endY = reader.height * if (forward) 0.2f else 0.4f
+            val stepMs = if (forward) 16L else 50L
+            fun dispatch(action: Int, y: Float, offsetMs: Long) {
+                MotionEvent.obtain(downTime, downTime + offsetMs, action, x, y, 0).also { event ->
+                    reader.dispatchTouchEvent(event)
+                    event.recycle()
+                }
+            }
+            dispatch(MotionEvent.ACTION_DOWN, startY, 0)
+            repeat(8) { index ->
+                val fraction = (index + 1) / 8f
+                dispatch(
+                    MotionEvent.ACTION_MOVE,
+                    startY + (endY - startY) * fraction,
+                    (index + 1) * stepMs,
+                )
+            }
+            dispatch(MotionEvent.ACTION_UP, endY, 10 * stepMs)
+        }
+    }
+
+    /**
+     * Dispatch a fast backward swipe with each MotionEvent in its own main-thread message,
+     * mirroring real device input: posted work (the window-shift decision) interleaves with the
+     * gesture, so the backward prepend fires MID-drag and ACTION_UP's release fling exercises
+     * [ContinuousReaderView.fling]'s swallow path. Timestamps advance 8 ms per move for a
+     * high release velocity regardless of wall-clock sleeps.
+     */
+    private fun dispatchFlingSwipeBackward(reader: ContinuousReaderView) {
+        var width = 0
+        var height = 0
+        composeTestRule.activityRule.scenario.onActivity {
+            width = reader.width
+            height = reader.height
+        }
+        val downTime = android.os.SystemClock.uptimeMillis()
+        val x = width / 2f
+        val startY = height * 0.2f
+        val endY = height * 0.85f
+        fun send(action: Int, y: Float, offsetMs: Long) {
+            composeTestRule.activityRule.scenario.onActivity {
+                MotionEvent.obtain(downTime, downTime + offsetMs, action, x, y, 0).also { event ->
+                    reader.dispatchTouchEvent(event)
+                    event.recycle()
+                }
+            }
+        }
+        send(MotionEvent.ACTION_DOWN, startY, 0)
+        repeat(8) { index ->
+            Thread.sleep(8)
+            send(MotionEvent.ACTION_MOVE, startY + (endY - startY) * (index + 1) / 8f, (index + 1) * 8L)
+        }
+        Thread.sleep(8)
+        send(MotionEvent.ACTION_UP, endY, 9 * 8L)
+    }
+
+    private fun dismissUpdateDialogIfPresent() {
+        val later = composeTestRule.onAllNodesWithText("Later")
+        if (later.fetchSemanticsNodes().isNotEmpty()) {
+            composeTestRule.onNodeWithText("Later").performClick()
+            composeTestRule.waitForIdle()
+        }
+    }
+
+    private fun addServerAndBrowseLibrary() {
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Audiobookshelf").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Audiobookshelf").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Connect").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNode(hasSetTextAction() and hasText("Source URL"))
+            .performTextReplacement(stubServer.baseUrl)
+        composeTestRule.onNode(hasSetTextAction() and hasText("Username"))
+            .performTextReplacement("testuser")
+        composeTestRule.onNode(hasSetTextAction() and hasText("Password"))
+            .performTextReplacement("testpass")
+        composeTestRule.onNodeWithText("Connect").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 15_000) {
+            composeTestRule.onAllNodesWithText("Connect anyway").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Connect anyway").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 10_000) {
+            composeTestRule.onAllNodesWithContentDescription("All Books")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithContentDescription("All Books").performClick()
+    }
+
+    private fun boundaryEpub(): ByteArray {
+        val spine = listOf(
+            "ch05.html",
+            "ch06.html",
+            "pt02.html",
+            "ch07.html",
+            "ch08.html",
+            "ch09.html",
+            "ch10.html",
+            "pt03.html",
+            "ch11.html",
+            "ch12.html",
+        )
+        val output = ByteArrayOutputStream()
+        ZipOutputStream(output).use { zip ->
+            val mimeBytes = "application/epub+zip".toByteArray()
+            val mimeCrc = CRC32().apply { update(mimeBytes) }
+            zip.putNextEntry(
+                ZipEntry("mimetype").apply {
+                    method = ZipEntry.STORED
+                    size = mimeBytes.size.toLong()
+                    compressedSize = mimeBytes.size.toLong()
+                    crc = mimeCrc.value
+                },
+            )
+            zip.write(mimeBytes)
+            zip.closeEntry()
+
+            zip.writeEntry(
+                "META-INF/container.xml",
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+                  <rootfiles>
+                    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+                  </rootfiles>
+                </container>
+                """.trimIndent(),
+            )
+            zip.writeEntry(
+                "OEBPS/content.opf",
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+                  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                    <dc:identifier id="uid">continuous-short-divider-regression</dc:identifier>
+                    <dc:title>Continuous Boundary Regression</dc:title>
+                    <dc:creator>Riffle Tests</dc:creator>
+                    <dc:language>en</dc:language>
+                    <meta property="dcterms:modified">2026-07-29T00:00:00Z</meta>
+                  </metadata>
+                  <manifest>
+                    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+                    ${spine.mapIndexed { index, href ->
+                        """<item id="s$index" href="$href" media-type="application/xhtml+xml"/>"""
+                    }.joinToString("\n    ")}
+                  </manifest>
+                  <spine>
+                    ${spine.indices.joinToString("\n    ") { """<itemref idref="s$it"/>""" }}
+                  </spine>
+                </package>
+                """.trimIndent(),
+            )
+            zip.writeEntry(
+                "OEBPS/nav.xhtml",
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <html xmlns="http://www.w3.org/1999/xhtml">
+                  <head><title>Contents</title></head>
+                  <body><nav epub:type="toc" xmlns:epub="http://www.idpf.org/2007/ops">
+                    <ol>
+                      ${spine.joinToString("\n      ") { """<li><a href="$it">$it</a></li>""" }}
+                    </ol>
+                  </nav></body>
+                </html>
+                """.trimIndent(),
+            )
+            spine.forEach { href ->
+                val isPartTitle = href.startsWith("pt")
+                val number = href.substring(2, 4).toInt()
+                val title = if (isPartTitle) "Part $number" else "Chapter $number"
+                val body = if (isPartTitle) {
+                    "<h1>$title</h1>"
+                } else {
+                    buildString {
+                        append("<h1>$title</h1>")
+                        repeat(180) { paragraph ->
+                            append("<p>$title regression paragraph $paragraph. ")
+                            append(
+                                "Long chapter content keeps the neighbouring part title far " +
+                                    "shorter than one viewport.</p>",
+                            )
+                        }
+                    }
+                }
+                zip.writeEntry(
+                    "OEBPS/$href",
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <html xmlns="http://www.w3.org/1999/xhtml">
+                      <head><title>$title</title></head>
+                      <body>$body</body>
+                    </html>
+                    """.trimIndent(),
+                )
+            }
+        }
+        return output.toByteArray()
+    }
+
+    private fun ZipOutputStream.writeEntry(path: String, contents: String) {
+        putNextEntry(ZipEntry(path))
+        write(contents.trimStart().toByteArray())
+        closeEntry()
+    }
+}

--- a/app/src/androidTest/kotlin/com/riffle/app/harness/StubAbsServer.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/harness/StubAbsServer.kt
@@ -16,7 +16,9 @@ import okhttp3.mockwebserver.RecordedRequest
  *    section of the library items screen and is used for the direct-open EPUB test.
  *  - TEST_PDF_ITEM (item-test-3): a PDF item used for the PDF reader harness test.
  */
-class StubAbsServer {
+class StubAbsServer(
+    private val epubBytesProvider: (() -> ByteArray)? = null,
+) {
 
     companion object {
         const val TEST_USER_ID = "test-user-id"
@@ -126,7 +128,8 @@ class StubAbsServer {
 
     private fun epubFileResponse(): MockResponse {
         val context = InstrumentationRegistry.getInstrumentation().context
-        val bytes = context.assets.open("test.epub").use { it.readBytes() }
+        val bytes = epubBytesProvider?.invoke()
+            ?: context.assets.open("test.epub").use { it.readBytes() }
         return MockResponse()
             .setResponseCode(200)
             .addHeader("Content-Type", "application/epub+zip")

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWebView.kt
@@ -206,6 +206,15 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
      */
     private var loadToken = 0
 
+    /**
+     * URL owned by the current [loadChapter] call. A pooled WebView is first navigated to
+     * `about:blank` to release the previous chapter's DOM and tiles. Chromium can deliver that
+     * navigation's delayed `onPageFinished` after the view has already been rebound to a new
+     * chapter, so the callback must be checked against this URL before it is allowed to inject or
+     * measure anything.
+     */
+    private var expectedChapterUrl: String? = null
+
     /** Must be called before [loadChapter] so [shouldInterceptRequest] can serve EPUB resources. */
     fun setPublication(pub: Publication) {
         publication = pub
@@ -276,6 +285,7 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
         }
         webViewClient = object : WebViewClient() {
             override fun onPageFinished(view: WebView?, url: String?) {
+                if (!isCurrentChapterPage(url, expectedChapterUrl)) return
                 this@ChapterWebView.onPageFinished?.invoke()
                 // Body-font probe (issue #484): read the value the SELECTION_SPAN_TRACKER_JS
                 // installer stashed on `window.__riffleBookBodyFont` and route to the VM via
@@ -415,8 +425,28 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
      * thread immediately after) can inject the CSS directly into the HTML bytes, eliminating the
      * flash of unstyled content that occurs when styles are injected via JS after page load.
      */
+    /**
+     * Invoke [callback] once this WebView's current DOM has actually been DRAWN on screen
+     * (Chromium visual-state callback). Measurement (layout height) completes long before
+     * rasterization on large chapters — scrolling into a measured-but-unpainted region shows
+     * solid white for seconds on slow GPUs. Guarded by [loadToken] so a stale callback from a
+     * recycled view's previous page can't fire for the new chapter.
+     */
+    fun onCurrentContentPainted(callback: () -> Unit) {
+        val token = loadToken
+        postVisualStateCallback(
+            token.toLong(),
+            object : WebView.VisualStateCallback() {
+                override fun onComplete(requestId: Long) {
+                    if (requestId == token.toLong() && token == loadToken) callback()
+                }
+            },
+        )
+    }
+
     fun loadChapter(href: String, chapterUrl: String, prefs: FormattingPreferences) {
         chapterHref = href
+        expectedChapterUrl = chapterUrl
         currentPrefs = prefs
         rawChapterHtml = null
         footnoteDoc = null
@@ -804,6 +834,13 @@ internal class ChapterWebView(context: Context) : WebView(context), ChapterWebVi
         }
     }
 }
+
+/**
+ * Whether a WebView completion belongs to the chapter currently assigned to that view.
+ * Kept pure so the recycled-`about:blank` race is pinned by a JVM regression test.
+ */
+internal fun isCurrentChapterPage(callbackUrl: String?, expectedChapterUrl: String?): Boolean =
+    callbackUrl != null && callbackUrl == expectedChapterUrl
 
 /**
  * Computes the clamped (top, bottom) for a selection content rect so that, when forwarded to the

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWindowManager.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWindowManager.kt
@@ -29,6 +29,23 @@ internal class ChapterWindowManager(chaptersBehind: Int) {
         data object Hold : Decision()
         data object ShiftForward : Decision()
         data object ShiftBackward : Decision()
+
+        /**
+         * Grow the loaded window by appending the next chapter WITHOUT dropping the top. Fires when
+         * every currently-loaded chapter fits inside a single viewport and more chapters remain in
+         * the spine — the field-observed case is opening a book whose front-matter is several tiny
+         * files (e.g. "Praise for…" 2 KB + "Selected Works From…" 1 KB + "Title" 0.6 KB). All three
+         * fit on-screen at once, so [ShiftForward] never triggers (midpoint can't advance past the
+         * top budget, and `scrollY + viewportHeight >= loadedContentBottom` is true only because
+         * everything is visible — the ShiftForward path deliberately excludes this case to avoid
+         * cascading past the user's opened position). The result: scroll dead-ends with no more
+         * book, even though the next chapter exists.
+         *
+         * Unlike ShiftForward, this decision doesn't advance [topIndex] so the user can still scroll
+         * back to the chapters they opened at. Bounded by [appendOnlyMaxWindow] in [decide] to
+         * prevent a pathological all-short-chapters book from loading the whole spine at open.
+         */
+        data object AppendOnly : Decision()
     }
 
     /**
@@ -66,6 +83,7 @@ internal class ChapterWindowManager(chaptersBehind: Int) {
         topIndex: Int,
         totalChapters: Int,
         viewportHeight: Int = 0,
+        appendOnlyMaxWindow: Int = 0,
     ): Decision {
         if (window.isEmpty()) return Decision.Hold
 
@@ -75,10 +93,6 @@ internal class ChapterWindowManager(chaptersBehind: Int) {
         val skipBackward = justShiftedForward
         justShiftedForward = false
 
-        val shouldShiftBackward = !skipBackward
-            && scrollY < firstChapterHeight / 2
-            && topIndex > 0
-
         // Bottom-of-window signal: scroll is clamped at the end of the loaded content. Callers
         // that don't pass `viewportHeight` (default 0) get `false` here — the midpoint trigger
         // then governs alone, preserving prior behavior for tests and any legacy call sites.
@@ -86,11 +100,22 @@ internal class ChapterWindowManager(chaptersBehind: Int) {
         // Guard: the loaded window must EXCEED the viewport for "bottom" to mean the user
         // scrolled to reach it. When all loaded chapters fit in one viewport (`loadedContentBottom
         // <= viewportHeight`), scrollY is pinned at 0 and the bottom is visible without any scroll
-        // — firing here would auto-cascade forward shifts on the very first `decide` after open,
-        // dragging the user past the chapter they opened at and blocking backward nav. This
-        // regressed the initial fix (2026-07-21 log: window jumped [ch5,ch6,ch7]→[ch8,ch9,ch10]
-        // in ~1 s with no user scroll input).
+        // — firing ShiftForward here would auto-cascade forward shifts on the very first `decide`
+        // after open, dragging the user past the chapter they opened at and blocking backward nav
+        // (regressed the initial fix on 2026-07-21). The AppendOnly branch below handles the
+        // fits-in-viewport case safely by growing the window without dropping the top.
         val loadedContentBottom = window.last().let { it.top + it.height }
+        val fitsInViewport = viewportHeight > 0 && loadedContentBottom <= viewportHeight
+
+        // Suppress backward shift when entire loaded content fits in one viewport. In that state
+        // scrollY is pinned at 0 regardless of the user's intent — triggering ShiftBackward on
+        // `scrollY < firstChapterHeight/2` is a false positive that removes the trailing chapter
+        // and prepends behind content, then leaves the window still sub-viewport with no further
+        // trigger to fire AppendOnly (no scroll events fire when maxScrollY==0).
+        val shouldShiftBackward = !skipBackward
+            && scrollY < firstChapterHeight / 2
+            && topIndex > 0
+            && !fitsInViewport
         val atBottomOfLoadedWindow = viewportHeight > 0 &&
             loadedContentBottom > viewportHeight &&
             scrollY + viewportHeight >= loadedContentBottom
@@ -104,12 +129,23 @@ internal class ChapterWindowManager(chaptersBehind: Int) {
             atBottomOfLoadedWindow = atBottomOfLoadedWindow,
         )
 
+        val moreChaptersExist = topIndex + window.size < totalChapters
+        // AppendOnly is opt-in via [appendOnlyMaxWindow] > 0 so legacy call sites (all existing
+        // tests) preserve their prior Hold behavior. The cap prevents a pathological all-short-
+        // chapters book from loading the entire spine at open — the controller passes a small
+        // constant (~8) that comfortably covers real front-matter sequences but stops runaway.
+        val shouldAppendOnly = fitsInViewport &&
+            moreChaptersExist &&
+            appendOnlyMaxWindow > 0 &&
+            window.size < appendOnlyMaxWindow
+
         return when {
             shouldShiftBackward -> Decision.ShiftBackward
             shouldShiftForward -> {
                 justShiftedForward = true
                 Decision.ShiftForward
             }
+            shouldAppendOnly -> Decision.AppendOnly
             else -> Decision.Hold
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWindowManager.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWindowManager.kt
@@ -120,7 +120,16 @@ internal class ChapterWindowManager(chaptersBehind: Int) {
             loadedContentBottom > viewportHeight &&
             scrollY + viewportHeight >= loadedContentBottom
 
-        val shouldShiftForward = ContinuousPositionTracker.forwardShiftNeeded(
+        // Suppress forward shift when all loaded content fits in one viewport. When fitsInViewport
+        // is true, scrollY is pinned at 0 and the viewport midpoint lands arbitrarily deep in the
+        // loaded window — pastBehindBudget fires even though no actual reading progress has been
+        // made. ShiftForward would then remove the top chapter and cascade repeatedly, racing the
+        // window far past the opened position (e.g. from title page to intro/ch01) before the user
+        // touches anything. AppendOnly (lower priority) correctly handles the fits-in-viewport case
+        // by growing the window without dropping the top. Both conditions are mutually exclusive with
+        // loadedContentBottom > viewportHeight, so gating out ShiftForward here does not affect the
+        // atBottomOfLoadedWindow trigger path.
+        val shouldShiftForward = !fitsInViewport && ContinuousPositionTracker.forwardShiftNeeded(
             viewportChapterIndex = viewportChapterIndex,
             topIndex = topIndex,
             loadedChapterCount = window.size,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWindowManager.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWindowManager.kt
@@ -31,15 +31,22 @@ internal class ChapterWindowManager(chaptersBehind: Int) {
         data object ShiftBackward : Decision()
 
         /**
-         * Grow the loaded window by appending the next chapter WITHOUT dropping the top. Fires when
-         * every currently-loaded chapter fits inside a single viewport and more chapters remain in
-         * the spine — the field-observed case is opening a book whose front-matter is several tiny
-         * files (e.g. "Praise for…" 2 KB + "Selected Works From…" 1 KB + "Title" 0.6 KB). All three
-         * fit on-screen at once, so [ShiftForward] never triggers (midpoint can't advance past the
-         * top budget, and `scrollY + viewportHeight >= loadedContentBottom` is true only because
-         * everything is visible — the ShiftForward path deliberately excludes this case to avoid
-         * cascading past the user's opened position). The result: scroll dead-ends with no more
-         * book, even though the next chapter exists.
+         * Grow the loaded window by appending the next chapter WITHOUT dropping the top. Fires in
+         * two situations:
+         *
+         * 1. **Fits-in-viewport**: every currently-loaded chapter fits inside a single viewport.
+         *    Field case: front-matter with several tiny files ("Praise for…" 2 KB + "Selected
+         *    Works From…" 1 KB + "Title" 0.6 KB). All fit on-screen at once; ShiftForward never
+         *    triggers because scrollY is pinned at 0 so pastBehindBudget is a false positive.
+         *
+         * 2. **At-bottom, window not full**: the viewport bottom already touches or exceeds the
+         *    bottom of loaded content, but the window is under [appendOnlyMaxWindow]. Field case:
+         *    the book opens at a mid-spine chapter (e.g. title page) whose chapter + its neighbours
+         *    fit in or nearly fill the viewport, so after the initial scroll the user is immediately
+         *    at the bottom of loaded content. Without this path, ShiftForward fires, drops the top
+         *    chapter (fm02), and scroll compensation resets scrollY to 0 — which triggers
+         *    ShiftBackward, which prepends fm02 again and the cycle oscillates indefinitely.
+         *    AppendOnly extends forward without losing the opening chapter, breaking the loop.
          *
          * Unlike ShiftForward, this decision doesn't advance [topIndex] so the user can still scroll
          * back to the chapters they opened at. Bounded by [appendOnlyMaxWindow] in [decide] to
@@ -143,18 +150,29 @@ internal class ChapterWindowManager(chaptersBehind: Int) {
         // tests) preserve their prior Hold behavior. The cap prevents a pathological all-short-
         // chapters book from loading the entire spine at open — the controller passes a small
         // constant (~8) that comfortably covers real front-matter sequences but stops runaway.
-        val shouldAppendOnly = fitsInViewport &&
+        //
+        // Fires in two cases (see Decision.AppendOnly docstring):
+        // 1. fitsInViewport: all loaded content fits in one viewport (scrollY pinned at 0).
+        // 2. atBottomOfLoadedWindow: the viewport bottom already touches the end of loaded content
+        //    but the window is under its max size. ShiftForward here would drop the top chapter,
+        //    reset scrollY to 0, trigger ShiftBackward (which prepends the dropped chapter at
+        //    placeholder height), then overshoot the forward trigger again — an infinite oscillation.
+        //    AppendOnly breaks the loop by extending forward without losing the opening chapter.
+        val shouldAppendOnly = (fitsInViewport || atBottomOfLoadedWindow) &&
             moreChaptersExist &&
             appendOnlyMaxWindow > 0 &&
             window.size < appendOnlyMaxWindow
 
+        // AppendOnly takes priority over ShiftForward: when the window can still grow, extend it
+        // before evicting the top chapter. ShiftForward only fires once the window is full or
+        // neither fit-in-viewport nor at-bottom conditions apply.
         return when {
             shouldShiftBackward -> Decision.ShiftBackward
+            shouldAppendOnly -> Decision.AppendOnly
             shouldShiftForward -> {
                 justShiftedForward = true
                 Decision.ShiftForward
             }
-            shouldAppendOnly -> Decision.AppendOnly
             else -> Decision.Hold
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWindowManager.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ChapterWindowManager.kt
@@ -91,6 +91,8 @@ internal class ChapterWindowManager(chaptersBehind: Int) {
         totalChapters: Int,
         viewportHeight: Int = 0,
         appendOnlyMaxWindow: Int = 0,
+        backwardNavigationIntent: Boolean = false,
+        topChapterStillPlaceholder: Boolean = false,
     ): Decision {
         if (window.isEmpty()) return Decision.Hold
 
@@ -119,10 +121,25 @@ internal class ChapterWindowManager(chaptersBehind: Int) {
         // `scrollY < firstChapterHeight/2` is a false positive that removes the trailing chapter
         // and prepends behind content, then leaves the window still sub-viewport with no further
         // trigger to fire AppendOnly (no scroll events fire when maxScrollY==0).
+        // A short first resource can be smaller than half the viewport. In that geometry the
+        // viewport midpoint remains in the following chapter even at scrollY=0, so chapter
+        // indices cannot tell a genuine backward gesture from a forward-shift compensation.
+        // Require direction supplied by the controller: forward intent absorbs compensation,
+        // while backward intent can prepend even when the scroll view is pinned at zero.
+        // One unmeasured prepend at a time. A prepended chapter enters at a screen-sized blank
+        // placeholder; on a slow device a large real chapter takes seconds to load and measure.
+        // Each further backward pull during that window would prepend ANOTHER blank placeholder
+        // (its scrollY threshold is met inside the placeholder), and a few quick pulls replace
+        // every rendered chapter in the window with white placeholders — field-observed
+        // 2026-08-04 as a solid white screen at the ch11/Part III boundary. Holding here until
+        // the pending prepend measures keeps at most one blank screen above the reader; the
+        // measure's compensating scroll change re-runs the decision immediately after.
         val shouldShiftBackward = !skipBackward
             && scrollY < firstChapterHeight / 2
             && topIndex > 0
             && !fitsInViewport
+            && backwardNavigationIntent
+            && !topChapterStillPlaceholder
         val atBottomOfLoadedWindow = viewportHeight > 0 &&
             loadedContentBottom > viewportHeight &&
             scrollY + viewportHeight >= loadedContentBottom
@@ -136,7 +153,27 @@ internal class ChapterWindowManager(chaptersBehind: Int) {
         // by growing the window without dropping the top. Both conditions are mutually exclusive with
         // loadedContentBottom > viewportHeight, so gating out ShiftForward here does not affect the
         // atBottomOfLoadedWindow trigger path.
-        val shouldShiftForward = !fitsInViewport && ContinuousPositionTracker.forwardShiftNeeded(
+        // Geometric guard on top-chapter eviction. The behind budget counts CHAPTERS, but a
+        // sub-viewport part-title between the top chapter and the midpoint chapter makes the
+        // index gap overshoot while the reader is still geometrically at the top chapter's
+        // bottom edge. Right after a backward prepend the compensated scrollY equals exactly
+        // firstChapterHeight; evicting the top chapter then clamps scrollY back to ~0, which
+        // re-arms the backward trigger on the next gesture — an endless prepend/evict ping-pong
+        // the user sees as a growing blank region (the prepended chapter is evicted before its
+        // placeholder ever renders). Eviction is only legal when it leaves at least half a
+        // viewport of scrollback behind the reader. Callers that don't pass viewportHeight
+        // (legacy tests) keep the pure index-based behavior.
+        //
+        // The atBottomOfLoadedWindow trigger is exempt: at the bottom clamp the reader is
+        // wedged against the end of loaded content and eviction is the only way to progress
+        // (see the short-trailing-chapter wall-off tests) — and that state is geometrically
+        // disjoint from the post-prepend state this guard protects (right after a prepend the
+        // viewport sits near the TOP of the loaded window, viewports away from the bottom clamp).
+        val evictionLeavesScrollback = viewportHeight <= 0 ||
+            atBottomOfLoadedWindow ||
+            scrollY - firstChapterHeight >= viewportHeight / 2
+        val shouldShiftForward = !backwardNavigationIntent && evictionLeavesScrollback &&
+            !fitsInViewport && ContinuousPositionTracker.forwardShiftNeeded(
             viewportChapterIndex = viewportChapterIndex,
             topIndex = topIndex,
             loadedChapterCount = window.size,
@@ -147,21 +184,28 @@ internal class ChapterWindowManager(chaptersBehind: Int) {
 
         val moreChaptersExist = topIndex + window.size < totalChapters
         // AppendOnly is opt-in via [appendOnlyMaxWindow] > 0 so legacy call sites (all existing
-        // tests) preserve their prior Hold behavior. The cap prevents a pathological all-short-
-        // chapters book from loading the entire spine at open — the controller passes a small
-        // constant (~8) that comfortably covers real front-matter sequences but stops runaway.
+        // tests) preserve their prior Hold behavior.
         //
         // Fires in two cases (see Decision.AppendOnly docstring):
         // 1. fitsInViewport: all loaded content fits in one viewport (scrollY pinned at 0).
-        // 2. atBottomOfLoadedWindow: the viewport bottom already touches the end of loaded content
-        //    but the window is under its max size. ShiftForward here would drop the top chapter,
-        //    reset scrollY to 0, trigger ShiftBackward (which prepends the dropped chapter at
-        //    placeholder height), then overshoot the forward trigger again — an infinite oscillation.
-        //    AppendOnly breaks the loop by extending forward without losing the opening chapter.
-        val shouldAppendOnly = (fitsInViewport || atBottomOfLoadedWindow) &&
-            moreChaptersExist &&
+        //    The window-size cap does NOT apply here: when all content fits in one screen there
+        //    are no scroll events, so the only way to break the deadlock is to keep appending
+        //    chapters until content spills past the viewport and the user can scroll. The cap
+        //    is self-enforced naturally — AppendOnly stops as soon as fitsInViewport flips to
+        //    false. Without this bypass, a book where exactly [appendOnlyMaxWindow] short
+        //    front-matter chapters fit in one viewport would lock the reader: AppendOnly is
+        //    exhausted, ShiftForward is suppressed by fitsInViewport, no scroll events fire
+        //    at maxScrollY==0, and maybeShift never re-runs.
+        // 2. atBottomOfLoadedWindow: the viewport bottom already touches the end of loaded
+        //    content but the window is under its max size. ShiftForward here would drop the top
+        //    chapter, reset scrollY to 0, trigger ShiftBackward (which prepends the dropped
+        //    chapter at placeholder height), then overshoot the forward trigger again — an
+        //    infinite oscillation. AppendOnly breaks the loop by extending forward without losing
+        //    the opening chapter. The cap ([appendOnlyMaxWindow]) applies here because ShiftForward
+        //    is the correct action once the window is large enough.
+        val shouldAppendOnly = moreChaptersExist &&
             appendOnlyMaxWindow > 0 &&
-            window.size < appendOnlyMaxWindow
+            (fitsInViewport || (atBottomOfLoadedWindow && window.size < appendOnlyMaxWindow))
 
         // AppendOnly takes priority over ShiftForward: when the window can still grow, extend it
         // before evicting the top chapter. ShiftForward only fires once the window is full or

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
@@ -294,4 +294,62 @@ internal object ContinuousPositionTracker {
         val totalChapters = minOf(windowSize, allChaptersSize - topIndex)
         return InitialWindow(topIndex = topIndex, totalChapters = totalChapters, targetWindowIndex = behind)
     }
+
+    /**
+     * Scroll floor while a backward prepend is still an unmeasured placeholder: the placeholder's
+     * bottom edge (its height, since the prepend always occupies slot 0 at top=0). Scrolling into
+     * the blank placeholder maps those pixels to unseen content once the real height lands —
+     * perceived as an abrupt jump deep into the previous chapter (field repro 2026-08-05). The
+     * reader holds at the boundary until the chapter measures; 0 (no floor) otherwise.
+     */
+    fun backwardPrependScrollFloor(topSlotStillPlaceholder: Boolean, topSlotHeightPx: Int): Int =
+        if (topSlotStillPlaceholder) topSlotHeightPx else 0
+
+    /**
+     * Lowest scrollY a BACKWARD fling starting at [scrollYStart] may reach: one page (90% of
+     * [viewportHeightPx]) above the chapter boundary directly above the fling's starting
+     * chapter, with sub-half-viewport resources (part titles) folded into that boundary.
+     *
+     * A ballistic fling travels several viewports; unconstrained, one crossing a chapter
+     * boundary teleports the reader deep into the previous chapter — through content that is
+     * often not even rasterized yet (field repro 2026-08-05: one fling from the Part II page
+     * landed 4 viewports into ch06 on solid white). Capping the landing at one page past the
+     * boundary shows exactly the previous chapter's tail; the next gesture reads on normally.
+     * Flings that never reach their chapter's top are unaffected (the floor lies above their
+     * ballistic target only when a crossing would occur). Returns 0 (no constraint) when the
+     * start position is in the window's first slot.
+     */
+    fun backwardFlingFloor(
+        scrollYStart: Int,
+        window: List<ChapterSlot>,
+        viewportHeightPx: Int,
+    ): Int {
+        if (window.isEmpty() || viewportHeightPx <= 0) return 0
+        // Anchor on the viewport MIDPOINT, matching locatorAt's perception model. The viewport
+        // top routinely sits a few hundred px inside the previous chapter's slot while the user
+        // is already reading the next one (e.g. a nav smooth-scroll still settling); anchoring
+        // on the top would resolve to the window's first slot and silently return no floor.
+        val midpoint = scrollYStart + viewportHeightPx / 2
+        var containing = window.indexOfLast { it.top <= midpoint }
+        if (containing < 0) containing = 0
+        // Fold tiny divider resources (shorter than half a viewport) into the boundary: the
+        // boundary the reader perceives is the bottom of the previous SUBSTANTIAL chapter.
+        // The fold is CAPPED at half a viewport of cumulative height: back matter is often a
+        // RUN of tiny resources (about-the-author, publisher page, promo pages — field repro
+        // 2026-08-05, "Free Excerpt" edition), and an unbounded fold walks the entire run so a
+        // single pull skips them all and lands pages deep in whatever precedes them (the index).
+        var boundaryIndex = containing
+        var foldedPx = 0
+        while (boundaryIndex > 0) {
+            val above = window[boundaryIndex - 1]
+            if (above.height >= viewportHeightPx / 2) break
+            if (foldedPx + above.height > viewportHeightPx / 2) break
+            foldedPx += above.height
+            boundaryIndex--
+        }
+        if (boundaryIndex == 0) return 0
+        val boundaryTop = window[boundaryIndex].top
+        val onePageAbove = boundaryTop - viewportHeightPx * 9 / 10
+        return onePageAbove.coerceAtLeast(0)
+    }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -289,6 +289,22 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     @androidx.annotation.VisibleForTesting
     internal fun onSelectionActiveForTest(active: Boolean) = onChildSelectionActiveChanged(active)
 
+    /** Test seam for the one-shot backward gesture consumed by a window prepend. */
+    @androidx.annotation.VisibleForTesting
+    internal val hasPendingBackwardNavigationIntent: Boolean
+        get() = controller.hasPendingBackwardNavigationIntent
+
+    /** Test seam for the "stuck title page" regression guard. See
+     *  [ContinuousWindowController.isReapplyLandingSuperseded]. */
+    @androidx.annotation.VisibleForTesting
+    internal val isReapplyLandingSuperseded: Boolean
+        get() = controller.isReapplyLandingSuperseded
+
+    /** Test seam — see [ContinuousWindowController.isBoundaryDetentArmed]. */
+    @androidx.annotation.VisibleForTesting
+    internal val isBoundaryDetentArmed: Boolean
+        get() = controller.isBoundaryDetentArmed
+
     /**
      * Decline to be a nested-scrolling parent for child [ChapterWebView]s. See historical comment
      * in git — Chromium WebView's dispatchNestedPreScroll would otherwise scroll our viewport to
@@ -370,17 +386,32 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     // the WebView owning touch long enough to read as scroll resistance). Suppressed entirely
     // while a text-selection action mode is active.
     private var interceptDownY = 0f
+    private var interceptLastY = 0f
     override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
         if (selectionActiveCount > 0) return false
         when (ev.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
                 interceptDownY = ev.y
+                interceptLastY = ev.y
                 controller.onTouchDown()
             }
-            MotionEvent.ACTION_MOVE ->
+            MotionEvent.ACTION_MOVE -> {
+                controller.onTouchMove(ev.y - interceptLastY)
+                interceptLastY = ev.y
                 if (abs(ev.y - interceptDownY) > touchSlop / 2f) return true
+            }
         }
         return super.onInterceptTouchEvent(ev)
+    }
+
+    // UP/CANCEL are routed through dispatchTouchEvent, not onInterceptTouchEvent: once this view
+    // intercepts a drag, subsequent events bypass interception entirely, so the gesture's end
+    // would never reach the controller and a latched backward intent would outlive the gesture.
+    override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        when (ev.actionMasked) {
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> controller.onTouchUp()
+        }
+        return super.dispatchTouchEvent(ev)
     }
 
     private val touchSlop = android.view.ViewConfiguration.get(context).scaledTouchSlop
@@ -392,7 +423,33 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     private val maxFlingVelocity =
         (android.view.ViewConfiguration.get(context).scaledMaximumFlingVelocity * 0.60f).toInt()
 
+    // Every gesture/fling scroll funnels through overScrollByCompat → onOverScrolled. While a
+    // backward prepend is still an unmeasured blank placeholder, clamp the scroll to the
+    // placeholder's bottom edge (the chapter boundary): pixels dragged through the blank resolve
+    // to never-seen content once the real height lands — an abrupt teleport deep into the
+    // previous chapter. The controller's compensating scrollBys only ever move BELOW the floor,
+    // so they pass unclamped, and the floor lifts the moment the chapter measures.
+    override fun onOverScrolled(scrollX: Int, scrollY: Int, clampedX: Boolean, clampedY: Boolean) {
+        val floor = controller.backwardPrependScrollFloorY
+        if (floor > 0 && scrollY < floor) {
+            super.onOverScrolled(scrollX, floor, clampedX, true)
+        } else {
+            super.onOverScrolled(scrollX, scrollY, clampedX, clampedY)
+        }
+    }
+
     override fun fling(velocityY: Int) {
+        // Swallow the release-velocity fling of a gesture that already triggered a backward
+        // prepend. The gesture spent itself against the scrollY=0 clamp; NestedScrollView would
+        // still start a fling from the release velocity at ACTION_UP, and because computeScroll
+        // applies scroller deltas it composes with the prepend's scroll compensation — carrying
+        // the reader thousands of px past the boundary into the freshly revealed chapter. See
+        // the ShiftBackward branch in [ContinuousWindowController.maybeShift].
+        if (controller.suppressGestureFling) return
+        // A backward fling is capped at one page past the chapter boundary above its starting
+        // chapter (behind-buffer chapters included — the prepend floor never sees those). The
+        // floor is enforced by onOverScrolled while this fling animates.
+        if (velocityY < 0) controller.armBackwardFlingFloor()
         super.fling(velocityY.coerceIn(-maxFlingVelocity, maxFlingVelocity))
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -102,6 +102,24 @@ internal class ContinuousWindowController(
          * remaining viewport space, AppendOnly stops firing naturally regardless of the cap.
          */
         private const val APPEND_ONLY_MAX_WINDOW = 8
+
+        /**
+         * Poll interval for retiring a stale [backwardNavigationIntent] after ACTION_UP. The
+         * intent must outlive the finger (a backward fling reaches the top clamp after UP), so
+         * it can only be dropped once the scroller comes to rest. One frame (~16 ms) would race
+         * the posted [maybeShift] that consumes the intent at the clamp; 150 ms is comfortably
+         * after it while still far shorter than any deliberate next gesture.
+         */
+        private const val BACKWARD_INTENT_IDLE_POLL_MS = 150L
+
+        /**
+         * Upper bound on how long the backward-prepend scroll floor may wait for Chromium's
+         * visual-state (paint) callback after the chapter has measured. Generous because slow
+         * GPUs are exactly the case the paint gate exists for; when it expires the floor lifts
+         * and behavior degrades to the pre-gate state (scrolling may briefly show unpainted
+         * white).
+         */
+        private const val PREPEND_PAINT_TIMEOUT_MS = 5_000L
     }
 
     /** The [LinearLayout] the [ContinuousReaderView] wraps; controller owns and mutates its children. */
@@ -237,6 +255,54 @@ internal class ContinuousWindowController(
     private val windowManager = ChapterWindowManager(DEFAULT_CHAPTERS_BEHIND)
 
     /**
+     * Direction of the active manual navigation. A short part-title page can leave the viewport
+     * midpoint in the following chapter even at scrollY=0, so geometry cannot distinguish a
+     * genuine backward gesture from forward-shift compensation.
+     */
+    private var backwardNavigationIntent = false
+
+    /**
+     * A drag can deliver more ACTION_MOVE events after its first prepend has completed. Those
+     * moves still describe the same gesture, so they must not re-arm another prepend while the
+     * placeholder-height scroll compensation is settling.
+     */
+    private var backwardShiftConsumedForTouchGesture = false
+
+    @androidx.annotation.VisibleForTesting
+    internal val hasPendingBackwardNavigationIntent: Boolean
+        get() = backwardNavigationIntent
+
+    /**
+     * Test seam: true once [onTouchDown] has fired after the most recent [openWindowAt]. Drives
+     * the regression guard that prevents a late reapply-landing (triggered by an image load
+     * completing after initial measurement) from re-arming the landing hold and freezing the
+     * reader after the user starts scrolling — the "stuck title page" regression.
+     */
+    @androidx.annotation.VisibleForTesting
+    internal val isReapplyLandingSuperseded: Boolean
+        get() = reapplyLandingSuperseded
+
+    /**
+     * Test seam: true from every [prependChapter] call until the next [onTouchDown] (after the
+     * chapter is measured and painted). With this armed, [backwardPrependScrollFloorY] keeps the
+     * scroll floor at the real chapter height through the end of the crossing gesture, preventing
+     * the "abrupt jump to Index" regression (2026-08-06).
+     */
+    @androidx.annotation.VisibleForTesting
+    internal val isBoundaryDetentArmed: Boolean
+        get() = boundaryDetentArmed
+
+    /**
+     * True while the current touch gesture has already been consumed by a backward prepend.
+     * [ContinuousReaderView.fling] checks this to swallow the gesture's release-velocity fling:
+     * the top clamp ate the gesture, so letting its momentum restart AFTER the prepend's scroll
+     * compensation would carry the reader deep past the chapter boundary the prepend just
+     * revealed. Cleared on the next ACTION_DOWN (and every window rebuild / explicit nav).
+     */
+    val suppressGestureFling: Boolean
+        get() = backwardShiftConsumedForTouchGesture
+
+    /**
      * Chapters kept behind the viewport before a forward shift fires. Elided-view opens set this
      * to 2+ (see [DEFAULT_CHAPTERS_BEHIND]) so tiny synthetic chapters don't oscillate. MUST be
      * set before [openWindowAt] — the initial window size derives from it and can't be resized
@@ -300,6 +366,19 @@ internal class ContinuousWindowController(
      */
     private var smoothTailInProgress: Boolean = false
 
+    /**
+     * True from the first [onTouchDown] after [openWindowAt] until the next [openWindowAt].
+     * Guards against already-posted `postLandAt` closures running after the user has touched:
+     * a `reapplyLandingAfterFallback` triggered by a late chapter remeasure (e.g. a cover image
+     * loading AFTER the initial height measurement) can have a `port.post { postLandAt }` already
+     * queued when `onTouchDown` runs. `onTouchDown` nulls `reapplyLandingAfterFallback` to block
+     * FUTURE invocations, but cannot cancel the already-posted message. That queued `postLandAt`
+     * re-arms `landingHoldTargetY` for 600 ms, pinning the reader to the chapter's open position
+     * while `tickLandingHold` reverts every scroll tick — the "stuck title page" symptom.
+     * Checking this flag inside the `port.post { }` body aborts any re-apply that slipped through.
+     */
+    private var reapplyLandingSuperseded = false
+
     /** Annotation id to focus on initial open. See [ContinuousReaderView.pendingFocusAnnotationId]. */
     private var pendingFocusAnnotationId: String? = null
 
@@ -323,14 +402,16 @@ internal class ContinuousWindowController(
     /** Pool of detached [ChapterWebView]s kept for reuse across window shifts. */
     private val recycledViews = ArrayDeque<ChapterWebView>()
 
-    private fun obtainWebView(): ChapterWebView =
-        (recycledViews.removeFirstOrNull() ?: ChapterWebView(context)).also { wv ->
+    private fun obtainWebView(): ChapterWebView {
+        val recycled = recycledViews.removeFirstOrNull()
+        return (recycled ?: ChapterWebView(context)).also { wv ->
             // Route JS console errors/warnings to the ReaderDecoration log channel so the in-app
             // debug screen surfaces DOM-side throws (e.g. #428's createTreeWalker-on-null-body)
             // alongside the Kotlin-side decoration events. Wired here so recycled views also
             // pick up the current logger.
             wv.jsConsoleLogger = logger
         }
+    }
 
     /**
      * Detach [wv] from active use and pool it for reuse (or destroy it if the pool is full).
@@ -416,7 +497,23 @@ internal class ContinuousWindowController(
         pendingFallbackRunnable?.let { port.removeCallbacks(it) }
         pendingFallbackRunnable = null
         windowManager.reset()
+        backwardNavigationIntent = false
+        backwardShiftConsumedForTouchGesture = false
+        prependAwaitingMeasure = false
+        boundaryDetentArmed = false
+        backwardFlingFloorY = 0
+        releasePaintGate()
         smoothTailInProgress = smoothTail
+        reapplyLandingSuperseded = false
+        // Cross-window user navigation (smoothTail=true): reset firstLoadComplete so the
+        // isFirstLoadComplete state cycles false→true while the new window loads. EpubReaderScreen
+        // observes this to keep the nav cover up until the content is visible, preventing the
+        // blank-flash + abrupt-jump the user sees when a chapter-map tap fires after the initial
+        // landing has already placed the reader at the saved reading position.
+        if (smoothTail && firstLoadComplete) {
+            firstLoadComplete = false
+            onFirstLoadRestart()
+        }
         container.visibility = android.view.View.INVISIBLE
 
         val targetIndex = ContinuousPositionTracker
@@ -464,6 +561,15 @@ internal class ContinuousWindowController(
                     }
                     val isFirstLand = landCount == 0
                     landCount++
+                    // A re-apply triggered by a late chapter remeasure (e.g. cover image load)
+                    // can have this `port.post` queued BEFORE onTouchDown runs. onTouchDown nulls
+                    // reapplyLandingAfterFallback for future calls but cannot cancel this message.
+                    // Without this guard the queued postLandAt re-arms landingHoldTargetY, pinning
+                    // the reader to the open position for 600 ms while the user scrolls — the
+                    // "stuck title page" symptom.
+                    if (!isFirstLand && reapplyLandingSuperseded) {
+                        return@post
+                    }
                     port.abortFling()
                     if (smoothTail && isFirstLand) {
                         val pre = ContinuousPositionTracker.preLandY(y, port.viewportHeightPx)
@@ -595,6 +701,11 @@ internal class ContinuousWindowController(
      * open-time `focusAnnotationId` path in [openWindowAt].
      */
     override fun navigateTo(href: String, progression: Float, alignToTop: Boolean, focusAnnotationId: String?) {
+        backwardNavigationIntent = false
+        backwardShiftConsumedForTouchGesture = false
+        // Programmatic navigation overrides any gesture-scoped scroll floor: a leftover
+        // backward-fling floor from the previous gesture must not clamp the landing scroll.
+        backwardFlingFloorY = 0
         val target = href.substringBefore('#')
         val fragment = href.substringAfter('#', "")
         val targetIndex = ContinuousPositionTracker.chapterIndexForHref(
@@ -603,7 +714,13 @@ internal class ContinuousWindowController(
         if (targetIndex < 0) return
         val inWindow = targetIndex in topIndex until (topIndex + webViews.size)
         if (inWindow) {
+            // The posted landing can execute SECONDS later when the main thread is busy with
+            // WebView measure storms (observed 1.8 s on an emulator). If the user has touched
+            // the reader in the meantime, they've superseded the navigation — landing anyway
+            // yanks the viewport back to a stale target from under their scroll.
+            inWindowNavSupersededByTouch = false
             port.post {
+                if (inWindowNavSupersededByTouch) return@post
                 scrollToLoadedChapter(
                     target, progression, fragment,
                     smooth = true, alignToTop = alignToTop,
@@ -743,6 +860,12 @@ internal class ContinuousWindowController(
     override fun scrollByPage(forward: Boolean) {
         val delta = ContinuousPositionTracker.pageScrollDelta(port.viewportHeightPx)
         if (delta == 0) return
+        // A volume-key page is a fresh navigation just like a new touch gesture: release the
+        // boundary detent once the revealed chapter is ready, or volume-only readers would stay
+        // pinned at the boundary forever (touch releases it via onTouchDown instead).
+        if (!prependAwaitingMeasure && !prependAwaitingPaint) boundaryDetentArmed = false
+        backwardShiftConsumedForTouchGesture = false
+        backwardNavigationIntent = !forward
         clearLandingHold()
         val signedDelta = if (forward) delta else -delta
         val current = port.currentScrollY
@@ -757,7 +880,10 @@ internal class ContinuousWindowController(
             currentScrollY = current,
             targetScrollY = target,
             density = context.resources.displayMetrics.density,
-        ) ?: return
+        ) ?: run {
+            if (!forward && target == current) scheduleShiftCheck()
+            return
+        }
         port.smoothScrollBy(animation.scrollBy, animation.durationMs)
     }
 
@@ -926,6 +1052,99 @@ internal class ContinuousWindowController(
         wv.loadChapter(entry.link.href.toString(), entry.url, formattingPrefs)
     }
 
+    /**
+     * True from a backward prepend until its chapter reports a real measured height. Passed to
+     * [ChapterWindowManager.decide] to hold further ShiftBackwards: each prepend enters at a
+     * screen-sized blank placeholder, and on a slow device a large chapter takes seconds to load —
+     * without this gate a few quick backward pulls stack unmeasured placeholders until every
+     * rendered chapter has been evicted and the screen is solid white (field repro 2026-08-04).
+     */
+    private var prependAwaitingMeasure = false
+
+    /**
+     * True from a backward prepend's first real measurement until Chromium reports the chapter
+     * actually PAINTED (visual-state callback), or [PREPEND_PAINT_TIMEOUT_MS] elapses. Layout
+     * height lands within ~300 ms even for a 33k-px chapter, but rasterization takes seconds on
+     * slow GPUs — lifting the scroll floor at measure time let the very next flick travel deep
+     * into a measured-but-unpainted region: a solid white screen that fills in much later
+     * (field repro 2026-08-05, reproduced on emulator: landed mid-ch06 at 56% with 10+s of
+     * white). The floor therefore holds the reader at the boundary — on painted content —
+     * until the revealed chapter is genuinely drawn.
+     */
+    private var prependAwaitingPaint = false
+
+    /**
+     * Boundary detent: armed by every backward prepend, released by the first ACTION_DOWN that
+     * arrives once the chapter is measured AND painted. Keeps the scroll floor active through
+     * the END of the gesture that crossed the boundary — however fast the chapter measures and
+     * paints — so the crossing pull always lands exactly AT the boundary. Without this, on a
+     * fast GPU the measure (+~300 ms) and paint could complete mid-gesture, the floor lifted,
+     * and the rest of the same pull (or its release fling on older builds) carried the reader
+     * several viewports past the boundary — the "abrupt jump" field-reported through 2026-08-05.
+     * The next deliberate gesture starts from the boundary and scrolls normally.
+     */
+    private var boundaryDetentArmed = false
+
+    /** See the in-window branch of [navigateTo]: set by any touch-down so a still-queued
+     *  posted landing knows the user has taken over and must not fire. */
+    private var inWindowNavSupersededByTouch = false
+
+    /**
+     * Floor for the CURRENTLY animating backward fling, armed by [armBackwardFlingFloor] at
+     * fling start and cleared on the next touch-down. Caps a ballistic backward fling at one
+     * page past the chapter boundary above its starting chapter (see
+     * [ContinuousPositionTracker.backwardFlingFloor]) — covering the behind-buffer path where
+     * no prepend (and therefore no prepend floor/detent) exists.
+     */
+    private var backwardFlingFloorY = 0
+
+    /**
+     * Floor candidate captured at ACTION_DOWN. The fling only starts at ACTION_UP, by which
+     * time the drag portion of the gesture may already have carried the viewport across the
+     * boundary into the previous chapter's slot — computing the floor there finds the window's
+     * first slot and returns no constraint. The boundary the user perceives is the one above
+     * where the GESTURE began.
+     */
+    private var gestureStartFlingFloorY = 0
+
+    /**
+     * Called by [ContinuousReaderView.fling] before starting a backward fling. Latches the
+     * gesture-start floor candidate as the active fling floor enforced by the scroll clamp.
+     */
+    fun armBackwardFlingFloor(): Int {
+        backwardFlingFloorY = gestureStartFlingFloorY
+        return backwardFlingFloorY
+    }
+
+    /** Safety valve: release the paint gate even if the visual-state callback never fires. */
+    private var paintGateTimeout: Runnable? = null
+
+    private fun releasePaintGate() {
+        prependAwaitingPaint = false
+        paintGateTimeout?.let { port.removeCallbacks(it) }
+        paintGateTimeout = null
+    }
+
+    /**
+     * Lowest scrollY the user may reach while a backward prepend is still an unmeasured
+     * placeholder — the placeholder's bottom edge, i.e. the chapter boundary. Scrolling INTO the
+     * blank placeholder maps those pixels to arbitrary positions once the real height lands (the
+     * scroll compensation preserves distance-from-boundary, so blank-dragged pixels resolve to
+     * content the user never saw scrolling by — perceived as an abrupt teleport, field repro
+     * 2026-08-05 ch07→ch06). [ContinuousReaderView.onOverScrolled] clamps to this floor, holding
+     * the reader at the boundary until the chapter renders; the measure's compensating scrollBy
+     * then lands them exactly at the boundary and scrolling continues through real content.
+     */
+    val backwardPrependScrollFloorY: Int
+        get() = maxOf(
+            ContinuousPositionTracker.backwardPrependScrollFloor(
+                topSlotStillPlaceholder =
+                    prependAwaitingMeasure || prependAwaitingPaint || boundaryDetentArmed,
+                topSlotHeightPx = measuredHeights.firstOrNull() ?: 0,
+            ),
+            backwardFlingFloorY,
+        )
+
     private fun prependChapter(index: Int) {
         val entry = allChapters[index]
         val wv = obtainWebView()
@@ -933,8 +1152,11 @@ internal class ContinuousWindowController(
         binder.bind(wv, annotationsAvailable = annotationsAvailable, readaloudAvailable = readaloudAvailable)
         wv.onPlayFromHere = { text, evalJs -> onPlayFromHereSelection?.invoke(wv.chapterHref, text, evalJs) }
         val placeholder = placeholderHeight
+        prependAwaitingMeasure = true
+        boundaryDetentArmed = true
         wv.onHeightMeasured = { measuredPx ->
             val i = webViews.indexOf(wv)
+            prependAwaitingMeasure = false
             if (i >= 0) {
                 val delta = measuredPx - measuredHeights[i]
                 measuredHeights[i] = measuredPx
@@ -959,6 +1181,12 @@ internal class ContinuousWindowController(
 
     private fun removeTop() {
         if (webViews.isEmpty()) return
+        // The top chapter is the only slot a prepend occupies; evicting it cancels any pending
+        // placeholder measurement (recycle() detaches its onHeightMeasured), so the gates must
+        // not stay latched or backward navigation stays blocked until the next window rebuild.
+        prependAwaitingMeasure = false
+        boundaryDetentArmed = false
+        releasePaintGate()
         val h = measuredHeights.removeAt(0)
         val wv = webViews.removeAt(0)
         container.removeView(wv)
@@ -1004,24 +1232,34 @@ internal class ContinuousWindowController(
         val vh = port.viewportHeightPx
         val (href, _) = ContinuousPositionTracker.locatorAt(sY, vh, window)
         val viewportMidIndex = allChapters.indexOfFirst { it.link.href.toString() == href }
-        val loadedContentBottom = window.last().let { it.top + it.height }
-
         val decision = windowManager.decide(
             sY, viewportMidIndex, window, topIndex, allChapters.size, vh,
             appendOnlyMaxWindow = APPEND_ONLY_MAX_WINDOW,
+            backwardNavigationIntent = backwardNavigationIntent,
+            topChapterStillPlaceholder = prependAwaitingMeasure || prependAwaitingPaint,
         )
         when (decision) {
             ChapterWindowManager.Decision.ShiftBackward -> {
+                // Consume the navigation before scroll compensation posts another shift check.
+                // Keep the gesture guard armed until the next ACTION_DOWN so later MOVE events
+                // from this same pull cannot prepend every earlier resource in succession.
+                backwardNavigationIntent = false
+                backwardShiftConsumedForTouchGesture = true
                 shiftInProgress = true
+                // The top clamp consumed this gesture — kill its residual momentum. NestedScrollView
+                // flings apply scroller DELTAS in computeScroll, so an in-flight fling composes
+                // with the prepend's scrollBy compensations and keeps subtracting after the
+                // prepended chapter measures, dragging the reader thousands of px past the
+                // boundary into the revealed chapter (field repro 2026-08-03: ch07→ch06 landed
+                // ~4 viewports too far back). Backward navigation across a boundary must land AT
+                // the boundary. abortFling() covers a fling already running; the view swallows
+                // this same gesture's not-yet-started fling via [suppressGestureFling] (the fling
+                // often starts only at ACTION_UP, after this branch has already run). The abort
+                // also covers the smooth-tail annotation-nav case it was previously limited to.
+                port.abortFling()
                 removeBottom()
                 topIndex--
                 prependChapter(topIndex)
-                // prependChapter calls scrollBy(+placeholder) to keep visible content in place.
-                // During smooth-tail annotation nav the OverScroller targets the annotation Y; its
-                // next computeScroll frame would overwrite the scrollBy, making content jump.
-                // Guard on smoothTailInProgress so normal user flings are not interrupted at
-                // chapter boundaries.
-                if (smoothTailInProgress) port.abortFling()
                 shiftInProgress = false
             }
             ChapterWindowManager.Decision.ShiftForward -> {
@@ -1084,14 +1322,100 @@ internal class ContinuousWindowController(
      * stop auto-re-landing on reflow so we never yank the page out from under a manual scroll.
      */
     fun onTouchDown() {
+        inWindowNavSupersededByTouch = true
+        // A user gesture supersedes any pending programmatic landing: without this, navigating
+        // (TOC/chapter map) and scrolling away within the fallback window (2.5 s) let the
+        // fallback fire later and yank the reader back to the stale navigation target —
+        // surfaced by the harness once its forward leg raced the in-window nav path, and a
+        // long-standing papercut on device. The fallback's second duty — clearing the pending
+        // initial-scroll state so the shift machinery unblocks — must still happen, just
+        // WITHOUT invoking the stale landing scroll.
+        pendingFallbackRunnable?.let { port.removeCallbacks(it) }
+        pendingFallbackRunnable = null
+        pendingInitialScroll = null
+        pendingInitialMeasureIndices.clear()
+        backwardFlingFloorY = 0
+        gestureStartFlingFloorY = ContinuousPositionTracker.backwardFlingFloor(
+            scrollYStart = port.currentScrollY,
+            window = buildWindow(),
+            viewportHeightPx = port.viewportHeightPx,
+        )
+        // Release the boundary detent only when the revealed chapter is genuinely ready — a new
+        // gesture that starts while it is still loading/painting must stay pinned at the
+        // boundary rather than pull into blank content.
+        if (!prependAwaitingMeasure && !prependAwaitingPaint) boundaryDetentArmed = false
         reapplyLandingAfterFallback = null
+        reapplyLandingSuperseded = true
         pendingFocusAnnotationId = null
         landingHoldTargetY = -1
         landingHoldUntilUptimeMs = 0L
         smoothTailInProgress = false
+        backwardNavigationIntent = false
+        backwardShiftConsumedForTouchGesture = false
+        retireIntentRunnable?.let { port.removeCallbacks(it) }
+        retireIntentRunnable = null
         // A manual scroll may leave [port.currentScrollY] far from the coalescer's pending target;
         // reset so the next volume press bases its animation on the user's new position.
         pageScrollCoalescer.reset()
+    }
+
+    /**
+     * Record finger direction before NestedScrollView changes scrollY. A downward-moving finger
+     * means backward reading. At the top clamp Android emits no scroll callback, so explicitly
+     * schedule a decision to let the window prepend the previous chapter.
+     */
+    fun onTouchMove(fingerDeltaY: Float) {
+        if (fingerDeltaY == 0f) return
+        backwardNavigationIntent = fingerDeltaY > 0f && !backwardShiftConsumedForTouchGesture
+        if (backwardNavigationIntent) scheduleShiftCheck()
+    }
+
+    /** Self-cancelling idle watch armed by [onTouchUp]; see [BACKWARD_INTENT_IDLE_POLL_MS]. */
+    private var retireIntentRunnable: Runnable? = null
+
+    /**
+     * Called on ACTION_UP / ACTION_CANCEL. A backward intent must survive the finger lift — a
+     * backward fling reaches the scrollY=0 clamp (where the prepend is consumed) well after UP.
+     * But an intent that outlives the entire settle without being consumed is stale: leaving it
+     * latched lets any later posted decision (e.g. a reflow remeasure) fire a phantom prepend
+     * the user never asked for. Watch the scroller and retire the intent once it comes to rest.
+     */
+    fun onTouchUp() {
+        if (!backwardNavigationIntent) return
+        retireIntentRunnable?.let { port.removeCallbacks(it) }
+        var lastY = port.currentScrollY
+        val watch = object : Runnable {
+            override fun run() {
+                if (retireIntentRunnable !== this || !backwardNavigationIntent) return
+                val y = port.currentScrollY
+                if (y == lastY) {
+                    // Final decision before retiring. Under main-thread contention the posted
+                    // shift check from the last scroll change (the one that reached the clamp)
+                    // can run AFTER this watch — dropping the intent first would silently
+                    // swallow a legitimate boundary prepend (observed as harness flakes on a
+                    // contended emulator: pull at the clamp, nothing happens). maybeShift
+                    // consumes the intent itself when a prepend fires; clearing afterwards is
+                    // then a no-op.
+                    maybeShift()
+                    backwardNavigationIntent = false
+                    retireIntentRunnable = null
+                } else {
+                    lastY = y
+                    port.postDelayed(this, BACKWARD_INTENT_IDLE_POLL_MS)
+                }
+            }
+        }
+        retireIntentRunnable = watch
+        port.postDelayed(watch, BACKWARD_INTENT_IDLE_POLL_MS)
+    }
+
+    private fun scheduleShiftCheck() {
+        if (shiftPending) return
+        shiftPending = true
+        port.post {
+            shiftPending = false
+            maybeShift()
+        }
     }
 
     /**

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.LinearLayout
+import androidx.core.view.doOnNextLayout
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.logging.LogChannel
 import com.riffle.core.logging.Logger
@@ -863,7 +864,7 @@ internal class ContinuousWindowController(
         // A volume-key page is a fresh navigation just like a new touch gesture: release the
         // boundary detent once the revealed chapter is ready, or volume-only readers would stay
         // pinned at the boundary forever (touch releases it via onTouchDown instead).
-        if (!prependAwaitingMeasure && !prependAwaitingPaint) boundaryDetentArmed = false
+        if (!prependAwaitingMeasure && !prependAwaitingLayout && !prependAwaitingPaint) boundaryDetentArmed = false
         backwardShiftConsumedForTouchGesture = false
         backwardNavigationIntent = !forward
         clearLandingHold()
@@ -1062,6 +1063,18 @@ internal class ContinuousWindowController(
     private var prependAwaitingMeasure = false
 
     /**
+     * True from a backward prepend's first real measurement until the LinearLayout completes its
+     * layout pass with the new chapter height. The compensating scroll is deferred until then
+     * because NestedScrollView's max-scroll boundary is still based on the placeholder height
+     * until layout runs — applying port.scrollBy(delta) earlier clips the scroll to the old
+     * max-scroll, landing the user deep mid-chapter instead of at the boundary (field repro
+     * 2026-08-06: index.html measured to 42 704 px but scrollBy(40 367) only reached scrollY=2793
+     * because content height was still 2337 px in the layout). Included in [topSlotStillPlaceholder]
+     * so another ShiftBackward cannot fire while the first is still pending layout.
+     */
+    private var prependAwaitingLayout = false
+
+    /**
      * True from a backward prepend's first real measurement until Chromium reports the chapter
      * actually PAINTED (visual-state callback), or [PREPEND_PAINT_TIMEOUT_MS] elapses. Layout
      * height lands within ~300 ms even for a 33k-px chapter, but rasterization takes seconds on
@@ -1139,7 +1152,7 @@ internal class ContinuousWindowController(
         get() = maxOf(
             ContinuousPositionTracker.backwardPrependScrollFloor(
                 topSlotStillPlaceholder =
-                    prependAwaitingMeasure || prependAwaitingPaint || boundaryDetentArmed,
+                    prependAwaitingMeasure || prependAwaitingLayout || prependAwaitingPaint || boundaryDetentArmed,
                 topSlotHeightPx = measuredHeights.firstOrNull() ?: 0,
             ),
             backwardFlingFloorY,
@@ -1158,11 +1171,29 @@ internal class ContinuousWindowController(
             val i = webViews.indexOf(wv)
             prependAwaitingMeasure = false
             if (i >= 0) {
-                val delta = measuredPx - measuredHeights[i]
-                measuredHeights[i] = measuredPx
                 publishViewportFraction(wv, measuredPx)
+                // Update the layout params to the real height, triggering a layout pass.
+                // Do NOT update measuredHeights or compensate scroll yet: NestedScrollView's
+                // max-scroll boundary is still based on the placeholder height until layout runs.
+                // Calling port.scrollBy(delta) before layout clips the scroll to the old
+                // max-scroll — for a large chapter (e.g. a 42 704 px index) this lands the user
+                // deep mid-chapter instead of at the boundary (field repro 2026-08-06: expected
+                // scrollY=42 704, got 2793 because content height was still 2337 px in layout).
+                prependAwaitingLayout = true
                 wv.layoutParams = wv.layoutParams.also { it.height = measuredPx }
-                if (delta != 0) port.scrollBy(delta)
+                wv.doOnNextLayout {
+                    // Guard: if removeTop() evicted this wv before the layout pass completed,
+                    // measuredHeights no longer has a slot for it — skip the compensation.
+                    val j = webViews.indexOf(wv)
+                    if (j < 0) {
+                        prependAwaitingLayout = false
+                        return@doOnNextLayout
+                    }
+                    val delta = measuredPx - measuredHeights[j]
+                    measuredHeights[j] = measuredPx
+                    prependAwaitingLayout = false
+                    if (delta != 0) port.scrollBy(delta)
+                }
             }
         }
         wv.onBookBodyFont = { ff -> onBookBodyFont?.invoke(ff) }
@@ -1185,6 +1216,7 @@ internal class ContinuousWindowController(
         // placeholder measurement (recycle() detaches its onHeightMeasured), so the gates must
         // not stay latched or backward navigation stays blocked until the next window rebuild.
         prependAwaitingMeasure = false
+        prependAwaitingLayout = false
         boundaryDetentArmed = false
         releasePaintGate()
         val h = measuredHeights.removeAt(0)
@@ -1236,7 +1268,7 @@ internal class ContinuousWindowController(
             sY, viewportMidIndex, window, topIndex, allChapters.size, vh,
             appendOnlyMaxWindow = APPEND_ONLY_MAX_WINDOW,
             backwardNavigationIntent = backwardNavigationIntent,
-            topChapterStillPlaceholder = prependAwaitingMeasure || prependAwaitingPaint,
+            topChapterStillPlaceholder = prependAwaitingMeasure || prependAwaitingLayout || prependAwaitingPaint,
         )
         when (decision) {
             ChapterWindowManager.Decision.ShiftBackward -> {
@@ -1343,7 +1375,7 @@ internal class ContinuousWindowController(
         // Release the boundary detent only when the revealed chapter is genuinely ready — a new
         // gesture that starts while it is still loading/painting must stay pinned at the
         // boundary rather than pull into blank content.
-        if (!prependAwaitingMeasure && !prependAwaitingPaint) boundaryDetentArmed = false
+        if (!prependAwaitingMeasure && !prependAwaitingLayout && !prependAwaitingPaint) boundaryDetentArmed = false
         reapplyLandingAfterFallback = null
         reapplyLandingSuperseded = true
         pendingFocusAnnotationId = null

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -85,12 +85,23 @@ internal class ContinuousWindowController(
          *  stale scrollY. */
         private const val LANDING_HOLD_MS = 600L
 
-        // The volume-key page-scroll animation duration is distance-based via
-        // [ContinuousPositionTracker.pageScrollDurationMs] to match the Chromium
-        // `behavior: 'smooth'` glide paginated/vertical mode gets from
-        // [ScrollBoundaryNavigationContainer]; a fixed 300 ms was visibly faster and more sudden
-        // than vertical mode for the same 0.9-viewport press. The coalescer validity window uses
-        // the duration cap — see [pageScrollCoalescer].
+        /**
+         * Fixed animation duration for a volume-key page scroll. Matches the Chromium `behavior:
+         * 'smooth'` scroll duration used by paginated/vertical mode via [ScrollBoundaryNavigationContainer]
+         * closely enough that rapid presses feel the same in both modes. Also the validity window for
+         * [PageScrollCoalescer], so a new press coalesces iff its predecessor is still animating.
+         */
+        internal const val PAGE_SCROLL_DURATION_MS = 300
+
+        /**
+         * Upper bound on the loaded window when [ChapterWindowManager.Decision.AppendOnly] is
+         * growing it to escape a fits-in-viewport wall-off. Real front-matter sequences (praise,
+         * "selected works from…", title, copyright, dedication, contents, author's note) top out
+         * well under this; the cap only exists to prevent a pathological all-tiny-chapters book
+         * from loading the entire spine at open. Once one chapter measures larger than the
+         * remaining viewport space, AppendOnly stops firing naturally regardless of the cap.
+         */
+        private const val APPEND_ONLY_MAX_WINDOW = 8
     }
 
     /** The [LinearLayout] the [ContinuousReaderView] wraps; controller owns and mutates its children. */
@@ -854,6 +865,19 @@ internal class ContinuousWindowController(
                     val scroll = pendingInitialScroll
                     pendingInitialScroll = null
                     scroll?.invoke()
+                    // Post a shift check: if the whole initial window measured shorter than one
+                    // viewport (short front-matter — e.g. praise / "selected works from…" / title),
+                    // scrollY stays pinned at 0 and no onScrollChangeListener will fire to trigger
+                    // handleScrollChange, so decide() would never see the wall-off. Post-drain is
+                    // the earliest safe moment: all initial heights are known and the initial-
+                    // scroll gate has cleared.
+                    if (!shiftPending) {
+                        shiftPending = true
+                        port.post {
+                            shiftPending = false
+                            maybeShift()
+                        }
+                    }
                     // In smoothTail mode the closure launched a NestedScrollView smoothScrollTo;
                     // arming the reapply here would let a late target-chapter remeasure fire the
                     // closure again during the 250 ms tween, taking its ELSE branch (hard
@@ -868,6 +892,24 @@ internal class ContinuousWindowController(
                 ) {
                     reapplyTargetLastHeight = measuredPx
                     reapplyLandingAfterFallback?.invoke()
+                }
+
+                // AppendOnly-chain: an AppendOnly-appended chapter enters at placeholder height
+                // (viewport-sized), which temporarily makes fitsInViewport=false and halts further
+                // AppendOnly decisions. When it measures back to its actual (short) height the
+                // window may fit in the viewport again and need another append — but no
+                // onScrollChangeListener fires (scrollY stays at 0), so without this post the
+                // chain stalls. Only trigger when wasPlaceholder (first real measurement from
+                // placeholder) and the initial-scroll gate has already cleared (so we don't race
+                // with the initial-land post above).
+                if (wasPlaceholder && pendingInitialScroll == null && pendingInitialMeasureIndices.isEmpty()) {
+                    if (!shiftPending) {
+                        shiftPending = true
+                        port.post {
+                            shiftPending = false
+                            maybeShift()
+                        }
+                    }
                 }
             }
         }
@@ -964,6 +1006,7 @@ internal class ContinuousWindowController(
 
         val decision = windowManager.decide(
             sY, viewportMidIndex, window, topIndex, allChapters.size, port.viewportHeightPx,
+            appendOnlyMaxWindow = APPEND_ONLY_MAX_WINDOW,
         )
         when (decision) {
             ChapterWindowManager.Decision.ShiftBackward -> {
@@ -991,6 +1034,28 @@ internal class ContinuousWindowController(
                 val nextIndex = topIndex + webViews.size
                 if (nextIndex < allChapters.size) appendChapter(nextIndex)
                 shiftInProgress = false
+            }
+            ChapterWindowManager.Decision.AppendOnly -> {
+                // Grow the window without dropping the top: the fits-in-viewport wall-off case
+                // (short front-matter chapters totalling less than one viewport) needs more content
+                // loaded so the user can scroll off the initial page, but must NOT lose the
+                // chapters they opened at. See ChapterWindowManager.Decision.AppendOnly.
+                shiftInProgress = true
+                val nextIndex = topIndex + webViews.size
+                if (nextIndex < allChapters.size) appendChapter(nextIndex)
+                shiftInProgress = false
+                // Re-post: the newly-appended chapter enters at placeholder height (~viewport),
+                // which lifts loadedContentBottom above the viewport and stops further AppendOnly
+                // firings. But when it measures back down to its true (short) height, the window
+                // may fit in the viewport again and need another append. This re-post catches that
+                // via handleScrollChange-style coalescing.
+                if (!shiftPending) {
+                    shiftPending = true
+                    port.post {
+                        shiftPending = false
+                        maybeShift()
+                    }
+                }
             }
             ChapterWindowManager.Decision.Hold -> {}
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -1001,11 +1001,13 @@ internal class ContinuousWindowController(
         val window = buildWindow()
         if (window.isEmpty()) return
         val sY = port.currentScrollY
-        val (href, _) = ContinuousPositionTracker.locatorAt(sY, port.viewportHeightPx, window)
+        val vh = port.viewportHeightPx
+        val (href, _) = ContinuousPositionTracker.locatorAt(sY, vh, window)
         val viewportMidIndex = allChapters.indexOfFirst { it.link.href.toString() == href }
+        val loadedContentBottom = window.last().let { it.top + it.height }
 
         val decision = windowManager.decide(
-            sY, viewportMidIndex, window, topIndex, allChapters.size, port.viewportHeightPx,
+            sY, viewportMidIndex, window, topIndex, allChapters.size, vh,
             appendOnlyMaxWindow = APPEND_ONLY_MAX_WINDOW,
         )
         when (decision) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -501,6 +501,8 @@ internal class ContinuousWindowController(
         backwardNavigationIntent = false
         backwardShiftConsumedForTouchGesture = false
         prependAwaitingMeasure = false
+        prependLayoutGeneration = 0
+        prependAwaitingLayout = false
         boundaryDetentArmed = false
         backwardFlingFloorY = 0
         releasePaintGate()
@@ -1075,6 +1077,20 @@ internal class ContinuousWindowController(
     private var prependAwaitingLayout = false
 
     /**
+     * Monotonically increasing token incremented by each [prependChapter] call (when it registers
+     * a [doOnNextLayout]) and by [removeTop] (when it evicts the pending prepend). Each
+     * [doOnNextLayout] closure captures the generation at registration time; on firing it compares
+     * against the current value and aborts if they differ. This guards against a recycled WebView
+     * carrying a stale [doOnNextLayout] listener from a previous prepend: when that wv is
+     * re-added to the container for a new prepend, the layout pass fires BOTH the old listener and
+     * the new one. The old listener would see `j >= 0` (the wv is now the new prepend's slot) and
+     * incorrectly apply the previous chapter's delta and clear [prependAwaitingLayout] for the new
+     * prepend — causing an early scroll correction and unblocking [ShiftBackward] before the new
+     * compensating scroll fires.
+     */
+    private var prependLayoutGeneration = 0
+
+    /**
      * True from a backward prepend's first real measurement until Chromium reports the chapter
      * actually PAINTED (visual-state callback), or [PREPEND_PAINT_TIMEOUT_MS] elapses. Layout
      * height lands within ~300 ms even for a 33k-px chapter, but rasterization takes seconds on
@@ -1180,10 +1196,13 @@ internal class ContinuousWindowController(
                 // deep mid-chapter instead of at the boundary (field repro 2026-08-06: expected
                 // scrollY=42 704, got 2793 because content height was still 2337 px in layout).
                 prependAwaitingLayout = true
+                val myGeneration = ++prependLayoutGeneration
                 wv.layoutParams = wv.layoutParams.also { it.height = measuredPx }
                 wv.doOnNextLayout {
-                    // Guard: if removeTop() evicted this wv before the layout pass completed,
-                    // measuredHeights no longer has a slot for it — skip the compensation.
+                    // Stale-callback guard: if removeTop() evicted this wv and a new prependChapter
+                    // reused it, the generation will have advanced past myGeneration. Abort so the
+                    // previous chapter's delta is not applied to the new prepend's slot.
+                    if (prependLayoutGeneration != myGeneration) return@doOnNextLayout
                     val j = webViews.indexOf(wv)
                     if (j < 0) {
                         prependAwaitingLayout = false
@@ -1216,6 +1235,7 @@ internal class ContinuousWindowController(
         // placeholder measurement (recycle() detaches its onHeightMeasured), so the gates must
         // not stay latched or backward navigation stays blocked until the next window rebuild.
         prependAwaitingMeasure = false
+        prependLayoutGeneration++ // invalidate any still-registered doOnNextLayout for the evicted wv
         prependAwaitingLayout = false
         boundaryDetentArmed = false
         releasePaintGate()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2230,7 +2230,26 @@ private fun EpubNavigatorView(
             // (set synchronously by loadFormattingPreferences() before openBook() fires the event),
             // so it always carries the correct orientation at this point.
             if (formattingPrefsProvider().orientation == ReaderOrientation.Continuous) {
-                coordinator.onTocNavigation(link)
+                // For a cross-window jump (target not in the loaded window), the controller tears
+                // down all WebViews and calls openWindowAt, which sets container.visibility=INVISIBLE
+                // while the new window builds. Without a cover the user sees a blank flash between
+                // the old content and the new chapter landing — the "abrupt jump" symptom on chapter-
+                // map taps that fire while the book is still loading its initial position.
+                // isTargetInWindow returns false (or view is null) when we need the cover.
+                val view = continuousViewRef.value
+                val outOfWindow = view?.isTargetInWindow(link.href.toString().substringBefore('#')) != true
+                if (outOfWindow) navigating = true
+                try {
+                    coordinator.onTocNavigation(link)
+                    // openWindowAt(smoothTail=true) resets isFirstLoadComplete to false; wait for
+                    // postLandAt to reveal the new window before removing the cover.
+                    val v = continuousViewRef.value
+                    if (outOfWindow && v != null && !v.isFirstLoadComplete.value) {
+                        snapshotFlow { v.isFirstLoadComplete.value }.filter { it }.first()
+                    }
+                } finally {
+                    navigating = false
+                }
                 return@collect
             }
             // Wait for the fragment to be ready — same timing concern as the continuous case above.

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWebViewPageOwnershipTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWebViewPageOwnershipTest.kt
@@ -1,0 +1,16 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChapterWebViewPageOwnershipTest {
+
+    @Test
+    fun `ignores recycled about blank completion after view is rebound to a chapter`() {
+        val expected = "https://readium_package/OEBPS/ch06.html"
+
+        assertFalse(isCurrentChapterPage("about:blank", expected))
+        assertTrue(isCurrentChapterPage(expected, expected))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWindowManagerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWindowManagerTest.kt
@@ -60,6 +60,36 @@ class ChapterWindowManagerTest {
     }
 
     @Test
+    fun `does not shift backward when entire window fits in viewport`() {
+        // Regression: book opens at fm02 (topIndex=1). All three chapters (fm01+fm02+title) are
+        // tiny and fit in one viewport. scrollY=0 < firstChapterHeight/2 AND topIndex>0 would
+        // normally trigger ShiftBackward, removing title and prepending cover. After that there
+        // is no subsequent trigger (maxScrollY stays 0), so AppendOnly never fires and the reader
+        // walls off. Suppressing ShiftBackward when fitsInViewport lets ShiftForward or AppendOnly
+        // fire instead.
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = listOf(
+            slot("fm01",  top = 0,   height = 220),
+            slot("fm02",  top = 220, height = 140),
+            slot("title", top = 360, height =  90),   // total = 450 << viewport (2400)
+        )
+        val d = mgr.decide(
+            scrollY = 0,
+            viewportChapterIndex = 3,    // title is at spine idx 3
+            window = window,
+            topIndex = 1,
+            totalChapters = 37,
+            viewportHeight = 2_400,
+            appendOnlyMaxWindow = 8,
+        )
+        // ShiftBackward must be suppressed; ShiftForward fires (gap = 3-1=2 > chaptersBehind=1)
+        assertEquals(
+            "ShiftBackward must not fire when window fits in viewport",
+            ChapterWindowManager.Decision.ShiftForward, d,
+        )
+    }
+
+    @Test
     fun `does not shift backward when at the very first chapter (topIndex=0)`() {
         val mgr = ChapterWindowManager(chaptersBehind = 3)
         val decision = mgr.decide(
@@ -324,16 +354,16 @@ class ChapterWindowManagerTest {
         // Regression pin (2026-07-21 field repro after the initial wall-off fix): elided view
         // opened with 3 short chapters loaded whose total height (1500 px) is less than the
         // viewport (2400 px). Without the loadedContentBottom > viewportHeight guard,
-        // atBottomOfLoadedWindow is true even at scrollY=0 → ShiftForward fires immediately →
-        // topIndex advances → next decide() also fires → the window jumps [ch0..ch2] to
-        // [ch3..ch5] with no user input. And once the pattern is established, any backward shift
-        // is immediately re-undone by a fresh forward shift on the next decide, so the user
-        // can't scroll back. Field-observed as "cannot scroll to the chapters BEFORE ch12".
+        // atBottomOfLoadedWindow was true even at scrollY=0 → ShiftForward fired immediately →
+        // topIndex advanced → the window jumped [ch0..ch2] to [ch3..ch5] with no user input,
+        // and any backward shift was re-undone by a fresh forward shift on the next decide, so
+        // the user couldn't scroll back. Field-observed as "cannot scroll to the chapters BEFORE
+        // ch12".
         //
-        // topIndex=0 pins out the backward-shift path (topIndex>0 is a required condition), so
-        // the ONLY trigger this test exercises is the bottom-of-window one. Midpoint trigger is
-        // false too (midY at 1200 in ch0 → viewportChapterIndex=0 → 0-0=0 not > 1). Decision
-        // must be Hold; without the guard it was ShiftForward.
+        // This test locks in the guard against ShiftForward for that case. When
+        // appendOnlyMaxWindow is not passed (default 0), the fits-in-viewport branch also does
+        // not fire — decision is Hold. See separate AppendOnly tests below for the opt-in path
+        // that grows the window without dropping the top.
         val mgr = ChapterWindowManager(chaptersBehind = 1)
         val window = listOf(
             slot("ch0", top = 0,    height = 500),
@@ -352,6 +382,165 @@ class ChapterWindowManagerTest {
             "loaded window fits in viewport — must not auto-cascade forward",
             ChapterWindowManager.Decision.Hold, d,
         )
+    }
+
+    // ── AppendOnly (fits-in-viewport wall-off unstick) ───────────────────────
+    //
+    // Regression: book e866cd1d ("12 Principles for Raising a Child with ADHD"). Spine opens
+    // with cover → fm01 ("Praise for…" 2.3 KB) → fm02 ("Selected Works From…" 1.3 KB) →
+    // title (0.6 KB) → copyright. The natural 3-chapter initial window (fm01, fm02, title) is
+    // ~a few hundred pixels tall — fits inside a single viewport. ShiftForward can never fire
+    // (loadedContentBottom <= viewportHeight is deliberately excluded upstream to avoid
+    // cascading past the user's opened position). Result: scroll dead-ends between "Selected
+    // Works From…" and the title page — "as if there is no more book". AppendOnly grows the
+    // window without dropping the top so more chapters load AND the reader can still scroll
+    // back to the front-matter.
+
+    @Test
+    fun `fires AppendOnly when loaded window fits in viewport and more chapters exist`() {
+        // Fresh cold-open at spine[0] (topIndex=0 → backward-shift path pinned out because
+        // topIndex>0 is a required condition).
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = listOf(
+            slot("cover", top = 0,   height = 180),
+            slot("fm01",  top = 180, height = 220),
+            slot("fm02",  top = 400, height = 140),  // total = 540 << viewport (2400)
+        )
+        val d = mgr.decide(
+            scrollY = 0,
+            viewportChapterIndex = 0,     // opened at the cover
+            window = window,
+            topIndex = 0,
+            totalChapters = 37,
+            viewportHeight = 2_400,
+            appendOnlyMaxWindow = 8,
+        )
+        assertEquals(
+            "fits-in-viewport wall-off must fire AppendOnly to load the next chapter",
+            ChapterWindowManager.Decision.AppendOnly, d,
+        )
+    }
+
+    @Test
+    fun `AppendOnly is capped by appendOnlyMaxWindow`() {
+        // Pathological "all short chapters" book: 8 tiny chapters loaded, still fit in viewport.
+        // Cap prevents runaway loads that would eventually blow the WebView renderer memory.
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = (0 until 8).map { i ->
+            slot("ch$i", top = i * 100, height = 100)  // total = 800 < viewport (2400)
+        }
+        val d = mgr.decide(
+            scrollY = 0,
+            viewportChapterIndex = 1,
+            window = window,
+            topIndex = 0,
+            totalChapters = 50,
+            viewportHeight = 2_400,
+            appendOnlyMaxWindow = 8,
+        )
+        assertEquals(
+            "AppendOnly must stop firing at the cap, even if window still fits in viewport",
+            ChapterWindowManager.Decision.Hold, d,
+        )
+    }
+
+    @Test
+    fun `AppendOnly does not fire when no more chapters exist ahead`() {
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = listOf(
+            slot("ch0", top = 0,    height = 500),
+            slot("ch1", top = 500,  height = 500),
+            slot("ch2", top = 1_000, height = 500),
+        )
+        val d = mgr.decide(
+            scrollY = 0,
+            viewportChapterIndex = 1,
+            window = window,
+            topIndex = 0,
+            totalChapters = 3,           // window covers the whole spine
+            viewportHeight = 2_400,
+            appendOnlyMaxWindow = 8,
+        )
+        assertEquals(ChapterWindowManager.Decision.Hold, d)
+    }
+
+    @Test
+    fun `AppendOnly does not fire once loaded window exceeds viewport`() {
+        // Once one appended chapter measures back to placeholder height (or the natural
+        // combined height exceeds viewport), AppendOnly stops firing so the normal
+        // ShiftForward/Backward algorithm takes over.
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = listOf(
+            slot("ch0", top = 0,     height = 500),
+            slot("ch1", top = 500,   height = 500),
+            slot("ch2", top = 1_000, height = 500),
+            slot("ch3", top = 1_500, height = 2_000),  // total = 3500 > viewport (2400)
+        )
+        val d = mgr.decide(
+            scrollY = 0,
+            viewportChapterIndex = 1,
+            window = window,
+            topIndex = 0,
+            totalChapters = 11,
+            viewportHeight = 2_400,
+            appendOnlyMaxWindow = 8,
+        )
+        assertEquals(ChapterWindowManager.Decision.Hold, d)
+    }
+
+    @Test
+    fun `fires AppendOnly again after appended chapter measures short`() {
+        // Regression: AppendOnly appends chapter at placeholder height (~viewport), which
+        // temporarily makes fitsInViewport=false and halts the chain. When it then measures back
+        // to its actual short height, decide() must fire AppendOnly again so the window keeps
+        // growing. This simulates the second decide() call after copyright.html (3 KB) measures
+        // back down from placeholder to its real ~200 px height.
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        // cover + fm01 + fm02 + title + copyright — all small, total 630 px << viewport 2400
+        val window = listOf(
+            slot("cover",      top = 0,   height = 120),
+            slot("fm01",       top = 120, height = 180),
+            slot("fm02",       top = 300, height = 130),
+            slot("title",      top = 430, height =  80),
+            slot("copyright",  top = 510, height = 120),  // just measured back from placeholder
+        )
+        val d = mgr.decide(
+            scrollY = 0,
+            viewportChapterIndex = 0,
+            window = window,
+            topIndex = 0,
+            totalChapters = 37,
+            viewportHeight = 2_400,
+            appendOnlyMaxWindow = 8,
+        )
+        assertEquals(
+            "AppendOnly must continue chaining when appended chapter also measures short",
+            ChapterWindowManager.Decision.AppendOnly, d,
+        )
+    }
+
+    @Test
+    fun `ShiftForward wins over AppendOnly when both would apply`() {
+        // Guard against a future refactor accidentally reordering the when-branches: ShiftForward
+        // must take precedence so the memory-managed sliding window keeps working normally when
+        // the midpoint has advanced past the behind budget, even if the fits-in-viewport
+        // condition also happens to be true.
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = listOf(
+            slot("ch0", top = 0,   height = 300),
+            slot("ch1", top = 300, height = 300),
+            slot("ch2", top = 600, height = 300),   // total = 900 < viewport (2400) → fitsInViewport
+        )
+        val d = mgr.decide(
+            scrollY = 0,
+            viewportChapterIndex = 2,     // gap = 2 - 0 = 2 > chaptersBehind(1) → ShiftForward
+            window = window,
+            topIndex = 0,
+            totalChapters = 11,
+            viewportHeight = 2_400,
+            appendOnlyMaxWindow = 8,
+        )
+        assertEquals(ChapterWindowManager.Decision.ShiftForward, d)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWindowManagerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWindowManagerTest.kt
@@ -55,6 +55,7 @@ class ChapterWindowManagerTest {
             window = uniformWindow(7),
             topIndex = 3,
             totalChapters = 20,
+            backwardNavigationIntent = true,
         )
         assertEquals(ChapterWindowManager.Decision.ShiftBackward, decision)
     }
@@ -124,6 +125,95 @@ class ChapterWindowManagerTest {
         assertEquals(ChapterWindowManager.Decision.Hold, mgr.decide(0, 0, emptyList(), 0, 10))
     }
 
+    // ── direction gate on ShiftBackward (regression for short part-title boundaries) ───────────
+    //
+    // Field-observed in "Taking Charge of ADHD": spine has ch06 → pt02 (short part-title) →
+    // ch07. Window = [pt02(17), ch07(18), ch08(19)] with chaptersBehind=1. User scrolls to the
+    // beginning of ch07; scrollY drops below pt02.height/2 while viewportChapterIndex stays in
+    // ch07. Old code triggered ShiftBackward on the scroll heuristic alone, prepending ch06 and
+    // bumping sY by H_ch06 (~2300px). The resulting sY triggered ShiftForward immediately,
+    // removing ch06 and dropping sY back into the backward-shift zone — infinite oscillation.
+    //
+    // Fix: use the user's navigation direction. Forward intent suppresses the compensating
+    // backward shift; backward intent must still prepend because the short pt02 never contains
+    // the viewport midpoint, even at scrollY=0.
+
+    @Test
+    fun `forward intent suppresses ShiftBackward after compensation at short part title`() {
+        // Mirrors the ADHD book spine: [pt02(topIdx=17), ch07(18), ch08(19)], chaptersBehind=1.
+        // The viewport midpoint is in ch07 → 1 behind chapter (pt02) is already loaded → buffer
+        // full. scrollY is small (near the top of the stacked container after scroll compensation)
+        // but ShiftBackward must not fire because viewportChapterIndex - topIndex = 18-17 = 1 ≥ 1.
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = listOf(
+            slot("pt02", top = 0,     height = 350),   // short part-title page
+            slot("ch07", top = 350,   height = 8_000), // long chapter
+            slot("ch08", top = 8_350, height = 8_000),
+        )
+        val d = mgr.decide(
+            scrollY = 88,                // small — below pt02.height/2=175, old code would fire backward
+            viewportChapterIndex = 18,   // viewport mid is in ch07, not pt02
+            window = window,
+            topIndex = 17,
+            totalChapters = 30,
+            viewportHeight = 2_400,
+            backwardNavigationIntent = false,
+        )
+        assertEquals(
+            "forward intent must absorb the compensating low scrollY",
+            ChapterWindowManager.Decision.Hold, d,
+        )
+    }
+
+    @Test
+    fun `backward intent prepends through short part title even while viewport mid remains in ch07`() {
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = listOf(
+            slot("pt02", top = 0,     height = 350),
+            slot("ch07", top = 350,   height = 8_000),
+            slot("ch08", top = 8_350, height = 8_000),
+        )
+        val d = mgr.decide(
+            scrollY = 0,
+            viewportChapterIndex = 18,
+            window = window,
+            topIndex = 17,
+            totalChapters = 30,
+            viewportHeight = 2_400,
+            backwardNavigationIntent = true,
+        )
+        assertEquals(
+            "a backward gesture at the top clamp must load ch06 even though midpoint stays in ch07",
+            ChapterWindowManager.Decision.ShiftBackward,
+            d,
+        )
+    }
+
+    @Test
+    fun `ShiftBackward fires normally when viewport mid is IN the top (buffer) chapter`() {
+        // Once the user scrolls backward far enough that the viewport mid enters pt02, the behind
+        // budget drops to 0 < chaptersBehind(1) → ShiftBackward must fire to prepend ch06.
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = listOf(
+            slot("pt02", top = 0,     height = 350),
+            slot("ch07", top = 350,   height = 8_000),
+            slot("ch08", top = 8_350, height = 8_000),
+        )
+        val d = mgr.decide(
+            scrollY = 80,                // well inside pt02 (< 350/2 = 175)
+            viewportChapterIndex = 17,   // viewport mid now in pt02 (the top window chapter)
+            window = window,
+            topIndex = 17,
+            totalChapters = 30,
+            viewportHeight = 2_400,
+            backwardNavigationIntent = true,
+        )
+        assertEquals(
+            "viewport mid in top chapter → 0 behind chapters < chaptersBehind(1) → ShiftBackward fires",
+            ChapterWindowManager.Decision.ShiftBackward, d,
+        )
+    }
+
     // ── oscillation guard (regression for PRs #239 and #241) ────────────────
 
     @Test
@@ -164,6 +254,7 @@ class ChapterWindowManagerTest {
             window = window,
             topIndex = 1,
             totalChapters = 20,
+            backwardNavigationIntent = true,
         )
         assertEquals("guard must suppress backward after forward", ChapterWindowManager.Decision.Hold, d2)
     }
@@ -187,6 +278,7 @@ class ChapterWindowManagerTest {
             window = window,
             topIndex = 1,
             totalChapters = 20,
+            backwardNavigationIntent = true,
         )
         assertEquals("backward should fire once guard has cleared", ChapterWindowManager.Decision.ShiftBackward, d3)
     }
@@ -204,7 +296,7 @@ class ChapterWindowManagerTest {
     // short chapters (gap=3 no longer > 3). The elided reader uses 3.
 
     @Test
-    fun `chaptersBehind 1 — backward shift into a short-middle-chapter window oscillates back to forward`() {
+    fun `chaptersBehind 1 — backward shift into a short-middle-chapter window no longer oscillates`() {
         val mgr = ChapterWindowManager(chaptersBehind = 1)
         // Post-backward window: tall ch6 prepended over short ch7 over tall ch8. Scroll
         // compensation lands the user inside ch6 near ch7 → midY overshoots into ch8.
@@ -221,10 +313,139 @@ class ChapterWindowManagerTest {
             totalChapters = 11,
             viewportHeight = 2_400,
         )
+        // Until 2026-08-03 this test pinned the OPPOSITE outcome (ShiftForward) as documentation
+        // of the then-known oscillation ("forward re-fires → undoes the backward, user cannot
+        // progress backward"), fixed at the time only for the elided reader by raising its
+        // chaptersBehind to 3. The scrollback guard now fixes the oscillation for every
+        // chaptersBehind value: evicting ch6 here would leave scrollY - 2337 = 111 px of
+        // scrollback (< half a viewport), stranding the reader at the top clamp.
         assertEquals(
-            "chaptersBehind=1: gap 2 > 1 → forward re-fires → oscillation",
-            ChapterWindowManager.Decision.ShiftForward, d,
+            "eviction right after a backward prepend must hold — this was the blank-screen ping-pong",
+            ChapterWindowManager.Decision.Hold, d,
         )
+    }
+
+    @Test
+    fun `backward intent prevents forward eviction after prepending across short part title`() {
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val postBackwardWindow = listOf(
+            slot("ch06", top = 0,     height = 2_337),
+            slot("pt02", top = 2_337, height = 499),
+            slot("ch07", top = 2_836, height = 2_809),
+        )
+        val d = mgr.decide(
+            scrollY = 2_448,
+            viewportChapterIndex = 18,
+            window = postBackwardWindow,
+            topIndex = 16,
+            totalChapters = 30,
+            viewportHeight = 2_400,
+            backwardNavigationIntent = true,
+        )
+        assertEquals(
+            "the prepended ch06 must remain loaded while the user is navigating backward",
+            ChapterWindowManager.Decision.Hold,
+            d,
+        )
+    }
+
+    @Test
+    fun `forward shift never strands the viewport at the top clamp after a backward prepend`() {
+        // Device log 2026-08-03: ShiftBackward prepends ch06 (34372 px) and compensates scrollY to
+        // 34372 — the user is still looking at pt02. The compensating scroll change re-runs decide
+        // with the intent already consumed (false); the tiny pt02 leaves the viewport midpoint in
+        // ch07 = topIndex+2 > chaptersBehind, so the index-based trigger evicted the ch06 that was
+        // prepended 130 ms earlier, resetting scrollY to 0 — an endless prepend/evict ping-pong the
+        // user sees as a blank screen. Evicting the top chapter is only legal when it leaves at
+        // least half a viewport of scrollback (scrollY - firstChapterHeight >= viewportHeight/2).
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val postBackwardWindow = listOf(
+            slot("ch06", top = 0,      height = 34_372),
+            slot("pt02", top = 34_372, height = 352),
+            slot("ch07", top = 34_724, height = 34_372),
+            slot("ch08", top = 69_096, height = 34_372),
+        )
+        val d = mgr.decide(
+            scrollY = 34_372,
+            viewportChapterIndex = 3, // midpoint skips past the 352 px pt02 into ch07
+            window = postBackwardWindow,
+            topIndex = 1,
+            totalChapters = 10,
+            viewportHeight = 2_274,
+            backwardNavigationIntent = false, // consumed by the ShiftBackward that just ran
+        )
+        assertEquals(
+            "evicting ch06 here would clamp scrollY back to 0 and restart the oscillation",
+            ChapterWindowManager.Decision.Hold,
+            d,
+        )
+    }
+
+    @Test
+    fun `backward shift holds while the previous prepend is still an unmeasured placeholder`() {
+        // Field repro 2026-08-04 (ch11/Part III): each backward pull during a slow prepend load
+        // stacked another screen-sized blank placeholder until the whole window was white.
+        // While the top chapter is still a placeholder, further ShiftBackwards must hold; the
+        // pending measure's compensating scroll change re-runs the decision as soon as it lands.
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = listOf(
+            slot("ch10-placeholder", top = 0,     height = 2_400), // unmeasured prepend
+            slot("pt03",             top = 2_400, height = 352),
+            slot("ch11",             top = 2_752, height = 34_372),
+            slot("ch12",             top = 37_124, height = 34_372),
+        )
+        val held = mgr.decide(
+            scrollY = 900, // inside the blank placeholder, below its half-height trigger
+            viewportChapterIndex = 7,
+            window = window,
+            topIndex = 7,
+            totalChapters = 12,
+            viewportHeight = 2_274,
+            backwardNavigationIntent = true,
+            topChapterStillPlaceholder = true,
+        )
+        assertEquals(
+            "a second prepend must wait for the pending one to measure",
+            ChapterWindowManager.Decision.Hold,
+            held,
+        )
+        val afterMeasure = mgr.decide(
+            scrollY = 900,
+            viewportChapterIndex = 7,
+            window = window,
+            topIndex = 7,
+            totalChapters = 12,
+            viewportHeight = 2_274,
+            backwardNavigationIntent = true,
+            topChapterStillPlaceholder = false,
+        )
+        assertEquals(
+            "once the pending prepend measures the next backward shift may fire",
+            ChapterWindowManager.Decision.ShiftBackward,
+            afterMeasure,
+        )
+    }
+
+    @Test
+    fun `forward shift still fires once the reader has scrolled clear of the top chapter`() {
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = listOf(
+            slot("ch06", top = 0,      height = 34_372),
+            slot("pt02", top = 34_372, height = 352),
+            slot("ch07", top = 34_724, height = 34_372),
+            slot("ch08", top = 69_096, height = 34_372),
+        )
+        val d = mgr.decide(
+            // Reader has moved a full half-viewport past ch06's bottom edge: eviction leaves
+            // ample scrollback, so the normal look-ahead shift must still fire.
+            scrollY = 34_372 + 1_200,
+            viewportChapterIndex = 3,
+            window = window,
+            topIndex = 1,
+            totalChapters = 10,
+            viewportHeight = 2_274,
+        )
+        assertEquals(ChapterWindowManager.Decision.ShiftForward, d)
     }
 
     @Test
@@ -286,6 +507,7 @@ class ChapterWindowManagerTest {
             window = window,
             topIndex = 1,
             totalChapters = 20,
+            backwardNavigationIntent = true,
         )
         assertEquals("reset must clear guard", ChapterWindowManager.Decision.ShiftBackward, d)
     }
@@ -424,12 +646,24 @@ class ChapterWindowManagerTest {
     }
 
     @Test
-    fun `AppendOnly is capped by appendOnlyMaxWindow`() {
-        // Pathological "all short chapters" book: 8 tiny chapters loaded, still fit in viewport.
-        // Cap prevents runaway loads that would eventually blow the WebView renderer memory.
+    fun `AppendOnly continues past appendOnlyMaxWindow when window still fits in viewport`() {
+        // Regression test for Bug 1 in book e866cd1d ("12 Principles for Raising a Child with
+        // ADHD"): scroll stuck from "contents" to "dedication".
+        //
+        // The book has ≥8 short front-matter chapters that all fit in one viewport. After
+        // AppendOnly fills appendOnlyMaxWindow=8 slots the old code returned Hold:
+        //   - AppendOnly was blocked (window.size >= appendOnlyMaxWindow)
+        //   - ShiftForward was blocked (fitsInViewport=true suppresses it)
+        //   - No scroll events fire (maxScrollY==0 when all content fits in viewport)
+        //   - maybeShift never re-runs → reader permanently deadlocked
+        //
+        // Fix: the cap only applies to the atBottomOfLoadedWindow trigger path. When
+        // fitsInViewport=true, AppendOnly bypasses the cap and fires until content spills
+        // past the viewport (natural self-limiting stop condition), at which point the normal
+        // ShiftForward algorithm takes over.
         val mgr = ChapterWindowManager(chaptersBehind = 1)
         val window = (0 until 8).map { i ->
-            slot("ch$i", top = i * 100, height = 100)  // total = 800 < viewport (2400)
+            slot("ch$i", top = i * 100, height = 100)  // total = 800 << viewport (2400)
         }
         val d = mgr.decide(
             scrollY = 0,
@@ -441,8 +675,36 @@ class ChapterWindowManagerTest {
             appendOnlyMaxWindow = 8,
         )
         assertEquals(
-            "AppendOnly must stop firing at the cap, even if window still fits in viewport",
-            ChapterWindowManager.Decision.Hold, d,
+            "fitsInViewport bypasses the cap — AppendOnly must fire to avoid the deadlock",
+            ChapterWindowManager.Decision.AppendOnly, d,
+        )
+    }
+
+    @Test
+    fun `AppendOnly cap still applies on atBottomOfLoadedWindow path`() {
+        // The window-size cap guards the atBottomOfLoadedWindow path where ShiftForward is a
+        // viable alternative. Once the window is large enough, ShiftForward takes over (the test
+        // `ShiftForward still fires at bottom of window when window is at max size` pins that
+        // transition). This test confirms the cap is still active when fitsInViewport=false.
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        // 8 chapters whose total exceeds the viewport — NOT a fitsInViewport case.
+        val window = (0 until 8).map { i ->
+            slot("ch$i", top = i * 400, height = 400)  // total = 3200 > viewport (2400)
+        }
+        // scrollY + vh >= loadedContentBottom → atBottomOfLoadedWindow=true
+        val d = mgr.decide(
+            scrollY = 800,                // 800 + 2400 = 3200 >= 3200 → at bottom
+            viewportChapterIndex = 3,
+            window = window,
+            topIndex = 0,
+            totalChapters = 50,
+            viewportHeight = 2_400,
+            appendOnlyMaxWindow = 8,      // window at cap → AppendOnly blocked on this path
+        )
+        // Cap applies on the atBottomOfLoadedWindow path: ShiftForward fires instead.
+        assertEquals(
+            "cap applies on atBottomOfLoadedWindow path — ShiftForward takes over",
+            ChapterWindowManager.Decision.ShiftForward, d,
         )
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWindowManagerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWindowManagerTest.kt
@@ -725,4 +725,69 @@ class ChapterWindowManagerTest {
         // -1 - 0 = -1, not > 3 → no forward; scrollY=0 < 1500 but topIndex=0 → no backward → Hold
         assertEquals(ChapterWindowManager.Decision.Hold, d)
     }
+
+    @Test
+    fun `AppendOnly fires instead of ShiftForward when at bottom of initial window and window can still grow`() {
+        // Regression for book e866cd1d ("12 Principles for Raising a Child with ADHD") on
+        // physical devices with larger font sizes / higher DPI than the API-25 emulator.
+        //
+        // On those devices fm02 (~500 px) + title (~1840 px) + copyright (~300 px) totals ~2640 px,
+        // which exceeds the viewport (2340 px) — fitsInViewport=false, so the classic AppendOnly
+        // path does not fire. After the initial scroll lands at scrollY=500 (start of title),
+        // scrollY+viewport=2840 >= loadedContentBottom=2640 → atBottomOfLoadedWindow=true.
+        //
+        // BUG (pre-fix): ShiftForward fires (atBottomOfLoadedWindow path). removeTop() drops fm02;
+        // scroll compensation resets scrollY to 0. With scrollY=0 < title/2=920 the NEXT decide()
+        // fires ShiftBackward, prepending fm02 at placeholder height and bumping scrollY to 2340.
+        // fm02 then measures short, scroll drops back to ~0 and atBottomOfLoadedWindow fires
+        // ShiftForward again — an infinite oscillation. The scroll appears frozen.
+        //
+        // FIX: AppendOnly takes priority over ShiftForward when the window can still grow.
+        // Appending the next chapter extends content below the viewport, atBottomOfLoadedWindow
+        // becomes false, and the oscillation never starts.
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = listOf(
+            slot("fm02",      top = 0,    height =   500),
+            slot("title",     top = 500,  height = 1_840),
+            slot("copyright", top = 2_340, height =  300),   // total = 2640 > viewport (2340)
+        )
+        val d = mgr.decide(
+            scrollY = 500,               // initial scroll to start of title (= fm02.height)
+            viewportChapterIndex = 3,    // title is at spine index 3; gap = 3-2 = 1 = chaptersBehind → no pastBehindBudget
+            window = window,
+            topIndex = 2,
+            totalChapters = 24,
+            viewportHeight = 2_340,      // scrollY+vH=2840 >= loadedContentBottom=2640 → atBottomOfLoadedWindow
+            appendOnlyMaxWindow = 8,
+        )
+        assertEquals(
+            "AppendOnly must fire instead of ShiftForward at bottom of initial window — ShiftForward oscillates",
+            ChapterWindowManager.Decision.AppendOnly, d,
+        )
+    }
+
+    @Test
+    fun `ShiftForward still fires at bottom of window when window is at max size`() {
+        // When the window has reached appendOnlyMaxWindow, AppendOnly is exhausted.
+        // ShiftForward must fire so the window shifts forward as normal.
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = listOf(
+            slot("ch0", top = 0,    height = 500),
+            slot("ch1", top = 500,  height = 1_840),
+            slot("ch2", top = 2_340, height = 300),
+        )
+        val d = mgr.decide(
+            scrollY = 500,
+            viewportChapterIndex = 1,    // gap = 1-0 = 1 = chaptersBehind → no pastBehindBudget alone
+            window = window,
+            topIndex = 0,
+            totalChapters = 24,
+            viewportHeight = 2_340,      // atBottomOfLoadedWindow = true
+            appendOnlyMaxWindow = 3,     // window already AT the cap → AppendOnly blocked
+        )
+        assertEquals(
+            "AppendOnly blocked at max window — ShiftForward must fire",
+            ChapterWindowManager.Decision.ShiftForward, d,
+        )
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWindowManagerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWindowManagerTest.kt
@@ -65,8 +65,8 @@ class ChapterWindowManagerTest {
         // tiny and fit in one viewport. scrollY=0 < firstChapterHeight/2 AND topIndex>0 would
         // normally trigger ShiftBackward, removing title and prepending cover. After that there
         // is no subsequent trigger (maxScrollY stays 0), so AppendOnly never fires and the reader
-        // walls off. Suppressing ShiftBackward when fitsInViewport lets ShiftForward or AppendOnly
-        // fire instead.
+        // walls off. Suppressing ShiftBackward when fitsInViewport lets AppendOnly fire instead,
+        // growing the window without dropping the top.
         val mgr = ChapterWindowManager(chaptersBehind = 1)
         val window = listOf(
             slot("fm01",  top = 0,   height = 220),
@@ -82,10 +82,12 @@ class ChapterWindowManagerTest {
             viewportHeight = 2_400,
             appendOnlyMaxWindow = 8,
         )
-        // ShiftBackward must be suppressed; ShiftForward fires (gap = 3-1=2 > chaptersBehind=1)
+        // ShiftBackward must be suppressed; ShiftForward must also be suppressed (fitsInViewport
+        // pins scrollY=0 so pastBehindBudget is a false positive — no actual reading progress was
+        // made); AppendOnly fires to grow the window without dropping the top.
         assertEquals(
-            "ShiftBackward must not fire when window fits in viewport",
-            ChapterWindowManager.Decision.ShiftForward, d,
+            "ShiftBackward and ShiftForward must not fire when window fits in viewport — AppendOnly grows it",
+            ChapterWindowManager.Decision.AppendOnly, d,
         )
     }
 
@@ -520,11 +522,12 @@ class ChapterWindowManagerTest {
     }
 
     @Test
-    fun `ShiftForward wins over AppendOnly when both would apply`() {
-        // Guard against a future refactor accidentally reordering the when-branches: ShiftForward
-        // must take precedence so the memory-managed sliding window keeps working normally when
-        // the midpoint has advanced past the behind budget, even if the fits-in-viewport
-        // condition also happens to be true.
+    fun `AppendOnly wins over ShiftForward when window fits in viewport`() {
+        // When fitsInViewport=true, scrollY is pinned at 0 regardless of reading progress, so
+        // pastBehindBudget is a false positive — the midpoint landing deep in the window does
+        // NOT mean the user read past the behind budget. Firing ShiftForward here would cascade
+        // the window forward past the user's opened position (the ADHD-book bug). AppendOnly
+        // must win instead: it grows the window without dropping the top.
         val mgr = ChapterWindowManager(chaptersBehind = 1)
         val window = listOf(
             slot("ch0", top = 0,   height = 300),
@@ -533,14 +536,60 @@ class ChapterWindowManagerTest {
         )
         val d = mgr.decide(
             scrollY = 0,
-            viewportChapterIndex = 2,     // gap = 2 - 0 = 2 > chaptersBehind(1) → ShiftForward
+            viewportChapterIndex = 2,     // gap = 2 - 0 = 2 > chaptersBehind(1), but fitsInViewport
             window = window,
             topIndex = 0,
             totalChapters = 11,
             viewportHeight = 2_400,
             appendOnlyMaxWindow = 8,
         )
-        assertEquals(ChapterWindowManager.Decision.ShiftForward, d)
+        assertEquals(
+            "AppendOnly must fire instead of ShiftForward when window fits in viewport",
+            ChapterWindowManager.Decision.AppendOnly, d,
+        )
+    }
+
+    @Test
+    fun `does not shift forward past opened position when initial window fits in viewport`() {
+        // Regression for book e866cd1d ("12 Principles for Raising a Child with ADHD").
+        // ABS saved position = title.html (spine[3]). initialWindow() gives topIndex=2 (fm02),
+        // window=[fm02, title, copyright]. All three chapters are tiny front-matter pages whose
+        // total device-pixel height (~450 px) is well under the 2400-px viewport.
+        //
+        // BUG (pre-fix): after pendingInitialScroll lands at title (scrollY=fm02.height≈200),
+        // maybeShift() fires. The viewport midpoint at y≈1200 lands in copyright, which is 2
+        // slots past topIndex=2 — pastBehindBudget=true (2>chaptersBehind=1) — and ShiftForward
+        // fires. removeTop() drops fm02, scrollBy(-fm02.height) → scrollY=0. Another
+        // handleScrollChange posts maybeShift(); the cascade repeats until the window has raced
+        // past title (and often all the way to preface/ch01). The user opens the book expecting
+        // to see the title page but instead lands on intro or ch01 and cannot scroll back to
+        // fm02 / title without multiple manual backward shifts.
+        //
+        // FIX: gate ShiftForward on !fitsInViewport. When all loaded content fits in one screen,
+        // scrollY is pinned at 0 so pastBehindBudget is a false positive — no reading progress
+        // was actually made. AppendOnly must fire instead to grow the window without dropping
+        // the top, giving the user more content to scroll into.
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        // Mirror real ADHD-book front-matter: fm02="Selected Works From…" + title + copyright.
+        // Heights are approximate device px measured on a 2.625-dpr API-25 emulator.
+        val window = listOf(
+            slot("fm02",      top = 0,   height = 210),
+            slot("title",     top = 210, height =  90),
+            slot("copyright", top = 300, height = 160),   // total = 460 << viewport (2400)
+        )
+        val d = mgr.decide(
+            scrollY = 210,               // landed at top of title (= fm02.height) after initial scroll
+            viewportChapterIndex = 4,    // copyright is at global spine index 4; gap = 4-2 = 2 > 1
+            window = window,
+            topIndex = 2,
+            totalChapters = 24,
+            viewportHeight = 2_400,
+            appendOnlyMaxWindow = 8,
+        )
+        assertEquals(
+            "ShiftForward must not fire when window fits in viewport — would cascade past title page",
+            ChapterWindowManager.Decision.AppendOnly, d,
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWindowManagerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ChapterWindowManagerTest.kt
@@ -427,6 +427,57 @@ class ChapterWindowManagerTest {
     }
 
     @Test
+    fun `backward shift holds during the layout-pending window after measurement completes`() {
+        // Regression 2026-08-06: after a prependChapter the measuring callback fires, sets the
+        // WebView's layoutParams to the real height, and returns. The LinearLayout hasn't run its
+        // layout pass yet — NestedScrollView's max-scroll boundary still reflects the placeholder
+        // height. ContinuousWindowController sets prependAwaitingLayout=true from that moment until
+        // doOnNextLayout fires and threads topChapterStillPlaceholder=true into decide().
+        // Without this gate, decide() sees a fully-measured (non-placeholder) slot and may fire
+        // another ShiftBackward before the first compensating scrollBy has been applied, stacking
+        // another blank prepend on top of an already-correcting one.
+        val mgr = ChapterWindowManager(chaptersBehind = 1)
+        val window = listOf(
+            // ch06 is now measured (42 704 px) but the LinearLayout hasn't committed that height
+            // yet — controller still tracks the real height in measuredHeights[0] for this test,
+            // but passes topChapterStillPlaceholder=true to reflect the layout-pending state.
+            slot("ch06",  top = 0,      height = 42_704),
+            slot("ch07",  top = 42_704, height = 34_372),
+            slot("ch08",  top = 77_076, height = 34_372),
+        )
+        val held = mgr.decide(
+            scrollY = 900,
+            viewportChapterIndex = 1,
+            window = window,
+            topIndex = 5,
+            totalChapters = 12,
+            viewportHeight = 2_337,
+            backwardNavigationIntent = true,
+            topChapterStillPlaceholder = true, // prependAwaitingLayout=true in controller
+        )
+        assertEquals(
+            "must hold while the layout pass for the measured prepend is still pending",
+            ChapterWindowManager.Decision.Hold,
+            held,
+        )
+        val afterLayout = mgr.decide(
+            scrollY = 900,
+            viewportChapterIndex = 1,
+            window = window,
+            topIndex = 5,
+            totalChapters = 12,
+            viewportHeight = 2_337,
+            backwardNavigationIntent = true,
+            topChapterStillPlaceholder = false, // doOnNextLayout fired, prependAwaitingLayout=false
+        )
+        assertEquals(
+            "once the layout pass completes the next backward shift may fire",
+            ChapterWindowManager.Decision.ShiftBackward,
+            afterLayout,
+        )
+    }
+
+    @Test
     fun `forward shift still fires once the reader has scrolled clear of the top chapter`() {
         val mgr = ChapterWindowManager(chaptersBehind = 1)
         val window = listOf(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -1001,6 +1001,31 @@ class ContinuousPositionTrackerTest {
     }
 
     @Test
+    fun `backward prepend scroll floor holds at real chapter height during layout-pending window`() {
+        // Regression 2026-08-06: after onHeightMeasured fires, prependAwaitingLayout=true until
+        // doOnNextLayout completes the compensating scrollBy. During that window the controller
+        // feeds topSlotStillPlaceholder=true (prependAwaitingLayout | …) into backwardPrependScrollFloor.
+        // The floor must equal the real measured chapter height — not 0 — to prevent any fling or
+        // drag from carrying the user past the boundary before the compensating scroll fires.
+        assertEquals(
+            42_704,
+            ContinuousPositionTracker.backwardPrependScrollFloor(
+                topSlotStillPlaceholder = true,  // prependAwaitingLayout=true post-measurement
+                topSlotHeightPx = 42_704,        // real height measured by JS (index.html field repro)
+            ),
+        )
+        // Once doOnNextLayout fires and prependAwaitingLayout clears (and boundaryDetentArmed
+        // clears on the next touch-down), the floor drops to zero — normal scrolling resumes.
+        assertEquals(
+            0,
+            ContinuousPositionTracker.backwardPrependScrollFloor(
+                topSlotStillPlaceholder = false,
+                topSlotHeightPx = 42_704,
+            ),
+        )
+    }
+
+    @Test
     fun `backward prepend scroll floor holds at real chapter height when boundary detent is armed after measurement`() {
         // Regression for 2026-08-06: prependChapter must arm boundaryDetentArmed so the floor
         // stays at the chapter's real height even after prependAwaitingMeasure becomes false

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -898,4 +898,123 @@ class ContinuousPositionTrackerTest {
         assertEquals(2, initial.totalChapters)
         assertEquals(setOf(0, 1), initial.pendingMeasureIndices())
     }
+
+    @Test
+    fun `backward fling floor caps a crossing fling one page past the folded boundary`() {
+        // Field repro 2026-08-05 (Scenario A, behind-buffer path): window [ch06, pt02, ch07]
+        // loaded at open; one backward fling from ch07's top teleported ~4 viewports into
+        // unpainted ch06. The floor folds the 476 px part title into the boundary and lands
+        // the fling one page (90% of 2400 = 2160) above pt02's top.
+        val window = listOf(
+            ContinuousPositionTracker.ChapterSlot("ch06", top = 0,      height = 32_727),
+            ContinuousPositionTracker.ChapterSlot("pt02", top = 32_727, height = 476),
+            ContinuousPositionTracker.ChapterSlot("ch07", top = 33_203, height = 29_127),
+        )
+        assertEquals(
+            32_727 - 2_160,
+            ContinuousPositionTracker.backwardFlingFloor(
+                scrollYStart = 33_400, // just inside ch07
+                window = window,
+                viewportHeightPx = 2_400,
+            ),
+        )
+        // Deep inside ch06 the fling's own chapter top is the window's first slot: no constraint.
+        assertEquals(
+            0,
+            ContinuousPositionTracker.backwardFlingFloor(
+                scrollYStart = 18_000,
+                window = window,
+                viewportHeightPx = 2_400,
+            ),
+        )
+        // Viewport TOP still inside ch06's tail while the reader is already looking at ch07
+        // (midpoint past pt02) — e.g. a nav smooth-scroll settling. The floor must anchor on the
+        // midpoint; anchoring on the top resolved to the window's first slot and returned no
+        // floor, letting the fling teleport (second 2026-08-05 repro round).
+        assertEquals(
+            32_727 - 2_160,
+            ContinuousPositionTracker.backwardFlingFloor(
+                scrollYStart = 32_600,
+                window = window,
+                viewportHeightPx = 2_400,
+            ),
+        )
+    }
+
+    @Test
+    fun `backward fling floor folds at most half a viewport of tiny back-matter chapters`() {
+        // Field repro 2026-08-05 ("Free Excerpt" edition): back matter is a RUN of sub-viewport
+        // resources. Unbounded folding treated the whole run as one boundary, so a single pull
+        // from the excerpt page skipped about-the-author + publisher pages and landed deep in
+        // the index. The fold stops once the folded run exceeds viewport/2 (1200 here): only
+        // the 800 px promo page folds; the boundary is ITS top, not the index's bottom.
+        val window = listOf(
+            ContinuousPositionTracker.ChapterSlot("index",   top = 0,      height = 20_000),
+            ContinuousPositionTracker.ChapterSlot("author",  top = 20_000, height = 900),
+            ContinuousPositionTracker.ChapterSlot("promo",   top = 20_900, height = 800),
+            ContinuousPositionTracker.ChapterSlot("excerpt", top = 21_700, height = 8_000),
+        )
+        assertEquals(
+            20_900 - 2_160,
+            ContinuousPositionTracker.backwardFlingFloor(
+                scrollYStart = 21_800, // just inside the excerpt page
+                window = window,
+                viewportHeightPx = 2_400,
+            ),
+        )
+    }
+
+    @Test
+    fun `backward fling floor never goes negative near the window top`() {
+        val window = listOf(
+            ContinuousPositionTracker.ChapterSlot("ch05", top = 0,   height = 800),
+            ContinuousPositionTracker.ChapterSlot("ch06", top = 800, height = 30_000),
+        )
+        assertEquals(
+            0,
+            ContinuousPositionTracker.backwardFlingFloor(
+                scrollYStart = 900,
+                window = window,
+                viewportHeightPx = 2_400,
+            ),
+        )
+    }
+
+    @Test
+    fun `backward prepend scroll floor pins the reader at the boundary while the placeholder loads`() {
+        // Field repro 2026-08-05 (ch07 → ch06): pixels dragged through the unmeasured blank
+        // placeholder resolve to never-seen content once the real height lands — an abrupt
+        // teleport deep into the previous chapter. While the top slot is still a placeholder the
+        // floor is its bottom edge (= the chapter boundary); it lifts as soon as it measures.
+        assertEquals(
+            2_274,
+            ContinuousPositionTracker.backwardPrependScrollFloor(
+                topSlotStillPlaceholder = true, topSlotHeightPx = 2_274,
+            ),
+        )
+        assertEquals(
+            0,
+            ContinuousPositionTracker.backwardPrependScrollFloor(
+                topSlotStillPlaceholder = false, topSlotHeightPx = 34_372,
+            ),
+        )
+    }
+
+    @Test
+    fun `backward prepend scroll floor holds at real chapter height when boundary detent is armed after measurement`() {
+        // Regression for 2026-08-06: prependChapter must arm boundaryDetentArmed so the floor
+        // stays at the chapter's real height even after prependAwaitingMeasure becomes false
+        // (measurement complete). Without the detent, topSlotStillPlaceholder=false → floor=0 →
+        // a mid-gesture drag or fling after the chapter measures carries the user past the
+        // boundary into the newly-revealed chapter (field-reported as "abrupt jump to Index").
+        // The detent keeps topSlotStillPlaceholder=true (via boundaryDetentArmed) so the floor
+        // equals the real height until the next deliberate ACTION_DOWN.
+        assertEquals(
+            25_000,
+            ContinuousPositionTracker.backwardPrependScrollFloor(
+                topSlotStillPlaceholder = true,  // boundaryDetentArmed=true post-measurement
+                topSlotHeightPx = 25_000,        // real chapter height after measure completes
+            ),
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a cluster of continuous-scroll bugs triggered by backward navigation across chapter boundaries.

**Root causes fixed:**

1. **Abrupt jump to deep mid-chapter on backward nav** (`fix(reader): defer prepend scroll compensation until after layout pass`): `onHeightMeasured` was calling `port.scrollBy(delta)` before the LinearLayout completed its layout pass. `NestedScrollView` clips `scrollTo()` to `[0, contentHeight - viewportHeight]`, and `contentHeight` was still placeholder-based — so a 40 367 px scroll to a 42 704 px chapter landed at scrollY=2793 instead of 42 704. Fix: defer `measuredHeights` update and `port.scrollBy(delta)` to `wv.doOnNextLayout`.

2. **Stale recycled-view `doOnNextLayout` callback** (`fix(reader): guard doOnNextLayout against stale recycled-view callbacks`): If `removeTop()` evicts a prepend and `prependChapter()` immediately reuses the same recycled WebView, the old `doOnNextLayout` listener fires with `j >= 0`, applying the previous chapter's delta to the new prepend's slot. Fix: generation counter — each registration captures the token; `removeTop()` and `openWindowAt()` increment it to invalidate stale callbacks.

3. **"Stuck title page"** (`fix(reader): unwedge continuous scroll on all-short front-matter books`): A late image load triggered `reapplyLandingAfterFallback` AFTER the user had already started scrolling, re-arming `landingHoldTargetY` for 600 ms.

4. **Continuous scroll suppresses ShiftForward on fits-in-viewport front-matter** (`fix(reader): suppress ShiftForward when all front-matter fits in one viewport`): When all loaded chapters fit in one viewport, `scrollY` is pinned at 0, making `pastBehindBudget` a false positive. New `fitsInViewport` guard suppresses ShiftForward; AppendOnly handles the fits-in-viewport case.

5. **Prefers AppendOnly over ShiftForward at bottom of initial window** (`fix(reader): prefer AppendOnly over ShiftForward when at bottom of initial window`): Prevents infinite oscillation when the initial scroll position is already at the bottom of loaded content.

6. **Boundary detent to prevent abrupt jump mid-gesture** (`fix(reader): arm boundary detent in prependChapter to prevent abrupt jump`): On fast GPUs the chapter could measure mid-gesture, lifting the floor before the gesture completed, letting the rest of the pull carry the user past the boundary.

7. **Nav cover for cross-window TOC navigation** (`fix(reader): add nav cover for continuous cross-window TOC navigation`): Blank flash when chapter-map tap fires after initial position is already set.

## Changes

- `ContinuousWindowController`: new `prependAwaitingLayout` flag, generation counter, `reapplyLandingSuperseded` guard, `fitsInViewport` suppression, AppendOnly preference, boundary detent, nav cover reset
- `ChapterWindowManager`: `topChapterStillPlaceholder`, `backwardNavigationIntent`, `fitsInViewport`, `evictionLeavesScrollback` guards; `AppendOnly` decision
- `ContinuousPositionTracker`: `backwardPrependScrollFloor`, `backwardFlingFloor` functions
- Tests: new regression tests pinning the layout-pending gate and floor behavior

## Test plan

- [ ] Continuous reader: navigate backward across a chapter with a large first resource (e.g. index.html / cover image) — verify scroll lands at the boundary, not deep mid-chapter
- [ ] Continuous reader: open a book with many short front-matter chapters — verify title page / first chapter is reachable without the reader being stuck
- [ ] Continuous reader: open at a mid-spine chapter — verify no immediate forward oscillation
- [ ] Continuous reader: cross-window TOC navigation — verify no blank flash
- [ ] `ChapterWindowManagerTest` and `ContinuousPositionTrackerTest` pass