### PR TITLE
fix(reader): align continuous volume-scroll speed + animation with vertical mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
@@ -147,7 +147,7 @@ internal object ContinuousPositionTracker {
      *  window in [ContinuousWindowController] — a window slightly longer than a finished animation
      *  is harmless because the pending target then equals the settled scroll position. */
     internal const val PAGE_SCROLL_MIN_DURATION_MS = 200
-    internal const val PAGE_SCROLL_MAX_DURATION_MS = 800
+    internal const val PAGE_SCROLL_MAX_DURATION_MS = 1000
 
     /**
      * Animation speed for a volume-key page scroll: ms per √(CSS px). Chromium's own rate for

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousPositionTracker.kt
@@ -147,23 +147,27 @@ internal object ContinuousPositionTracker {
      *  window in [ContinuousWindowController] — a window slightly longer than a finished animation
      *  is harmless because the pending target then equals the settled scroll position. */
     internal const val PAGE_SCROLL_MIN_DURATION_MS = 200
-    internal const val PAGE_SCROLL_MAX_DURATION_MS = 700
+    internal const val PAGE_SCROLL_MAX_DURATION_MS = 800
+
+    /**
+     * Animation speed for a volume-key page scroll: ms per √(CSS px). Chromium's own rate for
+     * `window.scrollBy({behavior:'smooth'})` is ~16.7 (= 1000/60). Continuous mode targets a
+     * higher value — tune this constant to align with vertical mode's feel on device.
+     */
+    internal const val PAGE_SCROLL_MS_PER_SQRT_CSS_PX = 35.0
 
     /**
      * Animation duration for a volume-key page scroll of [distancePx] physical pixels, on a screen
-     * with the given [density]. Approximates the delta-based duration Chromium picks for the
-     * `window.scrollBy({behavior: 'smooth'})` that paginated/vertical mode issues from
-     * [ScrollBoundaryNavigationContainer] — ~16.7 ms per √(CSS px), ease-shaped over ~445 ms for a
-     * typical 0.9-viewport press. A fixed 300 ms here made the same press visibly faster and more
-     * sudden in continuous mode than in vertical mode. Chromium computes in CSS pixels, so the
-     * physical distance is divided by [density] first; the result is clamped to
+     * with the given [density]. Uses [PAGE_SCROLL_MS_PER_SQRT_CSS_PX] scaled by √(CSS px) so
+     * coalesced presses (larger distance) get proportionally longer glides. Chromium computes in
+     * CSS pixels, so the physical distance is divided by [density] first; the result is clamped to
      * [[PAGE_SCROLL_MIN_DURATION_MS], [PAGE_SCROLL_MAX_DURATION_MS]]. Returns 0 for a non-positive
      * distance or density.
      */
     fun pageScrollDurationMs(distancePx: Int, density: Float): Int {
         if (distancePx <= 0 || density <= 0f) return 0
         val cssPx = distancePx / density
-        val ms = (1000.0 / 60.0) * kotlin.math.sqrt(cssPx.toDouble())
+        val ms = PAGE_SCROLL_MS_PER_SQRT_CSS_PX * kotlin.math.sqrt(cssPx.toDouble())
         return ms.toInt().coerceIn(PAGE_SCROLL_MIN_DURATION_MS, PAGE_SCROLL_MAX_DURATION_MS)
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -1,10 +1,12 @@
 package com.riffle.app.feature.reader
 
+import android.animation.ObjectAnimator
 import android.content.Context
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.OverScroller
 import androidx.compose.runtime.mutableStateOf
 import androidx.core.widget.NestedScrollView
@@ -76,7 +78,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         override fun smoothScrollTo(y: Int) = this@ContinuousReaderView.smoothScrollTo(0, y)
         override fun smoothScrollBy(dy: Int) = this@ContinuousReaderView.smoothScrollBy(0, dy)
         override fun smoothScrollBy(dy: Int, durationMs: Int) =
-            this@ContinuousReaderView.smoothScrollBy(0, dy, durationMs)
+            this@ContinuousReaderView.smoothScrollByDirect(dy, durationMs)
         override fun abortFling() = this@ContinuousReaderView.abortFling()
         override fun post(block: () -> Unit) { this@ContinuousReaderView.post(block) }
         override fun postOnAnimation(block: () -> Unit) { this@ContinuousReaderView.postOnAnimation(block) }
@@ -558,5 +560,38 @@ internal class ContinuousReaderView @JvmOverloads constructor(
             f.isAccessible = true
             (f.get(this) as? OverScroller)?.abortAnimation()
         } catch (_: Exception) {}
+    }
+
+    /**
+     * Animated scroll by [dy] physical pixels over [durationMs] milliseconds, bypassing
+     * [NestedScrollView]'s 250 ms ANIMATED_SCROLL_GAP check. That check coalesces rapid
+     * programmatic scroll calls into an instant [scrollBy], but volume-key presses repeat every
+     * ~50 ms — well inside the gap — so every press after the first would teleport instead of
+     * animating, making the duration constant irrelevant.
+     *
+     * Driving [mScroller] directly looks simpler but breaks: [NestedScrollView.computeScroll]
+     * computes each frame's delta as `mScroller.getCurrY() - mLastScrollerY`, and
+     * `mLastScrollerY` is only initialized by the private `runAnimatedScroll()` that we'd also
+     * have to replicate via reflection. Skipping it leaves a stale `mLastScrollerY` so the first
+     * frame jumps the full distance at once, causing the flicker.
+     *
+     * [ObjectAnimator] on `scrollY` sidesteps all of this: it drives [View.setScrollY] each
+     * frame, which goes through [NestedScrollView.scrollTo] (clamping, `onScrollChanged`) without
+     * touching the scroller state at all. The ongoing OverScroller fling (if any) is aborted first
+     * so the two don't compete.
+     */
+    private var pageScrollAnimator: ObjectAnimator? = null
+
+    private fun smoothScrollByDirect(dy: Int, durationMs: Int) {
+        abortFling()
+        val maxScroll = ((getChildAt(0)?.height ?: 0) - height).coerceAtLeast(0)
+        val targetY = (scrollY + dy).coerceIn(0, maxScroll)
+        if (targetY == scrollY) { pageScrollAnimator?.cancel(); return }
+        pageScrollAnimator?.cancel()
+        pageScrollAnimator = ObjectAnimator.ofInt(this, "scrollY", scrollY, targetY).apply {
+            duration = durationMs.toLong()
+            interpolator = AccelerateDecelerateInterpolator()
+            start()
+        }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2608,7 +2608,10 @@ private fun EpubNavigatorView(
         }
     }
 
-    LaunchedEffect(volumeNavEvents) {
+    // Key on readerPresenter so a mode flip (paginated/vertical ↔ continuous) restarts the
+    // collect with the new presenter. Without this, the closure captures the old detached
+    // presenter and pageBy() is a no-op — same rationale as returnNavEvents / searchNavigationEvents.
+    LaunchedEffect(volumeNavEvents, readerPresenter) {
         volumeNavEvents.collect { event ->
             val direction = if (event == VolumeNavEvent.Forward) PageDirection.Forward else PageDirection.Backward
             val container = containerRef.value

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -442,10 +442,9 @@ class ContinuousPositionTrackerTest {
     @Test
     fun `pageScrollDurationMs matches vertical mode's perceived glide for a phone-sized page press`() {
         // 0.9 of a 2160 px viewport at density 2.75 ≈ 707 CSS px; Chromium's bare rate is
-        // ~16.7 ms/√(CSS px) → ~443 ms. Continuous mode needs a higher rate to compensate for
-        // Android OverScroller's ease-out curve feeling faster than Chromium's ease-in-out at the
-        // same duration. PAGE_SCROLL_MS_PER_SQRT_CSS_PX sets that rate; verify the result is
-        // substantially longer than Chromium's bare 443 ms.
+        // ~16.7 ms/√(CSS px) → ~443 ms. Continuous mode targets a higher rate (device-tuned) for
+        // a more deliberate feel; PAGE_SCROLL_MS_PER_SQRT_CSS_PX sets that rate. Verify the result
+        // substantially exceeds Chromium's bare 443 ms.
         val delta = ContinuousPositionTracker.pageScrollDelta(2160)
         val duration = ContinuousPositionTracker.pageScrollDurationMs(delta, density = 2.75f)
         val cssPx = delta / 2.75

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousPositionTrackerTest.kt
@@ -440,14 +440,22 @@ class ContinuousPositionTrackerTest {
     // ── pageScrollDurationMs ──────────────────────────────────────────────────
 
     @Test
-    fun `pageScrollDurationMs matches Chromium's glide for a phone-sized page press`() {
-        // 0.9 of a 2160 px viewport at density 2.75 ≈ 707 CSS px; Chromium's delta-based
-        // duration is ~16.7 ms × √707 ≈ 443 ms. The old fixed 300 ms is what made continuous
-        // mode feel sudden next to vertical mode's smooth scroll — pin that we now exceed it.
+    fun `pageScrollDurationMs matches vertical mode's perceived glide for a phone-sized page press`() {
+        // 0.9 of a 2160 px viewport at density 2.75 ≈ 707 CSS px; Chromium's bare rate is
+        // ~16.7 ms/√(CSS px) → ~443 ms. Continuous mode needs a higher rate to compensate for
+        // Android OverScroller's ease-out curve feeling faster than Chromium's ease-in-out at the
+        // same duration. PAGE_SCROLL_MS_PER_SQRT_CSS_PX sets that rate; verify the result is
+        // substantially longer than Chromium's bare 443 ms.
         val delta = ContinuousPositionTracker.pageScrollDelta(2160)
         val duration = ContinuousPositionTracker.pageScrollDurationMs(delta, density = 2.75f)
-        assertEquals(443, duration)
-        assertTrue("duration must be longer than the old fixed 300 ms", duration > 300)
+        val cssPx = delta / 2.75
+        val chromiumBaseline = (16.7 * kotlin.math.sqrt(cssPx)).toInt()
+        assertEquals(
+            (ContinuousPositionTracker.PAGE_SCROLL_MS_PER_SQRT_CSS_PX * kotlin.math.sqrt(cssPx)).toInt()
+                .coerceIn(ContinuousPositionTracker.PAGE_SCROLL_MIN_DURATION_MS, ContinuousPositionTracker.PAGE_SCROLL_MAX_DURATION_MS),
+            duration,
+        )
+        assertTrue("duration must substantially exceed Chromium's bare heuristic of $chromiumBaseline ms", duration > chromiumBaseline)
     }
 
     @Test
@@ -471,8 +479,8 @@ class ContinuousPositionTrackerTest {
     @Test
     fun `pageScrollAnimation duration follows the actual animated distance, not the press delta`() {
         // A press near the bottom boundary: the coalescer clamps the target so only 30 px remain.
-        // The duration must come from the 30 px remainder (min-clamped to 200 ms), not the ~443 ms
-        // a full 0.9-viewport press would get — otherwise the remainder crawls.
+        // The duration must come from the 30 px remainder (min-clamped to 200 ms), not the full
+        // single-press duration — otherwise the remainder crawls.
         val boundary = ContinuousPositionTracker.pageScrollAnimation(
             currentScrollY = 9_970, targetScrollY = 10_000, density = 2.75f,
         )


### PR DESCRIPTION
## What changed

**Tunable speed constant** (`ContinuousPositionTracker`): replaced the hardcoded `1000/60` (Chromium's bare rate) with `PAGE_SCROLL_MS_PER_SQRT_CSS_PX = 35.0`. The constant is named, documented, and easy to retune. `PAGE_SCROLL_MAX_DURATION_MS` raised from 700 → 1000 so a single-viewport press (~930 ms uncapped) stays below the ceiling and a coalesced press (1316 ms → capped 1000 ms) is still visibly longer.

**ObjectAnimator-based scroll** (`ContinuousReaderView`): `NestedScrollView.smoothScrollBy(0, dy, durationMs)` has a 250 ms `ANIMATED_SCROLL_GAP` check — if two programmatic scroll calls arrive within 250 ms it bypasses the `OverScroller` and calls `scrollBy()` instantly. Volume-key repeats fire every ~50 ms, so every press after the first was teleporting regardless of the duration constant. `ObjectAnimator.ofInt(view, "scrollY", from, to)` drives `setScrollY()` per frame, bypassing the gap entirely. `AccelerateDecelerateInterpolator` matches Chromium's ease-in-out curve.

**Mode-switch regression fix** (`EpubReaderScreen`): `LaunchedEffect(volumeNavEvents)` captured `readerPresenter` at start time. Switching modes recreated the presenter via `remember(isContinuous)` but the effect didn't restart — the stale detached presenter's `pageBy()` silently dropped every volume press. Fix: add `readerPresenter` to the effect's key set (same pattern as `returnNavEvents`, `searchNavigationEvents`).

## Tests

`ContinuousPositionTrackerTest` updated: the speed-constant test now derives its expected value from `PAGE_SCROLL_MS_PER_SQRT_CSS_PX` so the test doesn't need to be touched on future constant retuning, while still asserting the result substantially exceeds Chromium's baseline. The coalesced-glide-is-longer assertion pins that two rapid presses still produce a visibly longer animation than one.

`smoothScrollByDirect` and the `LaunchedEffect` key fix are Android/Compose layer — not JVM-testable.