### PR TITLE
feat(audiobook): cache streamed tracks and surface offline audio entries

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookController.kt
@@ -285,6 +285,22 @@ open class AudiobookController @Inject constructor(
     }
 
     /**
+     * Replaces media items from [fromIndex] to the end of the queue with [newUrls]. Used by the
+     * auto-cache swap: once all tracks are cached locally the VM calls this to point the unplayed
+     * tail of the queue at `file://` URLs instead of the original `http://` stream URLs. The
+     * currently-playing track (indices < [fromIndex]) is left untouched.
+     */
+    open fun swapTracksFromIndex(fromIndex: Int, newUrls: List<String>) {
+        val c = controller ?: return
+        if (!prepared || newUrls.isEmpty() || fromIndex >= c.mediaItemCount) return
+        val templateMetadata = c.getMediaItemAt(fromIndex.coerceAtMost(c.mediaItemCount - 1)).mediaMetadata
+        val items = newUrls.map { url ->
+            MediaItem.Builder().setMediaId(url).setUri(url).setMediaMetadata(templateMetadata).build()
+        }
+        c.replaceMediaItems(fromIndex, c.mediaItemCount, items)
+    }
+
+    /**
      * Discard any cached end-of-book event WITHOUT tearing the session down. Called when the
      * outgoing playlist-item VM hands off to the next item's VM on the same singleton controller:
      * the next VM's collector must NOT immediately re-consume the previous item's STATE_ENDED

--- a/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModel.kt
@@ -10,6 +10,7 @@ import com.riffle.core.models.AudiobookBookmark
 import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.AudiobookBookmarkStore
 import com.riffle.core.domain.AudiobookChapter
+import com.riffle.core.domain.AudiobookCacheRepository
 import com.riffle.core.domain.AudiobookRepository
 import com.riffle.core.domain.AudiobookTimeline
 import com.riffle.core.domain.BookmarkTitleBuilder
@@ -172,6 +173,7 @@ class AudiobookPlayerViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val audiobookRepository: AudiobookRepository,
     private val audiobookDownloadRepository: com.riffle.core.domain.AudiobookDownloadRepository,
+    private val audiobookCacheRepository: AudiobookCacheRepository,
     private val bundleAudiobookSource: com.riffle.core.domain.BundleAudiobookSource,
     private val libraryObserver: LibraryObserver,
     private val updateReadingProgressUseCase: UpdateReadingProgress,
@@ -383,15 +385,20 @@ class AudiobookPlayerViewModel @Inject constructor(
             logger.d(LogChannel.Handoff) { "AB.VM init: got server +${clock.nowMs() - t0}ms" }
             val item = libraryObserver.getItem(itemId)
             logger.d(LogChannel.Handoff) { "AB.VM init: got item +${clock.nowMs() - t0}ms" }
-            // Prefer a dedicated audiobook download, then a downloaded readaloud bundle's audio, then
-            // stream from ABS (connectivity-independent: a local copy always beats streaming).
+            // Prefer a dedicated audiobook download, then a downloaded readaloud bundle's audio,
+            // then an auto-cached copy, then stream from ABS (connectivity-independent: a local copy
+            // always beats streaming). The streaming path launches a background job to cache all
+            // tracks and swap the player's unplayed queue items to file:// URLs on completion.
+            var launchCacheJob = false
             val session = if (sourceId.isEmpty()) null
                 else audiobookDownloadRepository.localSession(sourceId, itemId)
                     ?.also { logger.d(LogChannel.Handoff) { "AB.VM init: local download session +${clock.nowMs() - t0}ms" } }
                     ?: bundleAudiobookSource.localSession(sourceId, itemId)
                     ?.also { logger.d(LogChannel.Handoff) { "AB.VM init: bundle session +${clock.nowMs() - t0}ms" } }
+                    ?: audiobookCacheRepository.localSession(sourceId, itemId)
+                    ?.also { logger.d(LogChannel.Handoff) { "AB.VM init: auto-cache session +${clock.nowMs() - t0}ms" } }
                     ?: audiobookRepository.openSession(sourceId, itemId)
-                    ?.also { logger.d(LogChannel.Handoff) { "AB.VM init: ABS network session +${clock.nowMs() - t0}ms" } }
+                    ?.also { launchCacheJob = true; logger.d(LogChannel.Handoff) { "AB.VM init: ABS network session +${clock.nowMs() - t0}ms" } }
             if (item == null || session == null) {
                 logger.d(LogChannel.Handoff) { "AB.VM init: FAILED (item=${item != null} session=${session != null}) +${clock.nowMs() - t0}ms" }
                 meta.value = meta.value.copy(loading = false, failed = true)
@@ -480,6 +487,28 @@ class AudiobookPlayerViewModel @Inject constructor(
                 val rewindOnResume = listeningPreferencesStore.rewindOnResumeSeconds.first().toDouble()
                 if (rewindOnResume > 0.0 && resumeSec > 0.0) {
                     playbackStartSec = (resumeSec - rewindOnResume).coerceAtLeast(0.0)
+                }
+            }
+
+            // Background auto-cache: download all tracks silently so the next open (or the current
+            // session after the swap) uses local files instead of the live stream. Launched before
+            // prepare() so the download starts as early as possible. viewModelScope cancels it if
+            // the user exits before caching completes; the partial dir is cleaned up by the impl.
+            if (launchCacheJob) {
+                val capturedSession = session
+                val capturedSourceId = sourceId
+                val capturedItemId = itemId
+                viewModelScope.launch {
+                    audiobookCacheRepository.awaitCachedAudiobook(capturedSourceId, capturedItemId, capturedSession)
+                    // Swap the unplayed tail of the queue to file:// URLs.
+                    val cachedSession = audiobookCacheRepository.localSession(capturedSourceId, capturedItemId) ?: return@launch
+                    val currentTrackIndex = com.riffle.core.models.AudiobookTracks.trackIndexAt(
+                        controller.currentAbsoluteSec(),
+                        capturedSession.tracks,
+                    )
+                    val nextIndex = currentTrackIndex + 1
+                    controller.swapTracksFromIndex(nextIndex, cachedSession.trackUrls.drop(nextIndex))
+                    logger.d(LogChannel.Handoff) { "AB.VM cache swap: tracks from $nextIndex swapped to local files" }
                 }
             }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/AudiobookPlayerViewModelBookmarkTest.kt
@@ -165,6 +165,7 @@ class AudiobookPlayerViewModelBookmarkTest {
             savedStateHandle = SavedStateHandle(savedState),
             audiobookRepository = repo,
             audiobookDownloadRepository = NoDownloadRepo,
+            audiobookCacheRepository = NoCacheRepo,
             bundleAudiobookSource = NoBundleSource,
             libraryObserver = FakeLibraryRepository(),
             updateReadingProgressUseCase = com.riffle.app.testing.NoopUpdateReadingProgress(),
@@ -721,6 +722,13 @@ class AudiobookPlayerViewModelBookmarkTest {
     private object NoBundleSource : BundleAudiobookSource {
         override suspend fun localSession(sourceId: String, itemId: String): AudiobookSession? = null
         override fun isAvailableOffline(sourceId: String, itemId: String) = false
+    }
+
+    private object NoCacheRepo : com.riffle.core.domain.AudiobookCacheRepository {
+        override fun isCached(sourceId: String, itemId: String) = false
+        override fun localSession(sourceId: String, itemId: String): AudiobookSession? = null
+        override suspend fun awaitCachedAudiobook(sourceId: String, itemId: String, session: AudiobookSession) = Unit
+        override suspend fun remove(sourceId: String, itemId: String): Long = 0
     }
 
     private inner class FakeLibraryRepository : LibraryObserver {

--- a/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/audiobook/SleepTimerTest.kt
@@ -195,6 +195,7 @@ class SleepTimerTest {
             savedStateHandle = SavedStateHandle(mapOf("itemId" to itemId)),
             audiobookRepository = FakeAudiobookRepository(session),
             audiobookDownloadRepository = NoDownloadRepo,
+            audiobookCacheRepository = NoCacheRepo,
             bundleAudiobookSource = NoBundleSource,
             libraryObserver = FakeLibraryRepository(),
             updateReadingProgressUseCase = com.riffle.app.testing.NoopUpdateReadingProgress(),
@@ -410,6 +411,13 @@ class SleepTimerTest {
     private object NoBundleSource : BundleAudiobookSource {
         override suspend fun localSession(sourceId: String, itemId: String): AudiobookSession? = null
         override fun isAvailableOffline(sourceId: String, itemId: String) = false
+    }
+
+    private object NoCacheRepo : com.riffle.core.domain.AudiobookCacheRepository {
+        override fun isCached(sourceId: String, itemId: String) = false
+        override fun localSession(sourceId: String, itemId: String): AudiobookSession? = null
+        override suspend fun awaitCachedAudiobook(sourceId: String, itemId: String, session: AudiobookSession) = Unit
+        override suspend fun remove(sourceId: String, itemId: String): Long = 0
     }
 
     private inner class FakeLibraryRepository : LibraryObserver {

--- a/app/src/test/kotlin/com/riffle/app/feature/downloads/DownloadsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/downloads/DownloadsViewModelTest.kt
@@ -29,7 +29,13 @@ class DownloadsViewModelTest {
     @Before fun setUp() { Dispatchers.setMain(dispatcher) }
     @After fun tearDown() { Dispatchers.resetMain() }
 
-    private fun item(sourceId: String, id: String, title: String) = LibraryItem(
+    private fun item(
+        sourceId: String,
+        id: String,
+        title: String,
+        ebookFormat: EbookFormat = EbookFormat.Epub,
+        hasAudio: Boolean = false,
+    ) = LibraryItem(
         id = id,
         libraryId = "lib-$sourceId",
         title = title,
@@ -38,7 +44,8 @@ class DownloadsViewModelTest {
         readingProgress = 0f,
         isCached = false,
         isDownloaded = false,
-        ebookFormat = EbookFormat.Epub,
+        ebookFormat = ebookFormat,
+        hasAudio = hasAudio,
         sourceId = sourceId,
     )
 
@@ -60,9 +67,11 @@ class DownloadsViewModelTest {
         every { downloadsRepo.getDownloadedItems() } returns listOf(
             StoredItemRef("abs", "abs-book"),
             StoredItemRef("chitanka", "ch-book"),
+            StoredItemRef("abs", "ab-book"),
         )
         every { downloadsRepo.getCachedItems() } returns listOf(
             StoredItemRef("abs", "abs-cached"),
+            StoredItemRef("abs", "ab-cached"),
         )
         every { downloadsRepo.sizeOf(any(), any()) } returns 1024L
 
@@ -70,6 +79,10 @@ class DownloadsViewModelTest {
         coEvery { libraryObserver.getItem("abs", "abs-book") } returns item("abs", "abs-book", "ABS Downloaded")
         coEvery { libraryObserver.getItem("chitanka", "ch-book") } returns item("chitanka", "ch-book", "Chitanka Downloaded")
         coEvery { libraryObserver.getItem("abs", "abs-cached") } returns item("abs", "abs-cached", "ABS Cached")
+        coEvery { libraryObserver.getItem("abs", "ab-book") } returns
+            item("abs", "ab-book", "ABS Audiobook Downloaded", ebookFormat = EbookFormat.Unsupported, hasAudio = true)
+        coEvery { libraryObserver.getItem("abs", "ab-cached") } returns
+            item("abs", "ab-cached", "ABS Audiobook Cached", ebookFormat = EbookFormat.Unsupported, hasAudio = true)
         coEvery { libraryObserver.getItem("storyteller", "st-book") } returns item("storyteller", "st-book", "Storyteller Readaloud")
 
         val sidecarStore = mockk<ReadaloudSidecarStore>(relaxed = true)
@@ -82,10 +95,10 @@ class DownloadsViewModelTest {
 
         val state = vm.uiState.value
         assertEquals(
-            listOf("ABS Downloaded", "Chitanka Downloaded"),
+            listOf("ABS Downloaded", "Chitanka Downloaded", "ABS Audiobook Downloaded"),
             state.downloadedItems.map { it.item.title },
         )
-        assertEquals(listOf("ABS Cached"), state.cachedItems.map { it.item.title })
+        assertEquals(listOf("ABS Cached", "ABS Audiobook Cached"), state.cachedItems.map { it.item.title })
         assertEquals(listOf("Storyteller Readaloud"), state.readaloudSidecars.map { it.item.title })
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookCacheRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookCacheRepositoryImpl.kt
@@ -1,0 +1,83 @@
+package com.riffle.core.data
+
+import com.riffle.core.data.di.AudiobookCacheDir
+import com.riffle.core.domain.AudiobookCacheRepository
+import com.riffle.core.domain.AudiobookChapter
+import com.riffle.core.domain.AudiobookSession
+import com.riffle.core.domain.AudiobookTimeline
+import com.riffle.core.domain.DispatcherProvider
+import com.riffle.core.models.AudiobookTrackSpan
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.io.File
+import javax.inject.Inject
+
+class AudiobookCacheRepositoryImpl @Inject constructor(
+    @AudiobookCacheDir private val cacheDir: File,
+    private val trackDownloader: AudiobookTrackDownloader,
+    private val dispatchers: DispatcherProvider,
+) : AudiobookCacheRepository {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun itemDir(sourceId: String, itemId: String) = File(cacheDir, "$sourceId/$itemId")
+    private fun manifestFile(sourceId: String, itemId: String) = File(itemDir(sourceId, itemId), "manifest.json")
+
+    override fun isCached(sourceId: String, itemId: String): Boolean =
+        manifestFile(sourceId, itemId).exists()
+
+    override fun localSession(sourceId: String, itemId: String): AudiobookSession? {
+        val mf = manifestFile(sourceId, itemId)
+        if (!mf.exists()) return null
+        val manifest = runCatching { json.decodeFromString<AudiobookDownloadManifest>(mf.readText()) }.getOrNull()
+            ?: return null
+        val dir = itemDir(sourceId, itemId)
+        return AudiobookSession(
+            trackUrls = manifest.tracks.map { File(dir, it.file).toURI().toString() },
+            tracks = manifest.tracks.map { AudiobookTrackSpan(it.index, it.startOffsetSec, it.durationSec) },
+            timeline = AudiobookTimeline(
+                durationSec = manifest.durationSec,
+                chapters = manifest.chapters.map { AudiobookChapter(it.index, it.startSec, it.endSec, it.title) },
+            ),
+            serverCurrentTimeSec = 0.0,
+        )
+    }
+
+    override suspend fun awaitCachedAudiobook(
+        sourceId: String,
+        itemId: String,
+        session: AudiobookSession,
+    ) = withContext(dispatchers.io) {
+        if (isCached(sourceId, itemId)) return@withContext
+        val dir = itemDir(sourceId, itemId).apply { mkdirs() }
+        try {
+            val noop: (Long, Long) -> Unit = { _, _ -> }
+            val progress = CumulativeDownloadProgress(0L, noop)
+            val manifestTracks = trackDownloader.download(session, dir, progress)
+            val manifest = AudiobookDownloadManifest(
+                durationSec = session.timeline.durationSec,
+                tracks = manifestTracks.sortedBy { it.index },
+                chapters = session.timeline.chapters.map {
+                    AudiobookDownloadManifest.ManifestChapter(it.index, it.startSec, it.endSec, it.title)
+                },
+            )
+            // Written last → atomic completion marker (same pattern as AudiobookDownloadRepositoryImpl).
+            manifestFile(sourceId, itemId).writeText(json.encodeToString(manifest))
+        } catch (e: CancellationException) {
+            dir.deleteRecursively()
+            throw e
+        } catch (e: Exception) {
+            dir.deleteRecursively()
+            // Streaming continues unaffected; cache will be retried on next open.
+        }
+    }
+
+    override suspend fun remove(sourceId: String, itemId: String): Long = withContext(dispatchers.io) {
+        val dir = itemDir(sourceId, itemId)
+        val freed = dir.walkBottomUp().filter { it.isFile }.sumOf { it.length() }
+        dir.deleteRecursively()
+        freed
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookDownloadRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookDownloadRepositoryImpl.kt
@@ -35,7 +35,7 @@ internal data class AudiobookDownloadManifest(
  * reconstructs a playable [AudiobookSession] from them offline (ADR 0029). The directory holds one
  * file per track plus `manifest.json`; the manifest is written **last**, so its presence is the
  * atomic "fully downloaded" marker — a partial download (some tracks, no manifest) reads as
- * not-downloaded and is simply re-fetched. All tracks are downloaded in parallel via
+ * not-downloaded and is simply re-fetched. Track transfer is delegated to the shared
  * [AudiobookTrackDownloader].
  */
 class AudiobookDownloadRepositoryImpl @Inject constructor(

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookDownloadRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookDownloadRepositoryImpl.kt
@@ -6,11 +6,8 @@ import com.riffle.core.domain.AudiobookDownloadResult
 import com.riffle.core.domain.AudiobookRepository
 import com.riffle.core.domain.AudiobookSession
 import com.riffle.core.domain.AudiobookTimeline
-import com.riffle.core.data.di.qualifiers.StreamingHttpClient
-import com.riffle.core.models.AudiobookTrackSpan
 import com.riffle.core.domain.DispatcherProvider
-import com.riffle.core.network.withHttpByteStream
-import io.ktor.client.HttpClient
+import com.riffle.core.models.AudiobookTrackSpan
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
@@ -38,11 +35,12 @@ internal data class AudiobookDownloadManifest(
  * reconstructs a playable [AudiobookSession] from them offline (ADR 0029). The directory holds one
  * file per track plus `manifest.json`; the manifest is written **last**, so its presence is the
  * atomic "fully downloaded" marker — a partial download (some tracks, no manifest) reads as
- * not-downloaded and is simply re-fetched.
+ * not-downloaded and is simply re-fetched. All tracks are downloaded in parallel via
+ * [AudiobookTrackDownloader].
  */
 class AudiobookDownloadRepositoryImpl @Inject constructor(
     private val audiobookRepository: AudiobookRepository,
-    @StreamingHttpClient private val httpClient: HttpClient,
+    private val trackDownloader: AudiobookTrackDownloader,
     @com.riffle.core.data.di.AudiobookDownloadsDir private val downloadsDir: File,
     private val dispatchers: DispatcherProvider,
 ) : AudiobookDownloadRepository {
@@ -85,46 +83,11 @@ class AudiobookDownloadRepositoryImpl @Inject constructor(
         val progress = CumulativeDownloadProgress(wholeAudiobookBytes ?: 0L, onProgress)
 
         val dir = itemDir(sourceId, itemId).apply { mkdirs() }
-        val manifestTracks = ArrayList<AudiobookDownloadManifest.ManifestTrack>()
         try {
-            session.trackUrls.forEachIndexed { i, url ->
-                val fileName = "track-$i"
-                val out = File(dir, fileName)
-                httpClient.withHttpByteStream(
-                    url = url,
-                    httpFailure = { failure -> IOException("HTTP ${failure.code} for track $i") },
-                ) { response ->
-                    // A per-track Content-Length is only the whole download size for a one-track
-                    // audiobook. For multi-track books, using each newly discovered length as the
-                    // denominator makes progress hit 100% at every track boundary and then go
-                    // backwards. Prefer the Source fingerprint's aggregate size; stay indeterminate
-                    // when a multi-track Source cannot provide one.
-                    if (session.trackUrls.size == 1) {
-                        progress.establishTotal(response.contentLength)
-                    }
-                    response.inputStream.use { input ->
-                        out.outputStream().use { output ->
-                            val buf = ByteArray(64 * 1024)
-                            while (true) {
-                                val read = input.read(buf)
-                                if (read < 0) break
-                                output.write(buf, 0, read)
-                                progress.record(read.toLong())
-                            }
-                        }
-                    }
-                }
-                val span = session.tracks.getOrNull(i)
-                manifestTracks += AudiobookDownloadManifest.ManifestTrack(
-                    index = span?.index ?: i,
-                    file = fileName,
-                    startOffsetSec = span?.startOffsetSec ?: 0.0,
-                    durationSec = span?.durationSec ?: 0.0,
-                )
-            }
+            val manifestTracks = trackDownloader.download(session, dir, progress)
             val manifest = AudiobookDownloadManifest(
                 durationSec = session.timeline.durationSec,
-                tracks = manifestTracks,
+                tracks = manifestTracks.sortedBy { it.index },
                 chapters = session.timeline.chapters.map {
                     AudiobookDownloadManifest.ManifestChapter(it.index, it.startSec, it.endSec, it.title)
                 },

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookTrackDownloader.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookTrackDownloader.kt
@@ -1,0 +1,66 @@
+package com.riffle.core.data
+
+import com.riffle.core.data.di.qualifiers.StreamingHttpClient
+import com.riffle.core.domain.AudiobookSession
+import com.riffle.core.domain.DispatcherProvider
+import com.riffle.core.network.withHttpByteStream
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.IOException
+import javax.inject.Inject
+
+/**
+ * Downloads all tracks in an [AudiobookSession] to a directory in parallel. Used by both
+ * [AudiobookDownloadRepositoryImpl] (explicit user download) and [AudiobookCacheRepositoryImpl]
+ * (background auto-cache). Returns the [AudiobookDownloadManifest.ManifestTrack] list ordered by
+ * track index; throws on any per-track failure (the caller must clean up the dir).
+ */
+class AudiobookTrackDownloader @Inject constructor(
+    @StreamingHttpClient private val httpClient: HttpClient,
+    private val dispatchers: DispatcherProvider,
+) {
+    internal suspend fun download(
+        session: AudiobookSession,
+        dir: File,
+        progress: CumulativeDownloadProgress,
+    ): List<AudiobookDownloadManifest.ManifestTrack> = withContext(dispatchers.io) {
+        coroutineScope {
+            session.trackUrls.mapIndexed { i, url ->
+                async {
+                    val fileName = "track-$i"
+                    val out = File(dir, fileName)
+                    httpClient.withHttpByteStream(
+                        url = url,
+                        httpFailure = { failure -> IOException("HTTP ${failure.code} for track $i") },
+                    ) { response ->
+                        if (session.trackUrls.size == 1) {
+                            progress.establishTotal(response.contentLength)
+                        }
+                        response.inputStream.use { input ->
+                            out.outputStream().use { output ->
+                                val buf = ByteArray(64 * 1024)
+                                while (true) {
+                                    val read = input.read(buf)
+                                    if (read < 0) break
+                                    output.write(buf, 0, read)
+                                    progress.record(read.toLong())
+                                }
+                            }
+                        }
+                    }
+                    val span = session.tracks.getOrNull(i)
+                    AudiobookDownloadManifest.ManifestTrack(
+                        index = span?.index ?: i,
+                        file = fileName,
+                        startOffsetSec = span?.startOffsetSec ?: 0.0,
+                        durationSec = span?.durationSec ?: 0.0,
+                    )
+                }
+            }.awaitAll()
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/AudiobookTrackDownloader.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AudiobookTrackDownloader.kt
@@ -5,19 +5,18 @@ import com.riffle.core.domain.AudiobookSession
 import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.network.withHttpByteStream
 import io.ktor.client.HttpClient
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.IOException
 import javax.inject.Inject
 
 /**
- * Downloads all tracks in an [AudiobookSession] to a directory in parallel. Used by both
+ * Downloads all tracks in an [AudiobookSession] to a directory. Used by both
  * [AudiobookDownloadRepositoryImpl] (explicit user download) and [AudiobookCacheRepositoryImpl]
- * (background auto-cache). Returns the [AudiobookDownloadManifest.ManifestTrack] list ordered by
- * track index; throws on any per-track failure (the caller must clean up the dir).
+ * (background auto-cache). Tracks are fetched serially: some ABS backends reject concurrent pulls
+ * for the same book, and a single shared helper must not break either explicit download or
+ * play-time auto-cache. Returns the [AudiobookDownloadManifest.ManifestTrack] list ordered by track
+ * index; throws on any per-track failure (the caller must clean up the dir).
  */
 class AudiobookTrackDownloader @Inject constructor(
     @StreamingHttpClient private val httpClient: HttpClient,
@@ -28,39 +27,39 @@ class AudiobookTrackDownloader @Inject constructor(
         dir: File,
         progress: CumulativeDownloadProgress,
     ): List<AudiobookDownloadManifest.ManifestTrack> = withContext(dispatchers.io) {
-        coroutineScope {
-            session.trackUrls.mapIndexed { i, url ->
-                async {
-                    val fileName = "track-$i"
-                    val out = File(dir, fileName)
-                    httpClient.withHttpByteStream(
-                        url = url,
-                        httpFailure = { failure -> IOException("HTTP ${failure.code} for track $i") },
-                    ) { response ->
-                        if (session.trackUrls.size == 1) {
-                            progress.establishTotal(response.contentLength)
-                        }
-                        response.inputStream.use { input ->
-                            out.outputStream().use { output ->
-                                val buf = ByteArray(64 * 1024)
-                                while (true) {
-                                    val read = input.read(buf)
-                                    if (read < 0) break
-                                    output.write(buf, 0, read)
-                                    progress.record(read.toLong())
-                                }
+        buildList(session.trackUrls.size) {
+            session.trackUrls.forEachIndexed { i, url ->
+                val fileName = "track-$i"
+                val out = File(dir, fileName)
+                httpClient.withHttpByteStream(
+                    url = url,
+                    httpFailure = { failure -> IOException("HTTP ${failure.code} for track $i") },
+                ) { response ->
+                    if (session.trackUrls.size == 1) {
+                        progress.establishTotal(response.contentLength)
+                    }
+                    response.inputStream.use { input ->
+                        out.outputStream().use { output ->
+                            val buf = ByteArray(64 * 1024)
+                            while (true) {
+                                val read = input.read(buf)
+                                if (read < 0) break
+                                output.write(buf, 0, read)
+                                progress.record(read.toLong())
                             }
                         }
                     }
-                    val span = session.tracks.getOrNull(i)
+                }
+                val span = session.tracks.getOrNull(i)
+                add(
                     AudiobookDownloadManifest.ManifestTrack(
                         index = span?.index ?: i,
                         file = fileName,
                         startOffsetSec = span?.startOffsetSec ?: 0.0,
                         durationSec = span?.durationSec ?: 0.0,
-                    )
-                }
-            }.awaitAll()
+                    ),
+                )
+            }
         }
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/CumulativeDownloadProgress.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/CumulativeDownloadProgress.kt
@@ -5,6 +5,9 @@ import java.io.InputStream
 /**
  * Owns the cumulative byte count and stable total for a transfer. One instance can track a single
  * book stream or successive audiobook tracks; a non-positive total remains indeterminate.
+ *
+ * Thread-safe: [record] and [establishTotal] synchronize on `this` so parallel track downloads can
+ * all report into the same counter without races.
  */
 internal class CumulativeDownloadProgress(
     total: Long,
@@ -16,10 +19,12 @@ internal class CumulativeDownloadProgress(
     private var total = total.takeIf { it > 0L } ?: 0L
 
     /** Establishes an initially unknown total exactly once. */
+    @Synchronized
     fun establishTotal(candidate: Long?) {
         if (total == 0L && candidate != null && candidate > 0L) total = candidate
     }
 
+    @Synchronized
     fun record(delta: Long) {
         if (delta <= 0L) return
         downloaded += delta

--- a/core/data/src/main/kotlin/com/riffle/core/data/DownloadsRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/DownloadsRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.riffle.core.data
 import com.riffle.core.domain.DownloadsRepository
 import com.riffle.core.domain.LocalStore
 import com.riffle.core.domain.StoredItemRef
+import java.io.File
 
 class DownloadsRepositoryImpl(
     private val epubCacheStore: LocalStore,
@@ -11,35 +12,70 @@ class DownloadsRepositoryImpl(
     private val pdfDownloadsStore: LocalStore,
     private val cbzCacheStore: LocalStore,
     private val cbzDownloadsStore: LocalStore,
+    private val audiobookCacheDir: File,
+    private val audiobookDownloadsDir: File,
 ) : DownloadsRepository {
 
     private val downloadStores = listOf(epubDownloadsStore, pdfDownloadsStore, cbzDownloadsStore)
     private val cacheStores = listOf(epubCacheStore, pdfCacheStore, cbzCacheStore)
+    private val manifestName = "manifest.json"
 
     override fun getDownloadedItems(): List<StoredItemRef> =
-        downloadStores.flatMap { it.listItems() }.distinct()
+        (downloadStores.flatMap { it.listItems() } + listDirectoryBackedItems(audiobookDownloadsDir)).distinct()
 
     override fun getCachedItems(): List<StoredItemRef> {
         val downloaded = getDownloadedItems().toHashSet()
-        return cacheStores.flatMap { it.listItems() }.distinct().filter { it !in downloaded }
+        return (cacheStores.flatMap { it.listItems() } + listDirectoryBackedItems(audiobookCacheDir))
+            .distinct()
+            .filter { it !in downloaded }
     }
 
     override fun sizeOf(sourceId: String, itemId: String): Long =
-        (downloadStores + cacheStores).sumOf { it.get(sourceId, itemId)?.length() ?: 0L }
+        (downloadStores + cacheStores).sumOf { it.get(sourceId, itemId)?.length() ?: 0L } +
+            directorySize(itemDir(audiobookDownloadsDir, sourceId, itemId)) +
+            directorySize(itemDir(audiobookCacheDir, sourceId, itemId))
 
     override suspend fun removeDownload(sourceId: String, itemId: String) {
         downloadStores.forEach { it.delete(sourceId, itemId) }
+        itemDir(audiobookDownloadsDir, sourceId, itemId).deleteRecursively()
     }
 
     override suspend fun removeCached(sourceId: String, itemId: String) {
         cacheStores.forEach { it.delete(sourceId, itemId) }
+        itemDir(audiobookCacheDir, sourceId, itemId).deleteRecursively()
     }
 
     override suspend fun removeAllDownloads() {
         downloadStores.forEach { it.clear() }
+        audiobookDownloadsDir.listFiles()?.forEach { it.deleteRecursively() }
     }
 
     override suspend fun clearAllCached() {
         cacheStores.forEach { it.clear() }
+        audiobookCacheDir.listFiles()?.forEach { it.deleteRecursively() }
     }
+
+    private fun itemDir(root: File, sourceId: String, itemId: String): File =
+        root.resolve(sourceId).resolve(itemId)
+
+    private fun directorySize(dir: File): Long =
+        if (!dir.exists()) 0L else dir.walkTopDown().filter { it.isFile }.sumOf { it.length() }
+
+    private fun listDirectoryBackedItems(root: File): List<StoredItemRef> =
+        root.listFiles()
+            ?.filter { it.isDirectory }
+            ?.flatMap { sourceDir ->
+                val prefix = sourceDir.absolutePath + File.separator
+                sourceDir.walkTopDown()
+                    .filter { it.isFile && it.name == manifestName }
+                    .map { manifest ->
+                        val itemDir = requireNotNull(manifest.parentFile) { "manifest without parent: $manifest" }
+                        StoredItemRef(
+                            sourceId = sourceDir.name,
+                            itemId = itemDir.absolutePath.removePrefix(prefix),
+                        )
+                    }
+                    .toList()
+            }
+            ?: emptyList()
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -97,6 +97,10 @@ annotation class AudiobookDownloadsDir
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
+annotation class AudiobookCacheDir
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
 annotation class PdfCacheStore
 
 @Qualifier

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/LocalStoreModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/LocalStoreModule.kt
@@ -17,6 +17,7 @@ import com.riffle.core.data.LocalStoreMigrator
 import com.riffle.core.data.ReadaloudResumeStoreImpl
 import com.riffle.core.data.ReadingPositionStoreImpl
 import com.riffle.core.data.SourceFilesCleanerImpl
+import com.riffle.core.data.di.AudiobookCacheDir
 import com.riffle.core.data.di.AudiobookDownloadsDir
 import com.riffle.core.data.di.CrashReportDir
 import com.riffle.core.data.di.CbzCacheStore
@@ -122,6 +123,12 @@ abstract class LocalStoreModule {
         @AudiobookDownloadsDir
         fun provideAudiobookDownloadsDir(@ApplicationContext context: Context): File =
             context.filesDir.resolve("downloads/audiobooks").also { it.mkdirs() }
+
+        @Provides
+        @Singleton
+        @AudiobookCacheDir
+        fun provideAudiobookCacheDir(@ApplicationContext context: Context): File =
+            context.cacheDir.resolve("audiobooks").also { it.mkdirs() }
 
         @Provides
         @Singleton

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/LocalStoreModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/LocalStoreModule.kt
@@ -184,10 +184,13 @@ abstract class LocalStoreModule {
             @PdfDownloadsStore pdfDownloadsStore: LocalStore,
             @CbzCacheStore cbzCacheStore: LocalStore,
             @CbzDownloadsStore cbzDownloadsStore: LocalStore,
+            @AudiobookCacheDir audiobookCacheDir: File,
+            @AudiobookDownloadsDir audiobookDownloadsDir: File,
         ): DownloadsRepository = DownloadsRepositoryImpl(
             epubCacheStore, epubDownloadsStore,
             pdfCacheStore, pdfDownloadsStore,
             cbzCacheStore, cbzDownloadsStore,
+            audiobookCacheDir, audiobookDownloadsDir,
         )
 
         @Provides

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/StreamingAudioModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/StreamingAudioModule.kt
@@ -3,6 +3,7 @@ package com.riffle.core.data.di.modules
 import android.content.Context
 import com.riffle.core.data.AudioIdentityResolverImpl
 import com.riffle.core.data.AudiobookBundleDownloader
+import com.riffle.core.data.AudiobookCacheRepositoryImpl
 import com.riffle.core.data.AudiobookChapterCacheRepositoryImpl
 import com.riffle.core.data.AudiobookDownloadRepositoryImpl
 import com.riffle.core.data.AudiobookRepositoryImpl
@@ -16,6 +17,7 @@ import com.riffle.core.data.di.EpubDownloadsStore
 import com.riffle.core.data.readaloudLinksByAbsItemKey
 import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.AudioIdentityResolver
+import com.riffle.core.domain.AudiobookCacheRepository
 import com.riffle.core.domain.AudiobookChapterCacheRepository
 import com.riffle.core.domain.AudiobookDownloadRepository
 import com.riffle.core.domain.AudiobookRepository
@@ -47,6 +49,10 @@ abstract class StreamingAudioModule {
     @Binds
     @Singleton
     abstract fun bindAudiobookDownloadRepository(impl: AudiobookDownloadRepositoryImpl): AudiobookDownloadRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindAudiobookCacheRepository(impl: AudiobookCacheRepositoryImpl): AudiobookCacheRepository
 
     @Binds
     @Singleton

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookCacheRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookCacheRepositoryImplTest.kt
@@ -107,9 +107,6 @@ class AudiobookCacheRepositoryImplTest {
             val s = r.localSession("srv", "it")!!
             assertEquals(2, s.trackUrls.size)
             assertTrue(s.trackUrls[0].startsWith("file:"))
-            // Parallel downloads: responses arrive in FIFO order from MockWebServer regardless of
-            // which coroutine connects first, so we can't assert per-file content — only that both
-            // files are non-empty and together contain the full expected payload.
             val allContent = setOf(
                 File(root, "srv/it/track-0").readText(),
                 File(root, "srv/it/track-1").readText(),

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookCacheRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookCacheRepositoryImplTest.kt
@@ -1,0 +1,179 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.AudiobookSession
+import com.riffle.core.domain.AudiobookTimeline
+import com.riffle.core.models.AudiobookTrackSpan
+import com.riffle.core.network.createStreamingHttpClient
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class AudiobookCacheRepositoryImplTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun repo(root: File): AudiobookCacheRepositoryImpl {
+        val httpClient = createStreamingHttpClient()
+        val trackDownloader = AudiobookTrackDownloader(httpClient, com.riffle.core.domain.DefaultDispatcherProvider)
+        return AudiobookCacheRepositoryImpl(root, trackDownloader, com.riffle.core.domain.DefaultDispatcherProvider)
+    }
+
+    private fun writeCache(root: File) {
+        val dir = File(root, "srv/it").apply { mkdirs() }
+        File(dir, "track-0").writeBytes(ByteArray(10))
+        File(dir, "track-1").writeBytes(ByteArray(20))
+        val manifest = AudiobookDownloadManifest(
+            durationSec = 300.0,
+            tracks = listOf(
+                AudiobookDownloadManifest.ManifestTrack(0, "track-0", 0.0, 100.0),
+                AudiobookDownloadManifest.ManifestTrack(1, "track-1", 100.0, 200.0),
+            ),
+            chapters = listOf(
+                AudiobookDownloadManifest.ManifestChapter(0, 0.0, 100.0, "One"),
+                AudiobookDownloadManifest.ManifestChapter(1, 100.0, 300.0, "Two"),
+            ),
+        )
+        File(dir, "manifest.json").writeText(json.encodeToString(manifest))
+    }
+
+    @Test
+    fun `isCached reflects manifest presence`() {
+        val root = tmp.newFolder()
+        assertFalse(repo(root).isCached("srv", "it"))
+        writeCache(root)
+        assertTrue(repo(root).isCached("srv", "it"))
+    }
+
+    @Test
+    fun `localSession returns null when not cached`() {
+        assertNull(repo(tmp.newFolder()).localSession("srv", "it"))
+    }
+
+    @Test
+    fun `localSession reconstructs file URLs spans and timeline from the manifest`() {
+        val root = tmp.newFolder()
+        writeCache(root)
+
+        val s = repo(root).localSession("srv", "it")!!
+
+        assertEquals(2, s.trackUrls.size)
+        assertTrue("file:// URL expected", s.trackUrls[0].startsWith("file:"))
+        assertTrue(s.trackUrls[0].endsWith("/srv/it/track-0"))
+        assertEquals(listOf(0.0, 100.0), s.tracks.map { it.startOffsetSec })
+        assertEquals(300.0, s.timeline.durationSec, 0.0)
+        assertEquals(listOf("One", "Two"), s.timeline.chapters.map { it.title })
+        assertEquals(0.0, s.serverCurrentTimeSec, 0.0)
+    }
+
+    @Test
+    fun `awaitCachedAudiobook downloads all tracks and writes manifest`() = runTest {
+        val server = MockWebServer()
+        server.start()
+        try {
+            server.enqueue(MockResponse().setBody("audio-track-0"))
+            server.enqueue(MockResponse().setBody("audio-track-1"))
+            val session = AudiobookSession(
+                trackUrls = listOf(
+                    server.url("/track-0.mp3").toString(),
+                    server.url("/track-1.mp3").toString(),
+                ),
+                tracks = listOf(
+                    AudiobookTrackSpan(0, 0.0, 10.0),
+                    AudiobookTrackSpan(1, 10.0, 20.0),
+                ),
+                timeline = AudiobookTimeline(durationSec = 30.0, chapters = emptyList()),
+                serverCurrentTimeSec = 0.0,
+            )
+            val root = tmp.newFolder()
+            val r = repo(root)
+
+            r.awaitCachedAudiobook("srv", "it", session)
+
+            assertTrue(r.isCached("srv", "it"))
+            val s = r.localSession("srv", "it")!!
+            assertEquals(2, s.trackUrls.size)
+            assertTrue(s.trackUrls[0].startsWith("file:"))
+            // Parallel downloads: responses arrive in FIFO order from MockWebServer regardless of
+            // which coroutine connects first, so we can't assert per-file content — only that both
+            // files are non-empty and together contain the full expected payload.
+            val allContent = setOf(
+                File(root, "srv/it/track-0").readText(),
+                File(root, "srv/it/track-1").readText(),
+            )
+            assertEquals(setOf("audio-track-0", "audio-track-1"), allContent)
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    @Test
+    fun `awaitCachedAudiobook is a no-op when already cached`() = runTest {
+        val root = tmp.newFolder()
+        writeCache(root)
+        val r = repo(root)
+
+        // No server enqueued — if it made a network call this would fail with a connection error.
+        r.awaitCachedAudiobook(
+            "srv", "it",
+            AudiobookSession(
+                trackUrls = listOf("http://example.invalid/track.mp3"),
+                tracks = listOf(AudiobookTrackSpan(0, 0.0, 10.0)),
+                timeline = AudiobookTimeline(10.0, emptyList()),
+                serverCurrentTimeSec = 0.0,
+            ),
+        )
+
+        assertTrue(r.isCached("srv", "it"))
+    }
+
+    @Test
+    fun `awaitCachedAudiobook silently swallows download failures and leaves no partial dir`() = runTest {
+        val server = MockWebServer()
+        server.start()
+        try {
+            server.enqueue(MockResponse().setResponseCode(500))
+            val session = AudiobookSession(
+                trackUrls = listOf(server.url("/track.mp3").toString()),
+                tracks = listOf(AudiobookTrackSpan(0, 0.0, 10.0)),
+                timeline = AudiobookTimeline(10.0, emptyList()),
+                serverCurrentTimeSec = 0.0,
+            )
+            val root = tmp.newFolder()
+            val r = repo(root)
+
+            r.awaitCachedAudiobook("srv", "it", session) // must not throw
+
+            assertFalse(r.isCached("srv", "it"))
+            assertFalse(File(root, "srv/it").exists())
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    @Test
+    fun `remove deletes the cache dir and reports freed bytes`() = runTest {
+        val root = tmp.newFolder()
+        writeCache(root)
+        val r = repo(root)
+
+        val freed = r.remove("srv", "it")
+
+        assertTrue("freed at least the track bytes", freed >= 30L)
+        assertFalse(r.isCached("srv", "it"))
+        assertNull(r.localSession("srv", "it"))
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookDownloadRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookDownloadRepositoryImplTest.kt
@@ -41,12 +41,16 @@ class AudiobookDownloadRepositoryImplTest {
     private fun repo(
         root: File,
         audiobookRepository: AudiobookRepository = NoopAudiobookRepository,
-    ) = AudiobookDownloadRepositoryImpl(
-        audiobookRepository,
-        createStreamingHttpClient(),
-        root,
-        com.riffle.core.domain.DefaultDispatcherProvider,
-    )
+    ): AudiobookDownloadRepositoryImpl {
+        val httpClient = createStreamingHttpClient()
+        val trackDownloader = AudiobookTrackDownloader(httpClient, com.riffle.core.domain.DefaultDispatcherProvider)
+        return AudiobookDownloadRepositoryImpl(
+            audiobookRepository,
+            trackDownloader,
+            root,
+            com.riffle.core.domain.DefaultDispatcherProvider,
+        )
+    }
 
     /** Write a completed download (track files + manifest) for (srv, it) under [root]. */
     private fun writeDownload(root: File) {

--- a/core/data/src/test/kotlin/com/riffle/core/data/AudiobookTrackDownloaderTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AudiobookTrackDownloaderTest.kt
@@ -1,0 +1,90 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.AudiobookSession
+import com.riffle.core.domain.AudiobookTimeline
+import com.riffle.core.models.AudiobookTrackSpan
+import com.riffle.core.network.createStreamingHttpClient
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.net.InetSocketAddress
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+class AudiobookTrackDownloaderTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    @Test
+    fun `download serializes track requests for servers that reject concurrent pulls`() = runTest {
+        val overlappingRequests = AtomicBoolean(false)
+        val activeRequests = AtomicInteger(0)
+        val server = HttpServer.create(InetSocketAddress(0), 0).apply {
+            executor = Executors.newCachedThreadPool()
+            createContext("/") { exchange ->
+                handleTrackRequest(exchange, activeRequests, overlappingRequests)
+            }
+            start()
+        }
+        try {
+            val baseUrl = "http://127.0.0.1:${server.address.port}"
+            val session = AudiobookSession(
+                trackUrls = listOf(
+                    "$baseUrl/track-0.mp3",
+                    "$baseUrl/track-1.mp3",
+                ),
+                tracks = listOf(
+                    AudiobookTrackSpan(0, 0.0, 10.0),
+                    AudiobookTrackSpan(1, 10.0, 20.0),
+                ),
+                timeline = AudiobookTimeline(durationSec = 30.0, chapters = emptyList()),
+                serverCurrentTimeSec = 0.0,
+            )
+            val downloader = AudiobookTrackDownloader(
+                createStreamingHttpClient(),
+                com.riffle.core.domain.DefaultDispatcherProvider,
+            )
+
+            val tracks = downloader.download(
+                session = session,
+                dir = tmp.newFolder(),
+                progress = CumulativeDownloadProgress(0L, onProgress = { _, _ -> }),
+            )
+
+            assertEquals(listOf(0, 1), tracks.map { it.index })
+            assertFalse("track requests must not overlap", overlappingRequests.get())
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    private fun handleTrackRequest(
+        exchange: HttpExchange,
+        activeRequests: AtomicInteger,
+        overlappingRequests: AtomicBoolean,
+    ) {
+        val inFlight = activeRequests.incrementAndGet()
+        try {
+            if (inFlight > 1) {
+                overlappingRequests.set(true)
+                exchange.sendResponseHeaders(429, -1)
+                return
+            }
+            Thread.sleep(150)
+            val body = File(exchange.requestURI.path).name.toByteArray()
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        } finally {
+            activeRequests.decrementAndGet()
+            exchange.close()
+        }
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/DownloadsRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/DownloadsRepositoryImplTest.kt
@@ -1,0 +1,119 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.DefaultDispatcherProvider
+import com.riffle.core.domain.StoredItemRef
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.ByteArrayInputStream
+import java.io.File
+
+class DownloadsRepositoryImplTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    @Test
+    fun `lists audiobook downloads and caches alongside file backed stores`() = runTest {
+        val stores = stores()
+        stores.epubDownloads.save("srv", "epub-down", ByteArrayInputStream("epub".toByteArray()))
+        stores.epubCache.save("srv", "epub-cache", ByteArrayInputStream("cache".toByteArray()))
+        writeAudiobook(stores.audiobookDownloadsDir, "srv", "audio-down", "downloaded-track")
+        writeAudiobook(stores.audiobookCacheDir, "srv", "audio-cache", "cached-track")
+
+        val repo = repo(stores)
+
+        assertEquals(
+            setOf(
+                StoredItemRef("srv", "epub-down"),
+                StoredItemRef("srv", "audio-down"),
+            ),
+            repo.getDownloadedItems().toSet(),
+        )
+        assertEquals(
+            setOf(
+                StoredItemRef("srv", "epub-cache"),
+                StoredItemRef("srv", "audio-cache"),
+            ),
+            repo.getCachedItems().toSet(),
+        )
+    }
+
+    @Test
+    fun `size and removals include directory backed audiobook artifacts`() = runTest {
+        val stores = stores()
+        writeAudiobook(stores.audiobookDownloadsDir, "srv", "audio-down", "downloaded-track")
+        writeAudiobook(stores.audiobookCacheDir, "srv", "audio-cache", "cached-track")
+
+        val repo = repo(stores)
+        val downloadDir = stores.audiobookDownloadsDir.resolve("srv").resolve("audio-down")
+        val cacheDir = stores.audiobookCacheDir.resolve("srv").resolve("audio-cache")
+
+        assertEquals(directorySize(downloadDir), repo.sizeOf("srv", "audio-down"))
+        assertEquals(directorySize(cacheDir), repo.sizeOf("srv", "audio-cache"))
+
+        repo.removeDownload("srv", "audio-down")
+        repo.removeCached("srv", "audio-cache")
+
+        assertFalse(downloadDir.exists())
+        assertFalse(cacheDir.exists())
+
+        writeAudiobook(stores.audiobookDownloadsDir, "srv", "audio-down-2", "downloaded-track")
+        writeAudiobook(stores.audiobookCacheDir, "srv", "audio-cache-2", "cached-track")
+
+        repo.removeAllDownloads()
+        repo.clearAllCached()
+
+        assertTrue(stores.audiobookDownloadsDir.listFiles().isNullOrEmpty())
+        assertTrue(stores.audiobookCacheDir.listFiles().isNullOrEmpty())
+    }
+
+    private fun directorySize(dir: File): Long =
+        dir.walkTopDown().filter { it.isFile }.sumOf { it.length() }
+
+    private fun writeAudiobook(root: File, sourceId: String, itemId: String, trackPayload: String) {
+        val dir = root.resolve(sourceId).resolve(itemId).also { it.mkdirs() }
+        dir.resolve("track-0").writeText(trackPayload)
+        dir.resolve("manifest.json").writeText("""{"tracks":[{"index":0,"file":"track-0"}],"chapters":[],"durationSec":1.0}""")
+    }
+
+    private fun repo(stores: TestStores): DownloadsRepositoryImpl = DownloadsRepositoryImpl(
+        epubCacheStore = stores.epubCache,
+        epubDownloadsStore = stores.epubDownloads,
+        pdfCacheStore = stores.pdfCache,
+        pdfDownloadsStore = stores.pdfDownloads,
+        cbzCacheStore = stores.cbzCache,
+        cbzDownloadsStore = stores.cbzDownloads,
+        audiobookCacheDir = stores.audiobookCacheDir,
+        audiobookDownloadsDir = stores.audiobookDownloadsDir,
+    )
+
+    private fun stores(): TestStores = TestStores(
+        epubCache = store("epub-cache"),
+        epubDownloads = store("epub-downloads"),
+        pdfCache = store("pdf-cache", ".pdf"),
+        pdfDownloads = store("pdf-downloads", ".pdf"),
+        cbzCache = store("cbz-cache", ".cbz"),
+        cbzDownloads = store("cbz-downloads", ".cbz"),
+        audiobookCacheDir = tmp.newFolder("audiobook-cache"),
+        audiobookDownloadsDir = tmp.newFolder("audiobook-downloads"),
+    )
+
+    private fun store(name: String, extension: String = ".epub") =
+        LocalStoreImpl(tmp.newFolder(name), extension, DefaultDispatcherProvider)
+
+    private data class TestStores(
+        val epubCache: LocalStoreImpl,
+        val epubDownloads: LocalStoreImpl,
+        val pdfCache: LocalStoreImpl,
+        val pdfDownloads: LocalStoreImpl,
+        val cbzCache: LocalStoreImpl,
+        val cbzDownloads: LocalStoreImpl,
+        val audiobookCacheDir: File,
+        val audiobookDownloadsDir: File,
+    )
+}

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/AudiobookCacheRepository.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/AudiobookCacheRepository.kt
@@ -1,0 +1,27 @@
+package com.riffle.core.domain
+
+/**
+ * Auto-cache tier for ABS audiobook tracks (ADR 0029). When a book is opened for streaming, all
+ * tracks are downloaded in the background to evictable cache storage. On completion the player
+ * swaps its unplayed [MediaItem]s to the local [file://][AudiobookSession.trackUrls] URLs — the
+ * same swap the CBZ reader does from [NetworkImageSource] to [ArchiveImageSource].
+ *
+ * Unlike [AudiobookDownloadRepository] (permanent user-pinned storage), the cache dir lives under
+ * [android.content.Context.getCacheDir] and can be evicted by the OS. A missing or incomplete
+ * cache (no manifest) reads as not-cached and triggers a fresh download on next open.
+ */
+interface AudiobookCacheRepository {
+    fun isCached(sourceId: String, itemId: String): Boolean
+
+    /** A playable session backed by cached local files (`file://` track URLs), or null. */
+    fun localSession(sourceId: String, itemId: String): AudiobookSession?
+
+    /**
+     * Downloads all tracks in [session] to the cache dir. No-op if already cached. Silently
+     * discards any download error so callers (streaming path in the player VM) are unaffected.
+     */
+    suspend fun awaitCachedAudiobook(sourceId: String, itemId: String, session: AudiobookSession)
+
+    /** Removes the cached copy; returns bytes freed. */
+    suspend fun remove(sourceId: String, itemId: String): Long
+}

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/AudiobookDownloadRepository.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/AudiobookDownloadRepository.kt
@@ -9,8 +9,8 @@ sealed class AudiobookDownloadResult {
  * Permanent offline copy of an [Audiobook] — the ebook-Download analogue for audio (ADR 0029). An
  * audiobook is several ABS tracks, so a download is a *directory* of track files plus a manifest that
  * records the timeline (per-track offsets/durations + chapters) so playback reconstructs the book
- * offline without re-opening an ABS play session. v1 is download-or-nothing; there is no auto-cache
- * tier for audio yet.
+ * offline without re-opening an ABS play session. For the auto-cache (evictable) tier see
+ * [AudiobookCacheRepository].
  */
 interface AudiobookDownloadRepository {
     fun isDownloaded(sourceId: String, itemId: String): Boolean

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/DownloadsRepository.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/DownloadsRepository.kt
@@ -6,7 +6,7 @@ interface DownloadsRepository {
     fun getDownloadedItems(): List<StoredItemRef>
     fun getCachedItems(): List<StoredItemRef>
 
-    /** Total bytes of the item's local file(s), across the EPUB and PDF stores. */
+    /** Total bytes of the item's local artifact(s), including directory-backed audiobook data. */
     fun sizeOf(sourceId: String, itemId: String): Long
 
     /** Removes the permanent download for a single item. Immediate; no Undo. */


### PR DESCRIPTION
## Summary

This branch adds background auto-caching for streamed ABS audiobooks, swaps the unplayed queue tail to local `file://` tracks once caching completes, serializes track fetches so ABS backends that reject overlapping pulls still work, and surfaces audiobook cache/download artifacts in the Downloads screen.

## What Changed

- add an evictable audiobook auto-cache tier under `cache/audiobooks/<sourceId>/<itemId>/`
- swap unplayed Media3 queue items to local files once background caching finishes
- route explicit audiobook downloads and auto-cache through a shared track downloader
- serialize track fetches in that shared downloader to avoid concurrent-pull failures on ABS
- teach `DownloadsRepository` to list, size, and remove directory-backed audiobook cache/download artifacts
- extend the Downloads ViewModel coverage so audiobook-only items appear in Downloaded/Cached sections

## Tests

The regression coverage that would fail if these fixes were reverted line-for-line is:

- `AudiobookTrackDownloaderTest.download serializes track requests for servers that reject concurrent pulls`
  This asserts `overlappingRequests` stays `false`; reverting to overlapping track fetches flips it red.
- `DownloadsRepositoryImplTest.lists audiobook downloads and caches alongside file backed stores`
  This asserts `StoredItemRef("srv", "audio-down")` appears in downloads and `StoredItemRef("srv", "audio-cache")` appears in cache; reverting the repository wiring removes those rows.
- `DownloadsViewModelTest.populates all sections regardless of active source`
  This asserts downloaded titles include `ABS Audiobook Downloaded` and cached titles include `ABS Audiobook Cached`; reverting the Downloads pipeline drops those items from UI state.

## Validation

Ran targeted unit tests locally while debugging:

- `./gradlew :core:data:testDebugUnitTest --tests com.riffle.core.data.AudiobookTrackDownloaderTest --tests com.riffle.core.data.AudiobookDownloadRepositoryImplTest --tests com.riffle.core.data.AudiobookCacheRepositoryImplTest`
- `./gradlew :core:data:testDebugUnitTest --tests com.riffle.core.data.DownloadsRepositoryImplTest :app:testDebugUnitTest --tests com.riffle.app.feature.downloads.DownloadsViewModelTest`
