### PR TITLE
feat(library): add Not Started filter to unbounded catalog sources

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
@@ -8,12 +8,14 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Home
@@ -23,6 +25,7 @@ import com.riffle.app.ui.theme.RiffleIcons
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -222,7 +225,8 @@ private fun LibraryTabContent(
     searchOpen: Boolean,
     onCoverScaleChange: (Float) -> Unit,
 ) {
-    val items by viewModel.items.collectAsState()
+    val items by viewModel.filteredItems.collectAsState()
+    val notStartedFilterActive by viewModel.notStartedFilterActive.collectAsState()
     val facets by viewModel.facets.collectAsState()
     val selectedFacet by viewModel.selectedFacet.collectAsState()
     val query by viewModel.query.collectAsState()
@@ -244,11 +248,27 @@ private fun LibraryTabContent(
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
             )
         }
-        if (facets.isNotEmpty()) {
-            LazyRow(
-                contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
+        LazyRow(
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            item {
+                FilterChip(
+                    selected = notStartedFilterActive,
+                    onClick = { viewModel.toggleNotStartedFilter() },
+                    label = { Text("Not Started") },
+                    leadingIcon = if (notStartedFilterActive) {
+                        {
+                            Icon(
+                                Icons.Filled.Check,
+                                contentDescription = null,
+                                modifier = Modifier.size(FilterChipDefaults.IconSize),
+                            )
+                        }
+                    } else null,
+                )
+            }
+            if (facets.isNotEmpty()) {
                 item {
                     FilterChip(
                         selected = selectedFacet == null,

--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModel.kt
@@ -7,6 +7,7 @@ import com.riffle.core.catalog.chitanka.ChitankaCatalog
 import com.riffle.core.data.websource.WebSourceItemGate
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
 import com.riffle.core.domain.CoverGridDensityStore
+import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -28,6 +29,7 @@ class ChitankaBrowseViewModel @Inject constructor(
     libraryItemUpserter: WebSourceLibraryItemUpserter,
     webSourceItemGate: WebSourceItemGate,
     coverGridDensityStore: CoverGridDensityStore,
+    libraryObserver: LibraryObserver,
 ) : UnboundedBrowseViewModel(
     savedStateHandle = savedStateHandle,
     sourceRepository = sourceRepository,
@@ -35,6 +37,7 @@ class ChitankaBrowseViewModel @Inject constructor(
     libraryItemUpserter = libraryItemUpserter,
     webSourceItemGate = webSourceItemGate,
     coverGridDensityStore = coverGridDensityStore,
+    libraryObserver = libraryObserver,
     sourceType = SourceType.CHITANKA,
     defaultRootId = ChitankaCatalog.ROOT_BOOKS,
     // Chitanka lists ~30 items per page in most views; 50 gives us a small safety margin so the

--- a/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
@@ -8,12 +8,14 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Home
@@ -23,6 +25,7 @@ import com.riffle.app.ui.theme.RiffleIcons
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -195,7 +198,8 @@ private fun LibraryTabContent(
     searchOpen: Boolean,
     onCoverScaleChange: (Float) -> Unit,
 ) {
-    val items by viewModel.items.collectAsState()
+    val items by viewModel.filteredItems.collectAsState()
+    val notStartedFilterActive by viewModel.notStartedFilterActive.collectAsState()
     val facets by viewModel.facets.collectAsState()
     val selectedFacet by viewModel.selectedFacet.collectAsState()
     val query by viewModel.query.collectAsState()
@@ -217,11 +221,27 @@ private fun LibraryTabContent(
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
             )
         }
-        if (facets.isNotEmpty()) {
-            LazyRow(
-                contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
+        LazyRow(
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            item {
+                FilterChip(
+                    selected = notStartedFilterActive,
+                    onClick = { viewModel.toggleNotStartedFilter() },
+                    label = { Text("Not Started") },
+                    leadingIcon = if (notStartedFilterActive) {
+                        {
+                            Icon(
+                                Icons.Filled.Check,
+                                contentDescription = null,
+                                modifier = Modifier.size(FilterChipDefaults.IconSize),
+                            )
+                        }
+                    } else null,
+                )
+            }
+            if (facets.isNotEmpty()) {
                 item {
                     FilterChip(
                         selected = selectedFacet == null,

--- a/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModel.kt
@@ -7,6 +7,7 @@ import com.riffle.core.catalog.gutenberg.GutenbergCatalog
 import com.riffle.core.data.websource.WebSourceItemGate
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
 import com.riffle.core.domain.CoverGridDensityStore
+import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -28,6 +29,7 @@ class GutenbergBrowseViewModel @Inject constructor(
     libraryItemUpserter: WebSourceLibraryItemUpserter,
     webSourceItemGate: WebSourceItemGate,
     coverGridDensityStore: CoverGridDensityStore,
+    libraryObserver: LibraryObserver,
 ) : UnboundedBrowseViewModel(
     savedStateHandle = savedStateHandle,
     sourceRepository = sourceRepository,
@@ -35,6 +37,7 @@ class GutenbergBrowseViewModel @Inject constructor(
     libraryItemUpserter = libraryItemUpserter,
     webSourceItemGate = webSourceItemGate,
     coverGridDensityStore = coverGridDensityStore,
+    libraryObserver = libraryObserver,
     sourceType = SourceType.GUTENBERG,
     defaultRootId = GutenbergCatalog.ROOT_BOOKS,
     // Gutendex ships 32 items per page — matching the server-side size keeps our request-page

--- a/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
@@ -10,6 +10,7 @@ import com.riffle.core.catalog.FacetSelection
 import com.riffle.core.data.websource.WebSourceItemGate
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
 import com.riffle.core.domain.CoverGridDensityStore
+import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
 import kotlinx.coroutines.CancellationException
@@ -23,6 +24,8 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -64,6 +67,7 @@ abstract class UnboundedBrowseViewModel(
     private val libraryItemUpserter: WebSourceLibraryItemUpserter,
     private val webSourceItemGate: WebSourceItemGate,
     private val coverGridDensityStore: CoverGridDensityStore,
+    private val libraryObserver: LibraryObserver,
     private val sourceType: SourceType,
     defaultRootId: String,
     private val pageSize: Int,
@@ -119,6 +123,24 @@ abstract class UnboundedBrowseViewModel(
 
     private val _items = MutableStateFlow<List<CatalogItem>>(emptyList())
     val items: StateFlow<List<CatalogItem>> = _items.asStateFlow()
+
+    private val _notStartedFilterActive = MutableStateFlow(false)
+    val notStartedFilterActive: StateFlow<Boolean> = _notStartedFilterActive.asStateFlow()
+
+    fun toggleNotStartedFilter() {
+        _notStartedFilterActive.value = !_notStartedFilterActive.value
+    }
+
+    // IDs of Room-backed items that have been started (readingProgress > 0). Items absent from
+    // Room have no progress and are treated as not-started by the filter.
+    private val startedItemIds: StateFlow<Set<String>> = libraryObserver.observeAllBooks(rootId)
+        .map { books -> books.filter { it.readingProgress > 0f }.mapTo(HashSet()) { it.id } }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, emptySet())
+
+    val filteredItems: StateFlow<List<CatalogItem>> =
+        combine(_items, startedItemIds, _notStartedFilterActive) { catalog, started, active ->
+            if (active) catalog.filter { it.id !in started } else catalog
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()

--- a/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
@@ -8,6 +8,8 @@ import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.catalog.chitanka.ChitankaCatalog
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
 import com.riffle.core.domain.CoverGridDensityStore
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.models.LibraryItem
 import com.riffle.core.models.Source
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
@@ -18,6 +20,8 @@ import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -27,6 +31,8 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -61,6 +67,7 @@ class ChitankaBrowseViewModelTest {
         upserter: WebSourceLibraryItemUpserter = mockk(relaxed = true),
         sourceRepo: SourceRepository = fakeSourceRepo(chitankaSource),
         coverGridDensityStore: CoverGridDensityStore = fakeCoverGridDensityStore(),
+        libraryObserver: LibraryObserver = emptyLibraryObserver(),
         catalog: Catalog = mockk<Catalog>(relaxed = true).also {
             // Relaxed mocks return a stub CatalogItem instead of null for `getItem`, which breaks
             // the openDetail enrichment fallback in tests that don't explicitly stub it. Pin to
@@ -87,6 +94,7 @@ class ChitankaBrowseViewModelTest {
             upserter,
             gate,
             coverGridDensityStore,
+            libraryObserver,
         )
     }
 
@@ -150,6 +158,7 @@ class ChitankaBrowseViewModelTest {
             mockk<WebSourceLibraryItemUpserter>(relaxed = true),
             gate,
             fakeCoverGridDensityStore(),
+            emptyLibraryObserver(),
         )
         advanceUntilIdle()
 
@@ -181,6 +190,7 @@ class ChitankaBrowseViewModelTest {
             mockk<WebSourceLibraryItemUpserter>(relaxed = true),
             gate,
             fakeCoverGridDensityStore(),
+            emptyLibraryObserver(),
         )
         advanceUntilIdle()
 
@@ -212,6 +222,7 @@ class ChitankaBrowseViewModelTest {
             upserter,
             gate,
             fakeCoverGridDensityStore(),
+            emptyLibraryObserver(),
         )
         advanceUntilIdle()
 
@@ -395,4 +406,101 @@ class ChitankaBrowseViewModelTest {
             persistedScale = value
         }
     }
+
+    // ─── Not-Started filter ───────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `toggleNotStartedFilter hides catalog items that have been started in Room`() =
+        runTest(dispatcher) {
+            val startedId = "text/111"
+            val notStartedId = "text/222"
+            val neverSeenId = "text/333"
+
+            val startedItem = libraryItem(startedId, progress = 0.5f)
+            val notStartedItem = libraryItem(notStartedId, progress = 0f)
+            val roomItems = MutableStateFlow(listOf(startedItem, notStartedItem))
+
+            val catalog = mockk<Catalog>(relaxed = true)
+            coEvery { catalog.browse(rootId = any(), page = 0, pageSize = any(), facet = any()) } returns
+                listOf(item(startedId), item(notStartedId), item(neverSeenId))
+
+            val vm = makeVm(
+                catalog = catalog,
+                libraryObserver = libraryObserverWithAllBooks(roomItems),
+            )
+            advanceUntilIdle()
+
+            // Before filter: all three items visible
+            assertEquals(3, vm.filteredItems.value.size)
+            assertFalse(vm.notStartedFilterActive.value)
+
+            vm.toggleNotStartedFilter()
+            advanceUntilIdle()
+
+            // After filter: started item hidden; not-started (progress=0) and never-seen pass through
+            assertTrue(vm.notStartedFilterActive.value)
+            val ids = vm.filteredItems.value.map { it.id }
+            assertEquals(listOf(notStartedId, neverSeenId), ids)
+        }
+
+    @Test
+    fun `toggleNotStartedFilter off restores all catalog items`() = runTest(dispatcher) {
+        val startedId = "text/444"
+        val roomItems = MutableStateFlow(listOf(libraryItem(startedId, progress = 0.8f)))
+
+        val catalog = mockk<Catalog>(relaxed = true)
+        coEvery { catalog.browse(rootId = any(), page = 0, pageSize = any(), facet = any()) } returns
+            listOf(item(startedId), item("text/555"))
+
+        val vm = makeVm(catalog = catalog, libraryObserver = libraryObserverWithAllBooks(roomItems))
+        advanceUntilIdle()
+
+        vm.toggleNotStartedFilter()
+        advanceUntilIdle()
+        assertEquals(1, vm.filteredItems.value.size)
+
+        vm.toggleNotStartedFilter()
+        advanceUntilIdle()
+
+        assertFalse(vm.notStartedFilterActive.value)
+        assertEquals(2, vm.filteredItems.value.size)
+    }
+
+    // ---- filter helpers ----------------------------------------------------------
+
+    private fun libraryItem(id: String, progress: Float) = LibraryItem(
+        id = id,
+        libraryId = ChitankaCatalog.ROOT_BOOKS,
+        title = id,
+        author = "A",
+        coverUrl = null,
+        readingProgress = progress,
+        isCached = false,
+        isDownloaded = false,
+        ebookFormat = com.riffle.core.models.EbookFormat.Epub,
+    )
+
+    private fun emptyLibraryObserver(): LibraryObserver = libraryObserverWithAllBooks(flowOf(emptyList()))
+
+    private fun libraryObserverWithAllBooks(allBooks: Flow<List<LibraryItem>>): LibraryObserver =
+        object : LibraryObserver {
+            override fun observeAllBooks(libraryId: String) = allBooks
+            override fun observeLibraries() = flowOf(emptyList<com.riffle.core.models.Library>())
+            override fun observeLibraries(sourceId: String) = flowOf(emptyList<com.riffle.core.models.Library>())
+            override fun observeLibraryItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+            override fun observeUngroupedLibraryItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+            override fun observeInProgressItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+            override fun observeFinishedItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+            override fun observeRecentlyAddedItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+            override fun observeSeries(libraryId: String) = flowOf(emptyList<com.riffle.core.models.Series>())
+            override fun observeCollections(libraryId: String) = flowOf(emptyList<com.riffle.core.models.Collection>())
+            override fun observeSeriesItems(seriesId: String) = flowOf(emptyList<LibraryItem>())
+            override fun observeContinueSeriesItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+            override fun observeCollectionItems(collectionId: String) = flowOf(emptyList<LibraryItem>())
+            override suspend fun getItem(itemId: String): LibraryItem? = null
+            override fun observeItem(itemId: String) = flowOf<LibraryItem?>(null)
+            override suspend fun getItem(sourceId: String, itemId: String): LibraryItem? = null
+            override suspend fun getLibrary(libraryId: String): com.riffle.core.models.Library? = null
+            override suspend fun getSeriesIdForItem(sourceId: String, itemId: String): String? = null
+        }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
@@ -8,6 +8,7 @@ import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.core.catalog.chitanka.ChitankaCatalog
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
 import com.riffle.core.domain.CoverGridDensityStore
+import com.riffle.app.testing.FakeLibraryObserver
 import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.models.LibraryItem
 import com.riffle.core.models.Source
@@ -480,27 +481,8 @@ class ChitankaBrowseViewModelTest {
         ebookFormat = com.riffle.core.models.EbookFormat.Epub,
     )
 
-    private fun emptyLibraryObserver(): LibraryObserver = libraryObserverWithAllBooks(flowOf(emptyList()))
+    private fun emptyLibraryObserver(): LibraryObserver = FakeLibraryObserver()
 
     private fun libraryObserverWithAllBooks(allBooks: Flow<List<LibraryItem>>): LibraryObserver =
-        object : LibraryObserver {
-            override fun observeAllBooks(libraryId: String) = allBooks
-            override fun observeLibraries() = flowOf(emptyList<com.riffle.core.models.Library>())
-            override fun observeLibraries(sourceId: String) = flowOf(emptyList<com.riffle.core.models.Library>())
-            override fun observeLibraryItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
-            override fun observeUngroupedLibraryItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
-            override fun observeInProgressItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
-            override fun observeFinishedItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
-            override fun observeRecentlyAddedItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
-            override fun observeSeries(libraryId: String) = flowOf(emptyList<com.riffle.core.models.Series>())
-            override fun observeCollections(libraryId: String) = flowOf(emptyList<com.riffle.core.models.Collection>())
-            override fun observeSeriesItems(seriesId: String) = flowOf(emptyList<LibraryItem>())
-            override fun observeContinueSeriesItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
-            override fun observeCollectionItems(collectionId: String) = flowOf(emptyList<LibraryItem>())
-            override suspend fun getItem(itemId: String): LibraryItem? = null
-            override fun observeItem(itemId: String) = flowOf<LibraryItem?>(null)
-            override suspend fun getItem(sourceId: String, itemId: String): LibraryItem? = null
-            override suspend fun getLibrary(libraryId: String): com.riffle.core.models.Library? = null
-            override suspend fun getSeriesIdForItem(sourceId: String, itemId: String): String? = null
-        }
+        FakeLibraryObserver(allBooksFlow = allBooks)
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModelTest.kt
@@ -9,8 +9,7 @@ import com.riffle.core.catalog.gutenberg.GutenbergCatalog
 import com.riffle.core.data.websource.WebSourceItemGate
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
 import com.riffle.core.domain.CoverGridDensityStore
-import com.riffle.core.domain.LibraryObserver
-import com.riffle.core.models.LibraryItem
+import com.riffle.app.testing.FakeLibraryObserver
 import com.riffle.core.models.Source
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
@@ -21,7 +20,6 @@ import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -138,24 +136,5 @@ class GutenbergBrowseViewModelTest {
             override suspend fun setScale(value: Float) = Unit
         }
 
-    private fun emptyLibraryObserver(): LibraryObserver = object : LibraryObserver {
-        override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
-        override fun observeLibraries() = flowOf(emptyList<com.riffle.core.models.Library>())
-        override fun observeLibraries(sourceId: String) = flowOf(emptyList<com.riffle.core.models.Library>())
-        override fun observeLibraryItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
-        override fun observeUngroupedLibraryItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
-        override fun observeInProgressItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
-        override fun observeFinishedItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
-        override fun observeRecentlyAddedItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
-        override fun observeSeries(libraryId: String) = flowOf(emptyList<com.riffle.core.models.Series>())
-        override fun observeCollections(libraryId: String) = flowOf(emptyList<com.riffle.core.models.Collection>())
-        override fun observeSeriesItems(seriesId: String) = flowOf(emptyList<LibraryItem>())
-        override fun observeContinueSeriesItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
-        override fun observeCollectionItems(collectionId: String) = flowOf(emptyList<LibraryItem>())
-        override suspend fun getItem(itemId: String): LibraryItem? = null
-        override fun observeItem(itemId: String) = flowOf<LibraryItem?>(null)
-        override suspend fun getItem(sourceId: String, itemId: String): LibraryItem? = null
-        override suspend fun getLibrary(libraryId: String): com.riffle.core.models.Library? = null
-        override suspend fun getSeriesIdForItem(sourceId: String, itemId: String): String? = null
-    }
+    private fun emptyLibraryObserver() = FakeLibraryObserver()
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModelTest.kt
@@ -9,6 +9,8 @@ import com.riffle.core.catalog.gutenberg.GutenbergCatalog
 import com.riffle.core.data.websource.WebSourceItemGate
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
 import com.riffle.core.domain.CoverGridDensityStore
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.models.LibraryItem
 import com.riffle.core.models.Source
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
@@ -19,6 +21,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -84,6 +87,7 @@ class GutenbergBrowseViewModelTest {
             upserter,
             gate,
             fakeCoverGridDensityStore(),
+            emptyLibraryObserver(),
         )
         return vm to gate
     }
@@ -133,4 +137,25 @@ class GutenbergBrowseViewModelTest {
             override val scale = flowOf(1f)
             override suspend fun setScale(value: Float) = Unit
         }
+
+    private fun emptyLibraryObserver(): LibraryObserver = object : LibraryObserver {
+        override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override fun observeLibraries() = flowOf(emptyList<com.riffle.core.models.Library>())
+        override fun observeLibraries(sourceId: String) = flowOf(emptyList<com.riffle.core.models.Library>())
+        override fun observeLibraryItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+        override fun observeUngroupedLibraryItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+        override fun observeInProgressItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+        override fun observeFinishedItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+        override fun observeRecentlyAddedItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+        override fun observeSeries(libraryId: String) = flowOf(emptyList<com.riffle.core.models.Series>())
+        override fun observeCollections(libraryId: String) = flowOf(emptyList<com.riffle.core.models.Collection>())
+        override fun observeSeriesItems(seriesId: String) = flowOf(emptyList<LibraryItem>())
+        override fun observeContinueSeriesItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+        override fun observeCollectionItems(collectionId: String) = flowOf(emptyList<LibraryItem>())
+        override suspend fun getItem(itemId: String): LibraryItem? = null
+        override fun observeItem(itemId: String) = flowOf<LibraryItem?>(null)
+        override suspend fun getItem(sourceId: String, itemId: String): LibraryItem? = null
+        override suspend fun getLibrary(libraryId: String): com.riffle.core.models.Library? = null
+        override suspend fun getSeriesIdForItem(sourceId: String, itemId: String): String? = null
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/testing/LibraryObserverFakes.kt
+++ b/app/src/test/kotlin/com/riffle/app/testing/LibraryObserverFakes.kt
@@ -1,0 +1,37 @@
+package com.riffle.app.testing
+
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.models.Collection
+import com.riffle.core.models.Library
+import com.riffle.core.models.LibraryItem
+import com.riffle.core.models.Series
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+/**
+ * Minimal [LibraryObserver] stub for tests that need to control the [observeAllBooks] stream.
+ * All other methods return empty flows so callers that don't care about them compile without
+ * additional setup.
+ */
+class FakeLibraryObserver(
+    private val allBooksFlow: Flow<List<LibraryItem>> = flowOf(emptyList()),
+) : LibraryObserver {
+    override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> = allBooksFlow
+    override fun observeLibraries(): Flow<List<Library>> = flowOf(emptyList())
+    override fun observeLibraries(sourceId: String): Flow<List<Library>> = flowOf(emptyList())
+    override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+    override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+    override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+    override fun observeFinishedItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+    override fun observeRecentlyAddedItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+    override fun observeSeries(libraryId: String): Flow<List<Series>> = flowOf(emptyList())
+    override fun observeCollections(libraryId: String): Flow<List<Collection>> = flowOf(emptyList())
+    override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+    override fun observeContinueSeriesItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+    override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+    override suspend fun getItem(itemId: String): LibraryItem? = null
+    override fun observeItem(itemId: String): Flow<LibraryItem?> = flowOf(null)
+    override suspend fun getItem(sourceId: String, itemId: String): LibraryItem? = null
+    override suspend fun getLibrary(libraryId: String): Library? = null
+    override suspend fun getSeriesIdForItem(sourceId: String, itemId: String): String? = null
+}


### PR DESCRIPTION
Adds the "Not Started" filter chip to the Library tab of every unbounded catalog source — Chitanka, Gramofonche (Chitanka audiobook root), Gutenberg, and any future source that subclasses `UnboundedBrowseViewModel`.

## What changed

**`UnboundedBrowseViewModel`** — injected `LibraryObserver`, added:
- `notStartedFilterActive: StateFlow<Boolean>`
- `toggleNotStartedFilter()`
- `filteredItems: StateFlow<List<CatalogItem>>` — combines the server-fetched catalog with Room's started-ID set; when active, hides items whose ID maps to a Room row with `readingProgress > 0`

Items not in Room have no progress and pass through as unstarted — equivalent to how the ABS All Books filter works (ABS syncs all items to Room, so "not started" = `readingProgress == 0`; for unbounded sources the same semantics fall out naturally).

**`ChitankaBrowseViewModel` / `GutenbergBrowseViewModel`** — inject and forward `LibraryObserver` to the base class.

**`ChitankaBrowseScreen` / `GutenbergBrowseScreen`** — Library tab now reads `filteredItems` and shows a "Not Started" chip (with checkmark when active) before the existing facet chips. The chip row is now always shown (previously conditional on facets being non-empty).

**Tests** — `FakeLibraryObserver` added to `app/src/test/.../testing/` (shared). Both browse VM test files use it. Two new filter tests in `ChitankaBrowseViewModelTest` pin the toggle-on / toggle-off behaviour and the three item classes (started, zero-progress, never-seen).

## Review notes

- `items` (raw, unfiltered) remains public on the base VM for backward compat with existing pagination tests; screens read `filteredItems`.
- `SharingStarted.Eagerly` used for `startedItemIds` and `filteredItems` — consistent with how other StateFlows in the ViewModel layer work, and avoids subscriber-count issues in unit tests.