### PR TITLE
fix(library): fire immediate retry on first failed refresh to clear cold-start offline banner

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -329,6 +329,10 @@ class LibraryItemsViewModel @Inject constructor(
             combine(_refreshFailed, connectivityObserver.isOnline) { failed, online -> failed && online }
                 .collectLatest { shouldPoll ->
                     if (shouldPoll) {
+                        // Immediate retry covers cold-start transient failures (fast-fail
+                        // "network unreachable" clears within milliseconds). Subsequent
+                        // retries use the full interval for genuine server-down scenarios.
+                        runRefresh()
                         while (true) {
                             delay(FAILED_REFRESH_RETRY_INTERVAL_MS)
                             runRefresh()

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -905,6 +905,26 @@ class LibraryItemsViewModelTest {
     }
 
     @Test
+    fun `offline banner clears immediately on first retry after transient cold-start failure`() = runTest {
+        // Regression: the polling loop always delayed 10 s before its first retry, so a fast
+        // cold-start transient (network briefly unreachable → immediate fail) kept the banner
+        // up for the full interval even though the server was reachable moments later.
+        var callCount = 0
+        val vm = makeViewModel(
+            refreshLibraryItemsUseCase = CountingRefreshLibraryItems({
+                // First call (init refresh) fails; every subsequent call succeeds.
+                if (callCount == 1) LibraryRefreshResult.NetworkError(RuntimeException("transient"))
+                else LibraryRefreshResult.Success
+            }) { callCount++ },
+        )
+        backgroundScope.launch { vm.isOffline.collect {} }
+        // runCurrent() runs: (1) init refresh → NetworkError, then (2) immediate retry → Success.
+        // No time advance needed — the banner must clear without waiting 10 s.
+        testDispatcher.scheduler.runCurrent()
+        assertEquals(false, vm.isOffline.value)
+    }
+
+    @Test
     fun `filteredRecentlyAdded when offline cap still applies after filtering`() = runTest {
         val downloadedIds = (1..60).map { "id-Book $it" }.toSet()
         val vm = makeViewModel(


### PR DESCRIPTION
## What

On cold start the offline banner was (almost) always shown for 10 seconds before clearing.

## Why

The retry loop for failed library refreshes always started with `delay(FAILED_REFRESH_RETRY_INTERVAL_MS)` (10 s) before its first attempt. On cold start, a transient fast-fail — the WiFi data path isn't fully ready for the very first HTTP request, producing an immediate "network unreachable" — sets `_refreshFailed = true`. The banner then showed for the full 10-second interval before the first retry cleared it, even though the network (and server) was reachable moments later.

## Fix

Fire an immediate `runRefresh()` when `shouldPoll` first becomes true, before entering the 10-second delay loop. For cold-start transients (fast fail → network ready in milliseconds) the banner clears almost instantly. For genuine server-down, the immediate retry fails quickly too, then the 10-second interval takes over — same cadence as before with one extra cheap request.

## Tests

Added `offline banner clears immediately on first retry after transient cold-start failure` — first refresh returns `NetworkError`, immediate retry returns `Success`; asserts `isOffline = false` after `runCurrent()` with no time advance. This test fails before the fix (banner stays `true` because the first retry was behind a `delay`) and passes after.