### PR TITLE
feat(komga): show server address and version in source switcher and Settings

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
@@ -18,6 +18,7 @@ import com.riffle.core.domain.SyncNamespace
 import com.riffle.core.domain.TokenStorage
 import com.riffle.core.domain.WebSourceDescriptors
 import com.riffle.core.network.AbsServerInfoApi
+import com.riffle.core.network.KomgaServerInfoApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -29,6 +30,7 @@ class SourceRepositoryImpl @Inject constructor(
     private val dao: SourceDao,
     private val tokenStorage: TokenStorage,
     private val serverInfoApi: AbsServerInfoApi,
+    private val komgaServerInfoApi: KomgaServerInfoApi,
     private val libraryDao: LibraryDao,
     private val libraryItemDao: LibraryItemDao,
     private val filesCleaner: SourceFilesCleaner,
@@ -89,6 +91,15 @@ class SourceRepositoryImpl @Inject constructor(
         val source = dao.getById(sourceId)?.toDomain() ?: return null
         // Storyteller exposes no /server-info endpoint; the UI deliberately shows no version for it.
         if (source.serverType == ServerType.STORYTELLER_SERVICE) return null
+        if (source.type == SourceType.KOMGA) {
+            val password = tokenStorage.getPassword(sourceId) ?: return null
+            return komgaServerInfoApi.getServerVersion(
+                baseUrl = source.url.value,
+                username = source.username,
+                password = password,
+                insecureAllowed = source.insecureConnectionAllowed,
+            )
+        }
         val token = tokenStorage.getToken(sourceId) ?: return null
         return serverInfoApi.getServerInfo(
             baseUrl = source.url.value,

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/NetworkModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/NetworkModule.kt
@@ -15,6 +15,8 @@ import com.riffle.core.network.AbsSessionApi
 import com.riffle.core.network.AudiobookBundleApiImpl
 import com.riffle.core.network.GitHubReleaseApi
 import com.riffle.core.network.JvmHttpClientPool
+import com.riffle.core.network.KomgaServerInfoApi
+import com.riffle.core.network.KomgaServerInfoApiClient
 import com.riffle.core.network.StorytellerApi
 import com.riffle.core.network.StorytellerApiClient
 import com.riffle.core.network.StorytellerBundleApiImpl
@@ -169,6 +171,11 @@ abstract class NetworkModule {
             libraryApi: AbsLibraryApi,
             storytellerApi: StorytellerApi,
         ): AbsSourceAdapter = AbsSourceAdapter(absApi, libraryApi, storytellerApi)
+
+        @Provides
+        @Singleton
+        fun provideKomgaServerInfoApiClient(httpClient: HttpClient): KomgaServerInfoApi =
+            KomgaServerInfoApiClient(httpClient)
 
         @Provides
         @Singleton

--- a/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
@@ -19,6 +19,7 @@ import com.riffle.core.domain.TokenStorage
 import com.riffle.core.network.AbsApi
 import com.riffle.core.network.AbsLibraryApi
 import com.riffle.core.network.AbsServerInfoApi
+import com.riffle.core.network.KomgaServerInfoApi
 import com.riffle.core.network.NetworkLibrary
 import com.riffle.core.network.StorytellerApi
 import kotlinx.coroutines.flow.Flow
@@ -229,10 +230,14 @@ class ServerRepositoryTest {
         val resolvers = mapOf<com.riffle.core.models.SourceType, com.riffle.core.domain.RemoteUserIdResolver>(
             com.riffle.core.models.SourceType.ABS to absResolver,
         )
+        val fakeKomgaServerInfoApi = object : KomgaServerInfoApi {
+            override suspend fun getServerVersion(baseUrl: String, username: String, password: String, insecureAllowed: Boolean): String? = null
+        }
         return SourceRepositoryImpl(
             dao = dao,
             tokenStorage = tokens,
             serverInfoApi = serverInfoApi,
+            komgaServerInfoApi = fakeKomgaServerInfoApi,
             libraryDao = libraryDao,
             libraryItemDao = libraryItemDao,
             filesCleaner = filesCleaner,

--- a/core/net/src/commonMain/kotlin/com/riffle/core/network/KomgaServerInfoApi.kt
+++ b/core/net/src/commonMain/kotlin/com/riffle/core/network/KomgaServerInfoApi.kt
@@ -1,0 +1,10 @@
+package com.riffle.core.network
+
+interface KomgaServerInfoApi {
+    suspend fun getServerVersion(
+        baseUrl: String,
+        username: String,
+        password: String,
+        insecureAllowed: Boolean,
+    ): String?
+}

--- a/core/net/src/commonMain/kotlin/com/riffle/core/network/KomgaServerInfoApiClient.kt
+++ b/core/net/src/commonMain/kotlin/com/riffle/core/network/KomgaServerInfoApiClient.kt
@@ -1,0 +1,51 @@
+package com.riffle.core.network
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.isSuccess
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+
+class KomgaServerInfoApiClient(
+    private val httpClient: HttpClient,
+) : KomgaServerInfoApi {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun getServerVersion(
+        baseUrl: String,
+        username: String,
+        password: String,
+        insecureAllowed: Boolean,
+    ): String? = KtorClassifier.classify {
+        val client = if (insecureAllowed) httpClient.withInsecureTls() else httpClient
+        val response = client.get("${baseUrl.trimEnd('/')}/actuator/info") {
+            header(HttpHeaders.Authorization, buildBasicAuthHeader(username, password))
+        }
+        if (!response.status.isSuccess()) return@classify null
+        parseActuatorVersion(response.bodyAsText())
+    }.getOrNull()
+
+    companion object {
+        @OptIn(ExperimentalEncodingApi::class)
+        internal fun buildBasicAuthHeader(username: String, password: String): String {
+            val encoded = Base64.encode("$username:$password".toByteArray(Charsets.UTF_8))
+            return "Basic $encoded"
+        }
+
+        internal fun parseActuatorVersion(body: String): String? {
+            val obj = runCatching {
+                Json.parseToJsonElement(body).jsonObject
+            }.getOrNull() ?: return null
+            val build = (obj["build"] as? JsonObject) ?: return null
+            return (build["version"] as? JsonPrimitive)?.content?.takeIf { it.isNotBlank() }
+        }
+    }
+}

--- a/core/net/src/commonMain/kotlin/com/riffle/core/network/KomgaServerInfoApiClient.kt
+++ b/core/net/src/commonMain/kotlin/com/riffle/core/network/KomgaServerInfoApiClient.kt
@@ -17,8 +17,6 @@ class KomgaServerInfoApiClient(
     private val httpClient: HttpClient,
 ) : KomgaServerInfoApi {
 
-    private val json = Json { ignoreUnknownKeys = true }
-
     override suspend fun getServerVersion(
         baseUrl: String,
         username: String,

--- a/core/net/src/jvmTest/kotlin/com/riffle/core/network/KomgaServerInfoApiClientTest.kt
+++ b/core/net/src/jvmTest/kotlin/com/riffle/core/network/KomgaServerInfoApiClientTest.kt
@@ -6,7 +6,6 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -61,9 +60,10 @@ class KomgaServerInfoApiClientTest {
         )
         val request = server.takeRequest()
         assertEquals("/actuator/info", request.path)
-        // "admin:pass" base64-encoded
-        assertNotNull(request.getHeader("Authorization"))
-        assert(request.getHeader("Authorization")!!.startsWith("Basic "))
+        assertEquals(
+            KomgaServerInfoApiClient.buildBasicAuthHeader("admin", "pass"),
+            request.getHeader("Authorization"),
+        )
     }
 
     @Test

--- a/core/net/src/jvmTest/kotlin/com/riffle/core/network/KomgaServerInfoApiClientTest.kt
+++ b/core/net/src/jvmTest/kotlin/com/riffle/core/network/KomgaServerInfoApiClientTest.kt
@@ -1,0 +1,113 @@
+package com.riffle.core.network
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class KomgaServerInfoApiClientTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: KomgaServerInfoApiClient
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        client = KomgaServerInfoApiClient(createDefaultHttpClient(OkHttpClient()))
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `getServerVersion parses build version from actuator info`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"build":{"version":"1.19.0","artifact":"komga","name":"Komga"}}""")
+                .addHeader("Content-Type", "application/json"),
+        )
+        val version = client.getServerVersion(
+            baseUrl = server.url("/").toString().trimEnd('/'),
+            username = "test",
+            password = "secret",
+            insecureAllowed = false,
+        )
+        assertEquals("1.19.0", version)
+    }
+
+    @Test
+    fun `getServerVersion sends Basic auth header`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"build":{"version":"1.0.0"}}""")
+                .addHeader("Content-Type", "application/json"),
+        )
+        client.getServerVersion(
+            baseUrl = server.url("/").toString().trimEnd('/'),
+            username = "admin",
+            password = "pass",
+            insecureAllowed = false,
+        )
+        val request = server.takeRequest()
+        assertEquals("/actuator/info", request.path)
+        // "admin:pass" base64-encoded
+        assertNotNull(request.getHeader("Authorization"))
+        assert(request.getHeader("Authorization")!!.startsWith("Basic "))
+    }
+
+    @Test
+    fun `getServerVersion returns null on 403 forbidden`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(403))
+        val version = client.getServerVersion(
+            baseUrl = server.url("/").toString().trimEnd('/'),
+            username = "user",
+            password = "wrong",
+            insecureAllowed = false,
+        )
+        assertNull(version)
+    }
+
+    @Test
+    fun `getServerVersion returns null when build version is absent`() = runTest {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"git":{"branch":"main"}}""")
+                .addHeader("Content-Type", "application/json"),
+        )
+        val version = client.getServerVersion(
+            baseUrl = server.url("/").toString().trimEnd('/'),
+            username = "u",
+            password = "p",
+            insecureAllowed = false,
+        )
+        assertNull(version)
+    }
+
+    @Test
+    fun `parseActuatorVersion extracts version string`() {
+        val body = """{"build":{"version":"1.12.3","artifact":"komga"}}"""
+        assertEquals("1.12.3", KomgaServerInfoApiClient.parseActuatorVersion(body))
+    }
+
+    @Test
+    fun `parseActuatorVersion returns null for missing build object`() {
+        assertNull(KomgaServerInfoApiClient.parseActuatorVersion("""{}"""))
+    }
+
+    @Test
+    fun `parseActuatorVersion returns null for non-JSON`() {
+        assertNull(KomgaServerInfoApiClient.parseActuatorVersion("not-json"))
+    }
+}


### PR DESCRIPTION
Komga sources now populate the `serverVersions` map used by the navigation drawer source switcher and the Settings Sources screen, matching what Audiobookshelf already shows.

## What changed

- **`KomgaServerInfoApi`** — new interface in `core:net` (`getServerVersion(baseUrl, username, password, insecureAllowed): String?`), following the same shape as `AbsServerInfoApi`.
- **`KomgaServerInfoApiClient`** — implementation: GETs `actuator/info` with a Basic auth header, parses `build.version` from the JSON response. Gracefully returns `null` on 403 (non-admin user, which is Komga's default actuator gate) and when the endpoint is disabled.
- **`SourceRepositoryImpl.getSourceVersion`** — adds a `SourceType.KOMGA` branch that fetches the stored password and delegates to `KomgaServerInfoApiClient`. ABS path unchanged.
- **`NetworkModule`** — binds `KomgaServerInfoApiClient` as a `@Singleton`.

## Notes

- Version display for non-admin Komga users degrades gracefully to no version string (same behaviour as the existing `connectivityCheck` fallback).
- `actuator/info` is the only endpoint Komga exposes for server version; there is no unauthenticated `/status` equivalent.
- `parseActuatorVersion` is intentionally duplicated from `KomgaCatalog` — the two live in separate modules with no shared dep, and the snippet is small.