### PR TITLE
fix(updater): support versioned release APK assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,11 +76,27 @@ jobs:
             -PversionName=${{ steps.ver.outputs.name }} \
             -PversionCode=${{ steps.ver.outputs.code }}
 
+      - name: Rename APK release asset
+        id: apk
+        env:
+          NAME: ${{ steps.ver.outputs.name }}
+        run: |
+          mapfile -t APKS < <(find app/build/outputs/apk/release -maxdepth 1 -type f -name '*.apk' | sort)
+          if [[ "${#APKS[@]}" -ne 1 ]]; then
+            printf '::error::Expected exactly one release APK, found %s\n' "${#APKS[@]}" >&2
+            printf '%s\n' "${APKS[@]}" >&2
+            exit 1
+          fi
+          TARGET="app/build/outputs/apk/release/riffle-$NAME.apk"
+          if [[ "${APKS[0]}" != "$TARGET" ]]; then
+            mv "${APKS[0]}" "$TARGET"
+          fi
+          echo "path=$TARGET" >>"$GITHUB_OUTPUT"
+
       - name: Verify APK is signed
         run: |
-          APK=$(ls app/build/outputs/apk/release/*.apk | head -1)
           APKSIGNER=$(ls -d "$ANDROID_HOME"/build-tools/*/apksigner | sort -V | tail -1)
-          "$APKSIGNER" verify --verbose "$APK"
+          "$APKSIGNER" verify --verbose "${{ steps.apk.outputs.path }}"
 
       - name: Write F-Droid changelog
         if: steps.ver.outputs.prerelease == 'false'
@@ -121,7 +137,7 @@ jobs:
       - name: Upload APK to GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          files: app/build/outputs/apk/release/*.apk
+          files: ${{ steps.apk.outputs.path }}
           generate_release_notes: true
           prerelease: ${{ steps.ver.outputs.prerelease == 'true' }}
 

--- a/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
+++ b/core/network/src/main/kotlin/com/riffle/core/network/GitHubReleaseApi.kt
@@ -46,9 +46,7 @@ class GitHubReleaseApi(
             val parsed = response.body<List<ReleaseResponse>>()
             for (release in parsed) {
                 if (release.draft || release.prerelease) continue
-                val apk = release.assets.firstOrNull {
-                    it.name.endsWith(".apk", ignoreCase = true)
-                } ?: continue
+                val apk = release.releaseApkAsset() ?: continue
                 return GitHubReleaseResult.Success(
                     GitHubRelease(
                         tagName = release.tagName,
@@ -81,7 +79,7 @@ class GitHubReleaseApi(
             parsed
                 .filter { !it.draft && !it.prerelease }
                 .map { release ->
-                    val apk = release.assets.firstOrNull { it.name.endsWith(".apk", ignoreCase = true) }
+                    val apk = release.releaseApkAsset()
                     GitHubRelease(
                         tagName = release.tagName,
                         apkUrl = apk?.downloadUrl ?: "",
@@ -176,3 +174,12 @@ private data class AssetResponse(
     @SerialName("browser_download_url") val downloadUrl: String,
     val size: Long = 0,
 )
+
+private fun ReleaseResponse.releaseApkAsset(): AssetResponse? {
+    val versionName = tagName.removePrefix("v")
+    val versionedApkName = "riffle-$versionName.apk"
+    return assets.firstOrNull { it.name.equals(versionedApkName, ignoreCase = true) }
+        ?: assets.firstOrNull { it.name.equals(LEGACY_RELEASE_APK_NAME, ignoreCase = true) }
+}
+
+private const val LEGACY_RELEASE_APK_NAME = "app-release.apk"

--- a/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
+++ b/core/network/src/test/kotlin/com/riffle/core/network/GitHubReleaseApiTest.kt
@@ -67,6 +67,62 @@ class GitHubReleaseApiTest {
     }
 
     @Test
+    fun `latestRelease accepts legacy app release apk assets`() = runTest {
+        server.enqueue(
+            MockResponse().setBody(
+                """
+                [
+                  {
+                    "tag_name": "v1.4.0",
+                    "draft": false,
+                    "prerelease": false,
+                    "assets": [
+                      { "name": "app-release.apk", "browser_download_url": "https://x/app-release.apk", "size": 4100 }
+                    ]
+                  }
+                ]
+                """.trimIndent()
+            ).addHeader("Content-Type", "application/json")
+        )
+
+        val result = api.latestRelease("pkmetski/riffle")
+
+        assertTrue(result is GitHubReleaseResult.Success)
+        val release = (result as GitHubReleaseResult.Success).release
+        assertEquals("v1.4.0", release.tagName)
+        assertEquals("https://x/app-release.apk", release.apkUrl)
+        assertEquals(4100L, release.apkSizeBytes)
+    }
+
+    @Test
+    fun `latestRelease prefers the versioned riffle apk over legacy apk assets`() = runTest {
+        server.enqueue(
+            MockResponse().setBody(
+                """
+                [
+                  {
+                    "tag_name": "v1.7.0",
+                    "draft": false,
+                    "prerelease": false,
+                    "assets": [
+                      { "name": "app-release.apk", "browser_download_url": "https://x/legacy.apk", "size": 4100 },
+                      { "name": "riffle-1.7.0.apk", "browser_download_url": "https://x/riffle-1.7.0.apk", "size": 4700 }
+                    ]
+                  }
+                ]
+                """.trimIndent()
+            ).addHeader("Content-Type", "application/json")
+        )
+
+        val result = api.latestRelease("pkmetski/riffle")
+
+        assertTrue(result is GitHubReleaseResult.Success)
+        val release = (result as GitHubReleaseResult.Success).release
+        assertEquals("https://x/riffle-1.7.0.apk", release.apkUrl)
+        assertEquals(4700L, release.apkSizeBytes)
+    }
+
+    @Test
     fun `latestRelease skips a still-building release and falls back to the prior apk release`() = runTest {
         server.enqueue(
             MockResponse().setBody(
@@ -285,6 +341,26 @@ class GitHubReleaseApiTest {
         assertEquals("2026-07-28T21:14:00Z", releases[0].publishedAt)
         assertEquals("v1.5.0", releases[1].tagName)
         assertEquals("### Fixes\n- Bug fix", releases[1].body)
+    }
+
+    @Test
+    fun `listReleases keeps download metadata for legacy app release apk assets`() = runTest {
+        server.enqueue(
+            MockResponse().setBody(
+                """
+                [
+                  { "tag_name": "v1.4.0", "draft": false, "prerelease": false, "body": "Notes",
+                    "assets": [{ "name": "app-release.apk", "browser_download_url": "https://x/app-release.apk", "size": 4100 }] }
+                ]
+                """.trimIndent()
+            ).addHeader("Content-Type", "application/json")
+        )
+
+        val releases = api.listReleases("pkmetski/riffle")
+
+        assertEquals(1, releases.size)
+        assertEquals("https://x/app-release.apk", releases[0].apkUrl)
+        assertEquals(4100L, releases[0].apkSizeBytes)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- rename the signed release APK asset to `riffle-{version}.apk` before signature verification and GitHub Release upload
- make GitHub release parsing prefer `riffle-{version}.apk` while still accepting legacy `app-release.apk` assets
- add updater regression coverage for legacy asset compatibility and versioned-asset preference

## Regression coverage
- `latestRelease accepts legacy app release apk assets` fails if future updater builds stop finding old `app-release.apk` releases.
- `latestRelease prefers the versioned riffle apk over legacy apk assets` fails if future updater builds do not prefer the new `riffle-{version}.apk` release asset.
- `listReleases keeps download metadata for legacy app release apk assets` fails if changelog/update metadata drops download information for old releases.

## Tests
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ./gradlew :core:network:test --tests com.riffle.core.network.GitHubReleaseApiTest`
- `git diff --check`
