### PR TITLE
feat(audiobook): show chapter name in persistent notification

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audio/TimeFormat.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/TimeFormat.kt
@@ -1,5 +1,7 @@
 package com.riffle.app.feature.audio
 
+import com.riffle.core.domain.AudiobookChapter
+
 /** mm:ss under an hour, h:mm:ss otherwise. */
 internal fun formatHms(totalSec: Double): String {
     val s = totalSec.toLong().coerceAtLeast(0)
@@ -20,4 +22,13 @@ fun formatRemainingReadable(remainingSec: Double): String {
     val h = totalMinutes / 60
     val m = totalMinutes % 60
     return if (h > 0) "${h}h ${m}m left" else "${m}m left"
+}
+
+/**
+ * Artist line for the system media notification: "Chapter Title · 3h 12m left" when [chapter] is
+ * non-null (the book has chapter markers), or just the remaining time otherwise.
+ */
+internal fun notificationArtistText(chapter: AudiobookChapter?, remainingSec: Double): String {
+    val remaining = formatRemainingReadable(remainingSec)
+    return if (chapter != null) "${chapter.title} · $remaining" else remaining
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -92,7 +92,6 @@ open class AudiobookController @Inject constructor(
     private var pollJob: Job? = null
     private var spans: List<AudiobookTrackSpan> = emptyList()
     private var chapters: List<AudiobookChapter> = emptyList()
-    private var bookTitle: String? = null
     private var durationSec: Double = 0.0
     private var prepared = false
     private var wantsToPlay = false
@@ -146,7 +145,6 @@ open class AudiobookController @Inject constructor(
         val t0 = clock.nowMs()
         this.spans = spans
         this.chapters = chapters
-        this.bookTitle = bookTitle
         this.durationSec = durationSec
         SharedAudiobookContext.spans = spans
         SharedAudiobookContext.totalDurationMs = (durationSec * 1000.0).toLong()
@@ -311,7 +309,6 @@ open class AudiobookController @Inject constructor(
         connector?.release()
         spans = emptyList()
         chapters = emptyList()
-        bookTitle = null
         prepared = false
         wantsToPlay = false
         // Release the bundle reference only if THIS session set it (parity with ReadaloudController),
@@ -349,7 +346,6 @@ open class AudiobookController @Inject constructor(
         connector?.releaseForHandoff()
         spans = emptyList()
         chapters = emptyList()
-        bookTitle = null
         prepared = false
         wantsToPlay = false
         ownsSharedBundle = false

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -5,9 +5,10 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.session.MediaController
 import com.riffle.app.feature.audio.MediaSessionConnector
-import com.riffle.app.feature.audio.formatRemainingReadable
+import com.riffle.app.feature.audio.notificationArtistText
 import com.riffle.app.feature.reader.readaloud.SharedBundle
 import com.riffle.core.domain.ApplicationScope
+import com.riffle.core.domain.AudiobookChapter
 import com.riffle.core.models.AudiobookTrackSpan
 import com.riffle.core.models.AudiobookTracks
 import com.riffle.core.common.Clock
@@ -90,6 +91,8 @@ open class AudiobookController @Inject constructor(
     private val controller: MediaController? get() = connector?.controller
     private var pollJob: Job? = null
     private var spans: List<AudiobookTrackSpan> = emptyList()
+    private var chapters: List<AudiobookChapter> = emptyList()
+    private var bookTitle: String? = null
     private var durationSec: Double = 0.0
     private var prepared = false
     private var wantsToPlay = false
@@ -98,9 +101,10 @@ open class AudiobookController @Inject constructor(
     // player opened a streaming session, or failed to prepare at all, while Readaloud is still playing).
     private var ownsSharedBundle = false
     // Whole-minute bucket of remaining book time last written to the current MediaItem's metadata.
-    // We `replaceMediaItem` only when this bucket changes, so the system notification's "3h 12m
-    // left" subtitle updates at most once per minute regardless of poll cadence.
+    // We `replaceMediaItem` only when this bucket or the chapter changes, so the system notification
+    // artist line ("Chapter 3 · 3h 12m left") updates at most once per minute per chapter.
     private var lastRemainingMinuteBucket: Long = -1L
+    private var lastChapterIndex: Int = -1
 
     private val pendingSeek = PendingSeekGate()
 
@@ -136,10 +140,13 @@ open class AudiobookController @Inject constructor(
         localZipFile: File? = null,
         coverUri: String? = null,
         bookTitle: String? = null,
+        chapters: List<AudiobookChapter> = emptyList(),
     ) {
         logger.d(LogChannel.Handoff) { "AB.prepare start (controller already connected=${controller != null})" }
         val t0 = clock.nowMs()
         this.spans = spans
+        this.chapters = chapters
+        this.bookTitle = bookTitle
         this.durationSec = durationSec
         SharedAudiobookContext.spans = spans
         SharedAudiobookContext.totalDurationMs = (durationSec * 1000.0).toLong()
@@ -152,10 +159,12 @@ open class AudiobookController @Inject constructor(
         logger.d(LogChannel.Handoff) { "AB.prepare ensureConnected +${clock.nowMs() - t0}ms" }
         val initialRemainingSec = (durationSec - startAtSec).coerceAtLeast(0.0)
         lastRemainingMinuteBucket = (initialRemainingSec / 60.0).toLong()
+        val initialChapter = chapterAt(startAtSec)
+        lastChapterIndex = initialChapter?.index ?: -1
         val metadata = androidx.media3.common.MediaMetadata.Builder()
             .apply { if (coverUri != null) setArtworkUri(android.net.Uri.parse(coverUri)) }
             .apply { if (bookTitle != null) setTitle(bookTitle) }
-            .setArtist(formatRemainingReadable(initialRemainingSec))
+            .setArtist(notificationArtistText(initialChapter, initialRemainingSec))
             .build()
         val items = trackUrls.map { url ->
             MediaItem.Builder().setMediaId(url).setUri(url).setMediaMetadata(metadata).build()
@@ -301,6 +310,8 @@ open class AudiobookController @Inject constructor(
         _playbackEnded.resetReplayCache()
         connector?.release()
         spans = emptyList()
+        chapters = emptyList()
+        bookTitle = null
         prepared = false
         wantsToPlay = false
         // Release the bundle reference only if THIS session set it (parity with ReadaloudController),
@@ -311,6 +322,7 @@ open class AudiobookController @Inject constructor(
         SharedAudiobookContext.spans = emptyList()
         SharedAudiobookContext.totalDurationMs = 0L
         lastRemainingMinuteBucket = -1L
+        lastChapterIndex = -1
         pendingSeek.reset()
         _state.value = PlaybackState()
     }
@@ -336,12 +348,15 @@ open class AudiobookController @Inject constructor(
         }
         connector?.releaseForHandoff()
         spans = emptyList()
+        chapters = emptyList()
+        bookTitle = null
         prepared = false
         wantsToPlay = false
         ownsSharedBundle = false
         SharedAudiobookContext.spans = emptyList()
         SharedAudiobookContext.totalDurationMs = 0L
         lastRemainingMinuteBucket = -1L
+        lastChapterIndex = -1
         pendingSeek.reset()
         _state.value = PlaybackState()
     }
@@ -384,24 +399,33 @@ open class AudiobookController @Inject constructor(
 
     /**
      * Refreshes the current [MediaItem]'s `artist` metadata so the system media notification /
-     * lock-screen player shows "3h 12m left" style remaining-time text under the title. Fires at
-     * most once per whole-minute change; the URI is stripped over the session Binder and rebuilt
-     * by [com.riffle.app.feature.audio.MediaItemRestorerRegistry], so this is a metadata-only
-     * update that does not re-buffer.
+     * lock-screen player shows "Chapter 3 · 3h 12m left" style text under the title (or just the
+     * remaining time when the book has no chapters). Fires at most once per whole-minute change or
+     * chapter transition; the URI is stripped over the session Binder and rebuilt by
+     * [com.riffle.app.feature.audio.MediaItemRestorerRegistry], so this is a metadata-only update
+     * that does not re-buffer.
      */
     private fun maybeUpdateRemainingMetadata(c: MediaController?, positionSec: Double) {
         if (c == null || !prepared || durationSec <= 0.0) return
         val remaining = (durationSec - positionSec).coerceAtLeast(0.0)
         val bucket = (remaining / 60.0).toLong()
-        if (bucket == lastRemainingMinuteBucket) return
+        val chapter = chapterAt(positionSec)
+        val chapterIndex = chapter?.index ?: -1
+        if (bucket == lastRemainingMinuteBucket && chapterIndex == lastChapterIndex) return
         val index = c.currentMediaItemIndex
         if (index < 0) return
         val item = c.currentMediaItem ?: return
         lastRemainingMinuteBucket = bucket
+        lastChapterIndex = chapterIndex
         val newMetadata = item.mediaMetadata.buildUpon()
-            .setArtist(formatRemainingReadable(remaining))
+            .setArtist(notificationArtistText(chapter, remaining))
             .build()
         c.replaceMediaItem(index, item.buildUpon().setMediaMetadata(newMetadata).build())
+    }
+
+    private fun chapterAt(positionSec: Double): AudiobookChapter? {
+        if (chapters.isEmpty()) return null
+        return chapters.lastOrNull { positionSec >= it.startSec } ?: chapters.first()
     }
 
     companion object {

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -509,6 +509,7 @@ class AudiobookPlayerViewModel @Inject constructor(
                     localZipFile = session.localZipFile,
                     coverUri = item.coverUrl,
                     bookTitle = item.title,
+                    chapters = session.timeline.chapters,
                 )
                 // Record the active session so a media-notification tap reopens this audiobook player.
                 nowPlayingStore.set(com.riffle.app.playback.NowPlaying.Audiobook(itemId))
@@ -821,6 +822,7 @@ class AudiobookPlayerViewModel @Inject constructor(
             localZipFile = session.localZipFile,
             coverUri = resolvedCoverUri,
             bookTitle = resolvedBookTitle,
+            chapters = session.timeline.chapters,
         )
         logger.d(LogChannel.Handoff) { "AB.activateFromHandoff: prepare() done +${clock.nowMs() - t0}ms" }
         controller.setSpeed(resolvedInitialSpeed)

--- a/app/src/test/kotlin/com/riffle/app/feature/audio/TimeFormatTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audio/TimeFormatTest.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.audio
 
+import com.riffle.core.domain.AudiobookChapter
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -23,5 +24,14 @@ class TimeFormatTest {
 
     @Test fun `negative input clamps to zero`() {
         assertEquals("Less than a minute left", formatRemainingReadable(-42.0))
+    }
+
+    @Test fun `notification artist includes chapter title when chapter is present`() {
+        val chapter = AudiobookChapter(index = 2, startSec = 0.0, endSec = 100.0, title = "Part Two")
+        assertEquals("Part Two · 3h 12m left", notificationArtistText(chapter, 3 * 3600.0 + 12 * 60.0 + 30))
+    }
+
+    @Test fun `notification artist is just remaining time when no chapter`() {
+        assertEquals("45m left", notificationArtistText(null, 45 * 60.0))
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -116,6 +116,7 @@ class AudiobookPlayerViewModelBookmarkTest {
             localZipFile: File?,
             coverUri: String?,
             bookTitle: String?,
+            chapters: List<com.riffle.core.domain.AudiobookChapter>,
         ) {
             preparedStartAtSec = startAtSec
             preparedBookTitle = bookTitle

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -148,6 +148,7 @@ class SleepTimerTest {
             localZipFile: File?,
             coverUri: String?,
             bookTitle: String?,
+            chapters: List<AudiobookChapter>,
         ) { /* no-op */ }
 
         override fun play() {}


### PR DESCRIPTION
## What

When playing an audiobook with chapters, the system media notification (and lock-screen player) now shows the current chapter name in the artist/subtitle line alongside the remaining time:

> **My Audiobook**
> Part Two · 3h 12m left

Previously only the remaining time was shown. Books without chapter markers are unaffected — they still show just the remaining time.

## How

- Added `chapters: List<AudiobookChapter>` parameter to `AudiobookController.prepare()`, stored alongside `spans`.
- Added `lastChapterIndex` tracker (mirrors `lastRemainingMinuteBucket`) so `maybeUpdateRemainingMetadata` fires on chapter transitions in addition to whole-minute remaining-time changes.
- Extracted `notificationArtistText(chapter, remainingSec)` as an `internal` top-level function in `TimeFormat.kt` — keeps it testable without Media3 and co-located with the other notification formatting helpers.
- Fixed a prior broken attempt that referenced an undefined `timeline` field in the controller.
- Both `ViewModel.prepare()` call sites (normal open and readaloud→audiobook handoff) now pass `session.timeline.chapters`.

## Tests

- Two new assertions in `TimeFormatTest` cover the chapter-present and chapter-absent artist text formats; these would go red if the chapter title were dropped.
- Both `FakeController` stubs in `AudiobookPlayerViewModelBookmarkTest` and `SleepTimerTest` updated to match the new signature.