### PR TITLE
feat(library): add clear button to search field

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/library/LibrarySearchHeaderFocusTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/library/LibrarySearchHeaderFocusTest.kt
@@ -5,7 +5,10 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -37,5 +40,56 @@ class LibrarySearchHeaderFocusTest {
         composeTestRule
             .onNode(hasSetTextAction())
             .assert(SemanticsMatcher.expectValue(SemanticsProperties.Focused, false))
+    }
+
+    @Test
+    fun clearButtonIsHiddenWhenQueryIsEmpty() {
+        composeTestRule.setContent {
+            LibrarySearchHeader(
+                libraryName = "My Library",
+                searchQuery = "",
+                onSearchQueryChange = {},
+                onOpenDrawer = {},
+            )
+        }
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription("Clear search").assertDoesNotExist()
+    }
+
+    @Test
+    fun clearButtonIsVisibleWhenQueryIsNonEmpty() {
+        composeTestRule.setContent {
+            LibrarySearchHeader(
+                libraryName = "My Library",
+                searchQuery = "dune",
+                onSearchQueryChange = {},
+                onOpenDrawer = {},
+            )
+        }
+
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithContentDescription("Clear search").assertExists()
+    }
+
+    @Test
+    fun clearButtonClickInvokesOnSearchQueryChangeWithEmpty() {
+        val captured = mutableListOf<String>()
+        composeTestRule.setContent {
+            LibrarySearchHeader(
+                libraryName = "My Library",
+                searchQuery = "dune",
+                onSearchQueryChange = { captured.add(it) },
+                onOpenDrawer = {},
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithContentDescription("Clear search").performClick()
+        composeTestRule.waitForIdle()
+
+        assertEquals(listOf(""), captured)
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -41,11 +41,13 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.QueueMusic
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.FormatListNumbered
 import androidx.compose.material.icons.filled.GridView
@@ -1189,6 +1191,19 @@ internal fun LibrarySearchHeader(
                     }
                 },
             )
+            AnimatedVisibility(visible = searchQuery.isNotEmpty()) {
+                IconButton(
+                    onClick = { onSearchQueryChange("") },
+                    modifier = Modifier.size(32.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "Clear search",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+            }
         }
         HorizontalDivider()
     }


### PR DESCRIPTION
Adds an animated X button that appears trailing the search text field whenever the query is non-empty. Tapping it clears the query via the existing `onSearchQueryChange("")` path — the same mechanism as the Back key's `ClearSearch` action.

## Changes

- `LibraryItemsScreen.kt`: `AnimatedVisibility`-wrapped `IconButton` with `Icons.Default.Close` after the `BasicTextField` in `LibrarySearchHeader`
- `LibrarySearchHeaderFocusTest.kt`: three new harness tests — button hidden when empty, visible when non-empty, click invokes `onSearchQueryChange("")`