### PR TITLE
fix(reader): focus note field when editor opens

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightActionsPopupTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/HighlightActionsPopupTest.kt
@@ -1,6 +1,8 @@
 package com.riffle.app.feature.reader
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -101,5 +103,18 @@ class HighlightActionsPopupTest {
         showPopup(note = null, noteOnly = true)
         composeTestRule.onNodeWithText("Note").assertIsDisplayed()
         composeTestRule.onNodeWithText("Edit").assertDoesNotExist()
+    }
+
+    @Test
+    fun noteEditor_autofocusesTextFieldWhenOpened() {
+        composeTestRule.setContent {
+            NoteEditorDialog(
+                initialNote = "",
+                onConfirm = {},
+                onDismiss = {},
+            )
+        }
+
+        composeTestRule.onNode(hasSetTextAction()).assertIsFocused()
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/HighlightActionsSheet.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -43,6 +44,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
@@ -405,6 +408,8 @@ internal fun NoteEditorDialog(
     onDismiss: () -> Unit,
 ) {
     var text by rememberSaveable(initialNote) { mutableStateOf(initialNote) }
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("Note") },
@@ -415,7 +420,7 @@ internal fun NoteEditorDialog(
                 placeholder = { Text("Add a note…") },
                 minLines = 3,
                 maxLines = 6,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
             )
         },
         confirmButton = {


### PR DESCRIPTION
## Summary
- Request focus for the note editor text field when the dialog opens.
- Add an instrumentation regression test that asserts the note editor text field is focused immediately after opening.

## Tests
- `make harness-test` was run before finalizing: the new `HighlightActionsPopupTest.noteEditor_autofocusesTextFieldWhenOpened` passed, but the full suite failed on unrelated `AnnotationFocusHarnessTest.verticalMode_bookmarkTap_focusesBookmarkedPosition` because the Search control was not found.

## Regression assertion
- `HighlightActionsPopupTest.noteEditor_autofocusesTextFieldWhenOpened` would fail if the `FocusRequester.requestFocus()` call or `focusRequester(...)` modifier were removed.