### PR TITLE
fix(downloads): show media types for local items

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
@@ -16,8 +16,11 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.automirrored.filled.MenuBook
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.GraphicEq
+import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.filled.PictureAsPdf
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -40,10 +43,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.riffle.core.domain.ContentCacheAutoClear
 import com.riffle.app.ui.TabletContentWidthContainer
+import com.riffle.core.domain.ContentCacheAutoClear
 import com.riffle.core.models.LibraryItem
 import java.util.Locale
 
@@ -63,7 +67,7 @@ fun DownloadsScreen(
         AlertDialog(
             onDismissRequest = { showRemoveAllDownloadsDialog = false },
             title = { Text("Remove all downloads?") },
-            text = { Text("This will remove all downloaded books from your device.") },
+            text = { Text("This will remove all downloaded media from your device.") },
             confirmButton = {
                 TextButton(onClick = {
                     viewModel.removeAllDownloads()
@@ -113,10 +117,10 @@ fun DownloadsScreen(
                 }
                 if (uiState.downloadedItems.isEmpty()) {
                     item {
-                        EmptySection("No downloaded books")
+                        EmptySection("No downloaded media")
                     }
                 } else {
-                    items(uiState.downloadedItems, key = { it.sourceId + "/" + it.item.id }) { entry ->
+                    items(uiState.downloadedItems, key = { "${it.sourceId}_${it.item.id}" }) { entry ->
                         LocalItemRow(
                             entry = entry,
                             pillColor = PillColor.Downloaded,
@@ -142,34 +146,15 @@ fun DownloadsScreen(
                 }
                 if (uiState.cachedItems.isEmpty()) {
                     item {
-                        EmptySection("No cached books")
+                        EmptySection("No cached media")
                     }
                 } else {
-                    items(uiState.cachedItems, key = { it.sourceId + "/" + it.item.id }) { entry ->
+                    items(uiState.cachedItems, key = { "${it.sourceId}_${it.item.id}" }) { entry ->
                         LocalItemRow(
                             entry = entry,
                             pillColor = PillColor.Cached,
                             onClick = { onItemSelected(entry.item) },
-                            onRemove = { viewModel.removeCachedItem(entry.sourceId, entry.item.id) },
-                        )
-                    }
-                }
-
-                if (uiState.readaloudSidecars.isNotEmpty()) {
-                    item {
-                        SectionHeader(
-                            title = "Readaloud (streaming)",
-                            totalLabel = formatBytes(uiState.readaloudSidecarsTotalBytes),
-                            actionLabel = "Clear all",
-                            onAction = { viewModel.clearAllReadaloudSidecars() },
-                        )
-                    }
-                    items(uiState.readaloudSidecars, key = { "sidecar/" + it.sourceId + "/" + it.item.id }) { entry ->
-                        LocalItemRow(
-                            entry = entry,
-                            pillColor = PillColor.Readaloud,
-                            onClick = { onItemSelected(entry.item) },
-                            onRemove = { viewModel.removeReadaloudSidecar(entry.sourceId, entry.item.id) },
+                            onRemove = { viewModel.removeCachedItem(entry) },
                         )
                     }
                 }
@@ -217,7 +202,7 @@ private fun CacheSettingsDialog(
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 Text(
-                    text = "Cached book, audiobook, and comic files can be removed after they have not been opened for this long. Downloads are kept.",
+                    text = "Cached book, audiobook, comic, and readaloud files can be removed after they have not been opened for this long. Downloads are kept.",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -279,7 +264,7 @@ private fun EmptySection(message: String) {
     }
 }
 
-private enum class PillColor { Downloaded, Cached, Readaloud }
+private enum class PillColor { Downloaded, Cached }
 
 @Composable
 private fun LocalItemRow(
@@ -291,13 +276,12 @@ private fun LocalItemRow(
     val containerColor = when (pillColor) {
         PillColor.Downloaded -> MaterialTheme.colorScheme.primary
         PillColor.Cached -> MaterialTheme.colorScheme.secondary
-        PillColor.Readaloud -> MaterialTheme.colorScheme.tertiary
     }
     val contentColor = when (pillColor) {
         PillColor.Downloaded -> MaterialTheme.colorScheme.onPrimary
         PillColor.Cached -> MaterialTheme.colorScheme.onSecondary
-        PillColor.Readaloud -> MaterialTheme.colorScheme.onTertiary
     }
+    val mediaTypeLabel = entry.mediaTypes.displayLabel()
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -312,8 +296,8 @@ private fun LocalItemRow(
         ) {
             Box(contentAlignment = Alignment.Center) {
                 Icon(
-                    imageVector = Icons.Default.ArrowDownward,
-                    contentDescription = null,
+                    imageVector = entry.mediaTypes.primaryIcon(),
+                    contentDescription = mediaTypeLabel,
                     modifier = Modifier.size(18.dp),
                 )
             }
@@ -325,7 +309,9 @@ private fun LocalItemRow(
         ) {
             Text(text = entry.item.title, style = MaterialTheme.typography.bodyLarge)
             Text(
-                text = entry.item.author,
+                text = listOf(entry.item.author, mediaTypeLabel)
+                    .filter { it.isNotBlank() }
+                    .joinToString(" · "),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
@@ -344,6 +330,39 @@ private fun LocalItemRow(
         }
     }
 }
+
+private fun Set<LocalMediaType>.displayLabel(): String =
+    sortedBy { it.displayOrder }.joinToString(" + ") { it.label }
+
+private fun Set<LocalMediaType>.primaryIcon(): ImageVector =
+    minByOrNull { it.displayOrder }?.icon ?: Icons.AutoMirrored.Filled.MenuBook
+
+private val LocalMediaType.label: String
+    get() = when (this) {
+        LocalMediaType.Epub -> "EPUB"
+        LocalMediaType.Pdf -> "PDF"
+        LocalMediaType.Comic -> "Comic"
+        LocalMediaType.Audiobook -> "Audiobook"
+        LocalMediaType.Readaloud -> "Readaloud"
+    }
+
+private val LocalMediaType.displayOrder: Int
+    get() = when (this) {
+        LocalMediaType.Epub -> 0
+        LocalMediaType.Pdf -> 1
+        LocalMediaType.Comic -> 2
+        LocalMediaType.Audiobook -> 3
+        LocalMediaType.Readaloud -> 4
+    }
+
+private val LocalMediaType.icon: ImageVector
+    get() = when (this) {
+        LocalMediaType.Epub -> Icons.AutoMirrored.Filled.MenuBook
+        LocalMediaType.Pdf -> Icons.Default.PictureAsPdf
+        LocalMediaType.Comic -> Icons.Default.GridView
+        LocalMediaType.Audiobook -> Icons.Default.GraphicEq
+        LocalMediaType.Readaloud -> Icons.Default.GraphicEq
+    }
 
 /** Renders a byte count as a compact human-readable size (e.g. "312 MB", "1.2 GB"). */
 internal fun formatBytes(bytes: Long): String {

--- a/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsViewModel.kt
@@ -7,6 +7,10 @@ import com.riffle.core.domain.ContentCacheSettingsStore
 import com.riffle.core.domain.DownloadsRepository
 import com.riffle.core.models.LibraryItem
 import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.StoredItemArtifact
+import com.riffle.core.domain.StoredMediaType
+import com.riffle.core.models.isStorytellerService
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -19,23 +23,31 @@ data class LocalItemUi(
     val sourceId: String,
     val item: LibraryItem,
     val sizeBytes: Long,
+    val mediaTypes: Set<LocalMediaType>,
 )
+
+enum class LocalMediaType {
+    Epub,
+    Pdf,
+    Comic,
+    Audiobook,
+    Readaloud,
+}
 
 data class DownloadsUiState(
     val downloadedItems: List<LocalItemUi> = emptyList(),
     val cachedItems: List<LocalItemUi> = emptyList(),
-    val readaloudSidecars: List<LocalItemUi> = emptyList(),
     val cacheAutoClear: ContentCacheAutoClear = ContentCacheSettingsStore.DEFAULT_AUTO_CLEAR,
 ) {
     val downloadedTotalBytes: Long get() = downloadedItems.sumOf { it.sizeBytes }
     val cachedTotalBytes: Long get() = cachedItems.sumOf { it.sizeBytes }
-    val readaloudSidecarsTotalBytes: Long get() = readaloudSidecars.sumOf { it.sizeBytes }
 }
 
 @HiltViewModel
 class DownloadsViewModel @Inject constructor(
     private val downloadsRepository: DownloadsRepository,
     private val libraryObserver: LibraryObserver,
+    private val sourceRepository: SourceRepository,
     private val sidecarStore: com.riffle.core.data.ReadaloudSidecarStore,
     private val contentCacheSettingsStore: ContentCacheSettingsStore,
 ) : ViewModel() {
@@ -54,36 +66,78 @@ class DownloadsViewModel @Inject constructor(
 
     private fun load() {
         viewModelScope.launch {
-            val downloaded = downloadsRepository.getDownloadedItems()
-            val cached = downloadsRepository.getCachedItems()
-
-            val downloadedItems = downloaded.mapNotNull { ref ->
-                libraryObserver.getItem(ref.sourceId, ref.itemId)?.let {
-                    LocalItemUi(ref.sourceId, it, downloadsRepository.sizeOf(ref.sourceId, ref.itemId))
-                }
-            }
-            val cachedItems = cached.mapNotNull { ref ->
-                libraryObserver.getItem(ref.sourceId, ref.itemId)?.let {
-                    LocalItemUi(ref.sourceId, it, downloadsRepository.sizeOf(ref.sourceId, ref.itemId))
-                }
-            }
+            val downloadedArtifacts = downloadsRepository.getDownloadedArtifacts().toLocalArtifacts()
+            val cachedArtifacts = downloadsRepository.getCachedArtifacts().toLocalArtifacts()
             // Prepared readaloud sidecars (ADR 0028): the small audio-free streaming caches. Keyed by the
             // Storyteller (sourceId, bookId); resolve the title from the Storyteller readaloud library item.
-            val readaloudSidecars = sidecarStore.listCached().mapNotNull { sc ->
-                libraryObserver.getItem(sc.storytellerSourceId, sc.storytellerBookId)?.let {
-                    LocalItemUi(sc.storytellerSourceId, it, sc.sizeBytes)
-                }
+            val readaloudSidecars = sidecarStore.listCached().map { sc ->
+                LocalArtifact(
+                    sourceId = sc.storytellerSourceId,
+                    itemId = sc.storytellerBookId,
+                    mediaType = LocalMediaType.Readaloud,
+                    sizeBytes = sc.sizeBytes,
+                )
             }
+
+            val downloadedItems = buildLocalItems(downloadedArtifacts)
+            val cachedItems = buildLocalItems(cachedArtifacts + readaloudSidecars)
 
             _uiState.update { current ->
                 current.copy(
                     downloadedItems = downloadedItems,
                     cachedItems = cachedItems,
-                    readaloudSidecars = readaloudSidecars,
                 )
             }
         }
     }
+
+    private suspend fun buildLocalItems(artifacts: List<LocalArtifact>): List<LocalItemUi> =
+        artifacts
+            .groupBy { it.sourceId to it.itemId }
+            .mapNotNull { (key, group) ->
+                val (sourceId, itemId) = key
+                libraryObserver.getItem(sourceId, itemId)?.let { item ->
+                    val repositoryBytes = if (group.any { it.sizeBytes == null }) {
+                        downloadsRepository.sizeOf(sourceId, itemId)
+                    } else {
+                        0L
+                    }
+                    LocalItemUi(
+                        sourceId = sourceId,
+                        item = item,
+                        sizeBytes = repositoryBytes + group.sumOf { it.sizeBytes ?: 0L },
+                        mediaTypes = group.map { it.mediaType }.toSet(),
+                    )
+                }
+            }
+
+    private fun StoredMediaType.toLocalMediaType(): LocalMediaType = when (this) {
+        StoredMediaType.Epub -> LocalMediaType.Epub
+        StoredMediaType.Pdf -> LocalMediaType.Pdf
+        StoredMediaType.Cbz -> LocalMediaType.Comic
+        StoredMediaType.Audiobook -> LocalMediaType.Audiobook
+    }
+
+    private suspend fun List<StoredItemArtifact>.toLocalArtifacts(): List<LocalArtifact> =
+        buildList {
+            for (artifact in this@toLocalArtifacts) {
+                add(
+                    LocalArtifact(
+                        sourceId = artifact.sourceId,
+                        itemId = artifact.itemId,
+                        mediaType = artifact.toLocalMediaType(),
+                        sizeBytes = null,
+                    )
+                )
+            }
+        }
+
+    private suspend fun StoredItemArtifact.toLocalMediaType(): LocalMediaType =
+        if (mediaType == StoredMediaType.Epub && sourceRepository.getById(sourceId)?.isStorytellerService == true) {
+            LocalMediaType.Readaloud
+        } else {
+            mediaType.toLocalMediaType()
+        }
 
     fun setCacheAutoClear(value: ContentCacheAutoClear) {
         viewModelScope.launch {
@@ -98,13 +152,6 @@ class DownloadsViewModel @Inject constructor(
         }
     }
 
-    fun removeCachedItem(sourceId: String, itemId: String) {
-        viewModelScope.launch {
-            downloadsRepository.removeCached(sourceId, itemId)
-            load()
-        }
-    }
-
     fun removeAllDownloads() {
         viewModelScope.launch {
             downloadsRepository.removeAllDownloads()
@@ -115,17 +162,25 @@ class DownloadsViewModel @Inject constructor(
     fun clearAllCached() {
         viewModelScope.launch {
             downloadsRepository.clearAllCached()
+            sidecarStore.clearAll()
             load()
         }
     }
 
-    fun removeReadaloudSidecar(storytellerSourceId: String, storytellerBookId: String) {
-        sidecarStore.remove(storytellerSourceId, storytellerBookId)
-        load()
+    fun removeCachedItem(entry: LocalItemUi) {
+        viewModelScope.launch {
+            downloadsRepository.removeCached(entry.sourceId, entry.item.id)
+            if (LocalMediaType.Readaloud in entry.mediaTypes) {
+                sidecarStore.remove(entry.sourceId, entry.item.id)
+            }
+            load()
+        }
     }
 
-    fun clearAllReadaloudSidecars() {
-        sidecarStore.clearAll()
-        load()
-    }
+    private data class LocalArtifact(
+        val sourceId: String,
+        val itemId: String,
+        val mediaType: LocalMediaType,
+        val sizeBytes: Long?,
+    )
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -204,6 +204,7 @@ class LibraryItemDetailViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val itemId: String = savedStateHandle.get<String>("itemId") ?: ""
+    private val sourceId: String? = savedStateHandle.get<String>("sourceId")?.takeIf { it.isNotBlank() }
 
     private val _uiState = MutableStateFlow<LibraryItemDetailUiState>(LibraryItemDetailUiState.Loading)
     val uiState: StateFlow<LibraryItemDetailUiState> = _uiState
@@ -282,8 +283,8 @@ class LibraryItemDetailViewModel @Inject constructor(
         // case the refresh was added for. The refresher's own precondition checks handle a null
         // active source or a mismatched sourceId.
         viewModelScope.launch {
-            val sourceId = sourceRepository.getActive()?.id ?: return@launch
-            libraryRefresher.refreshItemProgress(sourceId, itemId)
+            val resolvedSourceId = sourceId ?: sourceRepository.getActive()?.id ?: return@launch
+            libraryRefresher.refreshItemProgress(resolvedSourceId, itemId)
         }
     }
 
@@ -335,7 +336,9 @@ class LibraryItemDetailViewModel @Inject constructor(
                 authToken = tokenStorage.getToken(server.id) ?: ""
             }
             _uiState.value = try {
-                val item = libraryObserver.getItem(itemId)
+                val item = sourceId
+                    ?.let { libraryObserver.getItem(it, itemId) }
+                    ?: libraryObserver.getItem(itemId)
                 if (item != null) {
                     loadedItem = item
                     _downloadState.value = deriveDownloadState(item)
@@ -490,7 +493,10 @@ class LibraryItemDetailViewModel @Inject constructor(
         // keep showing the one-shot snapshot taken in init. Observing the item patches the live row
         // (e.g. readingProgress) into the existing Ready state so book details matches where the
         // reader left off. Only patches once Ready, so it never pre-empts the Error/enrichment path.
-        libraryObserver.observeItem(itemId)
+        val itemFlow = sourceId
+            ?.let { libraryObserver.observeItem(it, itemId) }
+            ?: libraryObserver.observeItem(itemId)
+        itemFlow
             .onEach { latest ->
                 if (latest == null) return@onEach
                 val current = _uiState.value

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -55,6 +55,7 @@ import com.riffle.app.feature.settings.readaloud.ReadaloudMatchesScreen
 import com.riffle.app.feature.settings.readaloud.ReadaloudSettingsScreen
 import com.riffle.app.playback.NowPlaying
 import com.riffle.app.ui.isTabletLayout
+import com.riffle.core.models.LibraryItem
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
@@ -96,7 +97,7 @@ private const val LIBRARY_SECTION = "library_section/{libraryId}/{libraryName}/{
 private const val SERIES_DETAIL = "series_detail/{libraryId}/{seriesId}/{seriesName}"
 private const val COLLECTION_DETAIL = "collection_detail/{libraryId}/{collectionId}/{collectionName}"
 private const val FILTERED_BOOKS = "filtered_books/{libraryId}/{facetType}/{facetValue}"
-internal const val LIBRARY_ITEM_DETAIL = "library_item_detail/{itemId}"
+internal const val LIBRARY_ITEM_DETAIL = "library_item_detail/{itemId}?sourceId={sourceId}"
 private const val PLAYLIST_DETAIL = "playlist_detail/{libraryId}/{playlistId}/{playlistName}"
 private const val EPUB_READER =
     "epub_reader/{itemId}?startReadaloudAtSec={startReadaloudAtSec}&openAtCfi={openAtCfi}&openAnnotationId={openAnnotationId}&startTocHref={startTocHref}&source={source}&sourceId={sourceId}"
@@ -118,6 +119,16 @@ internal fun seriesDetailRoute(libraryId: String, seriesId: String, seriesName: 
 /** Same reasoning as [seriesDetailRoute] but for collection ids. */
 internal fun collectionDetailRoute(libraryId: String, collectionId: String, collectionName: String): String =
     "collection_detail/$libraryId/${URLEncoder.encode(collectionId, "UTF-8")}/${URLEncoder.encode(collectionName, "UTF-8")}"
+
+internal fun libraryItemDetailRoute(item: LibraryItem): String {
+    val encodedId = URLEncoder.encode(item.id, "UTF-8")
+    val encodedSourceId = URLEncoder.encode(item.sourceId, "UTF-8")
+    return if (item.sourceId.isBlank()) {
+        "library_item_detail/$encodedId"
+    } else {
+        "library_item_detail/$encodedId?sourceId=$encodedSourceId"
+    }
+}
 
 /**
  * Dispatches to the correct library entry point for [sourceType]:
@@ -561,8 +572,7 @@ fun MainScreen(
                     windowSizeClass = windowSizeClass,
                     onNavigateBack = { navController.popBackStack() },
                     onItemSelected = { item ->
-                        val encodedId = URLEncoder.encode(item.id, "UTF-8")
-                        navController.navigate("library_item_detail/$encodedId")
+                        navController.navigate(libraryItemDetailRoute(item))
                     },
                 )
             }
@@ -610,8 +620,7 @@ fun MainScreen(
                         navController.navigate(collectionDetailRoute(libraryId, collection.id, collection.name))
                     },
                     onItemSelected = { item ->
-                        val encodedId = URLEncoder.encode(item.id, "UTF-8")
-                        navController.navigate("library_item_detail/$encodedId")
+                        navController.navigate(libraryItemDetailRoute(item))
                     },
                     onAnnotationSelected = { result ->
                         val encodedId = URLEncoder.encode(result.annotation.itemId, "UTF-8")
@@ -656,8 +665,7 @@ fun MainScreen(
                 com.riffle.app.feature.library.playlists.PlaylistDetailScreen(
                     onNavigateBack = { navController.popBackStack() },
                     onItemSelected = { item ->
-                        val encodedId = URLEncoder.encode(item.id, "UTF-8")
-                        navController.navigate("library_item_detail/$encodedId")
+                        navController.navigate(libraryItemDetailRoute(item))
                     },
                     // Play launches the first item into the audiobook player carrying the playlist
                     // context (`playlistId` + `libraryId`) — the player VM uses those to look up
@@ -694,8 +702,7 @@ fun MainScreen(
                     sectionType = sectionType,
                     viewModel = hiltViewModel<LibraryItemsViewModel>(parentEntry),
                     onItemSelected = { item ->
-                        val encodedId = URLEncoder.encode(item.id, "UTF-8")
-                        navController.navigate("library_item_detail/$encodedId")
+                        navController.navigate(libraryItemDetailRoute(item))
                     },
                     onNavigateBack = { navController.popBackStack() },
                 )
@@ -715,8 +722,7 @@ fun MainScreen(
                 SeriesDetailScreen(
                     seriesName = seriesName,
                     onItemSelected = { item ->
-                        val encodedId = URLEncoder.encode(item.id, "UTF-8")
-                        navController.navigate("library_item_detail/$encodedId")
+                        navController.navigate(libraryItemDetailRoute(item))
                     },
                     onNavigateBack = { navController.popBackStack() },
                 )
@@ -736,8 +742,7 @@ fun MainScreen(
                 CollectionDetailScreen(
                     collectionName = collectionName,
                     onItemSelected = { item ->
-                        val encodedId = URLEncoder.encode(item.id, "UTF-8")
-                        navController.navigate("library_item_detail/$encodedId")
+                        navController.navigate(libraryItemDetailRoute(item))
                     },
                     onNavigateBack = { navController.popBackStack() },
                 )
@@ -746,6 +751,11 @@ fun MainScreen(
                 route = LIBRARY_ITEM_DETAIL,
                 arguments = listOf(
                     navArgument("itemId") { type = NavType.StringType },
+                    navArgument("sourceId") {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    },
                 )
             ) { backStackEntry ->
                 LibraryItemDetailScreen(
@@ -786,8 +796,7 @@ fun MainScreen(
             ) {
                 FilteredBooksScreen(
                     onItemSelected = { item ->
-                        val encodedId = URLEncoder.encode(item.id, "UTF-8")
-                        navController.navigate("library_item_detail/$encodedId")
+                        navController.navigate(libraryItemDetailRoute(item))
                     },
                     onNavigateBack = { navController.popBackStack() },
                 )

--- a/app/src/test/kotlin/com/riffle/app/feature/downloads/DownloadsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/downloads/DownloadsViewModelTest.kt
@@ -6,7 +6,12 @@ import com.riffle.core.domain.DownloadsRepository
 import com.riffle.core.models.EbookFormat
 import com.riffle.core.models.LibraryItem
 import com.riffle.core.domain.LibraryObserver
-import com.riffle.core.domain.StoredItemRef
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.StoredItemArtifact
+import com.riffle.core.domain.StoredMediaType
+import com.riffle.core.models.ServerType
+import com.riffle.core.models.Source
+import com.riffle.core.models.SourceUrl
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -58,22 +63,23 @@ class DownloadsViewModelTest {
      *  omits both capabilities), the ViewModel silently produced state that told the UI to hide
      *  every ABS/Chitanka/Storyteller Cached row and every Storyteller readaloud sidecar — even
      *  though the Downloaded list was rendered app-wide. The fix removes the capability lookup so
-     *  all three lists behave the same way (populated whenever local artifacts exist).
+     *  downloaded and cached media behave the same way (populated whenever local artifacts exist).
      *
      *  This test would fail if someone re-adds capability gating: injecting a CatalogRegistry (or any
-     *  active-source predicate) that drops rows from non-matching sources would make the cached and
-     *  sidecar lists empty here. */
+     *  active-source predicate) that drops rows from non-matching sources would make the cached list
+     *  lose the cached artifacts and folded readaloud sidecars here. */
     @Test
     fun `populates all sections regardless of active source`() = runTest(dispatcher) {
         val downloadsRepo = mockk<DownloadsRepository>(relaxed = true)
-        every { downloadsRepo.getDownloadedItems() } returns listOf(
-            StoredItemRef("abs", "abs-book"),
-            StoredItemRef("chitanka", "ch-book"),
-            StoredItemRef("abs", "ab-book"),
+        every { downloadsRepo.getDownloadedArtifacts() } returns listOf(
+            StoredItemArtifact("abs", "abs-book", StoredMediaType.Epub),
+            StoredItemArtifact("chitanka", "ch-book", StoredMediaType.Pdf),
+            StoredItemArtifact("abs", "ab-book", StoredMediaType.Audiobook),
+            StoredItemArtifact("storyteller", "st-down", StoredMediaType.Epub),
         )
-        every { downloadsRepo.getCachedItems() } returns listOf(
-            StoredItemRef("abs", "abs-cached"),
-            StoredItemRef("abs", "ab-cached"),
+        every { downloadsRepo.getCachedArtifacts() } returns listOf(
+            StoredItemArtifact("abs", "abs-cached", StoredMediaType.Cbz),
+            StoredItemArtifact("abs", "ab-cached", StoredMediaType.Audiobook),
         )
         every { downloadsRepo.sizeOf(any(), any()) } returns 1024L
 
@@ -83,9 +89,16 @@ class DownloadsViewModelTest {
         coEvery { libraryObserver.getItem("abs", "abs-cached") } returns item("abs", "abs-cached", "ABS Cached")
         coEvery { libraryObserver.getItem("abs", "ab-book") } returns
             item("abs", "ab-book", "ABS Audiobook Downloaded", ebookFormat = EbookFormat.Unsupported, hasAudio = true)
+        coEvery { libraryObserver.getItem("storyteller", "st-down") } returns
+            item("storyteller", "st-down", "Storyteller Downloaded")
         coEvery { libraryObserver.getItem("abs", "ab-cached") } returns
             item("abs", "ab-cached", "ABS Audiobook Cached", ebookFormat = EbookFormat.Unsupported, hasAudio = true)
         coEvery { libraryObserver.getItem("storyteller", "st-book") } returns item("storyteller", "st-book", "Storyteller Readaloud")
+
+        val sourceRepository = mockk<SourceRepository>(relaxed = true)
+        coEvery { sourceRepository.getById("abs") } returns source("abs", ServerType.AUDIOBOOKSHELF)
+        coEvery { sourceRepository.getById("chitanka") } returns source("chitanka", ServerType.AUDIOBOOKSHELF)
+        coEvery { sourceRepository.getById("storyteller") } returns source("storyteller", ServerType.STORYTELLER_SERVICE)
 
         val sidecarStore = mockk<ReadaloudSidecarStore>(relaxed = true)
         every { sidecarStore.listCached() } returns listOf(
@@ -94,16 +107,44 @@ class DownloadsViewModelTest {
         val cacheSettingsStore = mockk<ContentCacheSettingsStore>(relaxed = true)
         every { cacheSettingsStore.autoClear } returns MutableStateFlow(ContentCacheSettingsStore.DEFAULT_AUTO_CLEAR)
 
-        val vm = DownloadsViewModel(downloadsRepo, libraryObserver, sidecarStore, cacheSettingsStore)
+        val vm = DownloadsViewModel(downloadsRepo, libraryObserver, sourceRepository, sidecarStore, cacheSettingsStore)
         advanceUntilIdle()
 
         val state = vm.uiState.value
         assertEquals(
-            listOf("ABS Downloaded", "Chitanka Downloaded", "ABS Audiobook Downloaded"),
+            listOf("ABS Downloaded", "Chitanka Downloaded", "ABS Audiobook Downloaded", "Storyteller Downloaded"),
             state.downloadedItems.map { it.item.title },
         )
-        assertEquals(listOf("ABS Cached", "ABS Audiobook Cached"), state.cachedItems.map { it.item.title })
-        assertEquals(listOf("Storyteller Readaloud"), state.readaloudSidecars.map { it.item.title })
+        assertEquals(
+            listOf("ABS Cached", "ABS Audiobook Cached", "Storyteller Readaloud"),
+            state.cachedItems.map { it.item.title },
+        )
+        assertEquals(
+            listOf(
+                setOf(LocalMediaType.Epub),
+                setOf(LocalMediaType.Pdf),
+                setOf(LocalMediaType.Audiobook),
+                setOf(LocalMediaType.Readaloud),
+            ),
+            state.downloadedItems.map { it.mediaTypes },
+        )
+        assertEquals(
+            listOf(
+                setOf(LocalMediaType.Comic),
+                setOf(LocalMediaType.Audiobook),
+                setOf(LocalMediaType.Readaloud),
+            ),
+            state.cachedItems.map { it.mediaTypes },
+        )
         assertEquals(ContentCacheSettingsStore.DEFAULT_AUTO_CLEAR, state.cacheAutoClear)
     }
+
+    private fun source(id: String, serverType: ServerType) = Source(
+        id = id,
+        url = SourceUrl.parse("http://$id.local")!!,
+        isActive = false,
+        insecureConnectionAllowed = false,
+        username = "user",
+        serverType = serverType,
+    )
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -79,6 +79,8 @@ class LibraryItemDetailViewModelTest {
     private fun fakeRepo(
         item: LibraryItem? = null,
         itemFlow: MutableStateFlow<LibraryItem?> = MutableStateFlow(item),
+        sourceItem: LibraryItem? = item,
+        sourceItemFlow: MutableStateFlow<LibraryItem?> = MutableStateFlow(sourceItem),
     ): LibraryObserver = object : LibraryObserver {
         override fun observeLibraries(): Flow<List<Library>> = MutableStateFlow(emptyList())
         override fun observeLibraries(sourceId: String): Flow<List<Library>> = observeLibraries()
@@ -95,7 +97,8 @@ class LibraryItemDetailViewModelTest {
         override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
         override suspend fun getItem(itemId: String): LibraryItem? = item
         override fun observeItem(itemId: String): Flow<LibraryItem?> = itemFlow
-        override suspend fun getItem(sourceId: String, itemId: String): LibraryItem? = getItem(itemId)
+        override suspend fun getItem(sourceId: String, itemId: String): LibraryItem? = sourceItem
+        override fun observeItem(sourceId: String, itemId: String): Flow<LibraryItem?> = sourceItemFlow
         override suspend fun getLibrary(libraryId: String): com.riffle.core.models.Library? = null
         override suspend fun getSeriesIdForItem(sourceId: String, itemId: String): String? = null
     }
@@ -344,8 +347,14 @@ class LibraryItemDetailViewModelTest {
         libraryRefresher: com.riffle.core.domain.LibraryRefresher = com.riffle.app.testing.NoopLibraryRefresher,
         saveOverride: com.riffle.core.data.localfiles.SaveLocalFileMetadataOverrideUseCase = com.riffle.app.testing.noopSaveLocalFileMetadataOverride(),
         copyCoverImageFn: com.riffle.core.data.localfiles.CopyCoverImageUseCase = com.riffle.app.testing.noopCopyCoverImage(),
+        sourceId: String? = null,
     ) = LibraryItemDetailViewModel(
-        savedStateHandle = SavedStateHandle(mapOf("itemId" to itemId)),
+        savedStateHandle = SavedStateHandle(
+            buildMap {
+                put("itemId", itemId)
+                if (sourceId != null) put("sourceId", sourceId)
+            }
+        ),
         libraryObserver = repo,
         recordItemOpened = com.riffle.app.testing.NoopRecordItemOpened(),
         updateReadingProgressUseCase = com.riffle.app.testing.NoopUpdateReadingProgress(),
@@ -462,6 +471,25 @@ class LibraryItemDetailViewModelTest {
             ),
             vm.uiState.value,
         )
+    }
+
+    @Test
+    fun `uiState uses explicit source id when details are opened from cross-source downloads`() = runTest {
+        val downloadedItem = knownItem.copy(
+            id = "downloaded-1",
+            sourceId = "other-source",
+            libraryId = "other-library",
+        )
+        val vm = makeVm(
+            fakeRepo(item = null, sourceItem = downloadedItem),
+            itemId = downloadedItem.id,
+            sourceId = downloadedItem.sourceId,
+        )
+        backgroundScope.launch { vm.uiState.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val ready = vm.uiState.value as? LibraryItemDetailUiState.Ready
+        assertEquals(downloadedItem, ready?.item)
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/navigation/DetailRouteEncodingTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/DetailRouteEncodingTest.kt
@@ -1,5 +1,7 @@
 package com.riffle.app.navigation
 
+import com.riffle.core.models.EbookFormat
+import com.riffle.core.models.LibraryItem
 import com.riffle.core.models.SourceType
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -47,6 +49,26 @@ class DetailRouteEncodingTest {
         assertEquals(4, segments.size)
         assertEquals("collection_detail", segments[0])
         assertEquals("collection%2Fsome%2Fnested%2Fid", segments[2])
+    }
+
+    @Test
+    fun `libraryItemDetailRoute carries sourceId for cross-source downloads`() {
+        val route = libraryItemDetailRoute(
+            LibraryItem(
+                id = "book/123",
+                libraryId = "lib-1",
+                title = "Title",
+                author = "Author",
+                coverUrl = null,
+                readingProgress = 0f,
+                isCached = false,
+                isDownloaded = true,
+                ebookFormat = EbookFormat.Epub,
+                sourceId = "source/with space",
+            )
+        )
+
+        assertEquals("library_item_detail/book%2F123?sourceId=source%2Fwith+space", route)
     }
 
     // ─── libraryEntryRoute: generic dispatch driven by SourceType.isUnboundedCatalog ────────────

--- a/core/data/src/main/kotlin/com/riffle/core/data/DownloadsRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/DownloadsRepositoryImpl.kt
@@ -3,7 +3,8 @@ package com.riffle.core.data
 import com.riffle.core.domain.DownloadsRepository
 import com.riffle.core.domain.LocalAvailabilityEvents
 import com.riffle.core.domain.LocalStore
-import com.riffle.core.domain.StoredItemRef
+import com.riffle.core.domain.StoredItemArtifact
+import com.riffle.core.domain.StoredMediaType
 import java.io.File
 
 class DownloadsRepositoryImpl(
@@ -18,46 +19,60 @@ class DownloadsRepositoryImpl(
     private val localAvailabilityEvents: LocalAvailabilityEvents = NoopLocalAvailabilityEvents,
 ) : DownloadsRepository {
 
-    private val downloadStores = listOf(epubDownloadsStore, pdfDownloadsStore, cbzDownloadsStore)
-    private val cacheStores = listOf(epubCacheStore, pdfCacheStore, cbzCacheStore)
+    private val downloadStores = listOf(
+        TypedStore(epubDownloadsStore, StoredMediaType.Epub),
+        TypedStore(pdfDownloadsStore, StoredMediaType.Pdf),
+        TypedStore(cbzDownloadsStore, StoredMediaType.Cbz),
+    )
+    private val cacheStores = listOf(
+        TypedStore(epubCacheStore, StoredMediaType.Epub),
+        TypedStore(pdfCacheStore, StoredMediaType.Pdf),
+        TypedStore(cbzCacheStore, StoredMediaType.Cbz),
+    )
     private val manifestName = "manifest.json"
 
-    override fun getDownloadedItems(): List<StoredItemRef> =
-        (downloadStores.flatMap { it.listItems() } + listDirectoryBackedItems(audiobookDownloadsDir)).distinct()
+    override fun getDownloadedArtifacts(): List<StoredItemArtifact> =
+        (
+            downloadStores.flatMap { it.listArtifacts() } +
+                listDirectoryBackedArtifacts(audiobookDownloadsDir, StoredMediaType.Audiobook)
+            ).distinct()
 
-    override fun getCachedItems(): List<StoredItemRef> {
+    override fun getCachedArtifacts(): List<StoredItemArtifact> {
         val downloaded = getDownloadedItems().toHashSet()
-        return (cacheStores.flatMap { it.listItems() } + listDirectoryBackedItems(audiobookCacheDir))
+        return (
+            cacheStores.flatMap { it.listArtifacts() } +
+                listDirectoryBackedArtifacts(audiobookCacheDir, StoredMediaType.Audiobook)
+            )
             .distinct()
-            .filter { it !in downloaded }
+            .filter { it.ref !in downloaded }
     }
 
     override fun sizeOf(sourceId: String, itemId: String): Long =
-        (downloadStores + cacheStores).sumOf { it.get(sourceId, itemId)?.length() ?: 0L } +
+        (downloadStores + cacheStores).sumOf { it.store.get(sourceId, itemId)?.length() ?: 0L } +
             directorySize(itemDir(audiobookDownloadsDir, sourceId, itemId)) +
             directorySize(itemDir(audiobookCacheDir, sourceId, itemId))
 
     override suspend fun removeDownload(sourceId: String, itemId: String) {
-        downloadStores.forEach { it.delete(sourceId, itemId) }
-        cacheStores.forEach { it.delete(sourceId, itemId) }
+        downloadStores.forEach { it.store.delete(sourceId, itemId) }
+        cacheStores.forEach { it.store.delete(sourceId, itemId) }
         itemDir(audiobookDownloadsDir, sourceId, itemId).deleteRecursively()
         itemDir(audiobookCacheDir, sourceId, itemId).deleteRecursively()
         localAvailabilityEvents.notifyChanged(sourceId, itemId)
     }
 
     override suspend fun removeCached(sourceId: String, itemId: String) {
-        cacheStores.forEach { it.delete(sourceId, itemId) }
+        cacheStores.forEach { it.store.delete(sourceId, itemId) }
         itemDir(audiobookCacheDir, sourceId, itemId).deleteRecursively()
         localAvailabilityEvents.notifyChanged(sourceId, itemId)
     }
 
     override suspend fun removeAllDownloads() {
-        downloadStores.forEach { it.clear() }
+        downloadStores.forEach { it.store.clear() }
         audiobookDownloadsDir.listFiles()?.forEach { it.deleteRecursively() }
     }
 
     override suspend fun clearAllCached() {
-        cacheStores.forEach { it.clear() }
+        cacheStores.forEach { it.store.clear() }
         audiobookCacheDir.listFiles()?.forEach { it.deleteRecursively() }
     }
 
@@ -67,7 +82,7 @@ class DownloadsRepositoryImpl(
     private fun directorySize(dir: File): Long =
         if (!dir.exists()) 0L else dir.walkTopDown().filter { it.isFile }.sumOf { it.length() }
 
-    private fun listDirectoryBackedItems(root: File): List<StoredItemRef> =
+    private fun listDirectoryBackedArtifacts(root: File, mediaType: StoredMediaType): List<StoredItemArtifact> =
         root.listFiles()
             ?.filter { it.isDirectory }
             ?.flatMap { sourceDir ->
@@ -76,12 +91,24 @@ class DownloadsRepositoryImpl(
                     .filter { it.isFile && it.name == manifestName }
                     .map { manifest ->
                         val itemDir = requireNotNull(manifest.parentFile) { "manifest without parent: $manifest" }
-                        StoredItemRef(
+                        StoredItemArtifact(
                             sourceId = sourceDir.name,
                             itemId = itemDir.absolutePath.removePrefix(prefix),
+                            mediaType = mediaType,
                         )
                     }
                     .toList()
             }
             ?: emptyList()
+
+    private data class TypedStore(val store: LocalStore, val mediaType: StoredMediaType) {
+        fun listArtifacts(): List<StoredItemArtifact> =
+            store.listItems().map {
+                StoredItemArtifact(
+                    sourceId = it.sourceId,
+                    itemId = it.itemId,
+                    mediaType = mediaType,
+                )
+            }
+    }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -139,6 +139,9 @@ class LibraryRepositoryImpl @Inject constructor(
     override suspend fun getItem(sourceId: String, itemId: String): LibraryItem? =
         libraryItemDao.getById(sourceId, itemId)?.toDomain()
 
+    override fun observeItem(sourceId: String, itemId: String): Flow<LibraryItem?> =
+        libraryItemDao.observeById(sourceId, itemId).map { it?.toDomain() }
+
     // Library ids are only unique within a Source (issue #113); resolve against the active Source's
     // copy, mirroring how [getItem] keys item reads. No active Source → nothing to resolve.
     override suspend fun getLibrary(libraryId: String): Library? {

--- a/core/data/src/test/kotlin/com/riffle/core/data/DownloadsRepositoryImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/DownloadsRepositoryImplTest.kt
@@ -1,7 +1,9 @@
 package com.riffle.core.data
 
 import com.riffle.core.domain.DefaultDispatcherProvider
+import com.riffle.core.domain.StoredItemArtifact
 import com.riffle.core.domain.StoredItemRef
+import com.riffle.core.domain.StoredMediaType
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -21,7 +23,11 @@ class DownloadsRepositoryImplTest {
     fun `lists audiobook downloads and caches alongside file backed stores`() = runTest {
         val stores = stores()
         stores.epubDownloads.save("srv", "epub-down", ByteArrayInputStream("epub".toByteArray()))
+        stores.pdfDownloads.save("srv", "pdf-down", ByteArrayInputStream("pdf".toByteArray()))
+        stores.cbzDownloads.save("srv", "cbz-down", ByteArrayInputStream("cbz".toByteArray()))
         stores.epubCache.save("srv", "epub-cache", ByteArrayInputStream("cache".toByteArray()))
+        stores.pdfCache.save("srv", "pdf-cache", ByteArrayInputStream("cache".toByteArray()))
+        stores.cbzCache.save("srv", "cbz-cache", ByteArrayInputStream("cache".toByteArray()))
         writeAudiobook(stores.audiobookDownloadsDir, "srv", "audio-down", "downloaded-track")
         writeAudiobook(stores.audiobookCacheDir, "srv", "audio-cache", "cached-track")
 
@@ -30,6 +36,8 @@ class DownloadsRepositoryImplTest {
         assertEquals(
             setOf(
                 StoredItemRef("srv", "epub-down"),
+                StoredItemRef("srv", "pdf-down"),
+                StoredItemRef("srv", "cbz-down"),
                 StoredItemRef("srv", "audio-down"),
             ),
             repo.getDownloadedItems().toSet(),
@@ -37,9 +45,29 @@ class DownloadsRepositoryImplTest {
         assertEquals(
             setOf(
                 StoredItemRef("srv", "epub-cache"),
+                StoredItemRef("srv", "pdf-cache"),
+                StoredItemRef("srv", "cbz-cache"),
                 StoredItemRef("srv", "audio-cache"),
             ),
             repo.getCachedItems().toSet(),
+        )
+        assertEquals(
+            setOf(
+                StoredItemArtifact("srv", "epub-down", StoredMediaType.Epub),
+                StoredItemArtifact("srv", "pdf-down", StoredMediaType.Pdf),
+                StoredItemArtifact("srv", "cbz-down", StoredMediaType.Cbz),
+                StoredItemArtifact("srv", "audio-down", StoredMediaType.Audiobook),
+            ),
+            repo.getDownloadedArtifacts().toSet(),
+        )
+        assertEquals(
+            setOf(
+                StoredItemArtifact("srv", "epub-cache", StoredMediaType.Epub),
+                StoredItemArtifact("srv", "pdf-cache", StoredMediaType.Pdf),
+                StoredItemArtifact("srv", "cbz-cache", StoredMediaType.Cbz),
+                StoredItemArtifact("srv", "audio-cache", StoredMediaType.Audiobook),
+            ),
+            repo.getCachedArtifacts().toSet(),
         )
     }
 

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/LibraryRepository.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/LibraryRepository.kt
@@ -47,6 +47,10 @@ interface LibraryObserver {
 
     /** A specific Server's copy of an item — for cross-Server callers like the Downloads screen. */
     suspend fun getItem(sourceId: String, itemId: String): LibraryItem?
+
+    /** Reactive view of a specific Source's copy of an item. */
+    fun observeItem(sourceId: String, itemId: String): Flow<LibraryItem?> = observeItem(itemId)
+
     suspend fun getLibrary(libraryId: String): Library?
 
     /** The id of the series the given item belongs to, or null if it is not in any series. */

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/LibraryRepository.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/LibraryRepository.kt
@@ -45,7 +45,7 @@ interface LibraryObserver {
      */
     fun observeItem(itemId: String): Flow<LibraryItem?>
 
-    /** A specific Server's copy of an item — for cross-Server callers like the Downloads screen. */
+    /** A specific Source's copy of an item — for cross-Source callers like the Downloads screen. */
     suspend fun getItem(sourceId: String, itemId: String): LibraryItem?
 
     /** Reactive view of a specific Source's copy of an item. */

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/DownloadsRepository.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/DownloadsRepository.kt
@@ -1,10 +1,16 @@
 package com.riffle.core.domain
 
-// The Downloads screen is inherently cross-Server (it lists every file on disk), so it keys by
+// The Downloads screen is inherently cross-Source (it lists every file on disk), so it keys by
 // (sourceId, itemId) rather than itemId alone (ADR 0025).
 interface DownloadsRepository {
-    fun getDownloadedItems(): List<StoredItemRef>
-    fun getCachedItems(): List<StoredItemRef>
+    fun getDownloadedArtifacts(): List<StoredItemArtifact>
+    fun getCachedArtifacts(): List<StoredItemArtifact>
+
+    fun getDownloadedItems(): List<StoredItemRef> =
+        getDownloadedArtifacts().map { it.ref }.distinct()
+
+    fun getCachedItems(): List<StoredItemRef> =
+        getCachedArtifacts().map { it.ref }.distinct()
 
     /** Total bytes of the item's local artifact(s), including directory-backed audiobook data. */
     fun sizeOf(sourceId: String, itemId: String): Long
@@ -17,4 +23,19 @@ interface DownloadsRepository {
 
     suspend fun removeAllDownloads()
     suspend fun clearAllCached()
+}
+
+data class StoredItemArtifact(
+    val sourceId: String,
+    val itemId: String,
+    val mediaType: StoredMediaType,
+) {
+    val ref: StoredItemRef get() = StoredItemRef(sourceId, itemId)
+}
+
+enum class StoredMediaType {
+    Epub,
+    Pdf,
+    Cbz,
+    Audiobook,
 }

--- a/core/models/src/commonMain/kotlin/com/riffle/core/models/Source.kt
+++ b/core/models/src/commonMain/kotlin/com/riffle/core/models/Source.kt
@@ -22,3 +22,6 @@ data class Source(
      */
     val absUserId: String? = null,
 )
+
+val Source.isStorytellerService: Boolean
+    get() = serverType == ServerType.STORYTELLER_SERVICE


### PR DESCRIPTION
## Summary
- show downloaded/cached media type labels and icons instead of a separate Readaloud section
- fold readaloud sidecars into Cached while preserving sidecar removal/clear behavior
- pass sourceId into item detail navigation so cross-source downloaded items can resolve details

## Regression coverage
- DownloadsViewModelTest asserts ordinary ABS EPUB artifacts remain EPUB while Storyteller EPUB artifacts render as Readaloud.
- LibraryItemDetailViewModelTest asserts a detail screen opened with an explicit sourceId loads the cross-source item even when active-source lookup would return null.
- DetailRouteEncodingTest asserts library item detail routes carry encoded sourceId.
- DownloadsRepositoryImplTest asserts typed artifacts are reported for EPUB, PDF, CBZ, and audiobook stores.

## Validation
- Focused JVM tests passed before finalize: app downloads/detail/navigation tests and core data downloads tests.
- checkNoServerReferences passed before finalize.
