### PR TITLE
feat(cbz): stream pages from Komga on open; cache in background

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -203,7 +203,7 @@ fun CbzReaderScreen(
                 CbzThumbnailStrip(
                     currentPage = currentPage,
                     pageCount = ready.pageCount,
-                    imageSource = ready.imageSource,
+                    imageSource = ready.thumbnailSource ?: ready.imageSource,
                     onSeek = { viewModel.jumpToPage(it) },
                 )
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderState.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderState.kt
@@ -29,5 +29,7 @@ sealed class CbzReaderState {
         val title: String,
         val pageCount: Int,
         val imageSource: CbzImageSource,
+        /** Low-resolution source for the thumbnail strip. Null = use [imageSource] (fast for local archives). */
+        val thumbnailSource: CbzImageSource? = null,
     ) : CbzReaderState()
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
@@ -13,6 +13,7 @@ import com.riffle.core.domain.CbzRepository
 import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.ProgressSyncController
 import com.riffle.core.domain.ReadingSessionRepository
+import com.riffle.core.models.LibraryItem
 import com.riffle.core.models.SessionPayload
 import com.riffle.core.domain.WakeLockPreferencesStore
 import com.riffle.core.domain.comic.CbzArchive
@@ -151,6 +152,7 @@ class CbzReaderViewModel @Inject constructor(
         }
         when (val result = cbzRepository.openCbz(item)) {
             is CbzOpenResult.Success -> loadArchive(result.cbzFile, result.lastPosition, item.title)
+            is CbzOpenResult.Streaming -> loadStreaming(result, item)
             is CbzOpenResult.NetworkError -> _state.value = CbzReaderState.Error(
                 result.cause.message ?: "Network error"
             )
@@ -202,6 +204,76 @@ class CbzReaderViewModel @Inject constructor(
         syncSession.sync(payload)
         // Prefetch panels for the resume page and the next two.
         onCurrentPageChanged(resumeIndex)
+    }
+
+    private fun loadStreaming(result: CbzOpenResult.Streaming, item: LibraryItem) {
+        if (result.pageCount == 0) {
+            _state.value = CbzReaderState.Error("Comic has no pages")
+            return
+        }
+        val resumeIndex = result.lastPosition
+            ?.let { parsePageIndex(it) }
+            ?.coerceIn(0, result.pageCount - 1)
+            ?: 0
+        _currentPage.value = resumeIndex
+        lastSavedPage = resumeIndex
+        _currentPanelIndex.value = 0
+
+        val networkSource = NetworkImageSource(item.sourceId, item.id, result.pageCount, cbzRepository)
+        _state.value = CbzReaderState.Ready(
+            title = item.title,
+            pageCount = result.pageCount,
+            imageSource = networkSource,
+        )
+
+        val payload = result.lastPosition?.takeIf { it.isNotEmpty() }?.let {
+            SessionPayload(ebookLocation = it, ebookProgress = 0f)
+        } ?: SessionPayload("", 0f)
+        syncSession.sync(payload)
+
+        // Background: download the full file and swap to the local archive once ready.
+        viewModelScope.launch {
+            val file = withContext(Dispatchers.IO) { cbzRepository.awaitCachedFile(item) } ?: return@launch
+            swapToLocalArchive(file, item.title)
+        }
+    }
+
+    private suspend fun swapToLocalArchive(file: File, title: String) {
+        val (newArchive, actualPageCount) = try {
+            withContext(Dispatchers.IO) {
+                val a = CbzArchive(file)
+                a to a.pageCount
+            }
+        } catch (_: Throwable) {
+            return  // Keep streaming; archive open failed (corrupt download, etc.)
+        }
+        if (archiveClosed) {
+            newArchive.close()
+            return
+        }
+        val current = _state.value as? CbzReaderState.Ready
+        if (current == null) {
+            newArchive.close()
+            return
+        }
+        // Close any prior archive (shouldn't exist for the streaming path, but guard anyway).
+        archive?.close()
+        archive = newArchive
+        panelBook = panelOrchestrator.forBook(
+            bookId = bookId,
+            imageBytes = { pageIndex -> newArchive.imageBytes(pageIndex) },
+        )
+        // If the server-reported page count differed from the actual archive, clamp current page.
+        if (actualPageCount > 0 && _currentPage.value >= actualPageCount) {
+            _currentPage.value = actualPageCount - 1
+            lastSavedPage = _currentPage.value
+        }
+        val effectivePageCount = if (actualPageCount > 0) actualPageCount else current.pageCount
+        _state.value = current.copy(
+            pageCount = effectivePageCount,
+            imageSource = ArchiveImageSource(newArchive),
+        )
+        onCurrentPageChanged(_currentPage.value)
     }
 
     private fun parsePageIndex(json: String): Int? = try {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
@@ -271,16 +271,11 @@ class CbzReaderViewModel @Inject constructor(
             imageBytes = { pageIndex -> newArchive.imageBytes(pageIndex) },
         )
         // If the server-reported page count differed from the actual archive, clamp current page.
-        if (actualPageCount > 0 && _currentPage.value >= actualPageCount) {
-            _currentPage.value = actualPageCount - 1
-            lastSavedPage = _currentPage.value
+        clampPageForSwap(_currentPage.value, actualPageCount)?.let { clamped ->
+            _currentPage.value = clamped
+            lastSavedPage = clamped
         }
-        val effectivePageCount = if (actualPageCount > 0) actualPageCount else current.pageCount
-        _state.value = current.copy(
-            pageCount = effectivePageCount,
-            imageSource = ArchiveImageSource(newArchive),
-            thumbnailSource = null,
-        )
+        _state.value = computeArchiveSwapState(current, actualPageCount, ArchiveImageSource(newArchive))
         onCurrentPageChanged(_currentPage.value)
     }
 
@@ -483,3 +478,27 @@ class CbzReaderViewModel @Inject constructor(
         archive = null
     }
 }
+
+/**
+ * Computes the new [CbzReaderState.Ready] after a streaming→archive swap. Extracted for unit
+ * testing — the ViewModel extends AndroidViewModel and can't be instantiated in JVM tests.
+ */
+internal fun computeArchiveSwapState(
+    current: CbzReaderState.Ready,
+    actualPageCount: Int,
+    newSource: CbzImageSource,
+): CbzReaderState.Ready {
+    val effectivePageCount = if (actualPageCount > 0) actualPageCount else current.pageCount
+    return current.copy(
+        pageCount = effectivePageCount,
+        imageSource = newSource,
+        thumbnailSource = null,
+    )
+}
+
+/**
+ * Returns the clamped page index when an archive swap reveals the real page count is smaller
+ * than what the server reported during streaming, or null if no clamping is needed.
+ */
+internal fun clampPageForSwap(currentPage: Int, actualPageCount: Int): Int? =
+    if (actualPageCount > 0 && currentPage >= actualPageCount) actualPageCount - 1 else null

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
@@ -220,16 +220,23 @@ class CbzReaderViewModel @Inject constructor(
         _currentPanelIndex.value = 0
 
         val networkSource = NetworkImageSource(item.sourceId, item.id, result.pageCount, cbzRepository)
+        val thumbnailSource = NetworkImageSource(item.sourceId, item.id, result.pageCount, cbzRepository, thumbnailWidth = 300)
+        panelBook = panelOrchestrator.forBook(
+            bookId = bookId,
+            imageBytes = { pageIndex -> networkSource.imageBytes(pageIndex) },
+        )
         _state.value = CbzReaderState.Ready(
             title = item.title,
             pageCount = result.pageCount,
             imageSource = networkSource,
+            thumbnailSource = thumbnailSource,
         )
 
         val payload = result.lastPosition?.takeIf { it.isNotEmpty() }?.let {
             SessionPayload(ebookLocation = it, ebookProgress = 0f)
         } ?: SessionPayload("", 0f)
         syncSession.sync(payload)
+        onCurrentPageChanged(resumeIndex)
 
         // Background: download the full file and swap to the local archive once ready.
         viewModelScope.launch {
@@ -272,6 +279,7 @@ class CbzReaderViewModel @Inject constructor(
         _state.value = current.copy(
             pageCount = effectivePageCount,
             imageSource = ArchiveImageSource(newArchive),
+            thumbnailSource = null,
         )
         onCurrentPageChanged(_currentPage.value)
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSource.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSource.kt
@@ -1,0 +1,32 @@
+package com.riffle.app.feature.reader.cbz
+
+import com.riffle.core.domain.CbzRepository
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import kotlinx.coroutines.runBlocking
+
+/**
+ * [CbzImageSource] backed by on-demand network fetches via [CbzRepository]. Used during the
+ * streaming phase (Phase 1) before the full CBZ file has been cached locally.
+ *
+ * [imageBytes] and [openStream] are synchronous (not suspend) because [CbzImageSource] is a
+ * blocking interface consumed from [kotlinx.coroutines.Dispatchers.IO] via produceState in the
+ * reader. [runBlocking] on the IO dispatcher is safe — the IO pool is unbounded.
+ *
+ * Once the background download completes, the ViewModel replaces this source with an
+ * [ArchiveImageSource] backed by the local [com.riffle.core.domain.comic.CbzArchive].
+ */
+internal class NetworkImageSource(
+    private val sourceId: String,
+    private val itemId: String,
+    private val count: Int,
+    private val repository: CbzRepository,
+) : CbzImageSource {
+    override val pageCount: Int get() = count
+
+    override fun imageBytes(pageIndex: Int): ByteArray =
+        runBlocking { repository.fetchStreamingPageImage(sourceId, itemId, pageIndex) }
+
+    override fun openStream(pageIndex: Int): InputStream =
+        ByteArrayInputStream(imageBytes(pageIndex))
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSource.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSource.kt
@@ -3,15 +3,22 @@ package com.riffle.app.feature.reader.cbz
 import com.riffle.core.domain.CbzRepository
 import java.io.ByteArrayInputStream
 import java.io.InputStream
+import java.util.Collections
 import kotlinx.coroutines.runBlocking
 
 /**
  * [CbzImageSource] backed by on-demand network fetches via [CbzRepository]. Used during the
  * streaming phase (Phase 1) before the full CBZ file has been cached locally.
  *
+ * Pass [thumbnailWidth] (e.g. 300) to request a downscaled image from the server — use this for
+ * the thumbnail strip to avoid downloading full-resolution pages for small previews.
+ *
  * [imageBytes] and [openStream] are synchronous (not suspend) because [CbzImageSource] is a
  * blocking interface consumed from [kotlinx.coroutines.Dispatchers.IO] via produceState in the
  * reader. [runBlocking] on the IO dispatcher is safe — the IO pool is unbounded.
+ *
+ * A 3-entry byte cache eliminates the double-download that [decodeSampledBitmap] triggers
+ * (one bounds-only pass + one decode pass on the same page index).
  *
  * Once the background download completes, the ViewModel replaces this source with an
  * [ArchiveImageSource] backed by the local [com.riffle.core.domain.comic.CbzArchive].
@@ -21,12 +28,25 @@ internal class NetworkImageSource(
     private val itemId: String,
     private val count: Int,
     private val repository: CbzRepository,
+    private val thumbnailWidth: Int? = null,
 ) : CbzImageSource {
     override val pageCount: Int get() = count
 
-    override fun imageBytes(pageIndex: Int): ByteArray =
-        runBlocking { repository.fetchStreamingPageImage(sourceId, itemId, pageIndex) }
+    private val byteCache: MutableMap<Int, ByteArray> = Collections.synchronizedMap(
+        object : LinkedHashMap<Int, ByteArray>(5, 0.75f, true) {
+            override fun removeEldestEntry(eldest: Map.Entry<Int, ByteArray>?) = size > 3
+        }
+    )
+
+    override fun imageBytes(pageIndex: Int): ByteArray = getBytes(pageIndex)
 
     override fun openStream(pageIndex: Int): InputStream =
-        ByteArrayInputStream(imageBytes(pageIndex))
+        ByteArrayInputStream(getBytes(pageIndex))
+
+    private fun getBytes(pageIndex: Int): ByteArray {
+        byteCache[pageIndex]?.let { return it }
+        return runBlocking {
+            repository.fetchStreamingPageImage(sourceId, itemId, pageIndex, thumbnailWidth)
+        }.also { byteCache[pageIndex] = it }
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/NoopCbzRepository.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/NoopCbzRepository.kt
@@ -16,4 +16,7 @@ internal class NoopCbzRepository(
     ) = error("unused in test")
     override suspend fun removeDownload(sourceId: String, itemId: String) = error("unused in test")
     override suspend fun saveReadingPosition(itemId: String, locatorJson: String) = error("unused in test")
+    override suspend fun supportsStreaming(sourceId: String): Boolean = false
+    override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int): ByteArray = error("unused in test")
+    override suspend fun awaitCachedFile(item: com.riffle.core.models.LibraryItem): java.io.File? = null
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/NoopCbzRepository.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/NoopCbzRepository.kt
@@ -17,6 +17,6 @@ internal class NoopCbzRepository(
     override suspend fun removeDownload(sourceId: String, itemId: String) = error("unused in test")
     override suspend fun saveReadingPosition(itemId: String, locatorJson: String) = error("unused in test")
     override suspend fun supportsStreaming(sourceId: String): Boolean = false
-    override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int): ByteArray = error("unused in test")
+    override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int, maxWidth: Int?): ByteArray = error("unused in test")
     override suspend fun awaitCachedFile(item: com.riffle.core.models.LibraryItem): java.io.File? = null
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/CbzArchiveSwapTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/CbzArchiveSwapTest.kt
@@ -1,0 +1,78 @@
+package com.riffle.app.feature.reader.cbz
+
+import java.io.InputStream
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * Unit tests for the pure state-transition functions extracted from [CbzReaderViewModel.swapToLocalArchive].
+ * The ViewModel extends AndroidViewModel and cannot be instantiated in JVM tests; the functions are
+ * extracted so the key behaviors can be pinned without an Android dependency.
+ */
+class CbzArchiveSwapTest {
+
+    private fun fakeSource(count: Int = 10): CbzImageSource = object : CbzImageSource {
+        override val pageCount: Int = count
+        override fun imageBytes(pageIndex: Int): ByteArray = ByteArray(0)
+        override fun openStream(pageIndex: Int): InputStream = ByteArray(0).inputStream()
+    }
+
+    private fun readyState(
+        pageCount: Int = 10,
+        imageSource: CbzImageSource = fakeSource(pageCount),
+        thumbnailSource: CbzImageSource? = fakeSource(pageCount),
+    ) = CbzReaderState.Ready(
+        title = "Comic",
+        pageCount = pageCount,
+        imageSource = imageSource,
+        thumbnailSource = thumbnailSource,
+    )
+
+    // --- computeArchiveSwapState ---
+
+    @Test fun `thumbnailSource is null after swap`() {
+        val current = readyState(thumbnailSource = fakeSource())
+        val newSource = fakeSource()
+        val result = computeArchiveSwapState(current, actualPageCount = 10, newSource = newSource)
+        assertNull("thumbnailSource must be null after archive swap", result.thumbnailSource)
+    }
+
+    @Test fun `imageSource is replaced with the new source`() {
+        val current = readyState()
+        val newSource = fakeSource()
+        val result = computeArchiveSwapState(current, actualPageCount = 10, newSource = newSource)
+        assertSame("imageSource must be the new archive source", newSource, result.imageSource)
+    }
+
+    @Test fun `pageCount is updated to actualPageCount when positive`() {
+        val current = readyState(pageCount = 15)
+        val result = computeArchiveSwapState(current, actualPageCount = 12, newSource = fakeSource())
+        assertEquals("pageCount must use actualPageCount when > 0", 12, result.pageCount)
+    }
+
+    @Test fun `pageCount falls back to current when actualPageCount is zero`() {
+        val current = readyState(pageCount = 15)
+        val result = computeArchiveSwapState(current, actualPageCount = 0, newSource = fakeSource())
+        assertEquals("pageCount must keep current value when actualPageCount is 0", 15, result.pageCount)
+    }
+
+    // --- clampPageForSwap ---
+
+    @Test fun `returns null when currentPage is within bounds`() {
+        assertNull(clampPageForSwap(currentPage = 5, actualPageCount = 10))
+    }
+
+    @Test fun `returns null when currentPage equals last valid index`() {
+        assertNull(clampPageForSwap(currentPage = 9, actualPageCount = 10))
+    }
+
+    @Test fun `clamps to last valid page when currentPage is out of bounds`() {
+        assertEquals(9, clampPageForSwap(currentPage = 12, actualPageCount = 10))
+    }
+
+    @Test fun `returns null when actualPageCount is zero (no clamping, keep streaming count)`() {
+        assertNull(clampPageForSwap(currentPage = 99, actualPageCount = 0))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSourceTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSourceTest.kt
@@ -27,10 +27,12 @@ class NetworkImageSourceTest {
         override fun isCached(sourceId: String, itemId: String): Boolean = false
         override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {}
         override suspend fun supportsStreaming(sourceId: String): Boolean = true
-        override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int): ByteArray {
+        var requestedMaxWidth: Int? = null
+        override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int, maxWidth: Int?): ByteArray {
             requestedSourceId = sourceId
             requestedItemId = itemId
             requestedPageIndex = pageIndex
+            requestedMaxWidth = maxWidth
             return fakeBytes
         }
         override suspend fun awaitCachedFile(item: LibraryItem): File? = null
@@ -55,5 +57,31 @@ class NetworkImageSourceTest {
         val stream = source.openStream(0)
         val read = stream.readBytes()
         assertArrayEquals(fakeBytes, read)
+    }
+
+    @Test fun `thumbnailWidth is forwarded as maxWidth to repository`() {
+        val source = NetworkImageSource("src", "item", 10, fakeRepo, thumbnailWidth = 300)
+        source.imageBytes(2)
+        assertEquals(300, fakeRepo.requestedMaxWidth)
+    }
+
+    @Test fun `null thumbnailWidth passes null maxWidth to repository`() {
+        val source = NetworkImageSource("src", "item", 10, fakeRepo, thumbnailWidth = null)
+        source.imageBytes(2)
+        assertEquals(null, fakeRepo.requestedMaxWidth)
+    }
+
+    @Test fun `byte cache prevents second network request for same pageIndex`() {
+        var callCount = 0
+        val countingRepo = object : CbzRepository by fakeRepo {
+            override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int, maxWidth: Int?): ByteArray {
+                callCount++
+                return fakeBytes
+            }
+        }
+        val source = NetworkImageSource("src", "item", 10, countingRepo)
+        source.imageBytes(5)
+        source.imageBytes(5) // same index — should hit cache
+        assertEquals("expected only 1 network call due to byte cache", 1, callCount)
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSourceTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSourceTest.kt
@@ -1,0 +1,59 @@
+package com.riffle.app.feature.reader.cbz
+
+import com.riffle.core.domain.CbzDownloadResult
+import com.riffle.core.domain.CbzOpenResult
+import com.riffle.core.domain.CbzRepository
+import com.riffle.core.models.EbookFormat
+import com.riffle.core.models.LibraryItem
+import java.io.File
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NetworkImageSourceTest {
+
+    private val fakeBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47)
+
+    private val fakeRepo = object : CbzRepository {
+        var requestedSourceId: String? = null
+        var requestedItemId: String? = null
+        var requestedPageIndex: Int = -1
+
+        override suspend fun openCbz(item: LibraryItem): CbzOpenResult = CbzOpenResult.Offline
+        override suspend fun downloadCbz(item: LibraryItem, onProgress: (Long, Long) -> Unit): CbzDownloadResult =
+            CbzDownloadResult.Success
+        override suspend fun removeDownload(sourceId: String, itemId: String) {}
+        override fun isDownloaded(sourceId: String, itemId: String): Boolean = false
+        override fun isCached(sourceId: String, itemId: String): Boolean = false
+        override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {}
+        override suspend fun supportsStreaming(sourceId: String): Boolean = true
+        override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int): ByteArray {
+            requestedSourceId = sourceId
+            requestedItemId = itemId
+            requestedPageIndex = pageIndex
+            return fakeBytes
+        }
+        override suspend fun awaitCachedFile(item: LibraryItem): File? = null
+    }
+
+    @Test fun `pageCount returns the count passed at construction`() {
+        val source = NetworkImageSource("src", "item", 42, fakeRepo)
+        assertEquals(42, source.pageCount)
+    }
+
+    @Test fun `imageBytes delegates to repository with correct args`() {
+        val source = NetworkImageSource("src1", "item7", 10, fakeRepo)
+        val result = source.imageBytes(3)
+        assertArrayEquals(fakeBytes, result)
+        assertEquals("src1", fakeRepo.requestedSourceId)
+        assertEquals("item7", fakeRepo.requestedItemId)
+        assertEquals(3, fakeRepo.requestedPageIndex)
+    }
+
+    @Test fun `openStream wraps imageBytes in a ByteArrayInputStream`() {
+        val source = NetworkImageSource("src", "item", 5, fakeRepo)
+        val stream = source.openStream(0)
+        val read = stream.readBytes()
+        assertArrayEquals(fakeBytes, read)
+    }
+}

--- a/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalog.kt
+++ b/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalog.kt
@@ -16,6 +16,7 @@ import com.riffle.core.catalog.DownloadsCapability
 import com.riffle.core.catalog.FacetSelection
 import com.riffle.core.catalog.OfflineBrowseCapability
 import com.riffle.core.catalog.PlaylistsCapability
+import com.riffle.core.catalog.CbzPageStreamCapability
 import com.riffle.core.catalog.ProgressPeerCapability
 import com.riffle.core.catalog.ReadCapability
 import com.riffle.core.catalog.SeriesCapability
@@ -68,7 +69,8 @@ class KomgaCatalog(
     OfflineBrowseCapability,
     SeriesCapability,
     PlaylistsCapability,
-    ProgressPeerCapability {
+    ProgressPeerCapability,
+    CbzPageStreamCapability {
 
     override val sourceType: SourceType = SourceType.KOMGA
 
@@ -209,6 +211,21 @@ class KomgaCatalog(
             error = if (reachable) null else "Komga is unreachable",
         )
     }
+
+    // region CbzPageStreamCapability
+
+    override suspend fun fetchCbzPageImage(itemId: String, pageIndex: Int): ByteArray =
+        http.getBytes(apiUrl("books/$itemId/pages/${pageIndex + 1}"))
+
+    override suspend fun fetchCbzPageCount(itemId: String): Int {
+        val body = http.getString(apiUrl("books/$itemId"))
+        val dto = runCatching {
+            KomgaJson.decodeFromString(serializer<KomgaBookDto>(), body)
+        }.getOrNull()
+        return dto?.media?.pagesCount ?: 0
+    }
+
+    // endregion
 
     // region ProgressPeerCapability (#528)
 

--- a/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalog.kt
+++ b/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalog.kt
@@ -214,8 +214,11 @@ class KomgaCatalog(
 
     // region CbzPageStreamCapability
 
-    override suspend fun fetchCbzPageImage(itemId: String, pageIndex: Int): ByteArray =
-        http.getBytes(apiUrl("books/$itemId/pages/${pageIndex + 1}"))
+    override suspend fun fetchCbzPageImage(itemId: String, pageIndex: Int, maxWidth: Int?): ByteArray {
+        val base = apiUrl("books/$itemId/pages/${pageIndex + 1}")
+        val url = if (maxWidth != null) "$base?width=$maxWidth" else base
+        return http.getBytes(url)
+    }
 
     override suspend fun fetchCbzPageCount(itemId: String): Int {
         val body = http.getString(apiUrl("books/$itemId"))

--- a/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalogFactory.kt
+++ b/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalogFactory.kt
@@ -16,6 +16,7 @@ class KomgaCatalogFactory(
     private val httpClient: HttpClient,
     private val tokenStorage: TokenStorage,
     private val userAgent: String = "Riffle/dev (Android) komga-source",
+    private val bytesClient: HttpClient = httpClient,
 ) : CatalogFactory {
 
     override val sourceType: SourceType = SourceType.KOMGA
@@ -41,6 +42,6 @@ class KomgaCatalogFactory(
             basicAuthHeader = basicAuthHeader,
             userAgent = userAgent,
         )
-        return KomgaCatalog(config = config, http = http, bytesClient = httpClient)
+        return KomgaCatalog(config = config, http = http, bytesClient = bytesClient)
     }
 }

--- a/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaHttpClient.kt
+++ b/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaHttpClient.kt
@@ -10,6 +10,7 @@ import io.ktor.client.request.patch
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsBytes
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
@@ -82,6 +83,23 @@ class KomgaHttpClient(
             header(HttpHeaders.UserAgent, userAgent)
         }
         readSuccessOrThrow("DELETE", url, response)
+    }
+
+    /** GET [url], return response body as raw bytes. Throws [KomgaHttpException] on non-2xx. */
+    suspend fun getBytes(url: String): ByteArray {
+        val response = client.get(url) {
+            header(HttpHeaders.Authorization, basicAuthHeader)
+            header(HttpHeaders.UserAgent, userAgent)
+        }
+        if (!response.status.isSuccess()) {
+            throw KomgaHttpException(
+                code = response.status.value,
+                url = url,
+                method = "GET",
+                statusMessage = response.status.description,
+            )
+        }
+        return response.bodyAsBytes()
     }
 
     /** Status of a GET without reading the body. Returns HTTP code (or -1 on IOException). */

--- a/core/catalog-komga/src/test/kotlin/com/riffle/core/catalog/komga/KomgaCbzPageStreamTest.kt
+++ b/core/catalog-komga/src/test/kotlin/com/riffle/core/catalog/komga/KomgaCbzPageStreamTest.kt
@@ -1,0 +1,108 @@
+package com.riffle.core.catalog.komga
+
+import com.riffle.core.catalog.CbzPageStreamCapability
+import com.riffle.core.catalog.has
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okio.Buffer
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class KomgaCbzPageStreamTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var catalog: KomgaCatalog
+
+    @Before fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val header = buildBasicAuthHeader("user", "pass")
+        val config = KomgaCatalogConfig(
+            baseUrl = server.url("/").toString().trimEnd('/'),
+            basicAuthHeader = header,
+            insecureAllowed = true,
+        )
+        val httpClient = HttpClient(OkHttp) {}
+        catalog = KomgaCatalog(config, KomgaHttpClient(httpClient, header), httpClient)
+    }
+
+    @After fun tearDown() { server.shutdown() }
+
+    @Test fun `KomgaCatalog declares CbzPageStreamCapability`() {
+        assertTrue(catalog.has<CbzPageStreamCapability>())
+    }
+
+    @Test fun `fetchCbzPageImage calls correct URL and returns bytes`() = runTest {
+        val fakeBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47) // PNG header
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(Buffer().write(fakeBytes))
+        )
+
+        val cap = catalog as CbzPageStreamCapability
+        val result = cap.fetchCbzPageImage("BOOK1", 0)
+
+        val request = server.takeRequest()
+        assertEquals("/api/v1/books/BOOK1/pages/1", request.path)
+        assertArrayEquals(fakeBytes, result)
+    }
+
+    @Test fun `fetchCbzPageImage converts 0-based pageIndex to 1-based URL`() = runTest {
+        val fakeBytes = byteArrayOf(1, 2, 3, 4)
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(Buffer().write(fakeBytes))
+        )
+
+        val cap = catalog as CbzPageStreamCapability
+        cap.fetchCbzPageImage("B1", 4) // pageIndex 4 → page 5
+
+        val request = server.takeRequest()
+        assertEquals("/api/v1/books/B1/pages/5", request.path)
+    }
+
+    @Test fun `fetchCbzPageCount returns pagesCount from book metadata`() = runTest {
+        server.enqueue(MockResponse().setBody("""
+            {
+              "id": "B1",
+              "libraryId": "L1",
+              "name": "book.cbz",
+              "media": {"mediaType": "application/x-cbz", "pagesCount": 42},
+              "metadata": {"title": "My Comic", "authors": []}
+            }
+        """.trimIndent()))
+
+        val cap = catalog as CbzPageStreamCapability
+        val count = cap.fetchCbzPageCount("B1")
+
+        assertEquals(42, count)
+        val request = server.takeRequest()
+        assertEquals("/api/v1/books/B1", request.path)
+    }
+
+    @Test fun `fetchCbzPageCount returns 0 when pagesCount absent`() = runTest {
+        server.enqueue(MockResponse().setBody("""
+            {
+              "id": "B1",
+              "libraryId": "L1",
+              "name": "book.cbz",
+              "media": {"mediaType": "application/x-cbz"},
+              "metadata": {"title": "My Comic", "authors": []}
+            }
+        """.trimIndent()))
+
+        val cap = catalog as CbzPageStreamCapability
+        val count = cap.fetchCbzPageCount("B1")
+
+        assertEquals(0, count)
+    }
+}

--- a/core/catalog-komga/src/test/kotlin/com/riffle/core/catalog/komga/KomgaCbzPageStreamTest.kt
+++ b/core/catalog-komga/src/test/kotlin/com/riffle/core/catalog/komga/KomgaCbzPageStreamTest.kt
@@ -70,6 +70,36 @@ class KomgaCbzPageStreamTest {
         assertEquals("/api/v1/books/B1/pages/5", request.path)
     }
 
+    @Test fun `fetchCbzPageImage appends width query param when maxWidth is provided`() = runTest {
+        val fakeBytes = byteArrayOf(1, 2, 3, 4)
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(Buffer().write(fakeBytes))
+        )
+
+        val cap = catalog as CbzPageStreamCapability
+        cap.fetchCbzPageImage("B1", 0, maxWidth = 300)
+
+        val request = server.takeRequest()
+        assertEquals("/api/v1/books/B1/pages/1?width=300", request.path)
+    }
+
+    @Test fun `fetchCbzPageImage omits width query param when maxWidth is null`() = runTest {
+        val fakeBytes = byteArrayOf(1, 2, 3, 4)
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(Buffer().write(fakeBytes))
+        )
+
+        val cap = catalog as CbzPageStreamCapability
+        cap.fetchCbzPageImage("B1", 0, maxWidth = null)
+
+        val request = server.takeRequest()
+        assertEquals("/api/v1/books/B1/pages/1", request.path)
+    }
+
     @Test fun `fetchCbzPageCount returns pagesCount from book metadata`() = runTest {
         server.enqueue(MockResponse().setBody("""
             {

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/CbzPageStreamCapability.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/CbzPageStreamCapability.kt
@@ -9,8 +9,12 @@ package com.riffle.core.catalog
  * expects (Komga uses 1-based page numbers).
  */
 interface CbzPageStreamCapability : CatalogCapability {
-    /** Returns the raw image bytes for [pageIndex] (0-based). */
-    suspend fun fetchCbzPageImage(itemId: String, pageIndex: Int): ByteArray
+    /**
+     * Returns the raw image bytes for [pageIndex] (0-based).
+     * Pass [maxWidth] to request a downscaled image (e.g. 300 for thumbnails);
+     * null requests the full-resolution original.
+     */
+    suspend fun fetchCbzPageImage(itemId: String, pageIndex: Int, maxWidth: Int? = null): ByteArray
     /** Returns the total page count for the item. */
     suspend fun fetchCbzPageCount(itemId: String): Int
 }

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/CbzPageStreamCapability.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/CbzPageStreamCapability.kt
@@ -1,0 +1,16 @@
+package com.riffle.core.catalog
+
+/**
+ * Opt-in capability for catalogs that can serve individual CBZ page images
+ * without requiring a full file download. Komga implements this via
+ * GET /api/v1/books/{bookId}/pages/{pageNumber}.
+ *
+ * [pageIndex] is always 0-based; implementations map to whatever the server
+ * expects (Komga uses 1-based page numbers).
+ */
+interface CbzPageStreamCapability : CatalogCapability {
+    /** Returns the raw image bytes for [pageIndex] (0-based). */
+    suspend fun fetchCbzPageImage(itemId: String, pageIndex: Int): ByteArray
+    /** Returns the total page count for the item. */
+    suspend fun fetchCbzPageCount(itemId: String): Int
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/CbzRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/CbzRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.riffle.core.data
 
 import com.riffle.core.catalog.BookFormat
 import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.CbzPageStreamCapability
 import com.riffle.core.domain.CbzDownloadResult
 import com.riffle.core.domain.CbzOpenResult
 import com.riffle.core.domain.CbzRepository
@@ -28,23 +29,38 @@ class CbzRepositoryImpl(
         if (local == null) {
             cacheStore.delete(item.sourceId, item.id)
         }
-        val cbzFile = if (local != null) {
-            local
-        } else {
-            val catalog = catalogRegistry.forSourceId(item.sourceId)
-                ?: return CbzOpenResult.NetworkError(IllegalStateException("No catalog for item"))
-            try {
-                CatalogFileTransfer.acquire(
-                    catalog, item.sourceId, item.id, BookFormat.Cbz,
-                    item.ebookFileIno, cacheStore,
-                )
+        if (local != null) {
+            val activeSource = sourceRepository.getActive()
+            val lastPosition = activeSource?.let { positionStore.load(it.id, item.id) }
+            return CbzOpenResult.Success(cbzFile = local, lastPosition = lastPosition)
+        }
+        val catalog = catalogRegistry.forSourceId(item.sourceId)
+            ?: return CbzOpenResult.NetworkError(IllegalStateException("No catalog for item"))
+        val streamCap = catalog as? CbzPageStreamCapability
+        if (streamCap != null) {
+            val pageCount = try {
+                streamCap.fetchCbzPageCount(item.id)
             } catch (t: Throwable) {
                 return CbzOpenResult.NetworkError(t)
             }
+            if (pageCount <= 0) return CbzOpenResult.NetworkError(
+                IllegalStateException("Server returned zero page count for ${item.id}")
+            )
+            val activeSource = sourceRepository.getActive()
+            val lastPosition = activeSource?.let { positionStore.load(it.id, item.id) }
+            return CbzOpenResult.Streaming(pageCount = pageCount, lastPosition = lastPosition)
         }
-        val activeSource = sourceRepository.getActive()
-        val lastPosition = activeSource?.let { positionStore.load(it.id, item.id) }
-        return CbzOpenResult.Success(cbzFile = cbzFile, lastPosition = lastPosition)
+        return try {
+            val cbzFile = CatalogFileTransfer.acquire(
+                catalog, item.sourceId, item.id, BookFormat.Cbz,
+                item.ebookFileIno, cacheStore,
+            )
+            val activeSource = sourceRepository.getActive()
+            val lastPosition = activeSource?.let { positionStore.load(it.id, item.id) }
+            CbzOpenResult.Success(cbzFile = cbzFile, lastPosition = lastPosition)
+        } catch (t: Throwable) {
+            CbzOpenResult.NetworkError(t)
+        }
     }
 
     override suspend fun downloadCbz(
@@ -83,6 +99,30 @@ class CbzRepositoryImpl(
     override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {
         val sourceId = sourceRepository.getActive()?.id ?: return
         positionStore.save(sourceId, itemId, locatorJson)
+    }
+
+    override suspend fun supportsStreaming(sourceId: String): Boolean =
+        catalogRegistry.forSourceId(sourceId) as? CbzPageStreamCapability != null
+
+    override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int): ByteArray {
+        val cap = catalogRegistry.forSourceId(sourceId) as? CbzPageStreamCapability
+            ?: throw IllegalStateException("No CbzPageStreamCapability for source $sourceId")
+        return cap.fetchCbzPageImage(itemId, pageIndex)
+    }
+
+    override suspend fun awaitCachedFile(item: LibraryItem): File? {
+        val existing = (downloadsStore.get(item.sourceId, item.id) ?: cacheStore.get(item.sourceId, item.id))
+            ?.takeIf { it.isValidCbz() }
+        if (existing != null) return existing
+        val catalog = catalogRegistry.forSourceId(item.sourceId) ?: return null
+        return try {
+            CatalogFileTransfer.acquire(
+                catalog, item.sourceId, item.id, BookFormat.Cbz,
+                item.ebookFileIno, cacheStore,
+            )
+        } catch (_: Throwable) {
+            null
+        }
     }
 }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/CbzRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/CbzRepositoryImpl.kt
@@ -11,10 +11,13 @@ import com.riffle.core.domain.LocalStore
 import com.riffle.core.domain.ReadingPositionStore
 import com.riffle.core.domain.SourceRepository
 import java.io.File
+import java.io.IOException
+import java.util.zip.ZipException
+import java.util.zip.ZipFile
 
 /**
- * Mirrors [PdfRepositoryImpl]. CBZ is a plain ZIP-of-images so we validate by ZIP-signature only;
- * detailed structural validation happens when the reader opens the archive via `CbzArchive`.
+ * Mirrors [PdfRepositoryImpl]. Validates local files by opening their ZIP central directory
+ * (not just magic bytes) so truncated downloads are caught before the reader sees them.
  */
 class CbzRepositoryImpl(
     private val catalogRegistry: CatalogRegistry,
@@ -25,10 +28,7 @@ class CbzRepositoryImpl(
 ) : CbzRepository {
 
     override suspend fun openCbz(item: LibraryItem): CbzOpenResult {
-        val local = (downloadsStore.get(item.sourceId, item.id) ?: cacheStore.get(item.sourceId, item.id))?.takeIf { it.isValidCbz() }
-        if (local == null) {
-            cacheStore.delete(item.sourceId, item.id)
-        }
+        val local = resolveLocalFile(item.sourceId, item.id)
         if (local != null) {
             val activeSource = sourceRepository.getActive()
             val lastPosition = activeSource?.let { positionStore.load(it.id, item.id) }
@@ -84,6 +84,7 @@ class CbzRepositoryImpl(
             )
             CbzDownloadResult.Success
         } catch (t: Throwable) {
+            downloadsStore.delete(item.sourceId, item.id)
             CbzDownloadResult.NetworkError(t)
         }
     }
@@ -111,8 +112,7 @@ class CbzRepositoryImpl(
     }
 
     override suspend fun awaitCachedFile(item: LibraryItem): File? {
-        val existing = (downloadsStore.get(item.sourceId, item.id) ?: cacheStore.get(item.sourceId, item.id))
-            ?.takeIf { it.isValidCbz() }
+        val existing = resolveLocalFile(item.sourceId, item.id)
         if (existing != null) return existing
         val catalog = catalogRegistry.forSourceId(item.sourceId) ?: return null
         return try {
@@ -121,17 +121,48 @@ class CbzRepositoryImpl(
                 item.ebookFileIno, cacheStore,
             )
         } catch (_: Throwable) {
+            cacheStore.delete(item.sourceId, item.id)
             null
         }
     }
+
+    /**
+     * Returns the best available valid local file, preferring a user-pinned download over the
+     * background cache. Deletes any file that exists but fails the integrity check — a corrupt
+     * or truncated file in either store must not block the streaming fallback path.
+     */
+    private fun resolveLocalFile(sourceId: String, itemId: String): File? {
+        val dl = downloadsStore.get(sourceId, itemId)
+        if (dl != null) {
+            if (dl.isValidCbz()) return dl
+            downloadsStore.delete(sourceId, itemId)
+        }
+        val cached = cacheStore.get(sourceId, itemId)
+        if (cached != null) {
+            if (cached.isValidCbz()) return cached
+            cacheStore.delete(sourceId, itemId)
+        }
+        return null
+    }
 }
 
+/**
+ * Opens the file as a [ZipFile], which reads the End-of-Central-Directory record from the tail
+ * of the file. Truncated or partially-written downloads are missing this record and throw
+ * [ZipException] on construction — catching it here prevents the reader from seeing a corrupt
+ * file. A magic-byte-only check would pass on truncated downloads (the PK header is always at
+ * the start), so we need the full central-directory read.
+ *
+ * 22 bytes is the minimum valid ZIP (EOCD only, no entries). Performance is fine for large
+ * archives: [ZipFile] only reads the central-directory metadata, not file contents.
+ */
 private fun File.isValidCbz(): Boolean {
-    if (!exists() || length() < 4) return false
-    return inputStream().use { stream ->
-        val header = ByteArray(4).also { stream.read(it) }
-        // "PK\x03\x04" — ZIP local file header. Enough to reject truncation/garbage before the
-        // reader opens the archive; downstream `CbzArchive` filters non-image entries.
-        header.contentEquals(byteArrayOf(0x50, 0x4B, 0x03, 0x04))
+    if (!exists() || length() < 22) return false
+    return try {
+        ZipFile(this).use { true }
+    } catch (_: ZipException) {
+        false
+    } catch (_: IOException) {
+        false
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/CbzRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/CbzRepositoryImpl.kt
@@ -104,10 +104,10 @@ class CbzRepositoryImpl(
     override suspend fun supportsStreaming(sourceId: String): Boolean =
         catalogRegistry.forSourceId(sourceId) as? CbzPageStreamCapability != null
 
-    override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int): ByteArray {
+    override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int, maxWidth: Int?): ByteArray {
         val cap = catalogRegistry.forSourceId(sourceId) as? CbzPageStreamCapability
             ?: throw IllegalStateException("No CbzPageStreamCapability for source $sourceId")
-        return cap.fetchCbzPageImage(itemId, pageIndex)
+        return cap.fetchCbzPageImage(itemId, pageIndex, maxWidth)
     }
 
     override suspend fun awaitCachedFile(item: LibraryItem): File? {

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/CatalogModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/CatalogModule.kt
@@ -29,6 +29,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoMap
+import com.riffle.core.network.JvmHttpClientPool
 import io.ktor.client.HttpClient
 import javax.inject.Singleton
 
@@ -116,10 +117,12 @@ object CatalogModule {
     @SourceTypeKey(SourceType.KOMGA)
     fun provideKomgaCatalogFactory(
         httpClient: HttpClient,
+        pool: JvmHttpClientPool,
         tokenStorage: TokenStorage,
     ): CatalogFactory = KomgaCatalogFactory(
         httpClient = httpClient,
         tokenStorage = tokenStorage,
+        bytesClient = pool.fileTransferClient(),
         userAgent = "Riffle/dev (Android) komga-source",
     )
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/CbzRepositoryImplCorruptionTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/CbzRepositoryImplCorruptionTest.kt
@@ -1,0 +1,190 @@
+package com.riffle.core.data
+
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogFileHandle
+import com.riffle.core.catalog.CatalogFileStream
+import com.riffle.core.catalog.CatalogHealth
+import com.riffle.core.catalog.CatalogItem
+import com.riffle.core.catalog.CatalogRoot
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.CbzPageStreamCapability
+import com.riffle.core.catalog.FacetSelection
+import com.riffle.core.catalog.SortKey
+import com.riffle.core.models.SourceType
+import com.riffle.core.domain.CbzOpenResult
+import com.riffle.core.domain.LocalStore
+import com.riffle.core.domain.ReadingPositionStore
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.models.EbookFormat
+import com.riffle.core.models.LibraryItem
+import com.riffle.core.models.Source
+import java.io.File
+import java.io.InputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class CbzRepositoryImplCorruptionTest {
+
+    @get:Rule val tmp = TemporaryFolder()
+
+    // --- File helpers ---
+
+    /** A file with valid ZIP magic bytes but no EOCD — simulates a truncated download. */
+    private fun truncatedZip(): File = tmp.newFile("corrupt.cbz").also { f ->
+        f.writeBytes(byteArrayOf(0x50, 0x4B, 0x03, 0x04) + ByteArray(100) { it.toByte() })
+    }
+
+    /** A minimal valid ZIP (one dummy entry). */
+    private fun validZip(): File = tmp.newFile("valid.cbz").also { f ->
+        ZipOutputStream(f.outputStream()).use { zos ->
+            zos.putNextEntry(ZipEntry("page.jpg"))
+            zos.write(byteArrayOf(0xFF.toByte(), 0xD8.toByte())) // JPEG magic
+            zos.closeEntry()
+        }
+    }
+
+    // --- Fakes ---
+
+    private fun storeFor(file: File?): TrackingStore = TrackingStore(file)
+
+    inner class TrackingStore(private val file: File?) : LocalStore {
+        var deleted = false
+        override fun get(sourceId: String, itemId: String): File? = file
+        override suspend fun save(sourceId: String, itemId: String, stream: InputStream): File =
+            throw UnsupportedOperationException()
+        override fun delete(sourceId: String, itemId: String) { deleted = true }
+        override fun deleteSource(sourceId: String) {}
+        override fun clear() {}
+        override fun listItems() = emptyList<com.riffle.core.domain.StoredItemRef>()
+    }
+
+    private val emptyStore = storeFor(null)
+
+    private val streamingCatalog = object : Catalog, CbzPageStreamCapability {
+        override val sourceType: SourceType = SourceType.KOMGA
+        override suspend fun listRoots(): List<CatalogRoot> = emptyList()
+        override suspend fun browse(rootId: String, sort: SortKey, page: Int, pageSize: Int, facet: FacetSelection?): List<CatalogItem> = emptyList()
+        override suspend fun search(rootId: String, query: String, page: Int, pageSize: Int): List<CatalogItem> = emptyList()
+        override suspend fun getItem(itemId: String): CatalogItem? = null
+        override suspend fun fetchFile(itemId: String, format: BookFormat): CatalogFileHandle = throw UnsupportedOperationException()
+        override suspend fun <T> withFileStream(itemId: String, format: BookFormat, fileIno: String?, block: suspend (CatalogFileStream) -> T): T = throw UnsupportedOperationException()
+        override suspend fun connectivityCheck(): CatalogHealth = CatalogHealth(isReachable = true)
+        override suspend fun fetchCbzPageImage(itemId: String, pageIndex: Int, maxWidth: Int?): ByteArray = byteArrayOf()
+        override suspend fun fetchCbzPageCount(itemId: String): Int = 10
+    }
+
+    private fun registryFor(catalog: Catalog) = object : CatalogRegistry {
+        override suspend fun forActive(): Catalog? = catalog
+        override suspend fun forSource(source: Source): Catalog? = catalog
+        override suspend fun forSourceId(id: String): Catalog? = catalog
+    }
+
+    private val noPosition = object : ReadingPositionStore {
+        override suspend fun save(sourceId: String, itemId: String, payload: String) {}
+        override suspend fun load(sourceId: String, itemId: String): String? = null
+        override suspend fun loadLocalUpdatedAt(sourceId: String, itemId: String): Long = 0L
+        override suspend fun loadLastSyncedAt(sourceId: String, itemId: String): Long = 0L
+        override suspend fun acceptServer(sourceId: String, itemId: String, payload: String, serverStamp: Long) {}
+        override suspend fun markSyncedAt(sourceId: String, itemId: String, stamp: Long) {}
+        override suspend fun updateLocalTimestamp(sourceId: String, itemId: String, millis: Long) {}
+    }
+
+    private val noActiveSource = object : SourceRepository {
+        override fun observeAll(): Flow<List<Source>> = flowOf(emptyList())
+        override suspend fun getActive(): Source? = null
+        override suspend fun getById(sourceId: String): Source? = null
+        override suspend fun commit(pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>) = throw UnsupportedOperationException()
+        override suspend fun setActive(sourceId: String) {}
+        override suspend fun remove(sourceId: String) {}
+        override suspend fun getSourceVersion(sourceId: String): String? = null
+    }
+
+    private fun fakeItem(sourceId: String = "src1") = LibraryItem(
+        id = "item1", libraryId = "lib1", title = "Comic", author = "Author",
+        coverUrl = null, readingProgress = 0f, isCached = false, isDownloaded = false,
+        ebookFormat = EbookFormat.Cbz, sourceId = sourceId,
+    )
+
+    // --- Tests ---
+
+    @Test fun `openCbz falls back to Streaming when cached file is truncated`() = runTest {
+        val corruptCache = storeFor(truncatedZip())
+        val repo = CbzRepositoryImpl(
+            registryFor(streamingCatalog), corruptCache, emptyStore, noPosition, noActiveSource,
+        )
+        val result = repo.openCbz(fakeItem())
+        assertTrue("expected Streaming but got $result", result is CbzOpenResult.Streaming)
+    }
+
+    @Test fun `openCbz deletes corrupt cached file so next open can re-cache`() = runTest {
+        val corruptCache = storeFor(truncatedZip())
+        val repo = CbzRepositoryImpl(
+            registryFor(streamingCatalog), corruptCache, emptyStore, noPosition, noActiveSource,
+        )
+        repo.openCbz(fakeItem())
+        assertTrue("corrupt cache file must be deleted", corruptCache.deleted)
+    }
+
+    @Test fun `openCbz deletes corrupt downloaded file so streaming path is unblocked`() = runTest {
+        val corruptDownload = storeFor(truncatedZip())
+        val repo = CbzRepositoryImpl(
+            registryFor(streamingCatalog), emptyStore, corruptDownload, noPosition, noActiveSource,
+        )
+        repo.openCbz(fakeItem())
+        assertTrue("corrupt downloads file must be deleted", corruptDownload.deleted)
+    }
+
+    @Test fun `openCbz returns Success for a valid cached file`() = runTest {
+        val goodCache = storeFor(validZip())
+        val repo = CbzRepositoryImpl(
+            registryFor(streamingCatalog), goodCache, emptyStore, noPosition, noActiveSource,
+        )
+        val result = repo.openCbz(fakeItem())
+        assertTrue("expected Success but got $result", result is CbzOpenResult.Success)
+    }
+
+    @Test fun `awaitCachedFile deletes partial file on download failure`() = runTest {
+        var deleted = false
+        val failingCacheStore = object : LocalStore {
+            override fun get(sourceId: String, itemId: String): File? = null
+            override suspend fun save(sourceId: String, itemId: String, stream: InputStream): File =
+                throw RuntimeException("network cut")
+            override fun delete(sourceId: String, itemId: String) { deleted = true }
+            override fun deleteSource(sourceId: String) {}
+            override fun clear() {}
+            override fun listItems() = emptyList<com.riffle.core.domain.StoredItemRef>()
+        }
+        val failingCatalog = object : Catalog, CbzPageStreamCapability by streamingCatalog {
+            override val sourceType: SourceType = SourceType.KOMGA
+            override suspend fun listRoots(): List<CatalogRoot> = emptyList()
+            override suspend fun browse(rootId: String, sort: SortKey, page: Int, pageSize: Int, facet: FacetSelection?): List<CatalogItem> = emptyList()
+            override suspend fun search(rootId: String, query: String, page: Int, pageSize: Int): List<CatalogItem> = emptyList()
+            override suspend fun getItem(itemId: String): CatalogItem? = null
+            override suspend fun fetchFile(itemId: String, format: BookFormat): CatalogFileHandle = throw UnsupportedOperationException()
+            override suspend fun <T> withFileStream(
+                itemId: String, format: BookFormat, fileIno: String?,
+                block: suspend (CatalogFileStream) -> T,
+            ): T = block(object : CatalogFileStream {
+                override val contentLength: Long get() = 10L
+                override fun byteStream(): InputStream = ByteArray(10).inputStream()
+                override fun close() {}
+            })
+            override suspend fun connectivityCheck(): CatalogHealth = CatalogHealth(isReachable = true)
+        }
+        val repo = CbzRepositoryImpl(
+            registryFor(failingCatalog), failingCacheStore, emptyStore, noPosition, noActiveSource,
+        )
+        val result = repo.awaitCachedFile(fakeItem())
+        assertNull("should return null on failure", result)
+        assertTrue("partial cache file must be deleted on failure", deleted)
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/CbzRepositoryImplStreamingTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/CbzRepositoryImplStreamingTest.kt
@@ -1,0 +1,181 @@
+package com.riffle.core.data
+
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogFileHandle
+import com.riffle.core.catalog.CatalogFileStream
+import com.riffle.core.catalog.CatalogHealth
+import com.riffle.core.catalog.CatalogItem
+import com.riffle.core.catalog.CatalogRoot
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.CbzPageStreamCapability
+import com.riffle.core.catalog.SortKey
+import com.riffle.core.models.SourceType
+import com.riffle.core.domain.CbzOpenResult
+import com.riffle.core.domain.LocalStore
+import com.riffle.core.domain.ReadingPositionStore
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.models.EbookFormat
+import com.riffle.core.models.LibraryItem
+import com.riffle.core.models.Source
+import java.io.File
+import java.io.InputStream
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CbzRepositoryImplStreamingTest {
+
+    // --- Fakes ---
+
+    private val streamingCatalog = object : Catalog, CbzPageStreamCapability {
+        val imageBytes = byteArrayOf(1, 2, 3, 4)
+        var lastItemId: String? = null
+        var lastPageIndex: Int = -1
+
+        override val sourceType: SourceType = SourceType.KOMGA
+        override suspend fun listRoots(): List<CatalogRoot> = emptyList()
+        override suspend fun browse(rootId: String, sort: SortKey, page: Int, pageSize: Int, facet: com.riffle.core.catalog.FacetSelection?): List<CatalogItem> = emptyList()
+        override suspend fun search(rootId: String, query: String, page: Int, pageSize: Int): List<CatalogItem> = emptyList()
+        override suspend fun getItem(itemId: String): CatalogItem? = null
+        override suspend fun fetchFile(itemId: String, format: BookFormat): CatalogFileHandle = throw UnsupportedOperationException()
+        override suspend fun <T> withFileStream(
+            itemId: String, format: BookFormat, fileIno: String?,
+            block: suspend (CatalogFileStream) -> T,
+        ): T = throw UnsupportedOperationException()
+        override suspend fun connectivityCheck(): CatalogHealth = CatalogHealth(isReachable = true)
+        override suspend fun fetchCbzPageImage(itemId: String, pageIndex: Int): ByteArray {
+            lastItemId = itemId
+            lastPageIndex = pageIndex
+            return imageBytes
+        }
+        override suspend fun fetchCbzPageCount(itemId: String): Int = 20
+    }
+
+    private val basicCatalog = object : Catalog {
+        override val sourceType: SourceType = SourceType.KOMGA
+        override suspend fun listRoots(): List<CatalogRoot> = emptyList()
+        override suspend fun browse(rootId: String, sort: SortKey, page: Int, pageSize: Int, facet: com.riffle.core.catalog.FacetSelection?): List<CatalogItem> = emptyList()
+        override suspend fun search(rootId: String, query: String, page: Int, pageSize: Int): List<CatalogItem> = emptyList()
+        override suspend fun getItem(itemId: String): CatalogItem? = null
+        override suspend fun fetchFile(itemId: String, format: BookFormat): CatalogFileHandle = throw UnsupportedOperationException()
+        override suspend fun <T> withFileStream(
+            itemId: String, format: BookFormat, fileIno: String?,
+            block: suspend (CatalogFileStream) -> T,
+        ): T = throw UnsupportedOperationException("no streaming support")
+        override suspend fun connectivityCheck(): CatalogHealth = CatalogHealth(isReachable = true)
+    }
+
+    private fun registryFor(sourceId: String, catalog: Catalog?) = object : CatalogRegistry {
+        override suspend fun forActive(): Catalog? = catalog
+        override suspend fun forSource(source: Source): Catalog? = if (source.id == sourceId) catalog else null
+        override suspend fun forSourceId(id: String): Catalog? = if (id == sourceId) catalog else null
+    }
+
+    private val emptyStore = object : LocalStore {
+        override fun get(sourceId: String, itemId: String): File? = null
+        override suspend fun save(sourceId: String, itemId: String, stream: InputStream): File = throw UnsupportedOperationException()
+        override fun delete(sourceId: String, itemId: String) {}
+        override fun deleteSource(sourceId: String) {}
+        override fun clear() {}
+        override fun listItems() = emptyList<com.riffle.core.domain.StoredItemRef>()
+    }
+
+    private val emptyPositionStore = object : ReadingPositionStore {
+        override suspend fun save(sourceId: String, itemId: String, payload: String) {}
+        override suspend fun load(sourceId: String, itemId: String): String? = null
+        override suspend fun loadLocalUpdatedAt(sourceId: String, itemId: String): Long = 0L
+        override suspend fun loadLastSyncedAt(sourceId: String, itemId: String): Long = 0L
+        override suspend fun acceptServer(sourceId: String, itemId: String, payload: String, serverStamp: Long) {}
+        override suspend fun markSyncedAt(sourceId: String, itemId: String, stamp: Long) {}
+        override suspend fun updateLocalTimestamp(sourceId: String, itemId: String, millis: Long) {}
+    }
+
+    private val noActiveSource = object : SourceRepository {
+        override fun observeAll(): Flow<List<Source>> = flowOf(emptyList())
+        override suspend fun getActive(): Source? = null
+        override suspend fun getById(sourceId: String): Source? = null
+        override suspend fun commit(pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>) = throw UnsupportedOperationException()
+        override suspend fun setActive(sourceId: String) {}
+        override suspend fun remove(sourceId: String) {}
+        override suspend fun getSourceVersion(sourceId: String): String? = null
+    }
+
+    private fun fakeItem(sourceId: String = "src1") = LibraryItem(
+        id = "item1", libraryId = "lib1", title = "Comic", author = "Author",
+        coverUrl = null, readingProgress = 0f, isCached = false, isDownloaded = false,
+        ebookFormat = EbookFormat.Cbz, sourceId = sourceId,
+    )
+
+    // --- Tests ---
+
+    @Test fun `supportsStreaming returns true when catalog implements CbzPageStreamCapability`() = runTest {
+        val repo = CbzRepositoryImpl(
+            registryFor("src1", streamingCatalog),
+            emptyStore, emptyStore, emptyPositionStore, noActiveSource,
+        )
+        assertTrue(repo.supportsStreaming("src1"))
+    }
+
+    @Test fun `supportsStreaming returns false when catalog lacks capability`() = runTest {
+        val repo = CbzRepositoryImpl(
+            registryFor("src1", basicCatalog),
+            emptyStore, emptyStore, emptyPositionStore, noActiveSource,
+        )
+        assertFalse(repo.supportsStreaming("src1"))
+    }
+
+    @Test fun `supportsStreaming returns false when no catalog for sourceId`() = runTest {
+        val repo = CbzRepositoryImpl(
+            registryFor("other", streamingCatalog),
+            emptyStore, emptyStore, emptyPositionStore, noActiveSource,
+        )
+        assertFalse(repo.supportsStreaming("src1"))
+    }
+
+    @Test fun `openCbz returns Streaming when no local file and catalog supports streaming`() = runTest {
+        val repo = CbzRepositoryImpl(
+            registryFor("src1", streamingCatalog),
+            emptyStore, emptyStore, emptyPositionStore, noActiveSource,
+        )
+        val result = repo.openCbz(fakeItem("src1"))
+        assertTrue("Expected Streaming but got $result", result is CbzOpenResult.Streaming)
+        assertEquals(20, (result as CbzOpenResult.Streaming).pageCount)
+        assertNull(result.lastPosition)
+    }
+
+    @Test fun `openCbz returns NetworkError when no local file and no streaming support`() = runTest {
+        val repo = CbzRepositoryImpl(
+            registryFor("src1", basicCatalog),
+            emptyStore, emptyStore, emptyPositionStore, noActiveSource,
+        )
+        val result = repo.openCbz(fakeItem("src1"))
+        assertTrue("Expected NetworkError but got $result", result is CbzOpenResult.NetworkError)
+    }
+
+    @Test fun `fetchStreamingPageImage delegates to catalog capability`() = runTest {
+        val repo = CbzRepositoryImpl(
+            registryFor("src1", streamingCatalog),
+            emptyStore, emptyStore, emptyPositionStore, noActiveSource,
+        )
+        val bytes = repo.fetchStreamingPageImage("src1", "item1", 3)
+        assertArrayEquals(streamingCatalog.imageBytes, bytes)
+        assertEquals("item1", streamingCatalog.lastItemId)
+        assertEquals(3, streamingCatalog.lastPageIndex)
+    }
+
+    @Test fun `awaitCachedFile returns null when no catalog for sourceId`() = runTest {
+        val repo = CbzRepositoryImpl(
+            registryFor("other", streamingCatalog),
+            emptyStore, emptyStore, emptyPositionStore, noActiveSource,
+        )
+        val result = repo.awaitCachedFile(fakeItem("src1"))
+        assertNull(result)
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/CbzRepositoryImplStreamingTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/CbzRepositoryImplStreamingTest.kt
@@ -50,9 +50,11 @@ class CbzRepositoryImplStreamingTest {
             block: suspend (CatalogFileStream) -> T,
         ): T = throw UnsupportedOperationException()
         override suspend fun connectivityCheck(): CatalogHealth = CatalogHealth(isReachable = true)
-        override suspend fun fetchCbzPageImage(itemId: String, pageIndex: Int): ByteArray {
+        var lastMaxWidth: Int? = null
+        override suspend fun fetchCbzPageImage(itemId: String, pageIndex: Int, maxWidth: Int?): ByteArray {
             lastItemId = itemId
             lastPageIndex = pageIndex
+            lastMaxWidth = maxWidth
             return imageBytes
         }
         override suspend fun fetchCbzPageCount(itemId: String): Int = 20

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/CbzRepository.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/CbzRepository.kt
@@ -32,7 +32,7 @@ interface CbzRepository {
     fun isCached(sourceId: String, itemId: String): Boolean
     suspend fun saveReadingPosition(itemId: String, locatorJson: String)
     /** True when the catalog for [sourceId] implements [CbzPageStreamCapability]. */
-    fun supportsStreaming(sourceId: String): Boolean
+    suspend fun supportsStreaming(sourceId: String): Boolean
     /**
      * Fetch the raw image bytes for [pageIndex] (0-based) directly from the catalog.
      * Only valid when [supportsStreaming] returns true for the item's source.

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/CbzRepository.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/CbzRepository.kt
@@ -37,7 +37,7 @@ interface CbzRepository {
      * Fetch the raw image bytes for [pageIndex] (0-based) directly from the catalog.
      * Only valid when [supportsStreaming] returns true for the item's source.
      */
-    suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int): ByteArray
+    suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int, maxWidth: Int? = null): ByteArray
     /**
      * Download the full CBZ to the local cache store and return the [File].
      * Returns null on network failure. Idempotent: returns the existing file if already present.

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/CbzRepository.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/CbzRepository.kt
@@ -5,6 +5,12 @@ import com.riffle.core.models.LibraryItem
 
 sealed class CbzOpenResult {
     data class Success(val cbzFile: File, val lastPosition: String?) : CbzOpenResult()
+    /**
+     * No local file exists but the catalog supports per-page streaming. The reader may open
+     * immediately using [CbzRepository.fetchStreamingPageImage]; a background download will
+     * populate the local cache and the reader can swap to local access when ready.
+     */
+    data class Streaming(val pageCount: Int, val lastPosition: String?) : CbzOpenResult()
     data class NetworkError(val cause: Throwable) : CbzOpenResult()
     data object Offline : CbzOpenResult()
 }
@@ -25,4 +31,17 @@ interface CbzRepository {
     fun isDownloaded(sourceId: String, itemId: String): Boolean
     fun isCached(sourceId: String, itemId: String): Boolean
     suspend fun saveReadingPosition(itemId: String, locatorJson: String)
+    /** True when the catalog for [sourceId] implements [CbzPageStreamCapability]. */
+    fun supportsStreaming(sourceId: String): Boolean
+    /**
+     * Fetch the raw image bytes for [pageIndex] (0-based) directly from the catalog.
+     * Only valid when [supportsStreaming] returns true for the item's source.
+     */
+    suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int): ByteArray
+    /**
+     * Download the full CBZ to the local cache store and return the [File].
+     * Returns null on network failure. Idempotent: returns the existing file if already present.
+     * This is used by the reader to transition from network-streaming to local-archive access.
+     */
+    suspend fun awaitCachedFile(item: LibraryItem): File?
 }

--- a/core/net/src/jvmMain/kotlin/com/riffle/core/network/JvmHttpClientFactories.kt
+++ b/core/net/src/jvmMain/kotlin/com/riffle/core/network/JvmHttpClientFactories.kt
@@ -17,6 +17,15 @@ class JvmHttpClientPool internal constructor(
     fun defaultHttpClient(): HttpClient = createDefaultHttpClient(okHttpClient)
 
     fun streamingHttpClient(): HttpClient = createStreamingHttpClient(okHttpClient)
+
+    /**
+     * Ktor client for large file downloads. Uses a fresh OkHttpClient derived from the pool
+     * client (same connection pool and interceptors) but with no call timeout — the pool's
+     * 30-second ceiling kills multi-megabyte downloads before the body is fully read.
+     */
+    fun fileTransferClient(): HttpClient = createStreamingHttpClient(
+        okHttpClient.newBuilder().callTimeout(0, TimeUnit.SECONDS).build()
+    )
 }
 
 fun createDefaultJvmHttpClientPool(


### PR DESCRIPTION
## Summary

- When a CBZ is not cached locally, the reader now opens immediately by streaming individual page images from Komga's per-page image API, rather than waiting for the full file to download
- A background download populates the local cache; the reader transparently swaps to local archive access once ready
- Adds `CbzPageStreamCapability` mixin to `Catalog` — Komga implements it; other sources remain unaffected

## Bugs fixed

- **Caching timeout on large files**: the shared OkHttpClient had a 30 s `callTimeout` that killed multi-megabyte downloads mid-stream. Fixed by adding `fileTransferClient()` to `JvmHttpClientPool` — inherits the connection pool and interceptors but removes the ceiling
- **Slow thumbnail strip + re-fetch on every show**: full-res pages were loaded for thumbnails. Fixed with a dedicated 300 px-wide `thumbnailSource` that appends `?width=300` to Komga's page URL, plus a 3-entry LRU byte cache on `NetworkImageSource` to absorb `decodeSampledBitmap`'s two-pass decode
- **Panel-by-panel reading broken during streaming**: `panelBook` was never initialised in the streaming path. Fixed by calling `panelOrchestrator.forBook()` with the network source's `imageBytes` in `loadStreaming()`

## Corruption detection and recovery

`isValidCbz()` upgraded from a 4-byte magic check to a `ZipFile` constructor call — reads the EOCD from the file tail, catches truncated downloads that pass magic-byte validation. Corrupt or partial files are deleted from the correct store so the streaming fallback path is unblocked. If a cached file is found corrupt at open time, the reader falls back to streaming and re-caches.

## Tests

- `KomgaCbzPageStreamTest` — URL construction, 1-based page offset, `?width=` param presence/absence (MockWebServer)
- `NetworkImageSourceTest` — byte cache hit/miss, thumbnail width forwarding
- `CbzRepositoryImplStreamingTest` — streaming open path, network error path
- `CbzRepositoryImplCorruptionTest` — truncated-ZIP fallback, corrupt-file deletion from both stores, `awaitCachedFile` cleanup on failure
- `CbzArchiveSwapTest` — `computeArchiveSwapState` and `clampPageForSwap` covering: `thumbnailSource` nulled, `imageSource` replaced, `pageCount` updated, page clamped when archive is smaller than server-reported count

Specific assertions that would fail if the main behaviors were reverted:
- `CbzArchiveSwapTest.thumbnailSource is null after swap` — fails if `thumbnailSource = null` is removed from the state copy
- `CbzArchiveSwapTest.clamps to last valid page when currentPage is out of bounds` — fails if the page-clamp block is removed
- `CbzRepositoryImplCorruptionTest.openCbz falls back to Streaming when cached file is truncated` — fails if `isValidCbz` reverts to the magic-byte check