### PR TITLE
feat(library): show container format and EPUB version in item details

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCase.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCase.kt
@@ -108,7 +108,9 @@ class ExtractEpubTocUseCase @Inject constructor(
             else -> return Details(matchingCachedEntries.orEmpty(), matchingPositionCount, matchingEpubVersion)
         }
 
-        val extractedEpubVersion = EpubMetadataExtractor.extract(file).epubVersion
+        // Use "" as a sentinel meaning "extracted but version attribute absent", so a version-less
+        // EPUB doesn't permanently fail the cache-hit guard (which treats null as "never extracted").
+        val extractedEpubVersion = EpubMetadataExtractor.extract(file).epubVersion ?: ""
 
         val url = AbsoluteUrl("file://${file.absolutePath}")
             ?: return Details(matchingCachedEntries.orEmpty(), matchingPositionCount, matchingEpubVersion)

--- a/app/src/main/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCase.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCase.kt
@@ -1,6 +1,7 @@
 package com.riffle.app.feature.library
 
 import com.riffle.app.feature.reader.toTocEntries
+import com.riffle.core.domain.EpubMetadataExtractor
 import com.riffle.core.domain.EpubOpenResult
 import com.riffle.core.domain.EpubRepository
 import com.riffle.core.domain.PublicationMetrics
@@ -69,6 +70,7 @@ class ExtractEpubTocUseCase @Inject constructor(
     data class Details(
         val tocEntries: List<TocEntry>,
         val totalPositions: Int?,
+        val epubVersion: String? = null,
     )
 
     suspend operator fun invoke(item: LibraryItem): List<TocEntry> =
@@ -90,28 +92,33 @@ class ExtractEpubTocUseCase @Inject constructor(
             ?.takeIf { it.ebookFileIno == inode }
             ?.totalPositions
             ?.takeIf { it > 0 }
+        val matchingEpubVersion = cachedMetrics
+            ?.takeIf { it.ebookFileIno == inode }
+            ?.epubVersion
         // Only trust a cache hit that has entries. An empty cached list is treated as a miss so a
         // transient extraction failure (e.g. a Readium parse hiccup on first open) doesn't poison
         // the cache forever — especially under the "unknown" inode key used for ABS < v2.36, where
         // the key never changes and there's no other invalidation trigger.
         if (matchingCachedEntries != null && matchingPositionCount != null) {
-            return Details(matchingCachedEntries, matchingPositionCount)
+            return Details(matchingCachedEntries, matchingPositionCount, matchingEpubVersion)
         }
 
         val file = when (val r = epubRepository.openEpub(item)) {
             is EpubOpenResult.Success -> r.epubFile
-            else -> return Details(matchingCachedEntries.orEmpty(), matchingPositionCount)
+            else -> return Details(matchingCachedEntries.orEmpty(), matchingPositionCount, matchingEpubVersion)
         }
 
+        val extractedEpubVersion = EpubMetadataExtractor.extract(file).epubVersion
+
         val url = AbsoluteUrl("file://${file.absolutePath}")
-            ?: return Details(matchingCachedEntries.orEmpty(), matchingPositionCount)
+            ?: return Details(matchingCachedEntries.orEmpty(), matchingPositionCount, matchingEpubVersion)
         val asset = when (val r = assetRetriever.retrieve(url)) {
             is Try.Success -> r.value
-            is Try.Failure -> return Details(matchingCachedEntries.orEmpty(), matchingPositionCount)
+            is Try.Failure -> return Details(matchingCachedEntries.orEmpty(), matchingPositionCount, matchingEpubVersion)
         }
         val publication = when (val r = publicationOpener.open(asset, allowUserInteraction = false)) {
             is Try.Success -> r.value
-            is Try.Failure -> return Details(matchingCachedEntries.orEmpty(), matchingPositionCount)
+            is Try.Failure -> return Details(matchingCachedEntries.orEmpty(), matchingPositionCount, matchingEpubVersion)
         }
 
         val details = publication.use {
@@ -124,6 +131,7 @@ class ExtractEpubTocUseCase @Inject constructor(
                         layout = it.metadata.layout,
                     )
                 }.getOrNull(),
+                epubVersion = extractedEpubVersion,
             )
         }
         if (details.tocEntries.isNotEmpty()) {
@@ -136,6 +144,7 @@ class ExtractEpubTocUseCase @Inject constructor(
                 PublicationMetrics(
                     ebookFileIno = inode,
                     totalPositions = details.totalPositions,
+                    epubVersion = details.epubVersion,
                 ),
             )
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCase.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCase.kt
@@ -99,7 +99,7 @@ class ExtractEpubTocUseCase @Inject constructor(
         // transient extraction failure (e.g. a Readium parse hiccup on first open) doesn't poison
         // the cache forever — especially under the "unknown" inode key used for ABS < v2.36, where
         // the key never changes and there's no other invalidation trigger.
-        if (matchingCachedEntries != null && matchingPositionCount != null) {
+        if (matchingCachedEntries != null && matchingPositionCount != null && matchingEpubVersion != null) {
             return Details(matchingCachedEntries, matchingPositionCount, matchingEpubVersion)
         }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -473,7 +473,6 @@ private fun LibraryItemDetailContent(
             AudiobookDurationLine(item.audioDurationSec, item.readingProgress)
         }
 
-        FormatLine(item.ebookFormat, epubVersion)
         PublicationFactsLine(item, estimatedTotalReadingTimeSec, pdfPageCount)
 
         if (item.readingProgress > 0f) {
@@ -571,6 +570,7 @@ private fun LibraryItemDetailContent(
         }
 
         MetadataLines(item = item, onFacet = onFacet)
+        FormatLine(item.ebookFormat, epubVersion)
     }
 
     if (showTocSheet) {
@@ -775,7 +775,6 @@ internal fun LibraryItemDetailContentTablet(
             if (item.isListenable && item.audioDurationSec > 0) {
                 AudiobookDurationLine(item.audioDurationSec, item.readingProgress)
             }
-            FormatLine(item.ebookFormat, epubVersion)
             PublicationFactsLine(item, estimatedTotalReadingTimeSec, pdfPageCount)
             if (item.readingProgress > 0f) {
                 ReadingProgressIndicator(progress = item.readingProgress, listened = item.isListenable && !item.isReadable)
@@ -871,6 +870,7 @@ internal fun LibraryItemDetailContentTablet(
                 }
             }
             MetadataLines(item = item, onFacet = onFacet)
+            FormatLine(item.ebookFormat, epubVersion)
         }
     }
 
@@ -989,7 +989,6 @@ internal fun LibraryItemDetailContentPhoneLandscape(
             if (item.isListenable && item.audioDurationSec > 0) {
                 AudiobookDurationLine(item.audioDurationSec, item.readingProgress)
             }
-            FormatLine(item.ebookFormat, epubVersion)
             PublicationFactsLine(item, estimatedTotalReadingTimeSec, pdfPageCount)
             if (item.readingProgress > 0f) {
                 ReadingProgressIndicator(progress = item.readingProgress, listened = item.isListenable && !item.isReadable)
@@ -1071,6 +1070,7 @@ internal fun LibraryItemDetailContentPhoneLandscape(
                 CollapsibleDescription(desc)
             }
             MetadataLines(item = item, onFacet = onFacet)
+            FormatLine(item.ebookFormat, epubVersion)
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -118,6 +118,7 @@ fun LibraryItemDetailScreen(
     val currentPositionHref by viewModel.currentPositionHref.collectAsState()
     val estimatedTotalReadingTimeSec by viewModel.estimatedTotalReadingTimeSec.collectAsState()
     val pdfPageCount by viewModel.pdfPageCount.collectAsState()
+    val epubVersion by viewModel.epubVersion.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     var showAddToPlaylistSheet by remember { mutableStateOf(false) }
@@ -274,6 +275,7 @@ fun LibraryItemDetailScreen(
                         currentPositionHref = currentPositionHref,
                         estimatedTotalReadingTimeSec = estimatedTotalReadingTimeSec,
                         pdfPageCount = pdfPageCount,
+                        epubVersion = epubVersion,
                         onReadItem = { item -> viewModel.markOpened(); onReadItem(item) },
                         onListenItem = { item -> viewModel.markOpened(); onListenItem(item) },
                         onReadItemAtHref = { item, href -> viewModel.markOpened(); onReadItemAtHref(item, href) },
@@ -309,6 +311,7 @@ fun LibraryItemDetailScreen(
                         currentPositionHref = currentPositionHref,
                         estimatedTotalReadingTimeSec = estimatedTotalReadingTimeSec,
                         pdfPageCount = pdfPageCount,
+                        epubVersion = epubVersion,
                         onReadItem = { item -> viewModel.markOpened(); onReadItem(item) },
                         onListenItem = { item -> viewModel.markOpened(); onListenItem(item) },
                         onReadItemAtHref = { item, href -> viewModel.markOpened(); onReadItemAtHref(item, href) },
@@ -344,6 +347,7 @@ fun LibraryItemDetailScreen(
                         currentPositionHref = currentPositionHref,
                         estimatedTotalReadingTimeSec = estimatedTotalReadingTimeSec,
                         pdfPageCount = pdfPageCount,
+                        epubVersion = epubVersion,
                         onReadItem = { item -> viewModel.markOpened(); onReadItem(item) },
                         onListenItem = { item -> viewModel.markOpened(); onListenItem(item) },
                         onReadItemAtHref = { item, href -> viewModel.markOpened(); onReadItemAtHref(item, href) },
@@ -410,6 +414,7 @@ private fun LibraryItemDetailContent(
     currentPositionHref: String? = null,
     estimatedTotalReadingTimeSec: Long? = null,
     pdfPageCount: Int? = null,
+    epubVersion: String? = null,
     onReadItem: (LibraryItem) -> Unit,
     onListenItem: (LibraryItem) -> Unit = {},
     onReadItemAtHref: (LibraryItem, String) -> Unit = { _, _ -> },
@@ -468,6 +473,7 @@ private fun LibraryItemDetailContent(
             AudiobookDurationLine(item.audioDurationSec, item.readingProgress)
         }
 
+        FormatLine(item.ebookFormat, epubVersion)
         PublicationFactsLine(item, estimatedTotalReadingTimeSec, pdfPageCount)
 
         if (item.readingProgress > 0f) {
@@ -590,6 +596,21 @@ private fun LibraryItemDetailContent(
 }
 
 @Composable
+private fun FormatLine(format: EbookFormat, epubVersion: String?) {
+    val label = when (format) {
+        EbookFormat.Epub -> if (epubVersion != null) "EPUB $epubVersion" else "EPUB"
+        EbookFormat.Pdf -> "PDF"
+        EbookFormat.Cbz -> "CBZ"
+        EbookFormat.Unsupported -> return
+    }
+    Text(
+        text = label,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+}
+
+@Composable
 private fun PublicationFactsLine(
     item: LibraryItem,
     estimatedTotalReadingTimeSec: Long?,
@@ -688,6 +709,7 @@ internal fun LibraryItemDetailContentTablet(
     currentPositionHref: String? = null,
     estimatedTotalReadingTimeSec: Long? = null,
     pdfPageCount: Int? = null,
+    epubVersion: String? = null,
     onReadItem: (LibraryItem) -> Unit,
     onListenItem: (LibraryItem) -> Unit = {},
     onReadItemAtHref: (LibraryItem, String) -> Unit = { _, _ -> },
@@ -753,6 +775,7 @@ internal fun LibraryItemDetailContentTablet(
             if (item.isListenable && item.audioDurationSec > 0) {
                 AudiobookDurationLine(item.audioDurationSec, item.readingProgress)
             }
+            FormatLine(item.ebookFormat, epubVersion)
             PublicationFactsLine(item, estimatedTotalReadingTimeSec, pdfPageCount)
             if (item.readingProgress > 0f) {
                 ReadingProgressIndicator(progress = item.readingProgress, listened = item.isListenable && !item.isReadable)
@@ -899,6 +922,7 @@ internal fun LibraryItemDetailContentPhoneLandscape(
     currentPositionHref: String? = null,
     estimatedTotalReadingTimeSec: Long? = null,
     pdfPageCount: Int? = null,
+    epubVersion: String? = null,
     onReadItem: (LibraryItem) -> Unit,
     onListenItem: (LibraryItem) -> Unit = {},
     onReadItemAtHref: (LibraryItem, String) -> Unit = { _, _ -> },
@@ -965,6 +989,7 @@ internal fun LibraryItemDetailContentPhoneLandscape(
             if (item.isListenable && item.audioDurationSec > 0) {
                 AudiobookDurationLine(item.audioDurationSec, item.readingProgress)
             }
+            FormatLine(item.ebookFormat, epubVersion)
             PublicationFactsLine(item, estimatedTotalReadingTimeSec, pdfPageCount)
             if (item.readingProgress > 0f) {
                 ReadingProgressIndicator(progress = item.readingProgress, listened = item.isListenable && !item.isReadable)

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -240,6 +240,9 @@ class LibraryItemDetailViewModel @Inject constructor(
     private val _pdfPageCount = MutableStateFlow<Int?>(null)
     val pdfPageCount: StateFlow<Int?> = _pdfPageCount.asStateFlow()
 
+    private val _epubVersion = MutableStateFlow<String?>(null)
+    val epubVersion: StateFlow<String?> = _epubVersion.asStateFlow()
+
     fun reloadCurrentPositionHref() {
         val ready = _uiState.value as? LibraryItemDetailUiState.Ready ?: return
         val item = ready.item
@@ -403,6 +406,7 @@ class LibraryItemDetailViewModel @Inject constructor(
                         val details = extractEpubTocUseCase.extractDetails(item)
                         _tocState.value = TocState.Ready(details.tocEntries)
                         _epubTotalPositions.value = details.totalPositions
+                        _epubVersion.value = details.epubVersion
                     }
                 }
                 if (item.ebookFormat == EbookFormat.Pdf) {

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -406,7 +406,7 @@ class LibraryItemDetailViewModel @Inject constructor(
                         val details = extractEpubTocUseCase.extractDetails(item)
                         _tocState.value = TocState.Ready(details.tocEntries)
                         _epubTotalPositions.value = details.totalPositions
-                        _epubVersion.value = details.epubVersion
+                        _epubVersion.value = details.epubVersion?.ifEmpty { null }
                     }
                 }
                 if (item.ebookFormat == EbookFormat.Pdf) {

--- a/app/src/test/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCaseCacheTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCaseCacheTest.kt
@@ -1,0 +1,83 @@
+package com.riffle.app.feature.library
+
+import com.riffle.core.domain.EpubOpenResult
+import com.riffle.core.domain.EpubRepository
+import com.riffle.core.domain.PublicationMetrics
+import com.riffle.core.domain.PublicationMetricsRepository
+import com.riffle.core.domain.TocRepository
+import com.riffle.core.models.EbookFormat
+import com.riffle.core.models.LibraryItem
+import com.riffle.core.models.TocEntry
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.readium.r2.shared.util.asset.AssetRetriever
+import org.readium.r2.streamer.PublicationOpener
+
+class ExtractEpubTocUseCaseCacheTest {
+
+    private val inode = "ino-1"
+
+    private val item = LibraryItem(
+        id = "item-1", libraryId = "lib-1", title = "T", author = "A",
+        coverUrl = null, readingProgress = 0f, isCached = true, isDownloaded = false,
+        ebookFormat = EbookFormat.Epub, sourceId = "src-1", ebookFileIno = inode,
+    )
+
+    private val tocEntries = listOf(TocEntry("Ch 1", "ch1.html"))
+
+    private fun makeUseCase(
+        tocRepo: TocRepository,
+        metricsRepo: PublicationMetricsRepository,
+        epubRepo: EpubRepository = mockk(), // never called on full cache hit
+    ) = ExtractEpubTocUseCase(
+        epubRepository = epubRepo,
+        publicationOpener = mockk<PublicationOpener>(),
+        assetRetriever = mockk<AssetRetriever>(),
+        tocRepository = tocRepo,
+        publicationMetricsRepository = metricsRepo,
+    )
+
+    @Test
+    fun `cache hit with epubVersion returns version in Details`() = runTest {
+        val tocRepo = mockk<TocRepository>()
+        coEvery { tocRepo.getCachedToc("src-1", "item-1") } returns (inode to tocEntries)
+
+        val metricsRepo = mockk<PublicationMetricsRepository>()
+        coEvery { metricsRepo.get("src-1", "item-1") } returns
+            PublicationMetrics(ebookFileIno = inode, totalPositions = 100, epubVersion = "3.0")
+
+        val details = makeUseCase(tocRepo, metricsRepo).extractDetails(item)
+
+        assertEquals("3.0", details.epubVersion)
+        assertEquals(tocEntries, details.tocEntries)
+        assertEquals(100, details.totalPositions)
+    }
+
+    @Test
+    fun `cache hit with null epubVersion falls through to extraction`() = runTest {
+        // Pre-migration rows have NULL epubVersion. The early-return must NOT fire so the
+        // version is re-extracted on the next detail-screen open.
+        val tocRepo = mockk<TocRepository>()
+        coEvery { tocRepo.getCachedToc("src-1", "item-1") } returns (inode to tocEntries)
+
+        val metricsRepo = mockk<PublicationMetricsRepository>()
+        coEvery { metricsRepo.get("src-1", "item-1") } returns
+            PublicationMetrics(ebookFileIno = inode, totalPositions = 100, epubVersion = null)
+
+        val epubRepo = mockk<EpubRepository>()
+        // openEpub fails (file not cached) — extraction falls through but epub wasn't accessible
+        coEvery { epubRepo.openEpub(any()) } returns
+            EpubOpenResult.NetworkError(RuntimeException("unavailable"))
+
+        val details = makeUseCase(tocRepo, metricsRepo, epubRepo).extractDetails(item)
+
+        // epubVersion not yet available — extraction fell through but epub wasn't accessible
+        assertNull(details.epubVersion)
+        // cached entries are still returned as fallback
+        assertEquals(tocEntries, details.tocEntries)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCaseCacheTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCaseCacheTest.kt
@@ -58,6 +58,23 @@ class ExtractEpubTocUseCaseCacheTest {
     }
 
     @Test
+    fun `cache hit with empty-string sentinel epubVersion is a full cache hit`() = runTest {
+        // An EPUB whose <package> has no version attribute stores "" as the sentinel. The guard
+        // must treat "" as "already extracted" — not re-extract on every open.
+        val tocRepo = mockk<TocRepository>()
+        coEvery { tocRepo.getCachedToc("src-1", "item-1") } returns (inode to tocEntries)
+
+        val metricsRepo = mockk<PublicationMetricsRepository>()
+        coEvery { metricsRepo.get("src-1", "item-1") } returns
+            PublicationMetrics(ebookFileIno = inode, totalPositions = 100, epubVersion = "")
+
+        val details = makeUseCase(tocRepo, metricsRepo).extractDetails(item)
+
+        assertEquals("", details.epubVersion)
+        assertEquals(tocEntries, details.tocEntries)
+    }
+
+    @Test
     fun `cache hit with null epubVersion falls through to extraction`() = runTest {
         // Pre-migration rows have NULL epubVersion. The early-return must NOT fire so the
         // version is re-extracted on the next detail-screen open.

--- a/app/src/test/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCaseTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCaseTest.kt
@@ -271,7 +271,9 @@ class ExtractEpubTocUseCaseTest {
                 publicationMetricsRepository.save(
                     "srv1",
                     "item1",
-                    PublicationMetrics(ebookFileIno = "ino1", totalPositions = 120),
+                    // "" sentinel: the test EPUB has no valid OPF so extractor returns EMPTY;
+                    // the sentinel prevents infinite re-extraction for version-less EPUBs.
+                    PublicationMetrics(ebookFileIno = "ino1", totalPositions = 120, epubVersion = ""),
                 )
             }
             coVerifyOrder {
@@ -279,7 +281,7 @@ class ExtractEpubTocUseCaseTest {
                 publicationMetricsRepository.save(
                     "srv1",
                     "item1",
-                    PublicationMetrics(ebookFileIno = "ino1", totalPositions = 120),
+                    PublicationMetrics(ebookFileIno = "ino1", totalPositions = 120, epubVersion = ""),
                 )
             }
             coVerify(exactly = 0) { positionsService.positionsByReadingOrder() }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCaseTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCaseTest.kt
@@ -118,7 +118,7 @@ class ExtractEpubTocUseCaseTest {
         val cached = listOf(TocEntry("Chapter 1", "ch1.html"))
         coEvery { tocRepository.getCachedToc("srv1", "item1") } returns ("ino1" to cached)
         coEvery { publicationMetricsRepository.get("srv1", "item1") } returns
-            PublicationMetrics("ino1", totalPositions = 120)
+            PublicationMetrics("ino1", totalPositions = 120, epubVersion = "3.0")
 
         val result = useCase.extractDetails(makeItem())
 
@@ -160,7 +160,7 @@ class ExtractEpubTocUseCaseTest {
         val cached = listOf(TocEntry("Chapter 1", "ch1.html"))
         coEvery { tocRepository.getCachedToc("srv1", "item1") } returns ("unknown" to cached)
         coEvery { publicationMetricsRepository.get("srv1", "item1") } returns
-            PublicationMetrics("unknown", totalPositions = 120)
+            PublicationMetrics("unknown", totalPositions = 120, epubVersion = "3.0")
 
         val result = useCase(makeItem(ebookFileIno = null))
 

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
@@ -356,6 +356,22 @@ class LibraryItemDetailViewModelTocTest {
     }
 
     @Test
+    fun `epubVersion sentinel empty string is converted to null before UI exposure`() = runTest {
+        // The "" sentinel means "extracted, but <package> had no version attribute". The ViewModel
+        // must convert it to null so the UI shows plain "EPUB" rather than "EPUB ".
+        val extractUseCase = mockk<ExtractEpubTocUseCase>().also { uc ->
+            coEvery { uc.extractDetails(any<LibraryItem>()) } returns
+                ExtractEpubTocUseCase.Details(emptyList(), totalPositions = null, epubVersion = "")
+        }
+
+        val vm = makeVm(item = epubItem, extractEpubTocUseCase = extractUseCase)
+        backgroundScope.launch { vm.epubVersion.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(vm.epubVersion.value)
+    }
+
+    @Test
     fun `both tocState and chaptersState transition to Ready for a combined ebook+audiobook item`() = runTest {
         val combinedItem = epubItem.copy(id = "item-combined", hasAudio = true)
         val entries = listOf(TocEntry("Chapter 1", "ch1.html"))

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
@@ -342,6 +342,20 @@ class LibraryItemDetailViewModelTocTest {
     }
 
     @Test
+    fun `epubVersion is exposed after extractDetails completes`() = runTest {
+        val extractUseCase = mockk<ExtractEpubTocUseCase>().also { uc ->
+            coEvery { uc.extractDetails(any<LibraryItem>()) } returns
+                ExtractEpubTocUseCase.Details(emptyList(), totalPositions = null, epubVersion = "3.0")
+        }
+
+        val vm = makeVm(item = epubItem, extractEpubTocUseCase = extractUseCase)
+        backgroundScope.launch { vm.epubVersion.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("3.0", vm.epubVersion.value)
+    }
+
+    @Test
     fun `both tocState and chaptersState transition to Ready for a combined ebook+audiobook item`() = runTest {
         val combinedItem = epubItem.copy(id = "item-combined", hasAudio = true)
         val entries = listOf(TocEntry("Chapter 1", "ch1.html"))

--- a/core/data/src/main/kotlin/com/riffle/core/data/PublicationMetricsRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/PublicationMetricsRepositoryImpl.kt
@@ -20,6 +20,7 @@ class PublicationMetricsRepositoryImpl @Inject constructor(
             ebookFileIno = entity.ebookFileIno,
             totalPositions = entity.totalPositions,
             pageCount = entity.pageCount,
+            epubVersion = entity.epubVersion,
         )
     }
 
@@ -35,6 +36,7 @@ class PublicationMetricsRepositoryImpl @Inject constructor(
                 ebookFileIno = metrics.ebookFileIno,
                 totalPositions = metrics.totalPositions,
                 pageCount = metrics.pageCount,
+                epubVersion = metrics.epubVersion,
                 cachedAt = clock.nowMs(),
             )
         )

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -106,6 +106,7 @@ object DatabaseModule {
                 RiffleDatabase.MIGRATION_61_62,
                 RiffleDatabase.MIGRATION_62_63,
                 RiffleDatabase.MIGRATION_63_64,
+                RiffleDatabase.MIGRATION_64_65,
             )
             .build()
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/PublicationMetricsRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/PublicationMetricsRepositoryImplTest.kt
@@ -61,6 +61,32 @@ class PublicationMetricsRepositoryImplTest {
     }
 
     @Test
+    fun `epub version round trips`() = runTest {
+        val repository = PublicationMetricsRepositoryImpl(FakeDao(), TestClock(NOW_MS))
+
+        repository.save(
+            "src",
+            "epub",
+            PublicationMetrics(ebookFileIno = "ino-1", epubVersion = "3.0"),
+        )
+
+        assertEquals("3.0", repository.get("src", "epub")?.epubVersion)
+    }
+
+    @Test
+    fun `null epub version round trips`() = runTest {
+        val repository = PublicationMetricsRepositoryImpl(FakeDao(), TestClock(NOW_MS))
+
+        repository.save(
+            "src",
+            "epub",
+            PublicationMetrics(ebookFileIno = "ino-1", epubVersion = null),
+        )
+
+        assertNull(repository.get("src", "epub")?.epubVersion)
+    }
+
+    @Test
     fun `stale derived metrics are ignored`() = runTest {
         val dao = FakeDao()
         dao.rows["src" to "epub"] = PublicationMetricsCacheEntity(

--- a/core/database-api/src/main/kotlin/com/riffle/core/database/PublicationMetricsCacheEntity.kt
+++ b/core/database-api/src/main/kotlin/com/riffle/core/database/PublicationMetricsCacheEntity.kt
@@ -24,4 +24,5 @@ data class PublicationMetricsCacheEntity(
     val totalPositions: Int?,
     val pageCount: Int?,
     val cachedAt: Long,
+    val epubVersion: String? = null,
 )

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/65.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/65.json
@@ -1,0 +1,2067 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 65,
+    "identityHash": "167d2ceb5d44215af5b98e146aef2112",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER NOT NULL, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, `pageCount` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesSequence",
+            "columnName": "seriesSequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `coloredChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coloredChapterMap",
+            "columnName": "coloredChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "scope"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, `originFontFamily` TEXT, `emphasisStyles` TEXT, `textSnippetHtml` TEXT, `fragmentAnchor` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedFigures",
+            "columnName": "embeddedFigures",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageHref",
+            "columnName": "imageHref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageSvg",
+            "columnName": "imageSvg",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBytes",
+            "columnName": "imageBytes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originFontFamily",
+            "columnName": "originFontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "emphasisStyles",
+            "columnName": "emphasisStyles",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippetHtml",
+            "columnName": "textSnippetHtml",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fragmentAnchor",
+            "columnName": "fragmentAnchor",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "local_files_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `treeUri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `addedAtEpochMs` INTEGER NOT NULL, `libraryId` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `treeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtEpochMs",
+            "columnName": "addedAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "treeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `originalUri` TEXT NOT NULL, `copiedPath` TEXT NOT NULL, `coverPath` TEXT, `format` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `mtimeEpochMs` INTEGER NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, `displayName` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUri",
+            "columnName": "originalUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "copiedPath",
+            "columnName": "copiedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtimeEpochMs",
+            "columnName": "mtimeEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_files_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_file_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `folderTreeUri` TEXT NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`, `folderTreeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderTreeUri",
+            "columnName": "folderTreeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId",
+            "folderTreeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_file_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_local_files_file_folders_sourceId_folderTreeUri",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "folderTreeUri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId_folderTreeUri` ON `${TABLE_NAME}` (`sourceId`, `folderTreeUri`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_file_metadata_overrides",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `title` TEXT, `author` TEXT, `seriesName` TEXT, `seriesIndex` REAL, `coverUrl` TEXT, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "seriesIndex",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_file_metadata_overrides_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_file_metadata_overrides_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_item_freshness",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `lastFetchedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFetchedAt",
+            "columnName": "lastFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `rootId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootId",
+            "columnName": "rootId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_playlists_rootId",
+            "unique": false,
+            "columnNames": [
+              "rootId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_rootId` ON `${TABLE_NAME}` (`rootId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `orderIndex` INTEGER NOT NULL, PRIMARY KEY(`playlistId`, `sourceId`, `itemId`), FOREIGN KEY(`sourceId`, `playlistId`) REFERENCES `playlists`(`sourceId`, `id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "orderIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId",
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_items_sourceId_playlistId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_items_sourceId_playlistId` ON `${TABLE_NAME}` (`sourceId`, `playlistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId",
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "sourceId",
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "publication_metrics_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `totalPositions` INTEGER, `pageCount` INTEGER, `cachedAt` INTEGER NOT NULL, `epubVersion` TEXT, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPositions",
+            "columnName": "totalPositions",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epubVersion",
+            "columnName": "epubVersion",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_publication_metrics_cache_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_publication_metrics_cache_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '167d2ceb5d44215af5b98e146aef2112')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1919,7 +1919,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 64, true,
+            TEST_DB, 65, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -1983,6 +1983,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_61_62,
             RiffleDatabase.MIGRATION_62_63,
             RiffleDatabase.MIGRATION_63_64,
+            RiffleDatabase.MIGRATION_64_65,
         )
 
         db.query("SELECT url, username, serverType, absUserId, type FROM sources WHERE id = 's1'").use { cursor ->
@@ -2957,6 +2958,33 @@ class MigrationTest {
                 cursor.getString(cursor.getColumnIndexOrThrow("fragmentAnchor")),
             )
             cursor.close()
+        }
+    }
+
+    @Test
+    fun migration64To65_addsEpubVersionToPublicationMetrics() {
+        helper.createDatabase(TEST_DB, 64).use { db ->
+            db.execSQL(
+                "INSERT INTO sources (id, url, isActive, insecureConnectionAllowed, username, serverType, absUserId, type) " +
+                    "VALUES ('src1', 'http://localhost', 1, 0, '', 'AUDIOBOOKSHELF', NULL, 'ABS')"
+            )
+            db.execSQL(
+                "INSERT INTO publication_metrics_cache " +
+                    "(sourceId, itemId, ebookFileIno, totalPositions, pageCount, cachedAt) " +
+                    "VALUES ('src1', 'epub1', 'ino-1', 480, NULL, 1000)"
+            )
+        }
+
+        helper.runMigrationsAndValidate(TEST_DB, 65, true, RiffleDatabase.MIGRATION_64_65).use { db ->
+            db.query(
+                "SELECT epubVersion FROM publication_metrics_cache WHERE itemId = 'epub1'"
+            ).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertNull(
+                    "pre-existing row must have null epubVersion after migration",
+                    cursor.getString(cursor.getColumnIndexOrThrow("epubVersion")),
+                )
+            }
         }
     }
 }

--- a/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/main/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -36,7 +36,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         PlaylistItemEntity::class,
         PublicationMetricsCacheEntity::class,
     ],
-    version = 64,
+    version = 65,
     exportSchema = true,
 )
 abstract class RiffleDatabase : RoomDatabase() {
@@ -1722,6 +1722,12 @@ abstract class RiffleDatabase : RoomDatabase() {
         val MIGRATION_63_64 = object : Migration(63, 64) {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE `annotations` ADD COLUMN `fragmentAnchor` TEXT")
+            }
+        }
+
+        val MIGRATION_64_65 = object : Migration(64, 65) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `publication_metrics_cache` ADD COLUMN `epubVersion` TEXT")
             }
         }
     }

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/PublicationMetricsRepository.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/PublicationMetricsRepository.kt
@@ -8,6 +8,7 @@ data class PublicationMetrics(
     val ebookFileIno: String,
     val totalPositions: Int? = null,
     val pageCount: Int? = null,
+    val epubVersion: String? = null,
 )
 
 interface PublicationMetricsRepository {

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/EpubMetadataExtractor.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/EpubMetadataExtractor.kt
@@ -36,6 +36,8 @@ object EpubMetadataExtractor {
         val opfBytes = lookup(opfPath) ?: return EpubMetadata.EMPTY
         val opf = parseXml(opfBytes) ?: return EpubMetadata.EMPTY
 
+        val epubVersion = opf.getAttribute("version").ifEmpty { null }
+
         val metadataEl = opf.firstElementByTag("metadata")
         val title = metadataEl?.firstDcText("title")
         val author = metadataEl?.collectDcText("creator")?.joinToString(", ")?.ifEmpty { null }
@@ -65,6 +67,7 @@ object EpubMetadataExtractor {
             genres = genres,
             coverBytes = coverBytes,
             coverExtension = coverExt,
+            epubVersion = epubVersion,
         )
     } catch (_: Exception) {
         EpubMetadata.EMPTY

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/EpubMetadataExtractorTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/EpubMetadataExtractorTest.kt
@@ -206,12 +206,31 @@ class EpubMetadataExtractorTest {
         assertEquals(EpubMetadata.EMPTY, md)
     }
 
+    @Test
+    fun `epub3 package version is extracted`() {
+        val epub = buildEpub(opfMetadata = "<dc:title>T</dc:title>", packageVersion = "3.0")
+        assertEquals("3.0", EpubMetadataExtractor.extract(epub).epubVersion)
+    }
+
+    @Test
+    fun `epub2 package version is extracted`() {
+        val epub = buildEpub(opfMetadata = "<dc:title>T</dc:title>", packageVersion = "2.0")
+        assertEquals("2.0", EpubMetadataExtractor.extract(epub).epubVersion)
+    }
+
+    @Test
+    fun `package without version attribute returns null epubVersion`() {
+        val epub = buildEpub(opfMetadata = "<dc:title>T</dc:title>", packageVersion = "")
+        assertNull(EpubMetadataExtractor.extract(epub).epubVersion)
+    }
+
     // --- helpers ---
 
     private fun buildEpub(
         opfMetadata: String,
         extraManifestItems: String = "",
         extraZipEntries: List<Pair<String, ByteArray>> = emptyList(),
+        packageVersion: String = "3.0",
     ): ByteArray {
         val container = """<?xml version="1.0"?>
             <container xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
@@ -221,7 +240,7 @@ class EpubMetadataExtractorTest {
             </container>
         """.trimIndent()
         val opf = """<?xml version="1.0" encoding="UTF-8"?>
-            <package xmlns="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf" version="3.0">
+            <package xmlns="http://www.idpf.org/2007/opf" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf"${if (packageVersion.isNotEmpty()) " version=\"$packageVersion\"" else ""}>
               <metadata>
                 $opfMetadata
               </metadata>

--- a/core/models/src/commonMain/kotlin/com/riffle/core/models/EpubMetadata.kt
+++ b/core/models/src/commonMain/kotlin/com/riffle/core/models/EpubMetadata.kt
@@ -26,6 +26,7 @@ data class EpubMetadata(
     val genres: List<String>,
     val coverBytes: ByteArray?,
     val coverExtension: String?,
+    val epubVersion: String? = null,
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -35,6 +36,7 @@ data class EpubMetadata(
             description == other.description && isbn == other.isbn && asin == other.asin &&
             seriesName == other.seriesName && seriesSequence == other.seriesSequence &&
             genres == other.genres &&
+            epubVersion == other.epubVersion &&
             coverExtension == other.coverExtension &&
             (coverBytes?.contentEquals(other.coverBytes) ?: (other.coverBytes == null))
     }
@@ -53,6 +55,7 @@ data class EpubMetadata(
         r = 31 * r + genres.hashCode()
         r = 31 * r + (coverBytes?.contentHashCode() ?: 0)
         r = 31 * r + (coverExtension?.hashCode() ?: 0)
+        r = 31 * r + (epubVersion?.hashCode() ?: 0)
         return r
     }
 

--- a/docs/superpowers/specs/2026-08-07-item-details-format-and-epub-version-design.md
+++ b/docs/superpowers/specs/2026-08-07-item-details-format-and-epub-version-design.md
@@ -1,0 +1,59 @@
+# Item Details: Container Format + EPUB Version
+
+**Date:** 2026-08-07
+
+## Goal
+
+Show the file container format (EPUB / PDF / CBZ) in item details for every ebook item. For EPUB items, also show the EPUB version (e.g. "EPUB 3.0") once it has been extracted from the file.
+
+## Background
+
+`LibraryItem.ebookFormat` already carries the format enum (`Epub`, `Pdf`, `Cbz`, `Unsupported`). The existing `PublicationFactsLine` composable shows reading time or page count but is invisible when those values are not yet available — it does not show a format label at all. No field for EPUB version exists anywhere in the data model.
+
+## Design
+
+### Container format row
+
+A new `FormatLine` composable is added to `MetadataLines` in `LibraryItemDetailScreen.kt`. It shows unconditionally for `Epub`, `Pdf`, and `Cbz`; it is hidden for `Unsupported`. The label is plain text:
+
+- `Epub` (version unknown or not yet cached): `"EPUB"`
+- `Epub` (version cached): `"EPUB 3.0"` / `"EPUB 2.x"` (version string verbatim from OPF)
+- `Pdf`: `"PDF"`
+- `Cbz`: `"CBZ"`
+
+The version portion is appended only when non-null; the row never shows a loading state.
+
+### EPUB version extraction and caching
+
+The EPUB version is the `version` attribute on the `<package>` element in the OPF file inside the EPUB zip (e.g. `<package version="3.0">`).
+
+**Extraction point:** `ExtractEpubTocUseCase.extractDetails()` already opens the EPUB zip via Readium to extract the TOC and position count. After getting the `File` reference, call `EpubMetadataExtractor.extract(file).epubVersion` before opening via Readium. This keeps all derived-metadata extraction for item details in one call.
+
+**`EpubMetadataExtractor` change:** Add `val epubVersion = opf.getAttribute("version").ifEmpty { null }` in `extractFrom()`. Add `epubVersion: String?` to `EpubMetadata` and update `EMPTY`.
+
+**`PublicationMetrics` change:** Add `val epubVersion: String? = null`. Thread through `PublicationMetricsRepositoryImpl.get()` and `save()`, and `PublicationMetricsCacheEntity`.
+
+**Cache invalidation:** `PublicationMetrics` is already keyed by `(sourceId, itemId, ebookFileIno)` and respects `isDerivedCacheStale` TTL. No extra invalidation logic needed — if the file is replaced the inode changes, the cache miss triggers re-extraction.
+
+**`ExtractEpubTocUseCase.Details` change:** Add `epubVersion: String?`. Populated from the extraction result when a fresh read happens; taken from cached `PublicationMetrics.epubVersion` on a cache hit.
+
+### ViewModel
+
+`LibraryItemDetailViewModel` already calls `extractEpubTocUseCase.extractDetails()` and stores the result. Expose `epubVersion: String?` alongside `tocState` so the screen can bind to it.
+
+### Database migration
+
+`PublicationMetricsCacheEntity` gains a nullable `epubVersion TEXT` column. DB version bumps v64 → v65 with:
+
+```sql
+ALTER TABLE publication_metrics_cache ADD COLUMN epubVersion TEXT
+```
+
+All existing rows get `NULL`, which is correct — the version is re-extracted on next detail-screen open.
+
+## What is not in scope
+
+- Showing format/version in the library grid or list rows.
+- Fetching EPUB version from the ABS server (it does not expose it).
+- Showing version for PDF or CBZ (no equivalent concept).
+- Populating version at download time (lazy extraction on detail open is sufficient).


### PR DESCRIPTION
## Summary

- Adds a `FormatLine` composable at the bottom of the item details screen (after metadata) showing `EPUB 3.0` / `EPUB 2.x` / `PDF` / `CBZ` for every item.
- Extracts the EPUB version from `<package version="...">` in the OPF file inside the EPUB zip, cached in `publication_metrics_cache` (DB v64→v65).
- Caching follows the same inode-keyed pattern as TOC/position count; all derived-metadata extraction for item details stays in `ExtractEpubTocUseCase.Details`.
- Uses `""` as a sentinel for "extracted but version attribute absent" to prevent infinite re-extraction for version-less EPUBs; `null` means "pre-migration / never extracted".

## Design

Full spec: `docs/superpowers/specs/2026-08-07-item-details-format-and-epub-version-design.md`

## Test plan

- [ ] `EpubMetadataExtractorTest` — EPUB 3.0, EPUB 2.x, missing attribute → null
- [ ] `ExtractEpubTocUseCaseTest` — metrics saved with `""` sentinel when OPF absent
- [ ] `ExtractEpubTocUseCaseCacheTest` — cache hit with version, cache hit with sentinel `""`, cache miss with `null` (pre-migration)
- [ ] `LibraryItemDetailViewModelTocTest` — epubVersion exposed; `""` sentinel converted to `null` before UI
- [ ] `MigrationTest` — v64→v65 adds `epubVersion` column; full chain passes