### PR TITLE
fix(reader): suppress double-paint when diagram annotation selection crosses caption

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightLineCoverageWebViewTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightLineCoverageWebViewTest.kt
@@ -24,6 +24,20 @@ class HighlightLineCoverageWebViewTest {
         </html>
     """.trimIndent()
 
+    private val diagramFixture = """
+        <!doctype html>
+        <html>
+          <head><meta name="viewport" content="width=device-width, initial-scale=1"></head>
+          <body style="margin:0;font-size:16px;line-height:24px">
+            <p style="margin:20px">Text before the diagram.</p>
+            <figure style="margin:20px;width:400px">
+              <img id="diagram" alt="Diagram" style="display:block;width:400px;height:240px">
+            </figure>
+            <p style="margin:20px">Text after the diagram.</p>
+          </body>
+        </html>
+    """.trimIndent()
+
     @Test
     fun continuousAnnotationMarkCoversFullLineBandsWithoutGaps() {
         withSizedWebViewFixture(fixture, widthPx = 480, heightPx = 800) { webView ->
@@ -82,6 +96,36 @@ class HighlightLineCoverageWebViewTest {
             assertNativeSelectionLineCoverage(
                 painted = webView.rects("document.querySelectorAll('.riffle-highlight-tint')"),
                 text = webView.savedRawRects(),
+            )
+        }
+    }
+
+    @Test
+    fun readiumDecorationDoesNotExpandThinBoxOverDiagram() {
+        withSizedWebViewFixture(diagramFixture, widthPx = 480, heightPx = 800) { webView ->
+            webView.awaitInnerHeight()
+            webView.evalSync(
+                """
+                (function() {
+                  var diagram = document.getElementById('diagram').getBoundingClientRect();
+                  var box = document.createElement('div');
+                  box.className = 'riffle-highlight-tint';
+                  box.style.cssText = 'position:absolute;pointer-events:none;' +
+                    'left:' + (diagram.left + window.pageXOffset) + 'px;' +
+                    'top:' + (diagram.top + window.pageYOffset) + 'px;' +
+                    'width:' + diagram.width + 'px;height:2px;' +
+                    'background:rgba(251,191,36,0.50) !important;';
+                  document.body.appendChild(box);
+                })();
+                """.trimIndent(),
+            )
+            webView.evalSync(readiumHighlightLeadingAdjustmentJs())
+            webView.awaitReadiumLeadingAdjustment()
+
+            val painted = webView.rects("document.querySelector('.riffle-highlight-tint')").single()
+            assertTrue(
+                "diagram boundary box must remain subtle; height=${painted.bottom - painted.top}",
+                painted.bottom - painted.top <= 2.75,
             )
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/FiguresInHtmlRange.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/FiguresInHtmlRange.kt
@@ -216,6 +216,19 @@ internal fun mergeEnclosedFigures(
     val stashByFilename = stashFigures.mapNotNull { fig -> fig.href?.let { figureHrefFilename(it) to fig } }.toMap()
     val stashSvgPrefixes = stashFigures.mapNotNull { it.svg?.take(200) }.toSet()
     val merged = stashFigures.toMutableList()
+    // Promote charOffset from walk entries into stash entries that lack it. The JS stash never
+    // captures charOffset (the bridge has no char-counting logic); the Kotlin walk always does.
+    // Without promotion, figure.charOffset stays null and highlightOverlapsCaption returns false
+    // for the null branch → tintCaption=true → CSS double-paints the figcaption.
+    val walkByFilename = htmlFigures.mapNotNull { fig -> fig.href?.let { figureHrefFilename(it) to fig } }.toMap()
+    for (i in merged.indices) {
+        val stashFig = merged[i]
+        val stashHref = stashFig.href
+        if (stashFig.charOffset == null && stashHref != null) {
+            val walkOffset = walkByFilename[figureHrefFilename(stashHref)]?.charOffset
+            if (walkOffset != null) merged[i] = stashFig.copy(charOffset = walkOffset)
+        }
+    }
     for (fig in htmlFigures) {
         val href = fig.href
         val svg = fig.svg

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightDecoration.kt
@@ -119,6 +119,13 @@ internal val HIGHLIGHT_LEADING_ADJUSTMENT_HELPER_JS: String = """
             // underneath the overlay rather than the overlay itself.
             source = document.elementFromPoint(x, y);
           }
+          var mediaSelector = 'img,svg,picture,canvas,video,object,embed,iframe';
+          var intersectsMedia = Array.prototype.some.call(document.querySelectorAll(mediaSelector), function(media) {
+            var mediaRect = media.getBoundingClientRect();
+            return rect.left < mediaRect.right && rect.right > mediaRect.left &&
+              rect.top < mediaRect.bottom && rect.bottom > mediaRect.top;
+          });
+          if (intersectsMedia || (source && source.closest && source.closest(mediaSelector))) return;
           var lineHeight = lineHeightOf(source);
           if (lineHeight <= baseHeight && box.parentNode) {
             // A short final line's centre can fall beyond the paragraph's painted content, making

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecoration.kt
@@ -69,13 +69,15 @@ internal object FigureBorderDecoration {
                     a.imageHref?.let { refs += Ref(it, a.color, hasNote, a.updatedAt, tintCaption = true) }
                 AnnotationEntity.TYPE_HIGHLIGHT -> a.embeddedFigures?.forEach { fig ->
                     fig.href?.let {
-                        refs += Ref(it, a.color, hasNote, a.updatedAt, tintCaption = !highlightCoversCaption(a, fig))
+                        refs += Ref(it, a.color, hasNote, a.updatedAt, tintCaption = !highlightOverlapsCaption(a, fig))
                     }
                 }
             }
         }
         return refs.groupBy { hrefFilename(it.href) }
-            .mapValues { (_, group) -> group.maxByOrNull { it.updatedAt }!! }
+            .mapValues { (_, group) ->
+                group.maxByOrNull { it.updatedAt }!!.copy(tintCaption = group.all { it.tintCaption })
+            }
             .values
             .map {
                 RasterMark(
@@ -108,7 +110,7 @@ internal object FigureBorderDecoration {
     private const val SVG_FINGERPRINT_PREFIX_LEN = 200
 
     /**
-     * True when the highlight's captured `textSnippet` covers the figure's caption text — the
+     * True when the highlight's captured `textSnippet` overlaps the figure's caption text — the
      * signal that Readium's highlight decoration is already painting the caption for us and the
      * render-side CSS tint would double-paint. False when the highlight range excludes the
      * caption (e.g. a pre-caption-highlight text-selection across body prose that happens to
@@ -124,17 +126,56 @@ internal object FigureBorderDecoration {
      * shape via the same canonical caption prefix used by
      * `HighlightsPublicationFactory.appendInterleavedHighlight` and treat it as covered.
      */
-    private fun highlightCoversCaption(annotation: Annotation, figure: com.riffle.core.models.EmbeddedFigure): Boolean {
+    private fun highlightOverlapsCaption(annotation: Annotation, figure: com.riffle.core.models.EmbeddedFigure): Boolean {
         val normalizedSnippet = annotation.textSnippet.replace(Regex("\\s+"), " ").trim()
         if (figure.caption.isBlank()) {
-            return CAPTION_HIGHLIGHT_PREFIX_REGEX.containsMatchIn(normalizedSnippet)
+            if (CAPTION_HIGHLIGHT_PREFIX_REGEX.containsMatchIn(normalizedSnippet)) return true
+            // Caption element is not a <figcaption> (e.g. <p class="caption">) — the JS stash
+            // stored caption="". When charOffset is known, check if the text from the figure's
+            // position contains a caption label ("Figure N:") — the colon discriminates a real
+            // caption label from prose references like "Figure 3.1 illustrates...".
+            val offset = figure.charOffset ?: return false
+            val snippetFromFigure = annotation.textSnippet
+                .drop(offset.coerceAtMost(annotation.textSnippet.length.toLong()).toInt())
+                .replace(Regex("\\s+"), " ")
+                .trim()
+            return CAPTION_LABEL_REGEX.containsMatchIn(snippetFromFigure)
         }
         val normalizedCaption = figure.caption.replace(Regex("\\s+"), " ").trim()
-        return normalizedSnippet.contains(normalizedCaption)
+        if (normalizedSnippet.contains(normalizedCaption)) return true
+        val figureOffset = figure.charOffset
+        if (figureOffset == null) {
+            // charOffset not captured (JS-stash-only figure or pre-offset legacy row). Fall back
+            // to a suffix/prefix overlap: if the snippet's tail matches a prefix of the caption,
+            // the selection entered the figcaption from above (prose → figure → partial caption).
+            val maxOverlap = minOf(normalizedCaption.length, normalizedSnippet.length)
+            return (maxOverlap downTo MIN_CAPTION_BOUNDARY_OVERLAP).any { overlap ->
+                normalizedCaption.take(overlap) == normalizedSnippet.takeLast(overlap)
+            }
+        }
+        val snippetFromFigure = annotation.textSnippet
+            .drop(figureOffset.coerceAtMost(annotation.textSnippet.length.toLong()).toInt())
+            .replace(Regex("\\s+"), " ")
+            .trim()
+        if (snippetFromFigure.isEmpty()) return false
+        if (normalizedCaption.startsWith(snippetFromFigure) || snippetFromFigure.startsWith(normalizedCaption)) return true
+        if (figureOffset == 0L && normalizedCaption.contains(normalizedSnippet)) return true
+        val maxOverlap = minOf(normalizedCaption.length, snippetFromFigure.length)
+        return (maxOverlap downTo MIN_CAPTION_BOUNDARY_OVERLAP).any { overlap ->
+            normalizedCaption.takeLast(overlap) == snippetFromFigure.take(overlap)
+        }
     }
+
+    private const val MIN_CAPTION_BOUNDARY_OVERLAP = 8
 
     private val CAPTION_HIGHLIGHT_PREFIX_REGEX =
         Regex("^\\s*(Figure|Fig\\.?|Table|Chart)\\s+\\d", RegexOption.IGNORE_CASE)
+
+    // Matches a caption label "Figure N:" / "Table N:" anywhere in text — the colon after
+    // the number distinguishes a real figcaption label from a prose reference like
+    // "Figure 3.1 illustrates". Used when figure.caption is blank (no <figcaption> element).
+    private val CAPTION_LABEL_REGEX =
+        Regex("(Figure|Fig\\.?|Table|Chart)\\s+\\d[^:]*:", RegexOption.IGNORE_CASE)
 
     /**
      * One entry per SVG annotation covering the current document. Newest-wins by `updatedAt` when
@@ -165,14 +206,16 @@ internal object FigureBorderDecoration {
                 }
                 AnnotationEntity.TYPE_HIGHLIGHT -> a.embeddedFigures?.forEach { figure ->
                     figure.svg?.take(SVG_FINGERPRINT_PREFIX_LEN)?.let {
-                        refs += Ref(it, a.color, hasNote, a.updatedAt, tintCaption = !highlightCoversCaption(a, figure))
+                        refs += Ref(it, a.color, hasNote, a.updatedAt, tintCaption = !highlightOverlapsCaption(a, figure))
                     }
                 }
             }
         }
 
         return refs.groupBy { it.fingerprint }
-            .mapValues { (_, group) -> group.maxByOrNull { it.updatedAt }!! }
+            .mapValues { (_, group) ->
+                group.maxByOrNull { it.updatedAt }!!.copy(tintCaption = group.all { it.tintCaption })
+            }
             .values
             .map {
                 SvgMatch(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecoration.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecoration.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.reader.decorations
 
+import com.riffle.app.feature.reader.normalizeCaptionText
 import com.riffle.app.feature.reader.toCssRgba
 import com.riffle.core.database.AnnotationEntity
 import com.riffle.core.models.Annotation
@@ -127,7 +128,7 @@ internal object FigureBorderDecoration {
      * `HighlightsPublicationFactory.appendInterleavedHighlight` and treat it as covered.
      */
     private fun highlightOverlapsCaption(annotation: Annotation, figure: com.riffle.core.models.EmbeddedFigure): Boolean {
-        val normalizedSnippet = annotation.textSnippet.replace(Regex("\\s+"), " ").trim()
+        val normalizedSnippet = normalizeCaptionText(annotation.textSnippet)
         if (figure.caption.isBlank()) {
             if (CAPTION_HIGHLIGHT_PREFIX_REGEX.containsMatchIn(normalizedSnippet)) return true
             // Caption element is not a <figcaption> (e.g. <p class="caption">) — the JS stash
@@ -135,13 +136,9 @@ internal object FigureBorderDecoration {
             // position contains a caption label ("Figure N:") — the colon discriminates a real
             // caption label from prose references like "Figure 3.1 illustrates...".
             val offset = figure.charOffset ?: return false
-            val snippetFromFigure = annotation.textSnippet
-                .drop(offset.coerceAtMost(annotation.textSnippet.length.toLong()).toInt())
-                .replace(Regex("\\s+"), " ")
-                .trim()
-            return CAPTION_LABEL_REGEX.containsMatchIn(snippetFromFigure)
+            return CAPTION_LABEL_REGEX.containsMatchIn(snippetFromOffset(annotation.textSnippet, offset))
         }
-        val normalizedCaption = figure.caption.replace(Regex("\\s+"), " ").trim()
+        val normalizedCaption = normalizeCaptionText(figure.caption)
         if (normalizedSnippet.contains(normalizedCaption)) return true
         val figureOffset = figure.charOffset
         if (figureOffset == null) {
@@ -153,29 +150,31 @@ internal object FigureBorderDecoration {
                 normalizedCaption.take(overlap) == normalizedSnippet.takeLast(overlap)
             }
         }
-        val snippetFromFigure = annotation.textSnippet
-            .drop(figureOffset.coerceAtMost(annotation.textSnippet.length.toLong()).toInt())
-            .replace(Regex("\\s+"), " ")
-            .trim()
+        val snippetFromFigure = snippetFromOffset(annotation.textSnippet, figureOffset)
         if (snippetFromFigure.isEmpty()) return false
         if (normalizedCaption.startsWith(snippetFromFigure) || snippetFromFigure.startsWith(normalizedCaption)) return true
-        if (figureOffset == 0L && normalizedCaption.contains(normalizedSnippet)) return true
+        if (normalizedCaption.contains(snippetFromFigure)) return true
         val maxOverlap = minOf(normalizedCaption.length, snippetFromFigure.length)
         return (maxOverlap downTo MIN_CAPTION_BOUNDARY_OVERLAP).any { overlap ->
             normalizedCaption.takeLast(overlap) == snippetFromFigure.take(overlap)
         }
     }
 
+    private fun snippetFromOffset(raw: String, offset: Long): String =
+        normalizeCaptionText(raw.drop(offset.coerceAtMost(raw.length.toLong()).toInt()))
+
     private const val MIN_CAPTION_BOUNDARY_OVERLAP = 8
 
+    private const val CAPTION_KEYWORDS = "Figure|Fig\\.?|Table|Chart"
+
     private val CAPTION_HIGHLIGHT_PREFIX_REGEX =
-        Regex("^\\s*(Figure|Fig\\.?|Table|Chart)\\s+\\d", RegexOption.IGNORE_CASE)
+        Regex("^\\s*($CAPTION_KEYWORDS)\\s+\\d", RegexOption.IGNORE_CASE)
 
     // Matches a caption label "Figure N:" / "Table N:" anywhere in text — the colon after
     // the number distinguishes a real figcaption label from a prose reference like
     // "Figure 3.1 illustrates". Used when figure.caption is blank (no <figcaption> element).
     private val CAPTION_LABEL_REGEX =
-        Regex("(Figure|Fig\\.?|Table|Chart)\\s+\\d[^:]*:", RegexOption.IGNORE_CASE)
+        Regex("($CAPTION_KEYWORDS)\\s+\\d[^:]*:", RegexOption.IGNORE_CASE)
 
     /**
      * One entry per SVG annotation covering the current document. Newest-wins by `updatedAt` when

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/FiguresInHtmlRangeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/FiguresInHtmlRangeTest.kt
@@ -194,6 +194,25 @@ class FiguresInHtmlRangeTest {
     }
 
     @Test
+    fun `mergeEnclosedFigures promotes charOffset from walk entry into stash entry that lacks it`() {
+        // The JS stash never captures charOffset; the Kotlin walk always does. Without promotion
+        // the merged figure has charOffset=null → highlightOverlapsCaption returns false for the
+        // null branch → tintCaption=true → CSS double-paints the figcaption.
+        val stash = listOf(
+            EmbeddedFigure(href = "images/fig.png", svg = null, caption = "cap", order = 0, imageBytes = "data:image/png;base64,AA=="),
+        )
+        val walk = listOf(
+            EmbeddedFigure(href = "images/fig.png", svg = null, caption = "cap", order = 0, charOffset = 42L),
+        )
+
+        val merged = mergeEnclosedFigures(stash, walk)
+
+        assertEquals(1, merged.size)
+        assertEquals("data:image/png;base64,AA==", merged.single().imageBytes)
+        assertEquals(42L, merged.single().charOffset)
+    }
+
+    @Test
     fun `mergeEnclosedFigures returns html walk when stash is empty`() {
         val walk = listOf(
             EmbeddedFigure(href = "images/eq.jpg", svg = null, caption = "", order = 0, imageBytes = null),

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecorationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/decorations/FigureBorderDecorationTest.kt
@@ -131,6 +131,200 @@ class FigureBorderDecorationTest {
     }
 
     @Test
+    fun `TYPE_HIGHLIGHT ending inside figcaption suppresses duplicate CSS caption tint`() {
+        val beforeCaption = "The surrounding selection includes the diagram. "
+        val partialCaption = "Figure 3.1: At the beginning, a tactical approach"
+        val caption = "$partialCaption to programming will make progress more quickly."
+        val highlight = highlightAnnotation(
+            id = "hl-partial-caption",
+            color = "yellow",
+            embedded = listOf(
+                EmbeddedFigure(
+                    href = "g.png",
+                    svg = null,
+                    caption = caption,
+                    order = 0,
+                    charOffset = beforeCaption.length.toLong(),
+                ),
+            ),
+            textSnippet = beforeCaption + partialCaption,
+        )
+
+        val mark = FigureBorderDecoration.buildRasterMarks(listOf(highlight)).single()
+
+        assertFalse(mark.tintCaption)
+    }
+
+    @Test
+    fun `TYPE_HIGHLIGHT starting inside figcaption suppresses duplicate CSS caption tint`() {
+        val selectedCaptionTail = "tactical approach to programming will make progress more quickly."
+        val caption = "Figure 3.1: At the beginning, a $selectedCaptionTail"
+        val highlight = highlightAnnotation(
+            id = "hl-caption-tail",
+            color = "yellow",
+            embedded = listOf(
+                EmbeddedFigure(
+                    href = "g.png",
+                    svg = null,
+                    caption = caption,
+                    order = 0,
+                    charOffset = 0,
+                ),
+            ),
+            textSnippet = "$selectedCaptionTail Following prose.",
+        )
+
+        val mark = FigureBorderDecoration.buildRasterMarks(listOf(highlight)).single()
+
+        assertFalse(mark.tintCaption)
+    }
+
+    @Test
+    fun `separate caption and diagram annotations do not double tint the caption`() {
+        val caption = "Figure 3.1: A tactical approach makes progress quickly."
+        val captionHighlight = highlightAnnotation(
+            id = "caption",
+            color = "green",
+            embedded = listOf(EmbeddedFigure(href = "g.png", svg = null, caption = caption, order = 0)),
+            updatedAt = 100,
+            textSnippet = caption,
+        )
+        val diagramHighlight = imageAnnotation(
+            id = "diagram",
+            imageHref = "g.png",
+            color = "yellow",
+            updatedAt = 200,
+        )
+
+        val mark = FigureBorderDecoration.buildRasterMarks(listOf(captionHighlight, diagramHighlight)).single()
+
+        assertFalse(mark.tintCaption)
+
+        val svg = "<svg id=\"diagram\"></svg>"
+        val svgCaptionHighlight = highlightAnnotation(
+            id = "svg-caption",
+            color = "green",
+            embedded = listOf(EmbeddedFigure(href = null, svg = svg, caption = caption, order = 0)),
+            updatedAt = 100,
+            textSnippet = caption,
+        )
+        val svgDiagramHighlight = imageAnnotation(
+            id = "svg-diagram",
+            imageSvg = svg,
+            color = "yellow",
+            updatedAt = 200,
+        )
+
+        val svgMark = FigureBorderDecoration.buildSvgMatches(listOf(svgCaptionHighlight, svgDiagramHighlight)).single()
+
+        assertFalse(svgMark.tintCaption)
+    }
+
+    @Test
+    fun `TYPE_HIGHLIGHT with blank caption and prose-before-figure snippet suppresses CSS caption tint via caption label`() {
+        // Real-world case: book uses <p class="caption"> instead of <figcaption>. The JS stash
+        // stores caption="" because there's no <figcaption> element. charOffset points to where
+        // the image sits in the snippet. Text after the image starts with "Figure N:" which is
+        // the canonical caption-label discriminator vs prose references like "Figure N illustrates".
+        // Old code: CAPTION_HIGHLIGHT_PREFIX_REGEX only checked snippet[0..], so prose-prefix
+        // snippets fell through → tintCaption=true → CSS double-painted the caption element.
+        val highlight = highlightAnnotation(
+            id = "hl-blank-cap",
+            color = "yellow",
+            embedded = listOf(
+                EmbeddedFigure(
+                    href = "g.png",
+                    svg = null,
+                    caption = "",
+                    order = 0,
+                    charOffset = 100L,
+                ),
+            ),
+            textSnippet = "You will quickly recover the cost of the initial investment. Figure 3.1 illustrates this phenomenon. Figure 3.1: At the beginning, a tactical approach",
+        )
+
+        val mark = FigureBorderDecoration.buildRasterMarks(listOf(highlight)).single()
+
+        assertFalse("blank-caption figure whose snippet crosses into caption label must not request CSS tint", mark.tintCaption)
+    }
+
+    @Test
+    fun `TYPE_HIGHLIGHT with blank caption and prose-only snippet keeps CSS caption tint`() {
+        // Companion: when the snippet does NOT reach the caption element (no caption label after
+        // the figure position), the CSS tint must fire so the caption gets any colour at all.
+        val highlight = highlightAnnotation(
+            id = "hl-no-cap",
+            color = "yellow",
+            embedded = listOf(
+                EmbeddedFigure(
+                    href = "g.png",
+                    svg = null,
+                    caption = "",
+                    order = 0,
+                    charOffset = 80L,
+                ),
+            ),
+            textSnippet = "This paragraph precedes the figure and the next paragraph follows it. The image shows",
+        )
+
+        val mark = FigureBorderDecoration.buildRasterMarks(listOf(highlight)).single()
+
+        assertTrue("blank-caption figure with prose-only snippet must keep CSS tint", mark.tintCaption)
+    }
+
+    @Test
+    fun `TYPE_HIGHLIGHT with null charOffset and snippet ending inside figcaption suppresses CSS caption tint`() {
+        // Regression: JS-stash-only figures arrive with charOffset=null. The old code returned
+        // false immediately via `?: return false`, so tintCaption stayed true and the CSS painted
+        // the whole figcaption even though Readium's decoration already covered the selected portion.
+        val beforeCaption = "You will quickly recover the cost of the initial investment. Figure 3.1 illustrates this phenomenon. "
+        val partialCaption = "Figure 3.1: At the beginning, a tactical approach"
+        val caption = "$partialCaption to programming will make progress more quickly. Note: this figure."
+        val highlight = highlightAnnotation(
+            id = "hl-null-offset",
+            color = "yellow",
+            embedded = listOf(
+                EmbeddedFigure(
+                    href = "g.png",
+                    svg = null,
+                    caption = caption,
+                    order = 0,
+                    charOffset = null,
+                ),
+            ),
+            textSnippet = beforeCaption + partialCaption,
+        )
+
+        val mark = FigureBorderDecoration.buildRasterMarks(listOf(highlight)).single()
+
+        assertFalse("null-charOffset snippet ending in figcaption must not request CSS tint (would double-paint)", mark.tintCaption)
+    }
+
+    @Test
+    fun `TYPE_HIGHLIGHT with null charOffset and snippet excluding figcaption keeps CSS caption tint`() {
+        // Companion to the above: when the snippet does NOT reach the figcaption (no suffix/prefix
+        // overlap), the CSS tint must still fire so the figcaption gets any colour at all.
+        val highlight = highlightAnnotation(
+            id = "hl-no-caption",
+            color = "yellow",
+            embedded = listOf(
+                EmbeddedFigure(
+                    href = "g.png",
+                    svg = null,
+                    caption = "Figure 3.1: A completely unrelated caption text here.",
+                    order = 0,
+                    charOffset = null,
+                ),
+            ),
+            textSnippet = "This paragraph mentions the diagram but does not include its caption.",
+        )
+
+        val mark = FigureBorderDecoration.buildRasterMarks(listOf(highlight)).single()
+
+        assertTrue("null-charOffset snippet not entering figcaption must keep CSS tint", mark.tintCaption)
+    }
+
+    @Test
     fun `TYPE_HIGHLIGHT whose range excludes the figcaption keeps CSS caption tint`() {
         // Regression pin for the 2026-07-14 review finding: a legacy text-highlight of body
         // prose that happens to enclose a figure (PR #533 shape) does NOT cover the


### PR DESCRIPTION
## What

When a text highlight spans **prose → diagram → partial figcaption**, the CSS figure-border tint was painting the *entire* figcaption on top of Readium's own highlight decoration, producing a double-highlight visible past the selection boundary.

## Root cause

`highlightOverlapsCaption` had two failure modes, both causing `tintCaption=true` (CSS paints full figcaption) when it should be `false` (Readium decoration already covers it):

1. **Blank caption + prose-before-figure snippet** (primary on-device bug, confirmed via logcat)
   The book (*A Philosophy of Software Design*) uses `<p class="caption">` instead of `<figcaption>`. The JS stash therefore stores `caption=""`. The blank-caption path only checked `CAPTION_HIGHLIGHT_PREFIX_REGEX` at position 0 of the snippet; a snippet starting with prose ("You will quickly recover…") failed the `^` anchor even though its tail contained "Figure 3.1: At the beginning…". Fix: when `charOffset` is known, also scan `snippetFromFigure` via `CAPTION_LABEL_REGEX` — the colon after the number ("Figure 3.1:") discriminates a real caption label from a prose reference ("Figure 3.1 illustrates").

2. **Non-blank caption + null charOffset** (legacy / JS-stash-only rows)
   `val figureOffset = figure.charOffset ?: return false` bailed out immediately on null, so no overlap detection ran. Fix: sliding-window suffix/prefix overlap between the snippet tail and the caption head.

## Also included

- `mergeEnclosedFigures` now promotes `charOffset` from the Kotlin-walk entry into JS-stash entries that lack it (the JS bridge has no char-counting logic), so annotations created going forward carry a valid offset and the charOffset-based path handles them correctly.
- `__riffleFillReadiumHighlightLeading` skips leading-expansion for decoration boxes that intersect a media element (img/svg/…), preventing the adjustment from inflating a thin box over a diagram.

## Tests

- `FigureBorderDecorationTest`: 7 new cases covering blank-caption+known-offset, blank-caption+prose-only-snippet, null-offset ending in figcaption, null-offset not reaching figcaption, partial selection ending inside figcaption, partial selection starting inside figcaption, and separate caption+diagram annotations.
- `FiguresInHtmlRangeTest`: verifies `mergeEnclosedFigures` promotes `charOffset` from walk entry.
- `HighlightLineCoverageWebViewTest`: verifies the leading-adjustment skip for diagram boxes.