### PR TITLE
fix(audiobook): don't auto-play finished book on back-stack restore

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -523,7 +523,13 @@ class AudiobookPlayerViewModel @Inject constructor(
                 // playback immediately rather than landing on a paused player. A genuinely-newer remote
                 // resume is still honoured: attachReaderSync's inbound-only reconcile seeks the
                 // already-playing position to the reconciled point (ADR 0029).
-                controller.play()
+                //
+                // Exception: if the book was detected as finished on open (resume near the end →
+                // reset to 0 by the finished-book guard), skip auto-play. This prevents the player
+                // from starting a "replay from the beginning" without user intent when Android
+                // restores the back stack after killing the process while the book was playing in
+                // the background. The user presses Play explicitly to re-listen.
+                if (!resume.wasFinishedOnOpen) controller.play()
 
                 // The cross-EPUB index build (needed for the full ebook-sync coordinator) is self-healed
                 // by ReaderSyncFactory.createIfApplicable below: if the bundle is present but the index

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookResumeResolver.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookResumeResolver.kt
@@ -31,10 +31,15 @@ class AudiobookResumeResolver @Inject constructor(
      *   pull us back). Zero on the offline-with-bundle-only fallback path (where [resumeSec] came
      *   from `readingProgress`); non-zero when the resume came from a genuinely tracked position
      *   (reconciler decision or handoff override).
+     * @property wasFinishedOnOpen true when the reconciled resume was at/near the end of the book
+     *   and [resumeSec] was reset to 0 by the finished-book guard. The player should open paused
+     *   in this case — the user must press Play to explicitly re-listen — rather than auto-playing
+     *   from the start, which would surprise users whose back stack was restored after process death.
      */
     data class ResumePoint(
         val resumeSec: Double,
         val resumeStamp: Long,
+        val wasFinishedOnOpen: Boolean = false,
     )
 
     /**
@@ -96,9 +101,11 @@ class AudiobookResumeResolver @Inject constructor(
         // A finished book (resume at the end) is unplayable if seeded there — ExoPlayer lands in
         // STATE_ENDED and play() is a no-op. Reopening it is a replay, so restart from 0. Only on
         // a normal open: the handoff below sets an explicit position that must not be reset.
+        val resumeBeforeFinishedGuard = resumeSec
         if (startAtSec < 0.0) {
             resumeSec = audiobookStartSec(resumeSec, session.timeline.durationSec)
         }
+        val wasFinishedOnOpen = startAtSec < 0.0 && resumeSec != resumeBeforeFinishedGuard
 
         // readaloud→audiobook swipe handoff: continue from exactly where the reader handed off,
         // overriding the store/server resume (which can lag the just-left listen position). Persist
@@ -116,6 +123,7 @@ class AudiobookResumeResolver @Inject constructor(
         return ResumePoint(
             resumeSec = resumeSec,
             resumeStamp = resumeStamp,
+            wasFinishedOnOpen = wasFinishedOnOpen,
         )
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookResumeResolver.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookResumeResolver.kt
@@ -105,7 +105,13 @@ class AudiobookResumeResolver @Inject constructor(
         if (startAtSec < 0.0) {
             resumeSec = audiobookStartSec(resumeSec, session.timeline.durationSec)
         }
-        val wasFinishedOnOpen = startAtSec < 0.0 && resumeSec != resumeBeforeFinishedGuard
+        // Mirror the same guard condition as audiobookStartSec() rather than comparing
+        // before/after: a 1-second book at position 0 would give 0.0 == 0.0 (false negative)
+        // with an equality check, even though the guard fired and auto-play should be suppressed.
+        val durationSec = session.timeline.durationSec
+        val wasFinishedOnOpen = startAtSec < 0.0
+            && durationSec > 0.0
+            && resumeBeforeFinishedGuard >= durationSec - AUDIOBOOK_FINISHED_EPS_SEC
 
         // readaloud→audiobook swipe handoff: continue from exactly where the reader handed off,
         // overriding the store/server resume (which can lag the just-left listen position). Persist

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -993,7 +993,7 @@ class AudiobookPlayerViewModelBookmarkTest {
         // Position store: local = 999.5 s, timestamp > server timestamp → PushLocal wins → resumeSec = 999.5
         // audiobookStartSec(999.5, 1000.0) resets to 0.0 → wasFinishedOnOpen = true → play() skipped.
         val controller = FakeController(position = 0.0)
-        buildViewModel(
+        val vm = buildViewModel(
             controller = controller,
             bookmarkStore = FakeBookmarkStore(),
             positionStore = FakePositionStore(savedSec = 999.5, savedUpdatedAt = fixedNow),
@@ -1005,5 +1005,6 @@ class AudiobookPlayerViewModelBookmarkTest {
             0,
             controller.playCount,
         )
+        vm.clearForTest()
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -121,7 +121,8 @@ class AudiobookPlayerViewModelBookmarkTest {
             preparedStartAtSec = startAtSec
             preparedBookTitle = bookTitle
         }
-        override fun play() {}
+        var playCount = 0
+        override fun play() { playCount++ }
         override fun setSpeed(speed: Float) {}
         override fun currentAbsoluteSec(): Double = position
         override fun seekTo(absoluteSec: Double) { seeks.add(absoluteSec) }
@@ -982,5 +983,27 @@ class AudiobookPlayerViewModelBookmarkTest {
 
     private object StubBuildTrigger : CrossEpubIndexBuildTrigger {
         override fun enqueueBuild(link: ReadaloudLink) {}
+    }
+
+    @Test
+    fun `finished book does not auto-play on open — controller play() is not called`() = runTest(testDispatcher) {
+        // Regression: when Android restores the back stack after killing the process, the new VM's
+        // init resolves the saved position (near end), audiobookStartSec() resets it to 0, and
+        // controller.play() was called unconditionally. The guard added by the fix must suppress it.
+        // Position store: local = 999.5 s, timestamp > server timestamp → PushLocal wins → resumeSec = 999.5
+        // audiobookStartSec(999.5, 1000.0) resets to 0.0 → wasFinishedOnOpen = true → play() skipped.
+        val controller = FakeController(position = 0.0)
+        buildViewModel(
+            controller = controller,
+            bookmarkStore = FakeBookmarkStore(),
+            positionStore = FakePositionStore(savedSec = 999.5, savedUpdatedAt = fixedNow),
+        )
+        runCurrent()
+
+        assertEquals(
+            "play() must not be called when the book was finished on open",
+            0,
+            controller.playCount,
+        )
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookResumeResolverTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookResumeResolverTest.kt
@@ -119,6 +119,56 @@ class AudiobookResumeResolverTest {
     }
 
     @Test
+    fun `finished-book sets wasFinishedOnOpen true`() = runTest {
+        val store = FakePositionStore(loadedSec = 999.5, loadedTs = 5_000L)
+        val resolver = AudiobookResumeResolver(store, FakeClock(0L))
+
+        val result = resolver.resolve(
+            sourceId = "srv",
+            itemId = "book",
+            session = session(duration = 1000.0, serverCurrentTimeSec = 999.5, serverLastUpdate = 5_000L),
+            readingProgressFraction = 0f,
+            startAtSec = -1.0,
+        )
+
+        assertTrue("back-stack restore of finished book must not auto-play", result.wasFinishedOnOpen)
+    }
+
+    @Test
+    fun `in-progress book does not set wasFinishedOnOpen`() = runTest {
+        val store = FakePositionStore(loadedSec = 500.0, loadedTs = 5_000L)
+        val resolver = AudiobookResumeResolver(store, FakeClock(0L))
+
+        val result = resolver.resolve(
+            sourceId = "srv",
+            itemId = "book",
+            session = session(duration = 1000.0, serverCurrentTimeSec = 500.0, serverLastUpdate = 5_000L),
+            readingProgressFraction = 0f,
+            startAtSec = -1.0,
+        )
+
+        assertEquals(false, result.wasFinishedOnOpen)
+    }
+
+    @Test
+    fun `handoff to finished position does not set wasFinishedOnOpen`() = runTest {
+        // A readaloud→audiobook handoff at a position near the end must never be treated as a
+        // "finished open" — the handoff position is authoritative and auto-play should proceed.
+        val store = FakePositionStore(loadedSec = null, loadedTs = 0L)
+        val resolver = AudiobookResumeResolver(store, FakeClock(1L))
+
+        val result = resolver.resolve(
+            sourceId = "srv",
+            itemId = "book",
+            session = session(duration = 1000.0),
+            readingProgressFraction = 0f,
+            startAtSec = 999.5,
+        )
+
+        assertEquals(false, result.wasFinishedOnOpen)
+    }
+
+    @Test
     fun `handoff override overrides reconciler, stamps fresh, persists`() = runTest {
         val store = FakePositionStore(loadedSec = 100.0, loadedTs = 1_000L)
         val resolver = AudiobookResumeResolver(store, FakeClock(9_999L))

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookResumeResolverTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookResumeResolverTest.kt
@@ -204,6 +204,26 @@ class AudiobookResumeResolverTest {
     }
 
     @Test
+    fun `finished-book guard fires at exact boundary durationSec minus eps`() = runTest {
+        // Off-by-one protection: a position exactly at durationSec - AUDIOBOOK_FINISHED_EPS_SEC (the
+        // inclusive boundary) must trigger wasFinishedOnOpen. A change from >= to > in the guard would
+        // make this position fall through and auto-play a nearly-finished book from the end.
+        val store = FakePositionStore(loadedSec = 999.0, loadedTs = 5_000L)
+        val resolver = AudiobookResumeResolver(store, FakeClock(0L))
+
+        val result = resolver.resolve(
+            sourceId = "srv",
+            itemId = "book",
+            session = session(duration = 1000.0, serverCurrentTimeSec = 999.0, serverLastUpdate = 5_000L),
+            readingProgressFraction = 0f,
+            startAtSec = -1.0,
+        )
+
+        assertEquals(0.0, result.resumeSec, 0.0001)
+        assertTrue("inclusive boundary must set wasFinishedOnOpen", result.wasFinishedOnOpen)
+    }
+
+    @Test
     fun `zeroed session (Chitanka fresh open) → resumeSec=0, resumeStamp=0, no crash`() = runTest {
         // Chitanka's openAudiobook returns a stream with serverCurrentTimeSec=0, serverLastUpdate=0,
         // totalDurationSec=0 (unknown until ExoPlayer resolves each track). A fresh open has no local
@@ -224,6 +244,7 @@ class AudiobookResumeResolverTest {
         assertEquals(0.0, result.resumeSec, 0.0001)
         assertEquals(0L, result.resumeStamp)
         assertTrue("zeroed session must not write back to store", store.saves.isEmpty())
+        assertEquals("unknown duration cannot be finished", false, result.wasFinishedOnOpen)
     }
 
     @Test


### PR DESCRIPTION
## Problem

When Android kills the process while an audiobook is playing in the background and the user returns, the back stack is restored and the `AudiobookPlayerViewModel` initialises fresh. The resume resolver detects the saved position is near the end of the book and resets it to 0 (the "finished book" guard — ExoPlayer enters `STATE_ENDED` if seeded at the end). But after the reset, `controller.play()` was called unconditionally, auto-playing the book from the beginning without user intent.

## Fix

**Commit 1 — core fix:** Expose `wasFinishedOnOpen` from `ResumePoint` and skip `controller.play()` when the flag is set. The user must press Play explicitly to re-listen.

**Commit 2 — guard hardening:** The original `wasFinishedOnOpen` detection compared the position before/after the guard (`resumeSec != resumeBeforeFinishedGuard`). This fails for a book whose pre-reset and post-reset positions are equal (e.g. a 1-second book at position 0.0 — the guard resets to 0.0, same value, false negative). Replace with an explicit boundary check mirroring `audiobookStartSec()`:

```kotlin
val wasFinishedOnOpen = startAtSec < 0.0
    && durationSec > 0.0
    && resumeBeforeFinishedGuard >= durationSec - AUDIOBOOK_FINISHED_EPS_SEC
```

## Tests

- `AudiobookResumeResolverTest`: finished book sets `wasFinishedOnOpen = true`; in-progress book does not; readaloud→audiobook handoff at end does not; exact eps boundary fires the guard; zeroed session (unknown duration) returns `false`.
- `AudiobookPlayerViewModelBookmarkTest`: end-to-end regression — `controller.play()` is not called when the book was finished on open (position near end → resolved to 999.5 s → guard triggers → `playCount == 0`).