### PR TITLE
fix(nav): move drawer BackHandler after NavHost to close-only on back-with-drawer-open

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -188,23 +188,6 @@ fun MainScreen(
     // fills the width, matching the modal drawer's gesture suppression on phones.
     val hidePermanentDrawerPanel = isReaderRoute(currentRoute)
 
-    // Material3's ModalNavigationDrawer doesn't install its own BackHandler — so when the
-    // drawer is open or animating we add one here. Registered above the NavHost so screen-level
-    // handlers (e.g. LibraryItemsScreen) don't override it.
-    //
-    // Check both currentValue and targetValue: targetValue flips to Open the instant
-    // drawerState.open() is called (catches Back during the open animation), and currentValue
-    // stays Open until the close animation finishes (catches Back during the close animation).
-    // Using only targetValue misses the close-animation window; using only isOpen (currentValue)
-    // misses the open-animation window that caused the burger-tap white-screen freeze.
-    BackHandler(enabled = shouldInterceptBackForDrawer(
-        usePermanentDrawer,
-        drawerCurrentOpen = drawerState.currentValue == DrawerValue.Open,
-        drawerTargetOpen = drawerState.targetValue == DrawerValue.Open,
-    )) {
-        scope.launch { drawerState.close() }
-    }
-
     val lifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
         // Gate on seenStop so that rotation (which replays ON_START on the new observer
@@ -983,6 +966,26 @@ fun MainScreen(
                 )
             }
         }
+    }
+
+    // Material3's ModalNavigationDrawer doesn't install its own BackHandler — so when the
+    // drawer is open or animating we add one here. Must be registered AFTER RiffleNavigationDrawer
+    // (and thus after NavHost and the NavController) so it has higher priority in the
+    // OnBackPressedDispatcher (last-registered wins). A position before NavHost gives the
+    // NavController's callback higher priority, causing it to pop library_items and trigger a
+    // library reload instead of closing the drawer.
+    //
+    // Check both currentValue and targetValue: targetValue flips to Open the instant
+    // drawerState.open() is called (catches Back during the open animation), and currentValue
+    // stays Open until the close animation finishes (catches Back during the close animation).
+    // Using only targetValue misses the close-animation window; using only isOpen (currentValue)
+    // misses the open-animation window that caused the burger-tap white-screen freeze.
+    BackHandler(enabled = shouldInterceptBackForDrawer(
+        usePermanentDrawer,
+        drawerCurrentOpen = drawerState.currentValue == DrawerValue.Open,
+        drawerTargetOpen = drawerState.targetValue == DrawerValue.Open,
+    )) {
+        scope.launch { drawerState.close() }
     }
 
     updateDialogState?.let { dialogState ->

--- a/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
@@ -22,9 +22,10 @@ import org.junit.Test
  *   the close animation (targetValue is already Closed at that point, so isOpen alone
  *   would miss it in the opposite direction).
  *
- * The same predicate also gates LibraryItemsScreen's backEnabled, because that child
- * BackHandler has LIFO priority over the top-level handler and would otherwise intercept
- * Back first during the animation windows.
+ * The same predicate also gates LibraryItemsScreen's backEnabled as belt-and-suspenders:
+ * the drawer BackHandler is now registered AFTER NavHost (higher LIFO priority in
+ * OnBackPressedDispatcher) so it fires before the library handler. Disabling the library
+ * handler when the drawer is open avoids any residual edge-case race.
  */
 class ShouldInterceptBackForDrawerTest {
 


### PR DESCRIPTION
## Root cause

`OnBackPressedDispatcher` processes callbacks in LIFO order (last-registered = highest priority). The drawer `BackHandler` was registered **before** `RiffleNavigationDrawer`/`NavHost`, putting the `NavController`'s back callback at a higher priority.

When the drawer was open:
- `libBackEnabled = false` → library `BackHandler` disabled
- `NavController`'s callback fired next (higher priority) → popped `library_items`
- `HOME` surfaced → `navigateFromHome` re-navigated to the library → visible library reload

## Fix

Move the drawer `BackHandler` to **after** `RiffleNavigationDrawer`. It now registers last in the composition tree → highest priority in `OnBackPressedDispatcher` → fires before the `NavController` → closes the drawer with no side navigation.

The `libBackEnabled` drawer-state gate is kept as belt-and-suspenders but is no longer the primary mechanism.

## Testing

- Existing JVM unit tests for `shouldInterceptBackForDrawer` and `libraryItemsBackEnabled` predicates all pass (logic unchanged).
- Harness test pinning the full back-with-drawer-open path would fully close the regression; added as a follow-up.