### PR TITLE
feat(ui): default cover placeholder for books and audiobooks

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.riffle.app.ui.DefaultCoverPlaceholder
 import com.riffle.app.feature.audiobook.SleepTimerMode
 import com.riffle.app.feature.audiobook.formatCountdown
 
@@ -205,18 +206,23 @@ private fun PlayerSurfaceTwoColumn(
 /** Square audiobook cover (ADR 0029). [modifier] supplies the size (fraction of width, or fixed). */
 @Composable
 private fun PlayerCover(state: PlayerSurfaceState, modifier: Modifier) {
-    AsyncImage(
-        model = ImageRequest.Builder(LocalContext.current)
-            .data(state.coverUrl)
-            .addHeader("Authorization", "Bearer ${state.authToken}")
-            .build(),
-        contentDescription = null,
-        contentScale = ContentScale.Crop,
+    Box(
         modifier = modifier
             .aspectRatio(1f)
             .shadow(16.dp, RoundedCornerShape(12.dp))
             .clip(RoundedCornerShape(12.dp)),
-    )
+    ) {
+        DefaultCoverPlaceholder(isAudiobook = true, modifier = Modifier.fillMaxSize())
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(state.coverUrl)
+                .addHeader("Authorization", "Bearer ${state.authToken}")
+                .build(),
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -86,6 +86,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.riffle.app.feature.reader.TocPanel
+import com.riffle.app.ui.DefaultCoverPlaceholder
 import com.riffle.app.ui.isPhoneLandscape
 import com.riffle.app.ui.isTabletLayout
 import com.riffle.core.models.EbookFormat
@@ -436,32 +437,39 @@ private fun LibraryItemDetailContent(
             .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        item.coverUrl?.let { url ->
-            val configuration = LocalConfiguration.current
-            val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
-            // A tablet in portrait is below the 840dp Expanded breakpoint (ADR 0019), so it
-            // lands on this single-column phone layout. fillMaxWidth() makes the cover span
-            // the whole tablet width — ginormous. Cap it on tablet-wide screens; real phones
-            // (< 600dp) keep the full-bleed cover.
-            val isWideScreen = configuration.screenWidthDp >= 600
-            val coverWidth = when {
-                isLandscape -> Modifier.fillMaxWidth(0.4f)
-                isWideScreen -> Modifier.widthIn(max = 280.dp)
-                else -> Modifier.fillMaxWidth()
+        val configuration = LocalConfiguration.current
+        val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+        // A tablet in portrait is below the 840dp Expanded breakpoint (ADR 0019), so it
+        // lands on this single-column phone layout. fillMaxWidth() makes the cover span
+        // the whole tablet width — ginormous. Cap it on tablet-wide screens; real phones
+        // (< 600dp) keep the full-bleed cover.
+        val isWideScreen = configuration.screenWidthDp >= 600
+        val coverWidth = when {
+            isLandscape -> Modifier.fillMaxWidth(0.4f)
+            isWideScreen -> Modifier.widthIn(max = 280.dp)
+            else -> Modifier.fillMaxWidth()
+        }
+        val isAudiobook = item.isListenable && !item.isReadable
+        Box(
+            modifier = Modifier
+                .then(coverWidth)
+                .aspectRatio(if (isAudiobook) 1f else 2f / 3f)
+                .align(Alignment.CenterHorizontally)
+                .clip(RoundedCornerShape(4.dp)),
+        ) {
+            DefaultCoverPlaceholder(isAudiobook = isAudiobook, modifier = Modifier.fillMaxSize())
+            if (item.coverUrl != null) {
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(item.coverUrl)
+                        .addHeader("Authorization", token.asAuthHeader())
+                        .instrumentCover("detail", item.id, item.coverUrl)
+                        .build(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier.fillMaxSize(),
+                )
             }
-            AsyncImage(
-                model = ImageRequest.Builder(LocalContext.current)
-                    .data(url)
-                    .addHeader("Authorization", token.asAuthHeader())
-                    .instrumentCover("detail", item.id, url)
-                    .build(),
-                contentDescription = null,
-                contentScale = ContentScale.Fit,
-                modifier = Modifier
-                    .then(coverWidth)
-                    .aspectRatio(2f / 3f)
-                    .align(Alignment.CenterHorizontally),
-            )
         }
 
         if (item.isListenable && item.audioDurationSec > 0) {
@@ -718,31 +726,38 @@ internal fun LibraryItemDetailContentTablet(
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            item.coverUrl?.let { url ->
-                // The left pane is non-scrolling (CONTEXT.md / ADR 0020), so the cover
-                // must yield height to the action row. weight(fill = false) lets the
-                // cover shrink if it can't fit, keeping the Read button visible.
-                //
-                // The cap is orientation-aware: in portrait the pane is tall, so an
-                // uncapped cover dominates — cap it small. In landscape the pane is
-                // short and wide, so a small cap leaves the cover looking lost — allow
-                // it larger (weight still shrinks it if the action row needs the room).
-                val isLandscape =
-                    LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
-                AsyncImage(
-                    model = ImageRequest.Builder(LocalContext.current)
-                        .data(url)
-                        .addHeader("Authorization", token.asAuthHeader())
-                        .instrumentCover("detail", item.id, url)
-                        .build(),
-                    contentDescription = null,
-                    contentScale = ContentScale.Fit,
-                    modifier = Modifier
-                        .weight(1f, fill = false)
-                        .widthIn(max = if (isLandscape) 230.dp else 100.dp)
-                        .aspectRatio(2f / 3f)
-                        .align(Alignment.CenterHorizontally),
-                )
+            // The left pane is non-scrolling (CONTEXT.md / ADR 0020), so the cover
+            // must yield height to the action row. weight(fill = false) lets the
+            // cover shrink if it can't fit, keeping the Read button visible.
+            //
+            // The cap is orientation-aware: in portrait the pane is tall, so an
+            // uncapped cover dominates — cap it small. In landscape the pane is
+            // short and wide, so a small cap leaves the cover looking lost — allow
+            // it larger (weight still shrinks it if the action row needs the room).
+            val isLandscape =
+                LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+            val isAudiobook = item.isListenable && !item.isReadable
+            Box(
+                modifier = Modifier
+                    .weight(1f, fill = false)
+                    .widthIn(max = if (isLandscape) 230.dp else 100.dp)
+                    .aspectRatio(if (isAudiobook) 1f else 2f / 3f)
+                    .align(Alignment.CenterHorizontally)
+                    .clip(RoundedCornerShape(4.dp)),
+            ) {
+                DefaultCoverPlaceholder(isAudiobook = isAudiobook, modifier = Modifier.fillMaxSize())
+                if (item.coverUrl != null) {
+                    AsyncImage(
+                        model = ImageRequest.Builder(LocalContext.current)
+                            .data(item.coverUrl)
+                            .addHeader("Authorization", token.asAuthHeader())
+                            .instrumentCover("detail", item.id, item.coverUrl)
+                            .build(),
+                        contentDescription = null,
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
             }
             TitleWithReadaloudIndicator(
                 title = item.title,
@@ -919,27 +934,34 @@ internal fun LibraryItemDetailContentPhoneLandscape(
     var showChaptersSheet by remember { mutableStateOf(false) }
 
     Row(modifier = modifier.fillMaxSize()) {
-        item.coverUrl?.let { url ->
+        Box(
+            modifier = Modifier
+                .testTag(LIBRARY_ITEM_DETAIL_LEFT_PANE_TAG)
+                .fillMaxHeight()
+                .padding(start = 16.dp, top = 8.dp, bottom = 8.dp, end = 8.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            val isAudiobook = item.isListenable && !item.isReadable
             Box(
                 modifier = Modifier
-                    .testTag(LIBRARY_ITEM_DETAIL_LEFT_PANE_TAG)
-                    .fillMaxHeight()
-                    .padding(start = 16.dp, top = 8.dp, bottom = 8.dp, end = 8.dp),
-                contentAlignment = Alignment.Center,
-            ) {
-                AsyncImage(
-                    model = ImageRequest.Builder(LocalContext.current)
-                        .data(url)
-                        .addHeader("Authorization", token.asAuthHeader())
-                        .instrumentCover("detail", item.id, url)
-                        .build(),
-                    contentDescription = null,
-                    contentScale = ContentScale.Fit,
                     // The cover owns the column's full height; aspectRatio derives its width from that.
-                    modifier = Modifier
-                        .fillMaxHeight()
-                        .aspectRatio(2f / 3f, matchHeightConstraintsFirst = true),
-                )
+                    .fillMaxHeight()
+                    .aspectRatio(if (isAudiobook) 1f else 2f / 3f, matchHeightConstraintsFirst = true)
+                    .clip(RoundedCornerShape(4.dp)),
+            ) {
+                DefaultCoverPlaceholder(isAudiobook = isAudiobook, modifier = Modifier.fillMaxSize())
+                if (item.coverUrl != null) {
+                    AsyncImage(
+                        model = ImageRequest.Builder(LocalContext.current)
+                            .data(item.coverUrl)
+                            .addHeader("Authorization", token.asAuthHeader())
+                            .instrumentCover("detail", item.id, item.coverUrl)
+                            .build(),
+                        contentDescription = null,
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
             }
         }
         Column(

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -128,6 +128,7 @@ import com.riffle.core.models.Series
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlin.math.floor
 import kotlin.math.max
+import com.riffle.app.ui.DefaultCoverPlaceholder
 import com.riffle.app.ui.source.asAuthHeader
 
 
@@ -655,9 +656,9 @@ fun BookCoverTile(
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(coverAspect)
-                .clip(RoundedCornerShape(4.dp))
-                .background(MaterialTheme.colorScheme.surfaceVariant),
+                .clip(RoundedCornerShape(4.dp)),
         ) {
+            DefaultCoverPlaceholder(isAudiobook = isAudiobookOnly, modifier = Modifier.fillMaxSize())
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
                     .data(item.coverUrl)
@@ -665,7 +666,6 @@ fun BookCoverTile(
                     .crossfade(true)
                     .instrumentCover("item", item.id, item.coverUrl)
                     .build(),
-                placeholder = ColorPainter(MaterialTheme.colorScheme.surfaceVariant),
                 contentDescription = item.title,
                 contentScale = ContentScale.Crop,
                 modifier = Modifier.fillMaxSize(),
@@ -740,21 +740,25 @@ fun SeriesCoverTile(
     onClick: () -> Unit,
 ) {
     Column(modifier = Modifier.clickable(onClick = onClick)) {
-        AsyncImage(
-            model = ImageRequest.Builder(LocalContext.current)
-                .data(series.coverUrl)
-                .addHeader("Authorization", token.asAuthHeader())
-                .crossfade(true)
-                .instrumentCover("series", series.id, series.coverUrl)
-                .build(),
-            placeholder = ColorPainter(MaterialTheme.colorScheme.surfaceVariant),
-            contentDescription = series.name,
-            contentScale = ContentScale.Crop,
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(coverAspectRatio(LocalCoversAreSquare.current))
                 .clip(RoundedCornerShape(4.dp)),
-        )
+        ) {
+            DefaultCoverPlaceholder(isAudiobook = false, modifier = Modifier.fillMaxSize())
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(series.coverUrl)
+                    .addHeader("Authorization", token.asAuthHeader())
+                    .crossfade(true)
+                    .instrumentCover("series", series.id, series.coverUrl)
+                    .build(),
+                contentDescription = series.name,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
         Spacer(modifier = Modifier.height(4.dp))
         Text(
             text = series.name,
@@ -880,19 +884,19 @@ private fun SearchSeriesRow(series: Series, token: String, onClick: () -> Unit) 
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
     ) {
         Row(modifier = Modifier.padding(8.dp), verticalAlignment = Alignment.CenterVertically) {
-            AsyncImage(
-                model = ImageRequest.Builder(LocalContext.current)
-                    .data(series.coverUrl)
-                    .addHeader("Authorization", token.asAuthHeader())
-                    .crossfade(true)
-                    .build(),
-                placeholder = ColorPainter(MaterialTheme.colorScheme.surfaceVariant),
-                contentDescription = series.name,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier
-                    .size(width = 48.dp, height = 72.dp)
-                    .clip(RoundedCornerShape(4.dp)),
-            )
+            Box(modifier = Modifier.size(width = 48.dp, height = 72.dp).clip(RoundedCornerShape(4.dp))) {
+                DefaultCoverPlaceholder(isAudiobook = false, modifier = Modifier.fillMaxSize())
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(series.coverUrl)
+                        .addHeader("Authorization", token.asAuthHeader())
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = series.name,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
             Spacer(modifier = Modifier.width(12.dp))
             Column {
                 Text(text = series.name, style = MaterialTheme.typography.titleSmall, maxLines = 2, overflow = TextOverflow.Ellipsis)
@@ -1237,20 +1241,24 @@ internal fun LibraryItemCard(
         border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
     ) {
         Row(modifier = Modifier.padding(8.dp), verticalAlignment = Alignment.Top) {
-            AsyncImage(
-                model = ImageRequest.Builder(LocalContext.current)
-                    .data(item.coverUrl)
-                    .addHeader("Authorization", token.asAuthHeader())
-                    .crossfade(true)
-                    .instrumentCover("card", item.id, item.coverUrl)
-                    .build(),
-                placeholder = ColorPainter(MaterialTheme.colorScheme.surfaceVariant),
-                contentDescription = item.title,
-                contentScale = ContentScale.Crop,
+            Box(
                 modifier = Modifier
                     .size(width = 48.dp, height = if (isAudiobookOnly) 48.dp else 72.dp)
                     .clip(RoundedCornerShape(4.dp)),
-            )
+            ) {
+                DefaultCoverPlaceholder(isAudiobook = isAudiobookOnly, modifier = Modifier.fillMaxSize())
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(item.coverUrl)
+                        .addHeader("Authorization", token.asAuthHeader())
+                        .crossfade(true)
+                        .instrumentCover("card", item.id, item.coverUrl)
+                        .build(),
+                    contentDescription = item.title,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
             Spacer(modifier = Modifier.width(12.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Row(

--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
@@ -1,6 +1,5 @@
 package com.riffle.app.feature.source.chitanka
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -60,6 +59,7 @@ import com.riffle.app.feature.library.LocalCoversAreSquare
 import com.riffle.app.feature.library.ToReadTabContent
 import com.riffle.app.feature.source.websource.UnboundedCatalogGrid
 import com.riffle.app.feature.source.websource.UnboundedCoverGridZoomProvider
+import com.riffle.app.ui.DefaultCoverPlaceholder
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.core.catalog.CatalogItem
 import com.riffle.core.catalog.chitanka.ChitankaCatalog
@@ -376,20 +376,14 @@ private fun CatalogItemCard(
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(ratio)
-                .clip(RoundedCornerShape(8.dp))
-                .background(MaterialTheme.colorScheme.surfaceVariant),
+                .clip(RoundedCornerShape(8.dp)),
         ) {
+            DefaultCoverPlaceholder(isAudiobook = isAudio)
             if (!item.coverUrl.isNullOrBlank()) {
                 AsyncImage(
                     model = item.coverUrl,
                     contentDescription = null,
                     modifier = Modifier.fillMaxSize(),
-                )
-            } else {
-                Text(
-                    if (isAudio) "🎧" else "📖",
-                    modifier = Modifier.align(Alignment.Center),
-                    style = MaterialTheme.typography.headlineMedium,
                 )
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
@@ -1,6 +1,5 @@
 package com.riffle.app.feature.source.gutenberg
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -58,6 +57,7 @@ import com.riffle.app.feature.library.HomeTabContent
 import com.riffle.app.feature.library.ToReadTabContent
 import com.riffle.app.feature.source.websource.UnboundedCatalogGrid
 import com.riffle.app.feature.source.websource.UnboundedCoverGridZoomProvider
+import com.riffle.app.ui.DefaultCoverPlaceholder
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.core.catalog.CatalogItem
 
@@ -342,20 +342,14 @@ private fun CatalogItemCard(
             modifier = Modifier
                 .fillMaxWidth()
                 .aspectRatio(2f / 3f)
-                .clip(RoundedCornerShape(8.dp))
-                .background(MaterialTheme.colorScheme.surfaceVariant),
+                .clip(RoundedCornerShape(8.dp)),
         ) {
+            DefaultCoverPlaceholder(isAudiobook = false)
             if (!item.coverUrl.isNullOrBlank()) {
                 AsyncImage(
                     model = item.coverUrl,
                     contentDescription = null,
                     modifier = Modifier.fillMaxSize(),
-                )
-            } else {
-                Text(
-                    "📖",
-                    modifier = Modifier.align(Alignment.Center),
-                    style = MaterialTheme.typography.headlineMedium,
                 )
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/ui/DefaultCoverPlaceholder.kt
+++ b/app/src/main/kotlin/com/riffle/app/ui/DefaultCoverPlaceholder.kt
@@ -1,0 +1,115 @@
+package com.riffle.app.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.withTransform
+
+@Composable
+fun DefaultCoverPlaceholder(isAudiobook: Boolean, modifier: Modifier = Modifier) {
+    val dark = isSystemInDarkTheme()
+    val gradientStart: Color
+    val gradientEnd: Color
+    val glyphColor: Color
+    if (isAudiobook) {
+        gradientStart = if (dark) Color(0xFF1C3040) else Color(0xFFD9EFF8)
+        gradientEnd   = if (dark) Color(0xFF0F1E2A) else Color(0xFF9ECDE6)
+        glyphColor    = if (dark) Color(0xFF7DCAEC) else Color(0xFF0E5F8A)
+    } else {
+        gradientStart = if (dark) Color(0xFF352B4A) else Color(0xFFEAE0F8)
+        gradientEnd   = if (dark) Color(0xFF1F1830) else Color(0xFFC9B5E6)
+        glyphColor    = if (dark) Color(0xFFCDB8FF) else Color(0xFF5B3FA0)
+    }
+    Canvas(modifier = modifier.fillMaxSize()) {
+        drawRect(
+            brush = Brush.linearGradient(
+                colors = listOf(gradientStart, gradientEnd),
+                start = Offset(0f, 0f),
+                end = Offset(size.width, size.height),
+            )
+        )
+        if (isAudiobook) drawWaveformGlyph(glyphColor) else drawShelfGlyph(glyphColor)
+    }
+}
+
+// Shelf — three book spines standing on a line (viewBox 42×38, glyph ~58% of area)
+private fun DrawScope.drawShelfGlyph(color: Color) {
+    val glyphW = size.width * 0.58f
+    val glyphH = size.height * 0.58f
+    val ox = (size.width - glyphW) / 2f
+    val oy = (size.height - glyphH) / 2f
+    val sx = glyphW / 42f
+    val sy = glyphH / 38f
+
+    fun x(v: Float) = ox + v * sx
+    fun y(v: Float) = oy + v * sy
+    fun w(v: Float) = v * sx
+    fun h(v: Float) = v * sy
+    fun cr(v: Float) = CornerRadius(v * sx, v * sy)
+
+    drawRoundRect(
+        color = color.copy(alpha = 0.85f),
+        topLeft = Offset(x(1f), y(6f)),
+        size = Size(w(9f), h(30f)),
+        cornerRadius = cr(2f),
+    )
+    withTransform({ rotate(-4f, Offset(x(18f), y(19f))) }) {
+        drawRoundRect(
+            color = color.copy(alpha = 0.6f),
+            topLeft = Offset(x(13f), y(2f)),
+            size = Size(w(11f), h(34f)),
+            cornerRadius = cr(2f),
+        )
+    }
+    drawRoundRect(
+        color = color.copy(alpha = 0.4f),
+        topLeft = Offset(x(28f), y(4f)),
+        size = Size(w(10f), h(32f)),
+        cornerRadius = cr(2f),
+    )
+    drawLine(
+        color = color.copy(alpha = 0.5f),
+        start = Offset(x(0f), y(37f)),
+        end = Offset(x(42f), y(37f)),
+        strokeWidth = h(2.5f),
+        cap = StrokeCap.Round,
+    )
+}
+
+// Irregular waveform — 8 bars, asymmetric heights (viewBox 48×32, glyph ~52%×44% of area)
+private fun DrawScope.drawWaveformGlyph(color: Color) {
+    val glyphW = size.width * 0.52f
+    val glyphH = size.height * 0.44f
+    val ox = (size.width - glyphW) / 2f
+    val oy = (size.height - glyphH) / 2f
+    val sx = glyphW / 48f
+    val sy = glyphH / 32f
+
+    data class Bar(val x: Float, val y: Float, val h: Float, val alpha: Float)
+    listOf(
+        Bar(0f,  14f,  4f, 0.35f),
+        Bar(6f,  10f, 12f, 0.55f),
+        Bar(12f,  4f, 24f, 0.80f),
+        Bar(18f,  0f, 32f, 1.00f),
+        Bar(24f,  7f, 18f, 0.70f),
+        Bar(30f,  2f, 28f, 0.90f),
+        Bar(36f,  9f, 14f, 0.60f),
+        Bar(42f, 13f,  6f, 0.38f),
+    ).forEach { bar ->
+        drawRoundRect(
+            color = color.copy(alpha = bar.alpha),
+            topLeft = Offset(ox + bar.x * sx, oy + bar.y * sy),
+            size = Size(4f * sx, bar.h * sy),
+            cornerRadius = CornerRadius(2f * sx, 2f * sy),
+        )
+    }
+}

--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraper.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraper.kt
@@ -18,6 +18,14 @@ private fun textWithLineBreaks(el: Element): String {
 }
 
 /**
+ * Returns true when [imgSrc] is Chitanka's built-in "no cover" placeholder
+ * (`.../thumb/book-cover/00/0.{size}.{ext}`). Treat as null so the app's
+ * DefaultCoverPlaceholder renders instead of Chitanka's generic book icon.
+ */
+private fun isChitankaDefaultCover(imgSrc: String) =
+    imgSrc.contains("book-cover/00/0.")
+
+/**
  * Kotlin/jsoup port of `lib/scraper/chitanka.ts` from the reference
  * [chitanka-to-audiobookshelf](https://github.com/pkmetski/chitanka-to-audiobookshelf). Pure
  * parsing — no network, no I/O — every method takes raw HTML in and returns typed data out.
@@ -60,7 +68,7 @@ internal object ChitankaScraper {
             val url = toAbsolute(href)
             val title = el.selectFirst("[itemprop=name]")?.text()?.trim().orEmpty()
             val imgSrc = el.selectFirst("img[itemprop=image]")?.attr("src")
-            val coverUrl = if (!imgSrc.isNullOrEmpty()) toAbsolute(imgSrc) else null
+            val coverUrl = if (!imgSrc.isNullOrEmpty() && !isChitankaDefaultCover(imgSrc)) toAbsolute(imgSrc) else null
             val slug = href.replace(Regex("^/book/\\d+-"), "")
             if (title.isNotEmpty() && href.isNotEmpty()) {
                 items += ChitankaBookSummary(
@@ -111,7 +119,7 @@ internal object ChitankaScraper {
                     bookLink.attr("title").trim()
                 }
                 val imgSrc = el.selectFirst("img[itemprop=image]")?.attr("src")
-                val coverUrl = if (!imgSrc.isNullOrEmpty()) toAbsolute(imgSrc) else null
+                val coverUrl = if (!imgSrc.isNullOrEmpty() && !isChitankaDefaultCover(imgSrc)) toAbsolute(imgSrc) else null
 
                 val authors = el.select("[itemprop=author]")
                     .map { it.text().trim() }
@@ -196,7 +204,7 @@ internal object ChitankaScraper {
         }
 
         val imgSrc = doc.selectFirst("[itemprop=image]")?.attr("src")
-        val coverUrl = if (!imgSrc.isNullOrEmpty()) toAbsolute(imgSrc, pageUrl) else null
+        val coverUrl = if (!imgSrc.isNullOrEmpty() && !isChitankaDefaultCover(imgSrc)) toAbsolute(imgSrc, pageUrl) else null
 
         val epubHref = doc.selectFirst("a[href\$=.epub]")?.attr("href").orEmpty()
         val downloadUrl = if (epubHref.isNotEmpty()) toAbsolute(epubHref, pageUrl) else null

--- a/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraperTest.kt
+++ b/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraperTest.kt
@@ -23,6 +23,30 @@ class ChitankaScraperTest {
     }
 
     @Test
+    fun `category listing strips Chitanka default cover so DefaultCoverPlaceholder can show`() {
+        // book/1494-az-detektivytnobelist has src="…/thumb/book-cover/00/0.120.png" — Chitanka's
+        // "no cover" sentinel. Returning it as a non-null coverUrl causes Coil to load Chitanka's
+        // generic book icon instead of showing our DefaultCoverPlaceholder. Regression: would flip
+        // if isChitankaDefaultCover() filter is removed and null is replaced by the actual URL.
+        val html = fixture("chitanka-category.html")
+        val res = ChitankaScraper.parseSearchResults(html)
+        val noCoverBook = res.items.find { it.url.contains("/book/1494-") }
+        assertNotNull("expected book 1494 in category results", noCoverBook)
+        assertNull(
+            "book 1494 uses Chitanka's default cover — should be null, not '…/00/0.120.png'",
+            noCoverBook!!.coverUrl,
+        )
+        // Sanity: a book that has a real cover should still return it.
+        val withCover = res.items.find { it.url.contains("/book/3186-") }
+        assertNotNull("expected book 3186 in category results", withCover)
+        assertNotNull("book 3186 has a real cover — should not be null", withCover!!.coverUrl)
+        assertTrue(
+            "real cover URL should NOT contain the default-cover sentinel",
+            !withCover.coverUrl!!.contains("book-cover/00/0."),
+        )
+    }
+
+    @Test
     fun `categories page yields 20+ entries and are Bulgarian-sorted`() {
         val html = fixture("chitanka-categories.html")
         val cats = ChitankaScraper.parseCategories(html)


### PR DESCRIPTION
## Summary

- Adds `DefaultCoverPlaceholder` — a Canvas-drawn composable that renders a themed gradient background and a contextual glyph (three-spine shelf for books, irregular waveform for audiobooks) whenever a real cover is absent or fails to load. Colors are calibrated for both light and dark themes.
- Wires the placeholder into every cover surface: library grid tiles, series tiles, list-row thumbnails, item detail screen (all three layout variants: phone, tablet left-pane, phone-landscape two-pane), audiobook player, and the Chitanka/Gramofonche/Gutenberg browse screens.
- Replaces the old approach (flat `surfaceVariant` background + emoji / `ColorPainter` placeholder) uniformly across all surfaces.
- Fixes a Chitanka-specific bug: books with no custom cover on chitanka.info carry Chitanka's own "no cover" sentinel URL (`…/book-cover/00/0.120.png`). Coil was loading this image successfully, hiding `DefaultCoverPlaceholder` and showing Chitanka's generic book icon instead. The scraper now detects that URL pattern and returns `null` so the glyph shows. Regression test pins book/1494 (known no-cover entry in the category fixture) to `null` coverUrl while a real-cover book still returns its URL.

## Design

- **Book placeholder**: purple/lavender gradient (light: `#EAE0F8→#C9B5E6`, dark: `#352B4A→#1F1830`), shelf glyph with three rounded-rect spines and a shelf line.
- **Audio placeholder**: teal/blue gradient (light: `#D9EFF8→#9ECDE6`, dark: `#1C3040→#0F1E2A`), 8-bar asymmetric waveform glyph.

## Test plan

- [ ] `core:catalog-chitanka:test` — `category listing strips Chitanka default cover` regression passes
- [ ] Build and install; verify placeholder renders in library grid, player, detail screen for items without covers (Chitanka, Gramofonche, Gutenberg browse)
- [ ] Verify real covers still load correctly over the placeholder
- [ ] Check light and dark themes