### PR TITLE
fix(audiobook): prevent seek-bar flash on skip-forward in multi-track books

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -373,8 +373,14 @@ open class AudiobookController @Inject constructor(
 
     private fun pushState() {
         val c = controller
-        c?.let { pendingSeek.maybeConfirm(it.currentPosition / 1000.0) }
-        val position = currentAbsoluteSec()
+        // Snapshot raw position once: maybeConfirm and the fallback in sample both need it, and
+        // c.currentPosition interpolates via SystemClock (a JNI call) on every access.
+        val rawSec = c?.let {
+            val s = it.currentPosition / 1000.0
+            pendingSeek.maybeConfirm(s)
+            s
+        }
+        val position = if (rawSec != null) pendingSeek.sample { rawSec } else 0.0
         // While a seek is pending the client's [MediaController.bufferedPosition] mirror also holds the
         // raw local offsetMs we just issued; treating that as absolute would paint a phantom
         // buffer band. Pin it to the pending target (== "nothing loaded past the seek yet") until the

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -116,9 +116,6 @@ open class AudiobookController @Inject constructor(
                 && player.playbackState == Player.STATE_ENDED) {
                 _playbackEnded.tryEmit(Unit)
             }
-            if (events.contains(Player.EVENT_POSITION_DISCONTINUITY)) {
-                pendingSeek.onDiscontinuity()
-            }
             maybeStart(player)
             pushState()
         }
@@ -376,6 +373,7 @@ open class AudiobookController @Inject constructor(
 
     private fun pushState() {
         val c = controller
+        c?.let { pendingSeek.maybeConfirm(it.currentPosition / 1000.0) }
         val position = currentAbsoluteSec()
         // While a seek is pending the client's [MediaController.bufferedPosition] mirror also holds the
         // raw local offsetMs we just issued; treating that as absolute would paint a phantom

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -661,8 +661,9 @@ class AudiobookPlayerViewModel @Inject constructor(
             followLoopOrchestrator.flushNow()
         } else {
             val rewindSec = rewindOnResumeSec.value
+            val posBeforeRewind = controller.currentAbsoluteSec()
             if (rewindSec > 0) {
-                val newPos = (controller.currentAbsoluteSec() - rewindSec).coerceAtLeast(0.0)
+                val newPos = (posBeforeRewind - rewindSec).coerceAtLeast(0.0)
                 reconciledResumeSec = newPos
                 controller.seekTo(newPos)
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/PendingSeekGate.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/PendingSeekGate.kt
@@ -26,12 +26,14 @@ internal class PendingSeekGate {
         if (kotlin.math.abs(rawPositionSec - p) < CONFIRM_EPSILON_SEC) pendingSec = null
     }
 
-    fun onDiscontinuity() { pendingSec = null }
     fun reset() { pendingSec = null }
 
     inline fun sample(fallback: () -> Double): Double = pendingSec ?: fallback()
 
     companion object {
+        // Safe because perTrackOffset = bookAbsolute − trackStartSec, and any track that could be
+        // a seek target has startSec >> 0.5s; the only exception is track 0 (startSec == 0), where
+        // perTrackOffset == bookAbsolute and clearing immediately is correct.
         const val CONFIRM_EPSILON_SEC = 0.5
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/PendingSeekGate.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/PendingSeekGate.kt
@@ -2,19 +2,36 @@ package com.riffle.app.feature.audiobook
 
 /**
  * Suppresses the client-side [androidx.media3.session.MediaController] position mirror during the
- * window between a seek command being issued and the server relaying the position discontinuity
- * that confirms it landed. After [onSeekIssued] the client mirror snaps to the raw local-track
- * `offsetMs` we just sent — projecting that as book-absolute time (the caller does that further up)
- * would paint the seek bar at a bogus early position for one poll tick after every track-crossing
- * seek. [sample] returns the held target until [onDiscontinuity] clears it.
+ * window between a seek command being issued and the server relaying the confirmed book-absolute
+ * position. After [onSeekIssued] the client mirror snaps to the raw local-track `offsetMs` we just
+ * sent — projecting that as book-absolute time would paint the seek bar at a bogus early position
+ * for multiple poll ticks after every track-crossing seek.
+ *
+ * [sample] returns the held target until [maybeConfirm] observes that [MediaController.currentPosition]
+ * has converged to the expected book-absolute target (within [CONFIRM_EPSILON_SEC]), which means the
+ * [AbsolutePositionPlayer] projection on the service side has been applied and relayed back. Clearing
+ * on [EVENT_POSITION_DISCONTINUITY] is wrong: Media3 fires that event optimistically from the
+ * [seekTo] call itself, before the session responds, with [currentPosition] still holding the raw
+ * per-track offsetMs rather than the projected absolute value.
  */
 internal class PendingSeekGate {
     var pendingSec: Double? = null
         private set
 
     fun onSeekIssued(absoluteSec: Double) { pendingSec = absoluteSec }
+
+    /** Clears [pendingSec] only once [rawPositionSec] has converged to the held target. */
+    fun maybeConfirm(rawPositionSec: Double) {
+        val p = pendingSec ?: return
+        if (kotlin.math.abs(rawPositionSec - p) < CONFIRM_EPSILON_SEC) pendingSec = null
+    }
+
     fun onDiscontinuity() { pendingSec = null }
     fun reset() { pendingSec = null }
 
     inline fun sample(fallback: () -> Double): Double = pendingSec ?: fallback()
+
+    companion object {
+        const val CONFIRM_EPSILON_SEC = 0.5
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/PendingSeekGateTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/PendingSeekGateTest.kt
@@ -21,17 +21,6 @@ class PendingSeekGateTest {
         assertEquals(10_217.0, gate.sample { 355.0 }, 0.0)
     }
 
-    @Test
-    fun fallbackReturnsAfterDiscontinuity() {
-        val gate = PendingSeekGate()
-        gate.onSeekIssued(10_217.0)
-        gate.onDiscontinuity()
-        assertNull(gate.pendingSec)
-        assertEquals(10_217.0, gate.sample { 10_217.0 }, 0.0)
-        // Confirm subsequent samples read the fallback each time.
-        assertEquals(10_218.5, gate.sample { 10_218.5 }, 0.0)
-    }
-
     /**
      * Regression: skip-forward near the end of a multi-track book flashed the progress bar to
      * chapter 1 for ~0.75s. Root cause: EVENT_POSITION_DISCONTINUITY fired optimistically from the

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/PendingSeekGateTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/PendingSeekGateTest.kt
@@ -32,6 +32,32 @@ class PendingSeekGateTest {
         assertEquals(10_218.5, gate.sample { 10_218.5 }, 0.0)
     }
 
+    /**
+     * Regression: skip-forward near the end of a multi-track book flashed the progress bar to
+     * chapter 1 for ~0.75s. Root cause: EVENT_POSITION_DISCONTINUITY fired optimistically from the
+     * MediaController.seekTo() call with c.currentPosition = perTrackOffsetMs (not book-absolute),
+     * and calling onDiscontinuity() there cleared pendingSec, letting the small per-track value
+     * win the next sample(). If this test is reverted, that flash returns.
+     */
+    @Test
+    fun maybeConfirmIgnoresOptimisticPerTrackPosition() {
+        val gate = PendingSeekGate()
+        gate.onSeekIssued(39526.0) // ~10:58:46 book-absolute (near end of 11h book)
+        // Optimistic discontinuity: c.currentPosition = perTrackOffsetMs / 1000 = 2775s (not absolute)
+        gate.maybeConfirm(2775.0)
+        assertEquals(39526.0, gate.sample { 2775.0 }, 0.0)
+    }
+
+    @Test
+    fun maybeConfirmClearsWhenPositionConverges() {
+        val gate = PendingSeekGate()
+        gate.onSeekIssued(39526.0)
+        // PlayerInfo arrives from session with AbsolutePositionPlayer's projected value
+        gate.maybeConfirm(39526.0)
+        assertNull(gate.pendingSec)
+        assertEquals(39526.1, gate.sample { 39526.1 }, 0.0)
+    }
+
     @Test
     fun resetClearsPending() {
         val gate = PendingSeekGate()


### PR DESCRIPTION
## What

Fixes a ~0.75s flash of the audiobook progress bar to chapter 1 when pressing skip-forward near the end of a multi-track book.

## Root cause

Media3 fires `EVENT_POSITION_DISCONTINUITY` **optimistically** — immediately from `MediaController.seekTo()`, before the `MediaSession` responds — with `c.currentPosition = perTrackOffsetMs` (raw per-track, not book-absolute). `AbsolutePositionPlayer` on the service side projects per-track → book-absolute, but that value only arrives after the IPC round-trip.

The old code called `pendingSeek.onDiscontinuity()` in `onEvents` for `EVENT_POSITION_DISCONTINUITY`, which cleared `pendingSec` at that wrong moment. A subsequent `skipBy()` then read `c.currentPosition / 1000 = perTrackOffsetSec` (small, early) instead of the absolute target, and issued a seek to a bogus position — painting the progress bar at chapter 1 for ~0.75s until the second seek's PlayerInfo arrived.

## Fix

Replace the `onDiscontinuity()` call in `onEvents` with `maybeConfirm()` in `pushState()`. `maybeConfirm` clears `pendingSec` only when `c.currentPosition` has converged to the held book-absolute target within 0.5s — which only happens once `AbsolutePositionPlayer`'s projection has been applied and relayed back. The optimistic per-track value is always > 0.5s away from the absolute target for any seek crossing a track boundary (it differs by `trackStartSec`, which is >> 0.5s for any track after the first).

Single-track books are handled correctly: for track 0 `perTrackOffset == bookAbsolute`, so the gate clears on the first push — which is right since there is no offset error to suppress.

## Changes

- `PendingSeekGate`: add `maybeConfirm(rawPositionSec)` with epsilon 0.5s; remove `onDiscontinuity()` (was dead code after the fix, identical to `reset()`)
- `AudiobookController.onEvents`: remove `pendingSeek.onDiscontinuity()` call
- `AudiobookController.pushState()`: snapshot `c.currentPosition / 1000.0` once and pass to both `maybeConfirm` and the `sample` fallback, eliminating a redundant `SystemClock` JNI call on every 4 Hz poll tick
- `PendingSeekGateTest`: two new regression tests (`maybeConfirmIgnoresOptimisticPerTrackPosition`, `maybeConfirmClearsWhenPositionConverges`); removed `fallbackReturnsAfterDiscontinuity` (tested a now-deleted method; behavioral claim preserved by `resetClearsPending`)