### PR TITLE
fix(reader): preserve bold and paragraph breaks in elided-view excerpts

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderWebViewScripts.kt
@@ -549,6 +549,7 @@ internal val SELECTION_SPAN_TRACKER_JS = """
             var snippetHtml = '';
             try {
               var INLINE_ALLOW = { em: 1, i: 1, strong: 1, b: 1, sup: 1, sub: 1, u: 1, s: 1 };
+              var BLOCK_TAGS = { p: 1, div: 1, li: 1, ul: 1, ol: 1, h1: 1, h2: 1, h3: 1, h4: 1, h5: 1, h6: 1, blockquote: 1, dt: 1, dd: 1 };
               var frag = rng.cloneContents();
               var escInline = function (t) {
                 return String(t)
@@ -565,10 +566,18 @@ internal val SELECTION_SPAN_TRACKER_JS = """
                   return out;
                 }
                 var tag = String(node.tagName || '').toLowerCase();
+                if (tag === 'br') return '<br>';
                 var inner = '';
                 var k2 = node.childNodes;
                 for (var wj = 0; wj < k2.length; wj++) inner += walkInline(k2[wj]);
                 if (INLINE_ALLOW[tag]) return '<' + tag + '>' + inner + '</' + tag + '>';
+                if (BLOCK_TAGS[tag]) return inner ? inner + '<br>' : '';
+                if (tag === 'span') {
+                  var st = '';
+                  try { st = (node.getAttribute('style') || '').toLowerCase(); } catch (e) {}
+                  if (/font-weight\s*:\s*(bold\b|bolder\b|[6-9]\d{2})/.test(st)) inner = '<b>' + inner + '</b>';
+                  if (/font-style\s*:\s*italic/.test(st)) inner = '<em>' + inner + '</em>';
+                }
                 return inner;
               };
               snippetHtml = walkInline(frag);

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactory.kt
@@ -984,7 +984,7 @@ private const val PARAGRAPH_GAP_STYLE = "margin: 1em 0;"
  *  below re-enforces the allowlist as defence-in-depth (the DB is not a trust boundary and a
  *  legacy row / future extractor could put anything in the column). Text nodes are expected
  *  pre-XML-escaped by the extractor — we don't touch them here.  */
-private val ALLOWED_INLINE_SNIPPET_TAGS = setOf("em", "i", "strong", "b", "sup", "sub", "u", "s")
+private val ALLOWED_INLINE_SNIPPET_TAGS = setOf("em", "i", "strong", "b", "sup", "sub", "u", "s", "br")
 
 /**
  * Reduce [html] to a safe subset for the excerpt render path:
@@ -1016,7 +1016,9 @@ internal fun sanitizeInlineSnippetHtml(html: String): String {
             .lowercase()
             .trim()
         if (name in ALLOWED_INLINE_SNIPPET_TAGS) {
-            sb.append(if (isClose) "</" else "<").append(name).append('>')
+            // <br> is a void element — XHTML requires the self-closing form <br/>.
+            if (name == "br") sb.append("<br/>")
+            else sb.append(if (isClose) "</" else "<").append(name).append('>')
         }
         i = end + 1
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderWebViewScriptsTest.kt
@@ -804,4 +804,58 @@ class ReaderWebViewScriptsTest {
             js.substring(maxOf(0, bridgeIdx - 200), bridgeIdx).contains("RiffleSelBridge.onSnippetHtml"),
         )
     }
+
+    // Regression for line-break loss in elided view: block elements (<p>, <li>, etc.) were
+    // silently dropped by walkInline, merging paragraphs and list items into one run of text.
+    // walkInline now emits <br> after each block element's content, and <br> elements directly.
+    @Test
+    fun `SELECTION_SPAN_TRACKER_JS walkInline emits br for block element boundaries`() {
+        val js = SELECTION_SPAN_TRACKER_JS
+        // BLOCK_TAGS must be defined alongside INLINE_ALLOW so walkInline can test against it.
+        assertTrue(
+            "BLOCK_TAGS map is defined before walkInline",
+            js.contains("var BLOCK_TAGS = {"),
+        )
+        // Block elements must include the common structural tags a highlight might span.
+        assertTrue("BLOCK_TAGS includes p", js.contains("p: 1"))
+        assertTrue("BLOCK_TAGS includes li", js.contains("li: 1"))
+        assertTrue("BLOCK_TAGS includes blockquote", js.contains("blockquote: 1"))
+        // The br-emission path for block elements must be present in walkInline.
+        assertTrue(
+            "walkInline emits <br> after block element inner content",
+            js.contains("if (BLOCK_TAGS[tag]) return inner ? inner + '<br>' : '';"),
+        )
+        // <br> must return '<br>' directly (not empty string as before).
+        assertTrue(
+            "walkInline returns '<br>' for <br> element",
+            js.contains("if (tag === 'br') return '<br>';"),
+        )
+    }
+
+    // Regression for publisher bold not showing in elided view when publisher uses inline
+    // style (font-weight: bold) rather than semantic <b>/<strong>.
+    @Test
+    fun `SELECTION_SPAN_TRACKER_JS walkInline promotes span with inline font-weight bold to b`() {
+        val js = SELECTION_SPAN_TRACKER_JS
+        // The span branch must check the style attribute for font-weight.
+        assertTrue(
+            "walkInline inspects span style attribute",
+            js.contains("node.getAttribute('style')"),
+        )
+        // Must cover 'bold', 'bolder', and numeric weights 600–900.
+        assertTrue(
+            "walkInline regex covers bold keyword and weights >= 600",
+            js.contains("/font-weight\\s*:\\s*(bold\\b|bolder\\b|[6-9]\\d{2})/.test(st)"),
+        )
+        // Bold spans must be wrapped in <b>.
+        assertTrue(
+            "bold span is wrapped in <b>",
+            js.contains("inner = '<b>' + inner + '</b>'"),
+        )
+        // Italic spans must be wrapped in <em>.
+        assertTrue(
+            "italic span is wrapped in <em>",
+            js.contains("inner = '<em>' + inner + '</em>'"),
+        )
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/highlights/HighlightsPublicationFactoryTest.kt
@@ -778,6 +778,81 @@ class HighlightsPublicationFactoryTest {
         assertTrue("text of stripped <a> preserved", html.contains("hi"))
     }
 
+    @Test
+    fun brTagInSnippetHtmlPassesThroughSanitizerAndRendersInExcerpt() {
+        // Regression: block-element boundaries (e.g. <p>/<li> from a publisher's multi-paragraph
+        // selection) are emitted as <br> by walkInline(). The sanitizer must pass <br> through
+        // so line breaks are visible in the elided view instead of all text running together.
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "Chapter One",
+                    listOf(
+                        hl(
+                            id = "h1",
+                            snippet = "first line second line",
+                            textSnippetHtml = "first line<br>second line",
+                        ),
+                    ),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val html = readChapterHtml(pub, 0)
+        assertTrue("<br/> (XHTML self-closing) passes through sanitizer and is present in rendered HTML", html.contains("first line<br/>second line"))
+    }
+
+    @Test
+    fun boldTagInSnippetHtmlRendersInExcerpt() {
+        // Regression: publisher bold via <b> (or walkInline-promoted <span style="font-weight:bold">)
+        // must render in the elided view excerpt.
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "Chapter One",
+                    listOf(
+                        hl(
+                            id = "h1",
+                            snippet = "Thumbs up. Give thumbs up.",
+                            textSnippetHtml = "<b>Thumbs up.</b> Give thumbs up.",
+                        ),
+                    ),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val html = readChapterHtml(pub, 0)
+        assertTrue("<b> tag preserved in rendered excerpt", html.contains("<b>Thumbs up.</b>"))
+    }
+
+    @Test
+    fun brAndBoldCombinedInSnippetHtmlRendersCorrectly() {
+        // Multi-item list with bold leads — the common shape of a publisher's "tips" or
+        // "nonverbal signs" section. Each list item emits "bold lead<br>" from walkInline.
+        val pub = factory.build(
+            sourceId = "S1", itemId = "B1", bookTitle = null,
+            chapters = listOf(
+                ChapterElision(
+                    "ch0.xhtml", "Chapter One",
+                    listOf(
+                        hl(
+                            id = "h1",
+                            snippet = "Thumbs up. Give thumbs up. Eye contact. Make eye contact.",
+                            textSnippetHtml = "<b>Thumbs up.</b> Give thumbs up.<br><b>Eye contact.</b> Make eye contact.<br>",
+                        ),
+                    ),
+                ),
+            ),
+            urlFactory = ::testUrlFactory,
+        )
+        val html = readChapterHtml(pub, 0)
+        assertTrue("<b> preserved for first item", html.contains("<b>Thumbs up.</b>"))
+        assertTrue("<br/> separator between items", html.contains("Give thumbs up.<br/>"))
+        assertTrue("<b> preserved for second item", html.contains("<b>Eye contact.</b>"))
+    }
+
     // ===== emphasis styles (Case 2 — user-applied B/I/U/S) =====
 
     @Test


### PR DESCRIPTION
## What

Two formatting bugs in the elided (Highlights-mode) reader view:

1. **Publisher bold not rendered** — `<span style="font-weight:bold">` from publisher EPUB was not captured in the inline-HTML snapshot.
2. **Paragraph breaks lost** — multi-paragraph selections ran together with no line breaks between them.
3. **XHTML parse error (new fix)** — `sanitizeInlineSnippetHtml` was emitting `<br>` (HTML-style) into the synthesised XHTML document, which is invalid XML and caused a WebView parse error banner.

## How

**`SELECTION_SPAN_TRACKER_JS` (`walkInline`):**
- Block elements (`<p>`, `<div>`, `<li>`, `<ul>`, `<ol>`, `<h1>`–`<h6>`, `<blockquote>`, `<dt>`, `<dd>`) now emit `<br>` as a paragraph-boundary separator when they contain inner text.
- `<br>` elements return `'<br>'` directly.
- `<span>` elements with `font-weight: bold/bolder/600+` inline style are promoted to `<b>`.
- `<span>` elements with `font-style: italic` inline style are promoted to `<em>`.

**`sanitizeInlineSnippetHtml` (`HighlightsPublicationFactory`):**
- Added `"br"` to `ALLOWED_INLINE_SNIPPET_TAGS`.
- Void element `br` is emitted as `<br/>` (XHTML self-closing) to keep the synthesised document well-formed.

## Verification

Verified end-to-end on emulator (API 25):
- Elided view with a `<br/>`-annotated excerpt renders the line break visually (two lines instead of one run-on).
- Elided view with a `<b>`-annotated excerpt renders "disorder" in bold weight.
- No XHTML parse error banner.

JVM regression tests added for all fix paths:
- `walkInline emits br for block element boundaries`
- `walkInline promotes span with inline font-weight bold to b`
- `brTagInSnippetHtmlPassesThroughSanitizerAndRendersInExcerpt`
- `boldTagInSnippetHtmlRendersInExcerpt`
- `brAndBoldCombinedInSnippetHtmlRendersCorrectly`

## Notes

The fix is **prospective** — existing annotations stored before this change have `textSnippetHtml = null` and fall back to the plain `textSnippet`. Only annotations created after installing this build will capture the HTML.