### PR TITLE
fix(panel-detection): fix first-row panel detection and false splits

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/comic/panel/JsonPanelStore.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/comic/panel/JsonPanelStore.kt
@@ -83,8 +83,7 @@ class JsonPanelStore @Inject constructor(
     @Serializable
     private data class BookFile(
         // Missing on files written before the field was added (v1) — Serializable defaults it to
-        // 1, so those pre-versioning caches read back as v1 and mismatch the current version
-        // (currently 2, bumped when the detector algorithm changes materially).
+        // 1, so those pre-versioning caches read back as v1 and mismatch CURRENT_SCHEMA_VERSION.
         val schemaVersion: Int = 1,
         val bookId: String,
         val pages: List<PagePanels>,

--- a/core/data/src/main/kotlin/com/riffle/core/data/comic/panel/JsonPanelStore.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/comic/panel/JsonPanelStore.kt
@@ -116,8 +116,13 @@ class JsonPanelStore @Inject constructor(
          *  7 — PanelSource enum shrunk to Auto/Fallback (Acbf/ComicInfo removed since the
          *      ACBF sidecar path was never actually reachable in production). v6 caches would
          *      fail to deserialize the removed enum values.
+         *  8 — internal-gutter split criterion switched from content-count (5%) to flood-fill
+         *      fraction (30%) so hollow panel interiors (speech balloons, white fills) no longer
+         *      trigger false splits. projection path loses splitAtInternalGutters; instead a
+         *      suspiciousWideRow check detects under-split projection rows and hands them to CC.
+         *      v7 caches held either wrong splits or wrong merges from the old heuristic.
          */
-        internal const val CURRENT_SCHEMA_VERSION: Int = 7
+        internal const val CURRENT_SCHEMA_VERSION: Int = 8
 
         private val UNSAFE = Regex("[^A-Za-z0-9._-]")
     }

--- a/core/data/src/test/kotlin/com/riffle/core/data/comic/panel/JsonPanelStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/comic/panel/JsonPanelStoreTest.kt
@@ -151,6 +151,25 @@ class JsonPanelStoreTest {
     }
 
     @Test
+    fun `v7 cache file is rejected so stale pre-algorithm-fix detections are never served`() {
+        // Regression pin: three algorithm changes shipped in the panel-detection-first-row branch
+        // (flood-fill split criterion, suspiciousWideRow fallback, projection path no longer calls
+        // splitAtInternalGutters) but CURRENT_SCHEMA_VERSION was not bumped until after all three.
+        // During that window the store served old cached results on every page open, making the
+        // fixed detector code unreachable on device. Pinning v7 as "stale" ensures this class of
+        // mistake can't silently recur: if someone reverts the version bump to ≤7, this test fails.
+        val file = File(rootDir, "book-1.json")
+        file.writeText(
+            """{"schemaVersion":7,"bookId":"book-1","pages":[""" +
+                """{"pageIndex":0,"imageWidth":600,"imageHeight":840,""" +
+                """"panels":[{"x":0,"y":0,"width":600,"height":840}],"source":"Fallback"}""" +
+                "]}"
+        )
+        assertNull("v7 file must not be served — v7 caches hold stale detection results from before the algorithm fix", store.load("book-1", 0))
+        assertTrue(store.loadAll("book-1").isEmpty())
+    }
+
+    @Test
     fun `Fallback page round-trips`() {
         val fallback = PagePanels(
             pageIndex = 2,

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetector.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetector.kt
@@ -242,6 +242,13 @@ class PanelDetector(
         }
         if (suspiciousWideRow) return null
 
+        // Known limitation: a gutter narrower than projectionMinBandThickness (15px) but wider
+        // than internalGutterMinThickness (4px) will be missed by the column projection AND won't
+        // trigger suspiciousWideRow if the merged cell is < 90% of the cropped width. In that
+        // case the two panels appear merged here with no recovery. Accepted tradeoff: the
+        // alternative (calling splitAtInternalGutters on projection bboxes) risks false-splitting
+        // panels whose interiors are flood-fill-reachable through downscaling border gaps, causing
+        // panels to disappear entirely — a worse outcome than a merged zoom region.
         val bboxesInCropped = mutableListOf<Bbox>()
         for ((rowIndex, rowBand) in rowBands.withIndex()) {
             for (colBand in bandColBands[rowIndex]) {

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetector.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetector.kt
@@ -230,19 +230,24 @@ class PanelDetector(
         val totalCells = bandColBands.sumOf { it.size }
         if (totalCells < 2 && rowBands.size < 2) return null
 
-        // Build bboxes in cropped space from the projection-detected row/column bands. No
-        // internal-gutter split needed here: the projection already separated panels via gutter
-        // bands, so any bbox is already a single panel cell.
+        // Build bboxes in cropped space from the projection-detected row/column bands.
+        // The projection may miss thin gutters (< projectionMinBandThickness) between adjacent
+        // panels in the same row, leaving them as one merged cell. The flood-fill-based split
+        // corrects this: real between-panel gutters connect to the page border and score ~100%
+        // flood-fill gutter pixels; panel interiors are enclosed and score 0%, so they never
+        // trigger a false split.
         val bboxesInCropped = mutableListOf<Bbox>()
         for ((rowIndex, rowBand) in rowBands.withIndex()) {
             for (colBand in bandColBands[rowIndex]) {
                 bboxesInCropped.add(Bbox(colBand.start, rowBand.start, colBand.end, rowBand.end))
             }
         }
+        val projGutter = floodFillGutter(cropped)
+        val split = splitAtInternalGutters(bboxesInCropped, cropped, projGutter)
 
         val scaleX = originalWidth.toDouble() / downscaledWidth.toDouble()
         val scaleY = originalHeight.toDouble() / downscaledHeight.toDouble()
-        val regions = bboxesInCropped.map { bbox ->
+        val regions = split.map { bbox ->
             val minX = ((bbox.minX + cropped.offsetX) * scaleX).toInt().coerceIn(0, originalWidth - 1)
             val minY = ((bbox.minY + cropped.offsetY) * scaleY).toInt().coerceIn(0, originalHeight - 1)
             val maxX = ((bbox.maxX + 1 + cropped.offsetX) * scaleX).toInt().coerceIn(1, originalWidth)

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetector.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetector.kt
@@ -126,11 +126,14 @@ class PanelDetector(
         val maxInternalGutterSplitDepth: Int = 3,
 
         /**
-         * Fraction of the perpendicular dimension below which a row/column counts as "gutter"
-         * during internal-gutter detection. 0.05 = a row is a horizontal gutter if fewer than
-         * 5% of the panel's columns have content in that row.
+         * A row/column inside a CC bbox is a real internal gutter if at least this fraction of
+         * its pixels are flood-fill gutter pixels (i.e. background reachable from the page
+         * border). 0.3 = 30% of the row must be page-gutter. Genuine gutters between adjacent
+         * panels score ~100% (fully reachable); hollow panel interiors score 0% (enclosed by
+         * the panel border, not reachable from outside). This replaces the old content-fraction
+         * heuristic which fired on speech balloon interiors and dark-tone panel shadows.
          */
-        val internalGutterContentFraction: Double = 0.05,
+        val internalGutterFloodFillFraction: Double = 0.3,
 
         /**
          * Ignore internal gutters this close to the panel edge (fraction of panel dimension).
@@ -180,7 +183,7 @@ class PanelDetector(
         val filtered = filterAndTighten(components, cropped)
         // Split any bbox that straddles a full-crossing internal gutter — CC can merge two
         // real panels into one bbox when a stray content pixel bridges them at the edge.
-        val split = splitAtInternalGutters(filtered, cropped)
+        val split = splitAtInternalGutters(filtered, cropped, gutter)
 
         return sanityCheck(
             candidates = split,
@@ -227,19 +230,19 @@ class PanelDetector(
         val totalCells = bandColBands.sumOf { it.size }
         if (totalCells < 2 && rowBands.size < 2) return null
 
-        // Build bboxes in cropped space so we can post-process them (internal-gutter splits)
-        // before converting to original-image coordinates.
+        // Build bboxes in cropped space from the projection-detected row/column bands. No
+        // internal-gutter split needed here: the projection already separated panels via gutter
+        // bands, so any bbox is already a single panel cell.
         val bboxesInCropped = mutableListOf<Bbox>()
         for ((rowIndex, rowBand) in rowBands.withIndex()) {
             for (colBand in bandColBands[rowIndex]) {
                 bboxesInCropped.add(Bbox(colBand.start, rowBand.start, colBand.end, rowBand.end))
             }
         }
-        val split = splitAtInternalGutters(bboxesInCropped, cropped)
 
         val scaleX = originalWidth.toDouble() / downscaledWidth.toDouble()
         val scaleY = originalHeight.toDouble() / downscaledHeight.toDouble()
-        val regions = split.map { bbox ->
+        val regions = bboxesInCropped.map { bbox ->
             val minX = ((bbox.minX + cropped.offsetX) * scaleX).toInt().coerceIn(0, originalWidth - 1)
             val minY = ((bbox.minY + cropped.offsetY) * scaleY).toInt().coerceIn(0, originalHeight - 1)
             val maxX = ((bbox.maxX + 1 + cropped.offsetX) * scaleX).toInt().coerceIn(1, originalWidth)
@@ -263,32 +266,26 @@ class PanelDetector(
     }
 
     /**
-     * Recursively split any bbox that contains a full-crossing internal gutter — either a run
-     * of low-content rows (horizontal gutter → split top/bottom) or low-content columns
-     * (vertical gutter → split left/right).
+     * Recursively split any CC bbox that contains a full-crossing internal gutter — a run of
+     * rows or columns where ≥ [Config.internalGutterFloodFillFraction] of pixels are
+     * flood-fill gutter (background reachable from the page border).
      *
-     * This catches the failure mode where the projection detector or CC merged two real panels
-     * into one bbox because they share a wide dimension AND the between-panel gutter had a
-     * stray edge pixel that let flood-fill / projection connect them. Runs on each bbox in the
-     * cropped-mask coordinate space; caller converts to original coordinates afterwards.
+     * This catches the CC failure mode where two real adjacent panels are merged into one bbox
+     * because a stray pixel bridged their shared gutter. The flood-fill criterion is crucial:
+     * genuine between-panel gutters are fully reachable (~100% gutter pixels), while hollow
+     * panel interiors and dark-tone panel backgrounds are enclosed by the panel border and
+     * score 0% — so they never trigger a false split.
      */
-    private fun splitAtInternalGutters(bboxes: List<Bbox>, cropped: CroppedMask): List<Bbox> =
-        bboxes.flatMap { splitSinglePanelRecursively(it, cropped, depth = 0) }
+    private fun splitAtInternalGutters(bboxes: List<Bbox>, cropped: CroppedMask, gutter: BooleanArray): List<Bbox> =
+        bboxes.flatMap { splitSinglePanelRecursively(it, cropped, gutter, depth = 0) }
 
-    private fun splitSinglePanelRecursively(bbox: Bbox, cropped: CroppedMask, depth: Int): List<Bbox> {
+    private fun splitSinglePanelRecursively(bbox: Bbox, cropped: CroppedMask, gutter: BooleanArray, depth: Int): List<Bbox> {
         if (depth >= config.maxInternalGutterSplitDepth) return listOf(bbox)
         val height = bbox.maxY - bbox.minY + 1
         val width = bbox.maxX - bbox.minX + 1
-        // Don't split anything already small — real panels aren't hair-thin, and if we're this
-        // small we'll be dropped by the min-dimension sanity check anyway.
         val minSplitDim = 20
         if (width < minSplitDim * 2 || height < minSplitDim * 2) return listOf(bbox)
 
-        // Only apply the inner-sample trick to LARGE bboxes (>= 70% of the mask in a dimension) —
-        // these are the ones where a decorative page border or wraparound bleed can legitimately
-        // block detection of internal gutters through the interior. For smaller bboxes, sampling
-        // the whole width/height is more accurate (a hollow-border panel's interior looks like
-        // gutter in the inner-sample view, which would falsely split every panel).
         val useInnerWidthSample = width >= (cropped.width * 0.7)
         val useInnerHeightSample = height >= (cropped.height * 0.7)
 
@@ -297,22 +294,29 @@ class PanelDetector(
         val innerMinX = bbox.minX + innerMarginX
         val innerMaxX = bbox.maxX - innerMarginX
         val innerWidth = (innerMaxX - innerMinX + 1).coerceAtLeast(1)
-        val rowGutterCutoff = (innerWidth * config.internalGutterContentFraction).toInt().coerceAtLeast(1)
         val horizontalGutter = widestGutterRun(
             axisStart = bbox.minY + edgeMarginY,
             axisEnd = bbox.maxY - edgeMarginY,
-        ) { y -> cropped.rowContentCount(y, innerMinX, innerMaxX) < rowGutterCutoff }
+        ) { y ->
+            val base = y * cropped.width
+            var g = 0
+            for (x in innerMinX..innerMaxX) if (gutter[base + x]) g++
+            g.toLong() * 1000 >= innerWidth.toLong() * (config.internalGutterFloodFillFraction * 1000).toLong()
+        }
 
         val edgeMarginX = (width * config.internalGutterEdgeMargin).toInt().coerceAtLeast(2)
         val innerMarginY = if (useInnerHeightSample) (height * config.internalGutterInnerSampleInset).toInt().coerceAtLeast(0) else 0
         val innerMinY = bbox.minY + innerMarginY
         val innerMaxY = bbox.maxY - innerMarginY
         val innerHeight = (innerMaxY - innerMinY + 1).coerceAtLeast(1)
-        val colGutterCutoff = (innerHeight * config.internalGutterContentFraction).toInt().coerceAtLeast(1)
         val verticalGutter = widestGutterRun(
             axisStart = bbox.minX + edgeMarginX,
             axisEnd = bbox.maxX - edgeMarginX,
-        ) { x -> cropped.colContentCount(x, innerMinY, innerMaxY) < colGutterCutoff }
+        ) { x ->
+            var g = 0
+            for (y in innerMinY..innerMaxY) if (gutter[y * cropped.width + x]) g++
+            g.toLong() * 1000 >= innerHeight.toLong() * (config.internalGutterFloodFillFraction * 1000).toLong()
+        }
 
         val bestGutter = listOfNotNull(
             horizontalGutter?.let { Triple("h", it.first, it.second) },
@@ -327,13 +331,13 @@ class PanelDetector(
         return if (axis == "h") {
             val topBbox = Bbox(bbox.minX, bbox.minY, bbox.maxX, start - 1)
             val bottomBbox = Bbox(bbox.minX, end + 1, bbox.maxX, bbox.maxY)
-            splitSinglePanelRecursively(topBbox, cropped, depth + 1) +
-                splitSinglePanelRecursively(bottomBbox, cropped, depth + 1)
+            splitSinglePanelRecursively(topBbox, cropped, gutter, depth + 1) +
+                splitSinglePanelRecursively(bottomBbox, cropped, gutter, depth + 1)
         } else {
             val leftBbox = Bbox(bbox.minX, bbox.minY, start - 1, bbox.maxY)
             val rightBbox = Bbox(end + 1, bbox.minY, bbox.maxX, bbox.maxY)
-            splitSinglePanelRecursively(leftBbox, cropped, depth + 1) +
-                splitSinglePanelRecursively(rightBbox, cropped, depth + 1)
+            splitSinglePanelRecursively(leftBbox, cropped, gutter, depth + 1) +
+                splitSinglePanelRecursively(rightBbox, cropped, gutter, depth + 1)
         }
     }
 

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetector.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetector.kt
@@ -230,24 +230,28 @@ class PanelDetector(
         val totalCells = bandColBands.sumOf { it.size }
         if (totalCells < 2 && rowBands.size < 2) return null
 
-        // Build bboxes in cropped space from the projection-detected row/column bands.
-        // The projection may miss thin gutters (< projectionMinBandThickness) between adjacent
-        // panels in the same row, leaving them as one merged cell. The flood-fill-based split
-        // corrects this: real between-panel gutters connect to the page border and score ~100%
-        // flood-fill gutter pixels; panel interiors are enclosed and score 0%, so they never
-        // trigger a false split.
+        // If any row produced only one column band spanning the vast majority of the cropped
+        // width, the projection couldn't find interior column gutters — either they're narrower
+        // than projectionMinBandThickness, or dark art pixels pushed the column counts above the
+        // gutter cutoff. Rather than trying to re-split with a flood-fill heuristic (which
+        // creates false splits on panels whose interiors the flood-fill can penetrate through
+        // downscaling gaps), hand the page to the CC detector which is immune to this: it
+        // operates on flood-fill gutter connectivity, not projection valleys.
+        val suspiciousWideRow = bandColBands.any { colBands ->
+            colBands.size == 1 && colBands[0].let { it.end - it.start + 1 } >= cropped.width * 0.9
+        }
+        if (suspiciousWideRow) return null
+
         val bboxesInCropped = mutableListOf<Bbox>()
         for ((rowIndex, rowBand) in rowBands.withIndex()) {
             for (colBand in bandColBands[rowIndex]) {
                 bboxesInCropped.add(Bbox(colBand.start, rowBand.start, colBand.end, rowBand.end))
             }
         }
-        val projGutter = floodFillGutter(cropped)
-        val split = splitAtInternalGutters(bboxesInCropped, cropped, projGutter)
 
         val scaleX = originalWidth.toDouble() / downscaledWidth.toDouble()
         val scaleY = originalHeight.toDouble() / downscaledHeight.toDouble()
-        val regions = split.map { bbox ->
+        val regions = bboxesInCropped.map { bbox ->
             val minX = ((bbox.minX + cropped.offsetX) * scaleX).toInt().coerceIn(0, originalWidth - 1)
             val minY = ((bbox.minY + cropped.offsetY) * scaleY).toInt().coerceIn(0, originalHeight - 1)
             val maxX = ((bbox.maxX + 1 + cropped.offsetX) * scaleX).toInt().coerceIn(1, originalWidth)

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt
@@ -174,6 +174,9 @@ class LibraryItemOfflineAvailabilityTest {
         ) = error("unused")
         override suspend fun removeDownload(sourceId: String, itemId: String) = error("unused")
         override suspend fun saveReadingPosition(itemId: String, locatorJson: String) = error("unused")
+        override suspend fun supportsStreaming(sourceId: String) = false
+        override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int, maxWidth: Int?) = error("unused")
+        override suspend fun awaitCachedFile(item: LibraryItem): java.io.File? = null
     }
 
     private class FakeAudiobookDownloadRepository(

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/comic/panel/PanelDetectorTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/comic/panel/PanelDetectorTest.kt
@@ -371,22 +371,18 @@ class PanelDetectorTest {
     @Test
     fun `top strip with dark-bordered gutters is split into 4 panels`() {
         // Regression for the "4 top panels treated as one" bug. Layout: a narrow top strip with
-        // 4 panels whose between-panel gutters contain enough dark art pixels to confuse the
-        // column projection (colContent > 15% cutoff → gutter treated as content → all 4 panels
-        // merge into one wide cell in gridByProjection). The flood-fill-based split corrects it:
-        // the background pixels in those gutters are still reachable from the page border
-        // (≥30% flood-fill gutter pixels per column), so the split fires.
+        // 4 panels whose between-panel gutters have enough dark art pixels to push the column
+        // projection above the 15% cutoff, so gridByProjection merges all 4 into one wide cell.
+        // The detector detects the suspicious single-wide column band and falls back to CC
+        // detection, which correctly finds all 5 panels via separate connected components.
         val grid = fixture(width = 600, height = 800) { canvas ->
             canvas.fill(background = LIGHT)
             // Top strip: 4 panels each 125px wide with 12px gutters. Each gutter has enough dark
-            // pixels (spanning full gutter height in the middle half) to push the column
-            // projection above the 15% cutoff — simulating art that bleeds slightly into the gutter.
+            // pixels (spanning the middle portion) to push the column projection above the 15%
+            // cutoff, while still leaving white background pixels reachable from the page border.
             for (i in 0 until 4) {
                 canvas.rect(x = 15 + i * 137, y = 15, w = 125, h = 140, color = DARK)
             }
-            // Dark pixels filling the middle 80px of each gutter column — enough to exceed the
-            // projection cutoff (80/140 = 57% > 15%) yet leave background pixels reachable from
-            // the page border via the white top/bottom of the gutter.
             for (i in 0 until 3) {
                 val gx = 140 + i * 137  // first gutter column for gap i
                 canvas.rect(x = gx, y = 45, w = 12, h = 80, color = DARK)
@@ -402,6 +398,43 @@ class PanelDetectorTest {
             5, result.panels.size)
         val topPanels = result.panels.filter { it.y < 170 }
         assertEquals("expected 4 top-strip panels", 4, topPanels.size)
+    }
+
+    @Test
+    fun `panel with flood-fill-accessible interior is not falsely split by projection path`() {
+        // Regression: previously splitAtInternalGutters ran on every gridByProjection bbox.
+        // If the downscaled image had a gap in a speech-balloon border, the flood-fill would
+        // penetrate the white interior. The horizontal gutter check then fired on those interior
+        // rows (scoring ~70% gutter pixels, well above the 30% threshold) and the panel was
+        // halved; both halves were too short to survive minPanelDimensionFraction, so the first
+        // panel disappeared from the reading sequence entirely.
+        //
+        // Fix: gridByProjection no longer calls splitAtInternalGutters; projection already
+        // separates panels via gutter bands, so no further splitting is needed there.
+        //
+        // Fixture: 2×2 grid. Top-left panel has a white interior (x=60..199, y=50..149) connected
+        // to the top page gutter via a white channel (x=90..109, y=10..49) — this is the
+        // synthetic equivalent of a downscaling gap in the outer panel border. The channel makes
+        // the interior flood-fill-reachable, which would trigger the old false split.
+        val grid = fixture(width = 600, height = 400) { canvas ->
+            canvas.fill(background = LIGHT)
+            canvas.rect(x = 10, y = 10, w = 200, h = 190, color = DARK)
+            canvas.rect(x = 90, y = 10, w = 20, h = 40, color = LIGHT)   // gap → top gutter
+            canvas.rect(x = 60, y = 50, w = 140, h = 100, color = LIGHT) // large interior
+            canvas.rect(x = 250, y = 10, w = 200, h = 190, color = DARK)
+            canvas.rect(x = 10, y = 220, w = 200, h = 170, color = DARK)
+            canvas.rect(x = 250, y = 220, w = 200, h = 170, color = DARK)
+        }
+
+        val result = detector.detect(grid, pageIndex = 0, originalWidth = 600, originalHeight = 400)
+
+        assertEquals(PanelSource.Auto, result.source)
+        assertEquals("expected 4 panels, got ${result.panels.map { "(${it.x},${it.y})${it.width}x${it.height}" }}",
+            4, result.panels.size)
+        val topLeft = result.panels.filter { it.x < 240 && it.y < 200 }
+        assertEquals("top-left panel with flood-fill-accessible interior must survive as one panel", 1, topLeft.size)
+        assertTrue("top-left panel must span the full panel height, not just a falsely-split remnant",
+            topLeft[0].height >= 150)
     }
 
     // --- Fixture builders ---

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/comic/panel/PanelDetectorTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/comic/panel/PanelDetectorTest.kt
@@ -368,6 +368,42 @@ class PanelDetectorTest {
             8, result.panels.size)
     }
 
+    @Test
+    fun `top strip with dark-bordered gutters is split into 4 panels`() {
+        // Regression for the "4 top panels treated as one" bug. Layout: a narrow top strip with
+        // 4 panels whose between-panel gutters contain enough dark art pixels to confuse the
+        // column projection (colContent > 15% cutoff → gutter treated as content → all 4 panels
+        // merge into one wide cell in gridByProjection). The flood-fill-based split corrects it:
+        // the background pixels in those gutters are still reachable from the page border
+        // (≥30% flood-fill gutter pixels per column), so the split fires.
+        val grid = fixture(width = 600, height = 800) { canvas ->
+            canvas.fill(background = LIGHT)
+            // Top strip: 4 panels each 125px wide with 12px gutters. Each gutter has enough dark
+            // pixels (spanning full gutter height in the middle half) to push the column
+            // projection above the 15% cutoff — simulating art that bleeds slightly into the gutter.
+            for (i in 0 until 4) {
+                canvas.rect(x = 15 + i * 137, y = 15, w = 125, h = 140, color = DARK)
+            }
+            // Dark pixels filling the middle 80px of each gutter column — enough to exceed the
+            // projection cutoff (80/140 = 57% > 15%) yet leave background pixels reachable from
+            // the page border via the white top/bottom of the gutter.
+            for (i in 0 until 3) {
+                val gx = 140 + i * 137  // first gutter column for gap i
+                canvas.rect(x = gx, y = 45, w = 12, h = 80, color = DARK)
+            }
+            // Large panel below.
+            canvas.rect(x = 15, y = 175, w = 555, h = 600, color = DARK)
+        }
+
+        val result = detector.detect(grid, pageIndex = 0, originalWidth = 600, originalHeight = 800)
+
+        assertEquals(PanelSource.Auto, result.source)
+        assertEquals("expected 5 panels (4 top strip + 1 large), got ${result.panels.map { "(${it.x},${it.y})${it.width}x${it.height}" }}",
+            5, result.panels.size)
+        val topPanels = result.panels.filter { it.y < 170 }
+        assertEquals("expected 4 top-strip panels", 4, topPanels.size)
+    }
+
     // --- Fixture builders ---
 
     private val LIGHT: Byte = 240.toByte()

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/comic/panel/PanelDetectorTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/comic/panel/PanelDetectorTest.kt
@@ -319,6 +319,55 @@ class PanelDetectorTest {
         assertEquals(PanelSource.Fallback, result.source)
     }
 
+    @Test
+    fun `wide hollow-bordered panels are not falsely split at low-content interior rows`() {
+        // Regression: splitAtInternalGutters was classifying interior rows of hollow panels as
+        // "gutter" when the panel was wide (making the 5%-content threshold smaller than the 6
+        // border pixels each row contributed). Result: each CC bbox was split at the balloon
+        // interior, producing two tiny halves that were filtered by minHeight, leaving 0 panels.
+        // Fix: use flood-fill gutter pixel count instead of content count — panel interiors are
+        // not flood-fill-reachable so they never trigger a split.
+        val grid = fixture(width = 600, height = 400) { canvas ->
+            canvas.fill(background = LIGHT)
+            // Two wide (250px) hollow panels. Wide enough that (border pixels) / width < 5%,
+            // which previously triggered the false gutter classification.
+            canvas.hollowRect(x = 20, y = 20, w = 250, h = 360, borderPx = 3, color = DARK)
+            canvas.hollowRect(x = 300, y = 20, w = 250, h = 360, borderPx = 3, color = DARK)
+        }
+
+        val result = detector.detect(grid, pageIndex = 0, originalWidth = 600, originalHeight = 400)
+
+        assertEquals(PanelSource.Auto, result.source)
+        assertEquals("expected 2 panels (wide hollow rects), got ${result.panels.map { "(${it.x},${it.y})${it.width}x${it.height}" }}",
+            2, result.panels.size)
+    }
+
+    @Test
+    fun `multi-row page with sparse-interior panels detects all rows`() {
+        // Regression for the user's Maus-page bug: 4 rows of panels where each panel has a
+        // hollow border (white balloon interior). The top row survived in older code because
+        // panels happened to be wide enough; rows 2-4 were shorter and their sub-panels fell
+        // below minHeight after the false split. Fix: gutter-based split never triggers on
+        // enclosed panel interiors, so all 8 panels survive.
+        val grid = fixture(width = 400, height = 560) { canvas ->
+            canvas.fill(background = LIGHT)
+            // 4 rows × 2 panels, each hollow-bordered. Row height ~100px (much shorter than
+            // the 2-row case), so sub-panels after a false split would be ~15px — well below
+            // the 84px minHeight floor.
+            for (row in 0 until 4) {
+                val y = 20 + row * 130
+                canvas.hollowRect(x = 20, y = y, w = 160, h = 110, borderPx = 3, color = DARK)
+                canvas.hollowRect(x = 210, y = y, w = 160, h = 110, borderPx = 3, color = DARK)
+            }
+        }
+
+        val result = detector.detect(grid, pageIndex = 0, originalWidth = 400, originalHeight = 560)
+
+        assertEquals(PanelSource.Auto, result.source)
+        assertEquals("expected 8 panels (4-row grid of hollow rects), got ${result.panels.map { "(${it.x},${it.y})${it.width}x${it.height}" }}",
+            8, result.panels.size)
+    }
+
     // --- Fixture builders ---
 
     private val LIGHT: Byte = 240.toByte()


### PR DESCRIPTION
Fixes three bugs in CBZ comic panel detection and a cache invalidation bug that prevented any of the fixes from reaching the device.

## Bugs fixed

### Bug 1 & 2: hollow-bordered panels falsely split (speech balloons / dark interiors)

`splitSinglePanelRecursively` used a content-count criterion (≥5% of row pixels must be content) to find internal gutters. This false-triggered on:
- **White speech balloon interiors** — the row has very few content pixels, so it looked like a gutter
- **Dark panel interiors** — same issue; dark pixels match the background, interior rows score near-zero content

Fix: switch to a **flood-fill fraction criterion** (≥30% of row pixels must be flood-fill-reachable background). Real gutters between panels score ~100% (connected to the page border); enclosed panel interiors score 0% regardless of their colour. The false split never fires.

### Bug 3: top-strip panels merged because dark art in the gutter raises the column projection

When gutter-adjacent dark art pixels push the column projection above the 15% content cutoff, `gridByProjection` cannot see the column gutter and merges multiple panels into one wide cell. The old code then called `splitAtInternalGutters` on those bboxes to recover, but that path opened a new failure: flood-fill could penetrate a panel interior through a downscaling gap, causing a false horizontal split that deleted the panel.

Fix: add a `suspiciousWideRow` check — if any row has exactly 1 column band spanning ≥90% of the cropped width, `gridByProjection` returns null and the CC (connected-component) path handles the page instead. CC is immune to this failure because it uses flood-fill gutter connectivity, not projection valleys.

### Cache invalidation bug (root cause of "nothing works on device")

All three algorithm changes above were committed without bumping `CURRENT_SCHEMA_VERSION` in `JsonPanelStore`. The store returns cached results when `doc.schemaVersion == CURRENT_SCHEMA_VERSION`, so the fixed detector code **never ran on device** — the old (buggy) cached result was served on every page open.

Fix: bump `CURRENT_SCHEMA_VERSION` from 7 to 8. All v7 caches are treated as misses and pages are re-detected with the corrected algorithm.

## Tests

| Test | What it pins |
|---|---|
| `wide hollow-bordered panels are not falsely split at low-content interior rows` | Bug 1/2 — flood-fill criterion doesn't fire on enclosed interiors |
| `multi-row page with sparse-interior panels detects all rows` | Bug 1/2 — 4-row grid, all 8 panels survive |
| `top strip with dark-bordered gutters is split into 4 panels` | Bug 3 — suspiciousWideRow triggers CC fallback |
| `panel with flood-fill-accessible interior is not falsely split by projection path` | No splitAtInternalGutters on projection bboxes |
| `v7 cache file is rejected so stale pre-algorithm-fix detections are never served` | Schema version bump — reverts to ≤7 → assertNull flips red |

## Known limitation (documented inline)

A gutter 4–14px wide (above `internalGutterMinThickness` but below `projectionMinBandThickness`) with a combined cell < 90% of cropped width escapes both projection band detection and `suspiciousWideRow`. The two panels remain merged in the projection output. This is the accepted tradeoff: re-adding `splitAtInternalGutters` to the projection path would re-introduce the false-split-disappear bug for panels with flood-fill-accessible interiors, which is a worse outcome than a merged zoom region.