### PR TITLE
fix(nav): exit item details (and reader) when source is switched

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -56,6 +56,7 @@ import com.riffle.app.feature.settings.readaloud.ReadaloudSettingsScreen
 import com.riffle.app.playback.NowPlaying
 import com.riffle.app.ui.isTabletLayout
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
 import java.net.URLEncoder
@@ -95,7 +96,7 @@ private const val LIBRARY_SECTION = "library_section/{libraryId}/{libraryName}/{
 private const val SERIES_DETAIL = "series_detail/{libraryId}/{seriesId}/{seriesName}"
 private const val COLLECTION_DETAIL = "collection_detail/{libraryId}/{collectionId}/{collectionName}"
 private const val FILTERED_BOOKS = "filtered_books/{libraryId}/{facetType}/{facetValue}"
-private const val LIBRARY_ITEM_DETAIL = "library_item_detail/{itemId}"
+internal const val LIBRARY_ITEM_DETAIL = "library_item_detail/{itemId}"
 private const val PLAYLIST_DETAIL = "playlist_detail/{libraryId}/{playlistId}/{playlistName}"
 private const val EPUB_READER =
     "epub_reader/{itemId}?startReadaloudAtSec={startReadaloudAtSec}&openAtCfi={openAtCfi}&openAnnotationId={openAnnotationId}&startTocHref={startTocHref}&source={source}&sourceId={sourceId}"
@@ -249,9 +250,13 @@ fun MainScreen(
 
     LaunchedEffect(Unit) {
         viewModel.activeServer
+            .filterNotNull()
             .drop(1)
             .collect {
-                if (isItemDetailRoute(navController.currentDestination?.route)) {
+                val stackHasItemDetail = navController.currentBackStackSnapshot().any { entry ->
+                    isItemDetailRoute(entry.destination.route)
+                }
+                if (stackHasItemDetail) {
                     navController.navigateAsRoot(HOME)
                 }
             }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -55,6 +55,7 @@ import com.riffle.app.feature.settings.readaloud.ReadaloudMatchesScreen
 import com.riffle.app.feature.settings.readaloud.ReadaloudSettingsScreen
 import com.riffle.app.playback.NowPlaying
 import com.riffle.app.ui.isTabletLayout
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
 import java.net.URLEncoder
@@ -244,6 +245,16 @@ fun MainScreen(
             navController.navigateAsRoot(libraryEntryRoute(activeServer?.type, library.id, library.name))
             viewModel.setActiveLibrary(library.id)
         }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.activeServer
+            .drop(1)
+            .collect {
+                if (isItemDetailRoute(navController.currentDestination?.route)) {
+                    navController.navigateAsRoot(HOME)
+                }
+            }
     }
 
     RiffleNavigationDrawer(
@@ -1085,6 +1096,9 @@ internal fun NavController.popBackStackIfTop(backStackEntry: NavBackStackEntry) 
         popBack = { popBackStack() },
     )
 }
+
+internal fun isItemDetailRoute(route: String?): Boolean =
+    route?.startsWith(LIBRARY_ITEM_DETAIL.substringBefore("{")) == true
 
 internal fun isReaderRoute(route: String?): Boolean =
     route?.startsWith(EPUB_READER.substringBefore("{")) == true ||

--- a/app/src/test/kotlin/com/riffle/app/navigation/IsItemDetailRouteTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/IsItemDetailRouteTest.kt
@@ -8,7 +8,7 @@ class IsItemDetailRouteTest {
 
     @Test
     fun `library item detail route is recognized`() {
-        assertTrue(isItemDetailRoute("library_item_detail/item-id-123"))
+        assertTrue(isItemDetailRoute("${LIBRARY_ITEM_DETAIL.substringBefore("{")}item-id-123"))
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/navigation/IsItemDetailRouteTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/IsItemDetailRouteTest.kt
@@ -1,0 +1,33 @@
+package com.riffle.app.navigation
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IsItemDetailRouteTest {
+
+    @Test
+    fun `library item detail route is recognized`() {
+        assertTrue(isItemDetailRoute("library_item_detail/item-id-123"))
+    }
+
+    @Test
+    fun `null route is not an item detail route`() {
+        assertFalse(isItemDetailRoute(null))
+    }
+
+    @Test
+    fun `home route is not an item detail route`() {
+        assertFalse(isItemDetailRoute("home"))
+    }
+
+    @Test
+    fun `library items route is not an item detail route`() {
+        assertFalse(isItemDetailRoute("library_items/lib-1/My%20Library"))
+    }
+
+    @Test
+    fun `epub reader route is not an item detail route`() {
+        assertFalse(isItemDetailRoute("epub_reader/item-id"))
+    }
+}


### PR DESCRIPTION
When item details is shown and the user opens the burger menu and switches source, the item details screen was preserved — now stale in the context of a different source. Same bug applies if the reader was opened from item detail: pressing Back would land on the stale detail.

## What changed

A `LaunchedEffect` in `MainScreen.kt` watches `viewModel.activeServer` using `filterNotNull().drop(1)` (skipping the initial restored value to avoid a process-death false-positive). When the source changes, it scans the full back stack via `currentBackStackSnapshot()` for any `library_item_detail/…` entry; if found, it calls `navigateAsRoot(HOME)`, clearing the stale detail (and anything above it, e.g. a reader) from the stack. The `redirectToLibrary` flow then takes over to show the right library for the new source.

`isItemDetailRoute()` is extracted as a testable top-level function alongside the existing `isReaderRoute()`, and `LIBRARY_ITEM_DETAIL` is promoted to `internal` so tests can reference the constant directly.

## Test coverage

`IsItemDetailRouteTest` — 5 unit tests covering the route-matching function; the key assertion (`library_item_detail/…` → true) would flip red if the fix were reverted.