### PR TITLE
fix(reader): prevent Komga PDF progress reset on first open

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfLocatorGate.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfLocatorGate.kt
@@ -1,0 +1,37 @@
+package com.riffle.app.feature.reader
+
+import org.readium.r2.shared.publication.Locator
+
+/**
+ * Stateful gate that implements the PDF reader's initial-locator-seen logic.
+ *
+ * [org.readium.adapter.pdfium.navigator.PdfiumNavigatorFragment]'s underlying
+ * `PdfNavigatorViewModel` seeds its `currentLocator` StateFlow with `Locator.Locations()` (all
+ * null) before Pdfium has rendered any page. Without special handling, that seed emission would
+ * consume the "initial locator seen" guard, causing the next real Pdfium emission (page 1) to be
+ * treated as user navigation and saved to the local position store — bumping `localUpdatedAt` to
+ * "now" and making a subsequent LocalWins sync cycle push page 1 over the server's real progress
+ * (e.g. Komga page 50 → reset to page 1).
+ *
+ * The fix: a locator with `position == null` is a seed and does NOT consume the guard.
+ */
+internal class PdfLocatorGate {
+    private var initialLocatorSeen = false
+
+    /**
+     * Returns true when the locator represents user-driven navigation and should be persisted;
+     * false when it should be swallowed (StateFlow seed or the initial navigator position).
+     */
+    fun advance(locator: Locator): Boolean {
+        if (!initialLocatorSeen) {
+            // position == null means this is the all-null seed emission from PdfNavigatorViewModel's
+            // StateFlow constructor — skip it without consuming the guard.
+            if (locator.locations.position == null) return false
+            initialLocatorSeen = true
+            return false  // first real-position locator: consume guard, don't save
+        }
+        return true
+    }
+
+    fun reset() { initialLocatorSeen = false }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
@@ -160,7 +160,7 @@ class PdfReaderViewModel @Inject constructor(
     private var lastLocator: Locator? = null
     val latestLocator: Locator? get() = lastLocator
     private var closeSyncDone = false
-    private var initialLocatorSeen = false
+    private val locatorGate = PdfLocatorGate()
 
     // PDF heartbeat-sync only — speed-tracking stays opt-out (PDF "position" units don't share
     // semantics with EPUB's locator positions, so we leave the speed-store untouched by passing
@@ -503,7 +503,7 @@ class PdfReaderViewModel @Inject constructor(
     fun onReaderResumed() {
         readerStateHolder.isReaderActive = true
         closeSyncDone = false
-        initialLocatorSeen = false
+        locatorGate.reset()
         if (_state.value is ReaderState.Ready) {
             syncCurrentPosition()
             readingSessionCoordinator.onResumed(
@@ -543,10 +543,7 @@ class PdfReaderViewModel @Inject constructor(
     fun onPageChanged(locator: Locator) {
         lastLocator = locator
         _currentPage.value = locator.locations.position
-        if (!initialLocatorSeen) {
-            initialLocatorSeen = true
-            return
-        }
+        if (!locatorGate.advance(locator)) return
         viewModelScope.launch {
             positionSaveCoordinator.onChanged(locator.toJSON().toString())
         }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/PdfLocatorGateTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/PdfLocatorGateTest.kt
@@ -1,0 +1,89 @@
+package com.riffle.app.feature.reader
+
+import android.net.FakeUri
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.util.AbsoluteUrl
+import org.readium.r2.shared.util.mediatype.MediaType
+
+class PdfLocatorGateTest {
+
+    // Bypasses android.net.Uri by allocating AbsoluteUrl via Unsafe + FakeUri.
+    @Suppress("UNCHECKED_CAST")
+    private fun buildLocator(position: Int?): Locator {
+        val unsafe = Class.forName("sun.misc.Unsafe")
+            .getDeclaredField("theUnsafe")
+            .also { it.isAccessible = true }
+            .get(null) as sun.misc.Unsafe
+        val url = unsafe.allocateInstance(AbsoluteUrl::class.java) as AbsoluteUrl
+        AbsoluteUrl::class.java.getDeclaredField("uri")
+            .also { it.isAccessible = true }
+            .set(url, FakeUri("file:///book.pdf"))
+        return Locator(
+            href = url,
+            mediaType = MediaType.PDF,
+            locations = Locator.Locations(position = position),
+        )
+    }
+
+    /**
+     * Regression for the Komga PDF progress-reset bug:
+     *
+     * PdfNavigatorViewModel seeds its `currentLocator` StateFlow with Locator.Locations() (all
+     * null) before Pdfium renders any page. Without the fix, that null-position seed consumes the
+     * guard, so the next emission (Pdfium landing on page 1) is treated as user navigation and
+     * saved. A save of page 1 bumps localUpdatedAt to "now", and a LocalWins sync cycle then
+     * pushes page 1 over the server's real progress (e.g. Komga page 50).
+     *
+     * Assertion that fails if the fix is reverted (null check removed from PdfLocatorGate):
+     * [gate.advance(page1Locator)] returns false — the gate has NOT yet been consumed by the
+     * null-position seed and correctly swallows the initial page-1 render.
+     */
+    @Test
+    fun `null-position seed does not consume gate - initial page 1 is still swallowed`() {
+        val gate = PdfLocatorGate()
+
+        val seed = buildLocator(position = null)
+        val page1 = buildLocator(position = 1)
+        val page2 = buildLocator(position = 2)
+
+        assertFalse("seed should be swallowed", gate.advance(seed))
+        // Without the fix the seed would consume the guard; page1.advance() would then return true
+        // (treated as user navigation), failing this assertion and triggering the progress reset.
+        assertFalse("initial page-1 render should be swallowed (guard consumed here)", gate.advance(page1))
+        assertTrue("subsequent page change should pass through", gate.advance(page2))
+    }
+
+    @Test
+    fun `without seed - initial page is swallowed and subsequent pages pass through`() {
+        val gate = PdfLocatorGate()
+        assertFalse(gate.advance(buildLocator(position = 1)))
+        assertTrue(gate.advance(buildLocator(position = 2)))
+    }
+
+    @Test
+    fun `reset restores gate so the next initial page is swallowed again`() {
+        val gate = PdfLocatorGate()
+        assertFalse(gate.advance(buildLocator(position = 1)))
+        assertTrue(gate.advance(buildLocator(position = 2)))
+
+        gate.reset()
+
+        assertFalse("after reset, seed should be swallowed again", gate.advance(buildLocator(null)))
+        assertFalse("after reset, initial page should be swallowed again", gate.advance(buildLocator(1)))
+        assertTrue("after reset, navigation should pass through again", gate.advance(buildLocator(2)))
+    }
+
+    @Test
+    fun `multiple null-position seeds all swallowed without consuming gate`() {
+        val gate = PdfLocatorGate()
+        assertFalse(gate.advance(buildLocator(null)))
+        assertFalse(gate.advance(buildLocator(null)))
+        assertFalse(gate.advance(buildLocator(null)))
+        // Guard still not consumed; page 1 should be swallowed
+        assertFalse(gate.advance(buildLocator(1)))
+        assertTrue(gate.advance(buildLocator(2)))
+    }
+}


### PR DESCRIPTION
## Root cause

`PdfNavigatorViewModel` (Readium 3.3.0) seeds its `currentLocator` StateFlow with `Locator.Locations()` (all null, `position = null`) before Pdfium has rendered any page. The PDF reader's `onPageChanged()` has an "initial locator seen" guard — the first real emission is swallowed because it represents the restored position, not user navigation. Without this fix, the null-position seed consumed the guard, so the first real Pdfium emission (page 1) was saved to the local position store, bumping `localUpdatedAt` to "now". The sync cycle saw a newer local timestamp than Komga's `lastModified`, decided LocalWins, and PATCHed Komga with page 1 — permanently overwriting the server's saved progress on every open.

## Fix

Extracted the guard logic into `PdfLocatorGate` (a testable `internal` class). The gate ignores locators with `position == null` (the StateFlow seed) without consuming the guard. Only the first position-bearing locator consumes the guard (still swallowed as the initial render); subsequent locators pass through to be persisted.

## Tests

`PdfLocatorGateTest` covers:
- Primary regression: null-position seed → page 1 → page 2; asserts page 1 is still swallowed (fails if fix is reverted)
- No-seed path
- `reset()` re-arms the gate for the resume flow
- Multiple consecutive null-position seeds