### PR TITLE
fix(reader): double-sided layout bugs — margins, continuous blank screen, stepper precision

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -198,41 +198,52 @@ internal object ContinuousStyleInjector {
         return out
     }
 
-    /**
-     * JS that re-applies the user-settings `style` attribute on `<html>` after a live preference
-     * change (no reload), then re-measures. ReadiumCSS reads the `--USER__*` variables and
-     * `readium-*-on` flags straight from this attribute via its `[style*=…]` selectors, so setting
-     * the whole attribute string is enough to re-style without reloading the chapter.
-     */
+    /** Escapes [this] for embedding inside a JS single-quoted string literal. */
+    private fun String.escapeForJs() = replace("\\", "\\\\").replace("'", "\\'")
+
     /**
      * JS that sets the `--USER__*` style attribute on `<html>` at initial page load (from
-     * [onPageFinished]). Does NOT toggle `visibility: hidden` — there are no stale rasterised
-     * tiles to invalidate on a fresh page load. The visibility toggle in [buildStyleInjectionJs]
-     * creates a race at load time: HEIGHT_MEASUREMENT_JS fires `onHeightMeasured` which triggers
-     * `pendingInitialScroll` → `container.visibility = VISIBLE`, but the RAF restore for the
-     * `visibility: hidden` hasn't fired yet. The container is then Android-VISIBLE with the
-     * chapter root CSS-hidden, producing a blank screen until the RAF finally fires.
+     * [onPageFinished]), and also for live non-theme preference changes (margins, font size, …).
+     * Does NOT toggle `visibility: hidden` for two reasons:
      *
-     * Use [buildStyleInjectionJs] for LIVE preference changes where the pre-raster tile cache
-     * holds stale composited tiles (see [WebSettingsCompat.setOffscreenPreRaster]).
+     * - **Initial load:** Fresh pages have no stale rasterised tiles, so the tile-cache
+     *   invalidation is unnecessary. The toggle creates a race: HEIGHT_MEASUREMENT_JS fires
+     *   `onHeightMeasured` → `pendingInitialScroll` → `container.visibility = VISIBLE`, but the
+     *   RAF restore for `visibility: hidden` hasn't fired yet. The container is Android-VISIBLE
+     *   with the chapter root CSS-hidden → blank screen until RAF fires.
+     *
+     * - **Live layout changes (margins, font size, line spacing, …):** At large margin values
+     *   (1.8+) the CSS reflow is heavy (narrow content → more text wrapping), blocking the
+     *   renderer thread longer than the 100 ms RAF/setTimeout restore window. The blank persists
+     *   for the full reflow duration. Stale tiles for layout-only changes show the old geometry
+     *   for one or two frames at most — imperceptible compared to a persistent blank.
+     *
+     * Use [buildStyleInjectionJs] only for theme switches, where stale tile colours (sepia bg
+     * against dark text) make content unreadable.
      */
     fun buildStyleSetJs(prefs: FormattingPreferences): String {
-        val styleAttr = buildHtmlStyleAttr(prefs)
-            .replace("\\", "\\\\")
-            .replace("'", "\\'")
+        val styleAttr = buildHtmlStyleAttr(prefs).escapeForJs()
         return "(function() { document.documentElement.setAttribute('style', '$styleAttr'); })();"
     }
 
-    // Force Chromium to invalidate the composited raster tiles for this WebView after every live
-    // preference change. WebSettingsCompat.setOffscreenPreRaster(true) (#413) keeps rasterised
-    // tiles alive for off-screen chapters so the chapter-boundary blank-flash doesn't return; the
-    // side-effect is that a bare `:root` style-attribute mutation — how every live theme /
-    // typography change is applied — doesn't reliably invalidate those cached tiles. The CSSOM
-    // updates, ReadiumCSS re-cascades, `getComputedStyle` returns the new colours, but the
-    // composited image on screen still shows the pre-change theme: users see the OLD background
-    // survive a Sepia → Dim switch, with the text vanishing entirely because the stale sepia
-    // raster is now displaying dark-mode text against sepia bg with contrast the tile was never
-    // rasterised for.
+    /**
+     * Picks between [buildStyleSetJs] and [buildStyleInjectionJs] for a live preference change.
+     * Theme changes require tile-cache invalidation (stale sepia tiles against dark text make
+     * content invisible); all other changes (layout, font, justification) use the no-toggle path
+     * to avoid a blank screen at large margin values.
+     */
+    fun buildLiveUpdateJs(oldPrefs: FormattingPreferences, newPrefs: FormattingPreferences): String =
+        if (oldPrefs.theme != newPrefs.theme) buildStyleInjectionJs(newPrefs) else buildStyleSetJs(newPrefs)
+
+    // Force Chromium to invalidate the composited raster tiles for this WebView after every theme
+    // change. WebSettingsCompat.setOffscreenPreRaster(true) (#413) keeps rasterised tiles alive
+    // for off-screen chapters so the chapter-boundary blank-flash doesn't return; the side-effect
+    // is that a bare `:root` style-attribute mutation doesn't reliably invalidate those cached
+    // tiles. The CSSOM updates, ReadiumCSS re-cascades, `getComputedStyle` returns the new
+    // colours, but the composited image on screen still shows the pre-change theme: users see the
+    // OLD background survive a Sepia → Dim switch, with the text vanishing entirely because the
+    // stale sepia raster is now displaying dark-mode text against sepia bg with contrast the tile
+    // was never rasterised for.
     //
     // Toggling `visibility: hidden` on `:root`, then restoring on the next animation frame, is a
     // paint-invalidating change that overrides the pre-raster tile cache. Restoration is
@@ -243,9 +254,7 @@ internal object ContinuousStyleInjector {
     // suspenders guards against `requestAnimationFrame` being throttled or paused (Chromium pauses
     // RAF for backgrounded WebViews; off-screen stacked WebViews can hit that state).
     fun buildStyleInjectionJs(prefs: FormattingPreferences): String {
-        val styleAttr = buildHtmlStyleAttr(prefs)
-            .replace("\\", "\\\\")
-            .replace("'", "\\'")
+        val styleAttr = buildHtmlStyleAttr(prefs).escapeForJs()
         return """
             (function() {
                 document.documentElement.setAttribute('style', '$styleAttr');

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -204,6 +204,25 @@ internal object ContinuousStyleInjector {
      * `readium-*-on` flags straight from this attribute via its `[style*=…]` selectors, so setting
      * the whole attribute string is enough to re-style without reloading the chapter.
      */
+    /**
+     * JS that sets the `--USER__*` style attribute on `<html>` at initial page load (from
+     * [onPageFinished]). Does NOT toggle `visibility: hidden` — there are no stale rasterised
+     * tiles to invalidate on a fresh page load. The visibility toggle in [buildStyleInjectionJs]
+     * creates a race at load time: HEIGHT_MEASUREMENT_JS fires `onHeightMeasured` which triggers
+     * `pendingInitialScroll` → `container.visibility = VISIBLE`, but the RAF restore for the
+     * `visibility: hidden` hasn't fired yet. The container is then Android-VISIBLE with the
+     * chapter root CSS-hidden, producing a blank screen until the RAF finally fires.
+     *
+     * Use [buildStyleInjectionJs] for LIVE preference changes where the pre-raster tile cache
+     * holds stale composited tiles (see [WebSettingsCompat.setOffscreenPreRaster]).
+     */
+    fun buildStyleSetJs(prefs: FormattingPreferences): String {
+        val styleAttr = buildHtmlStyleAttr(prefs)
+            .replace("\\", "\\\\")
+            .replace("'", "\\'")
+        return "(function() { document.documentElement.setAttribute('style', '$styleAttr'); })();"
+    }
+
     // Force Chromium to invalidate the composited raster tiles for this WebView after every live
     // preference change. WebSettingsCompat.setOffscreenPreRaster(true) (#413) keeps rasterised
     // tiles alive for off-screen chapters so the chapter-boundary blank-flash doesn't return; the

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -674,21 +674,8 @@ internal class ContinuousWindowController(
     /** Update preferences and re-inject styles + remeasure all loaded chapters. */
     override fun updatePreferences(prefs: FormattingPreferences) {
         if (prefs == formattingPrefs) return
-        val oldPrefs = formattingPrefs
+        val styleJs = ContinuousStyleInjector.buildLiveUpdateJs(formattingPrefs, prefs)
         formattingPrefs = prefs
-        // Use the visibility-toggle invalidation ONLY for theme changes. The tile cache carries
-        // the old background and text colours — without an invalidation, stale sepia tiles
-        // persist against dark-mode text, making the content unreadable. For layout-only changes
-        // (margins, font size, line spacing, font family, justification) the stale tiles show the
-        // old layout shape for a frame or two at most, which is imperceptible. Using
-        // buildStyleInjectionJs for those changes causes a blank screen at large margin values
-        // (1.8+) because the heavy reflow blocks the renderer thread longer than the 100 ms
-        // restore timeout, so visibility:hidden hangs on until the reflow finishes.
-        val styleJs = if (oldPrefs.theme != prefs.theme) {
-            ContinuousStyleInjector.buildStyleInjectionJs(prefs)
-        } else {
-            ContinuousStyleInjector.buildStyleSetJs(prefs)
-        }
         webViews.forEach { wv -> wv.reinjectAndRemeasure(styleJs) }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -674,8 +674,21 @@ internal class ContinuousWindowController(
     /** Update preferences and re-inject styles + remeasure all loaded chapters. */
     override fun updatePreferences(prefs: FormattingPreferences) {
         if (prefs == formattingPrefs) return
+        val oldPrefs = formattingPrefs
         formattingPrefs = prefs
-        val styleJs = ContinuousStyleInjector.buildStyleInjectionJs(prefs)
+        // Use the visibility-toggle invalidation ONLY for theme changes. The tile cache carries
+        // the old background and text colours — without an invalidation, stale sepia tiles
+        // persist against dark-mode text, making the content unreadable. For layout-only changes
+        // (margins, font size, line spacing, font family, justification) the stale tiles show the
+        // old layout shape for a frame or two at most, which is imperceptible. Using
+        // buildStyleInjectionJs for those changes causes a blank screen at large margin values
+        // (1.8+) because the heavy reflow blocks the renderer thread longer than the 100 ms
+        // restore timeout, so visibility:hidden hangs on until the reflow finishes.
+        val styleJs = if (oldPrefs.theme != prefs.theme) {
+            ContinuousStyleInjector.buildStyleInjectionJs(prefs)
+        } else {
+            ContinuousStyleInjector.buildStyleSetJs(prefs)
+        }
         webViews.forEach { wv -> wv.reinjectAndRemeasure(styleJs) }
     }
 
@@ -1044,7 +1057,8 @@ internal class ContinuousWindowController(
         }
         wv.onBookBodyFont = { ff -> onBookBodyFont?.invoke(ff) }
         wv.onPageFinished = {
-            val styleJs = ContinuousStyleInjector.buildStyleInjectionJs(formattingPrefs)
+            // buildStyleSetJs: no visibility toggle at load time — see the doc on that function.
+            val styleJs = ContinuousStyleInjector.buildStyleSetJs(formattingPrefs)
             wv.injectStylesAndMeasure(styleJs)
             wv.evaluateJavascript(SELECTION_SPAN_TRACKER_JS, null as ((String?) -> Unit)?)
             decorations.onChapterLoaded(wv, onAnnotationsApplied = { onAnnotationHighlightsApplied(wv) })
@@ -1217,7 +1231,8 @@ internal class ContinuousWindowController(
         }
         wv.onBookBodyFont = { ff -> onBookBodyFont?.invoke(ff) }
         wv.onPageFinished = {
-            val styleJs = ContinuousStyleInjector.buildStyleInjectionJs(formattingPrefs)
+            // buildStyleSetJs: no visibility toggle at load time — see the doc on that function.
+            val styleJs = ContinuousStyleInjector.buildStyleSetJs(formattingPrefs)
             wv.injectStylesAndMeasure(styleJs)
             wv.evaluateJavascript(SELECTION_SPAN_TRACKER_JS, null as ((String?) -> Unit)?)
             decorations.onChapterLoaded(wv, onAnnotationsApplied = { onAnnotationHighlightsApplied(wv) })

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2738,7 +2738,11 @@ private fun EpubNavigatorView(
     val density = LocalDensity.current.density
     val isPaginated = !isFixedLayout && formattingPrefs.orientation == ReaderOrientation.Horizontal
     val isDoublePage = isPaginated && formattingPrefs.doublePageSpread && isLandscape
-    val alignViewport = isPaginated && !isDoublePage
+    // Both single-page and double-page paginated modes align the viewport to a whole-pixel width
+    // so the CSS column-snap pitch (window.innerWidth) matches the physical pixel pitch exactly.
+    // Without alignment, on non-integer-DPR devices the settle-snap fires a 1-2 CSS px correction
+    // after each page turn — the "shifts right before settling" double-page bug.
+    val alignViewport = isPaginated
     // MODE-FORK: continuous needs the container's own background painted (see the paginated-only
     // gutter branch above). ContinuousReaderView's NestedScrollView paints only over its child
     // heights; a short chapter (Highlights view with few annotations) leaves the area beneath
@@ -2882,10 +2886,6 @@ private fun EpubNavigatorView(
                 // RS properties (colCount/colWidth) are baked into the fragment at creation time and
                 // cannot be changed via submitPreferences. Recreate the fragment whenever the
                 // double-page mode changes so the new RS config takes effect.
-                val isDoublePage = !isFixedLayout &&
-                    formattingPrefs.orientation == ReaderOrientation.Horizontal &&
-                    formattingPrefs.doublePageSpread &&
-                    isLandscape
                 val existingFrag = fragmentRef.value
                 if (existingFrag != null && fragmentDoublePageHolder[0] != isDoublePage) {
                     fm.beginTransaction().remove(existingFrag).commitNowAllowingStateLoss()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderContainerPadding.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderContainerPadding.kt
@@ -1,10 +1,16 @@
 package com.riffle.app.feature.reader
 
 // Top/bottom padding (px) to reserve on the Readium fragment container before any WebView paints.
-// Paginated reflowable only. In scroll mode the container fills the screen and the WebView sits
-// permanently below topPx — content scrolls inside the WebView, not the container, so that gap
-// never closes (permanent white strip). Fixed-layout pages are pre-sized; padding would letterbox
-// them.
+// Paginated reflowable only (single-page and double-page). In scroll mode the container fills the
+// screen and the WebView sits permanently below topPx — content scrolls inside the WebView, not
+// the container, so that gap never closes (permanent white strip). Fixed-layout pages are pre-sized;
+// padding would letterbox them.
+//
+// ReadiumCSS forces body { padding: 0 calc(...) !important } in paginated mode, so top/bottom CSS
+// padding inside the WebView is always 0. The container padding here is the sole source of vertical
+// breathing room for all paginated modes (single-page and double-page). The container's Compose
+// background (painted because alignViewport = isPaginated) fills these gaps with the reader theme
+// color, so the gap looks like a proper margin rather than a bare surface strip.
 //
 // Top is 0.8× the horizontal gutter (~16dp base), bottom 1.0× (~20dp), both scaling with the
 // user's margins preference — matching the ratio of the old :root padding override that was

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import java.util.Locale
 import kotlin.math.abs
-import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.math.roundToInt
 
@@ -66,7 +65,7 @@ internal fun steppedTypographyValue(
     val n = if (step > 0) {
         floor(stepsFromStart + eps).toInt() + 1
     } else {
-        ceil(stepsFromStart - eps).toInt() - 1
+        floor(stepsFromStart - eps).toInt()
     }
     val maxSteps = ((range.endInclusive - range.start) / stepSize + eps).toInt()
     val next = (range.start + n.coerceIn(0, maxSteps) * stepSize).coerceIn(range)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
@@ -40,19 +40,36 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import java.util.Locale
 import kotlin.math.abs
+import kotlin.math.ceil
+import kotlin.math.floor
 import kotlin.math.roundToInt
 
 /**
- * Advance [current] by [step] (positive or negative), clamp to [range], and round to 1 decimal.
- * Used by the edge-icon tap handlers on the typography sliders so keyboard-analogue nudging
- * lands on the same 0.1× lattice the slider itself snaps to.
+ * Return the next step-grid value above (step > 0) or below (step < 0) [current], clamped to
+ * [range] and rounded to 1 decimal.
+ *
+ * Unlike a simple `current + step`, this function snaps to the step grid anchored at
+ * [range].start, so it always produces a valid grid value regardless of where the continuous
+ * slider left the current position. Example: from 1.7 (reachable by dragging the 0.2-step
+ * margins slider), pressing + returns 1.8, not 1.9.
  */
 internal fun steppedTypographyValue(
     current: Float,
     step: Float,
     range: ClosedFloatingPointRange<Float>,
 ): Float {
-    val next = (current + step).coerceIn(range)
+    val stepSize = abs(step)
+    // Small epsilon prevents float imprecision from misclassifying a value that is exactly
+    // on the grid as slightly-above (for increment) or slightly-below (for decrement).
+    val eps = 1e-5f
+    val stepsFromStart = (current - range.start) / stepSize
+    val n = if (step > 0) {
+        floor(stepsFromStart + eps).toInt() + 1
+    } else {
+        ceil(stepsFromStart - eps).toInt() - 1
+    }
+    val maxSteps = ((range.endInclusive - range.start) / stepSize + eps).toInt()
+    val next = (range.start + n.coerceIn(0, maxSteps) * stepSize).coerceIn(range)
     return (next * 10f).roundToInt() / 10f
 }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -193,6 +193,32 @@ class ContinuousStyleInjectorTest {
             .contains("ReadiumCSS-default.css"))
     }
 
+    // ── page-load + non-theme live-update style-set JS (no visibility toggle) ────
+    //
+    // buildStyleSetJs is used at two sites:
+    //  1. onPageFinished (initial chapter load): The visibility toggle in buildStyleInjectionJs
+    //     creates a race — HEIGHT_MEASUREMENT_JS fires onHeightMeasured → pendingInitialScroll
+    //     → container.visibility = VISIBLE, but the RAF restoring visibility: '' hasn't fired
+    //     yet. Container is Android-VISIBLE with the chapter root CSS-hidden → blank screen.
+    //  2. updatePreferences for non-theme changes (margins, font size, line spacing…): The
+    //     visibility:hidden reflow at large margin values (1.8+) is heavy enough to block the
+    //     renderer thread longer than the 100 ms restore timeout, causing a persistent blank
+    //     screen until the renderer finishes. For layout-only changes the stale tiles show the
+    //     old layout shape for at most one or two frames — imperceptible compared to a blank.
+    //     Only theme changes need the tile-invalidation toggle (stale sepia tiles against dark
+    //     text would make the text invisible).
+
+    @Test
+    fun `buildStyleSetJs sets the style attribute without visibility toggle`() {
+        val js = ContinuousStyleInjector.buildStyleSetJs(FormattingPreferences(fontSize = 1.5f))
+        assertTrue(js.contains("document.documentElement.setAttribute('style'"))
+        assertTrue(js.contains("--USER__fontSize: 150% !important;"))
+        assertFalse(
+            "no visibility: hidden at page load — would race pendingInitialScroll and blank the screen",
+            js.contains("visibility"),
+        )
+    }
+
     // ── live preference-change JS ───────────────────────────────────────────────
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderContainerPaddingTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderContainerPaddingTest.kt
@@ -88,4 +88,21 @@ class ReaderContainerPaddingTest {
         assertEquals(0, top)
         assertEquals(0, bottom)
     }
+
+    // Double-page mode gets the same container padding as single-page paginated. The container's
+    // Compose background (painted because alignViewport = isPaginated covers both modes) fills the
+    // gaps with the reader theme color, so the user's margins setting visually affects all four
+    // sides. ReadiumCSS forces body { padding: 0 calc(...) } in paginated mode, so the container
+    // padding is the only source of top/bottom breathing room in double-page mode too.
+    @Test
+    fun `double-page mode produces same non-zero padding as single-page paginated`() {
+        val (topSingle, bottomSingle) = readerContainerPaddingPx(
+            margins = 1.5f,
+            density = density,
+            isFixedLayout = false,
+            isScrollMode = false,
+        )
+        assertTrue("top must be > 0 in double-page mode", topSingle > 0)
+        assertTrue("bottom must be > 0 in double-page mode", bottomSingle > 0)
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/SteppedTypographyValueTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/SteppedTypographyValueTest.kt
@@ -40,6 +40,20 @@ class SteppedTypographyValueTest {
         assertEquals(0.2f, steppedTypographyValue(0.2f, -0.2f, marginsRange), 1e-4f)
     }
 
+    // Regression: if the user drags the continuous slider to an off-grid position (e.g. 1.7 on
+    // the 0.2-step margins slider), the icon tap must snap to the nearest grid point in the
+    // step direction — not blindly add the step (which gives 1.9, skipping 1.8 entirely).
+    @Test fun marginsIconTapFromOffGridSnapsToNearestGridPoint() {
+        // From 1.7 (between grid points 1.6 and 1.8): + → 1.8, not 1.9
+        assertEquals(1.8f, steppedTypographyValue(1.7f, 0.2f, marginsRange), 1e-4f)
+        // From 1.9 (between grid points 1.8 and 2.0): - → 1.8, not 1.7
+        assertEquals(1.8f, steppedTypographyValue(1.9f, -0.2f, marginsRange), 1e-4f)
+        // Symmetry: - from 1.7 → 1.6 (nearest grid point below)
+        assertEquals(1.6f, steppedTypographyValue(1.7f, -0.2f, marginsRange), 1e-4f)
+        // Symmetry: + from 1.9 → 2.0 (nearest grid point above)
+        assertEquals(2.0f, steppedTypographyValue(1.9f, 0.2f, marginsRange), 1e-4f)
+    }
+
     @Test fun wpmIconStepLandsOnTwentyWpmGrid() {
         // The pacing sliders route the icon-tap through AutoScrollSpeed.of so a 20-wpm delta
         // is re-snapped to the underlying 10-wpm lattice; both directions must clamp at the


### PR DESCRIPTION
## Summary

- **Top margin unresponsive in double-page (horizontal) mode**: a prior session zeroed container padding for `isDoublePage` as a symptom fix for the white-strip bug. The actual fix was `alignViewport = isPaginated` (both modes), which gives the container a themed background for the gap. Removing the guard restores vertical breathing room for all paginated modes. ReadiumCSS forces `body { padding: 0 calc(…) !important }` in paginated mode, so the container padding is the only source of vertical margins.

- **Blank screen at 1.8× margins in continuous mode** — two race conditions fixed:
  - *Initial load*: `buildStyleInjectionJs` set `visibility:hidden` in `onPageFinished`; `HEIGHT_MEASUREMENT_JS` then fired `onHeightMeasured` → `pendingInitialScroll` → `container.visibility = VISIBLE` before the RAF restore, leaving the content CSS-hidden but Android-visible. Fix: use `buildStyleSetJs` (no toggle) at initial load — fresh pages have no stale raster tiles.
  - *Live margin change* (`updatePreferences`): at 1.8+ margins the CSS reflow is heavy enough to block the renderer thread longer than the 100 ms RAF/setTimeout restore window, so `visibility:hidden` hangs until the reflow finishes. Fix: `buildStyleInjectionJs` (with tile-cache invalidation) is now only used for theme changes, where stale tile colors (sepia bg against dark text) make content unreadable. All other preference changes use `buildStyleSetJs`.

- **Typography stepper skipping values from off-grid positions**: `steppedTypographyValue` blindly added the step to the current value, so dragging the slider to an off-grid position (e.g. 1.7, reachable by the 0.1-interval slider but not the 0.2-step buttons) then pressing + gave 1.9 instead of 1.8. Fix: compute the next grid point from `range.start` rather than from `current`.

- **Simplification (post-review)**: extracted `String.escapeForJs()` private helper shared by both injection functions; added `buildLiveUpdateJs(old, new)` so the controller no longer needs field-level knowledge of what drives tile invalidation; dropped the redundant `ceil` import in `steppedTypographyValue` (`ceil(x - eps) - 1` == `floor(x - eps)`).