### PR TITLE
fix(downloads): open readaloud sidecars via linked item

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
@@ -125,7 +125,7 @@ fun DownloadsScreen(
                             entry = entry,
                             pillColor = PillColor.Downloaded,
                             onClick = { onItemSelected(entry.item) },
-                            onRemove = { viewModel.removeDownloadedItem(entry.sourceId, entry.item.id) },
+                            onRemove = { viewModel.removeDownloadedItem(entry) },
                         )
                     }
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsViewModel.kt
@@ -5,11 +5,13 @@ import androidx.lifecycle.viewModelScope
 import com.riffle.core.domain.ContentCacheAutoClear
 import com.riffle.core.domain.ContentCacheSettingsStore
 import com.riffle.core.domain.DownloadsRepository
-import com.riffle.core.models.LibraryItem
 import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.ReadaloudLinkRepository
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.StoredItemArtifact
 import com.riffle.core.domain.StoredMediaType
+import com.riffle.core.models.LibraryItem
+import com.riffle.core.models.ReadaloudLink
 import com.riffle.core.models.isStorytellerService
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,7 +26,13 @@ data class LocalItemUi(
     val item: LibraryItem,
     val sizeBytes: Long,
     val mediaTypes: Set<LocalMediaType>,
+    val storageRefs: Set<LocalStorageRef> = setOf(LocalStorageRef(sourceId, item.id)),
+    val readaloudSidecarRefs: Set<ReadaloudSidecarRef> = emptySet(),
 )
+
+data class LocalStorageRef(val sourceId: String, val itemId: String)
+
+data class ReadaloudSidecarRef(val storytellerSourceId: String, val storytellerBookId: String)
 
 enum class LocalMediaType {
     Epub,
@@ -48,6 +56,7 @@ class DownloadsViewModel @Inject constructor(
     private val downloadsRepository: DownloadsRepository,
     private val libraryObserver: LibraryObserver,
     private val sourceRepository: SourceRepository,
+    private val readaloudLinkRepository: ReadaloudLinkRepository,
     private val sidecarStore: com.riffle.core.data.ReadaloudSidecarStore,
     private val contentCacheSettingsStore: ContentCacheSettingsStore,
 ) : ViewModel() {
@@ -68,16 +77,10 @@ class DownloadsViewModel @Inject constructor(
         viewModelScope.launch {
             val downloadedArtifacts = downloadsRepository.getDownloadedArtifacts().toLocalArtifacts()
             val cachedArtifacts = downloadsRepository.getCachedArtifacts().toLocalArtifacts()
-            // Prepared readaloud sidecars (ADR 0028): the small audio-free streaming caches. Keyed by the
-            // Storyteller (sourceId, bookId); resolve the title from the Storyteller readaloud library item.
-            val readaloudSidecars = sidecarStore.listCached().map { sc ->
-                LocalArtifact(
-                    sourceId = sc.storytellerSourceId,
-                    itemId = sc.storytellerBookId,
-                    mediaType = LocalMediaType.Readaloud,
-                    sizeBytes = sc.sizeBytes,
-                )
-            }
+            // Prepared readaloud sidecars (ADR 0028): the small audio-free streaming caches. They
+            // are stored under the Storyteller service key but displayed on the linked Source item,
+            // because a Readaloud is a sidecar capability rather than a browsable item of its own.
+            val readaloudSidecars = sidecarStore.listCached().mapNotNull { it.toLocalArtifact() }
 
             val downloadedItems = buildLocalItems(downloadedArtifacts)
             val cachedItems = buildLocalItems(cachedArtifacts + readaloudSidecars)
@@ -93,20 +96,22 @@ class DownloadsViewModel @Inject constructor(
 
     private suspend fun buildLocalItems(artifacts: List<LocalArtifact>): List<LocalItemUi> =
         artifacts
-            .groupBy { it.sourceId to it.itemId }
+            .groupBy { it.displaySourceId to it.displayItemId }
             .mapNotNull { (key, group) ->
                 val (sourceId, itemId) = key
                 libraryObserver.getItem(sourceId, itemId)?.let { item ->
-                    val repositoryBytes = if (group.any { it.sizeBytes == null }) {
-                        downloadsRepository.sizeOf(sourceId, itemId)
-                    } else {
-                        0L
-                    }
+                    val repositoryBytes = group
+                        .filter { it.sizeBytes == null }
+                        .mapNotNull { it.repositoryStorageRef }
+                        .distinct()
+                        .sumOf { downloadsRepository.sizeOf(it.sourceId, it.itemId) }
                     LocalItemUi(
                         sourceId = sourceId,
                         item = item,
                         sizeBytes = repositoryBytes + group.sumOf { it.sizeBytes ?: 0L },
                         mediaTypes = group.map { it.mediaType }.toSet(),
+                        storageRefs = group.mapNotNull { it.repositoryStorageRef }.toSet(),
+                        readaloudSidecarRefs = group.mapNotNull { it.readaloudSidecarRef }.toSet(),
                     )
                 }
             }
@@ -121,11 +126,18 @@ class DownloadsViewModel @Inject constructor(
     private suspend fun List<StoredItemArtifact>.toLocalArtifacts(): List<LocalArtifact> =
         buildList {
             for (artifact in this@toLocalArtifacts) {
+                val mediaType = artifact.toLocalMediaType()
+                val displayRef = if (mediaType == LocalMediaType.Readaloud) {
+                    linkedSourceRef(artifact.sourceId, artifact.itemId) ?: continue
+                } else {
+                    LocalStorageRef(artifact.sourceId, artifact.itemId)
+                }
                 add(
                     LocalArtifact(
-                        sourceId = artifact.sourceId,
-                        itemId = artifact.itemId,
-                        mediaType = artifact.toLocalMediaType(),
+                        displaySourceId = displayRef.sourceId,
+                        displayItemId = displayRef.itemId,
+                        repositoryStorageRef = LocalStorageRef(artifact.sourceId, artifact.itemId),
+                        mediaType = mediaType,
                         sizeBytes = null,
                     )
                 )
@@ -139,15 +151,47 @@ class DownloadsViewModel @Inject constructor(
             mediaType.toLocalMediaType()
         }
 
+    private suspend fun com.riffle.core.data.ReadaloudSidecarStore.CachedSidecar.toLocalArtifact(): LocalArtifact? {
+        val displayRef = linkedSourceRef(storytellerSourceId, storytellerBookId) ?: return null
+        return LocalArtifact(
+            displaySourceId = displayRef.sourceId,
+            displayItemId = displayRef.itemId,
+            repositoryStorageRef = null,
+            mediaType = LocalMediaType.Readaloud,
+            sizeBytes = sizeBytes,
+            readaloudSidecarRef = ReadaloudSidecarRef(storytellerSourceId, storytellerBookId),
+        )
+    }
+
+    private suspend fun linkedSourceRef(storytellerSourceId: String, storytellerBookId: String): LocalStorageRef? =
+        readaloudLinkRepository
+            .findByStorytellerBook(storytellerSourceId, storytellerBookId)
+            .preferredDisplayLink()
+            ?.let { LocalStorageRef(it.absSourceId, it.absLibraryItemId) }
+
+    private suspend fun List<ReadaloudLink>.preferredDisplayLink(): ReadaloudLink? {
+        var firstExisting: ReadaloudLink? = null
+        for (link in this) {
+            val item = libraryObserver.getItem(link.absSourceId, link.absLibraryItemId) ?: continue
+            if (firstExisting == null) {
+                firstExisting = link
+            }
+            if (item.isReadable) {
+                return link
+            }
+        }
+        return firstExisting
+    }
+
     fun setCacheAutoClear(value: ContentCacheAutoClear) {
         viewModelScope.launch {
             contentCacheSettingsStore.setAutoClear(value)
         }
     }
 
-    fun removeDownloadedItem(sourceId: String, itemId: String) {
+    fun removeDownloadedItem(entry: LocalItemUi) {
         viewModelScope.launch {
-            downloadsRepository.removeDownload(sourceId, itemId)
+            entry.storageRefs.forEach { downloadsRepository.removeDownload(it.sourceId, it.itemId) }
             load()
         }
     }
@@ -169,18 +213,20 @@ class DownloadsViewModel @Inject constructor(
 
     fun removeCachedItem(entry: LocalItemUi) {
         viewModelScope.launch {
-            downloadsRepository.removeCached(entry.sourceId, entry.item.id)
-            if (LocalMediaType.Readaloud in entry.mediaTypes) {
-                sidecarStore.remove(entry.sourceId, entry.item.id)
+            entry.storageRefs.forEach { downloadsRepository.removeCached(it.sourceId, it.itemId) }
+            entry.readaloudSidecarRefs.forEach {
+                sidecarStore.remove(it.storytellerSourceId, it.storytellerBookId)
             }
             load()
         }
     }
 
     private data class LocalArtifact(
-        val sourceId: String,
-        val itemId: String,
+        val displaySourceId: String,
+        val displayItemId: String,
+        val repositoryStorageRef: LocalStorageRef?,
         val mediaType: LocalMediaType,
         val sizeBytes: Long?,
+        val readaloudSidecarRef: ReadaloudSidecarRef? = null,
     )
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/downloads/DownloadsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/downloads/DownloadsViewModelTest.kt
@@ -3,18 +3,22 @@ package com.riffle.app.feature.downloads
 import com.riffle.core.data.ReadaloudSidecarStore
 import com.riffle.core.domain.ContentCacheSettingsStore
 import com.riffle.core.domain.DownloadsRepository
+import com.riffle.core.domain.ReadaloudLinkRepository
 import com.riffle.core.models.EbookFormat
 import com.riffle.core.models.LibraryItem
 import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.StoredItemArtifact
 import com.riffle.core.domain.StoredMediaType
+import com.riffle.core.models.ReadaloudLink
 import com.riffle.core.models.ServerType
 import com.riffle.core.models.Source
 import com.riffle.core.models.SourceUrl
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -89,16 +93,25 @@ class DownloadsViewModelTest {
         coEvery { libraryObserver.getItem("abs", "abs-cached") } returns item("abs", "abs-cached", "ABS Cached")
         coEvery { libraryObserver.getItem("abs", "ab-book") } returns
             item("abs", "ab-book", "ABS Audiobook Downloaded", ebookFormat = EbookFormat.Unsupported, hasAudio = true)
-        coEvery { libraryObserver.getItem("storyteller", "st-down") } returns
-            item("storyteller", "st-down", "Storyteller Downloaded")
+        coEvery { libraryObserver.getItem("abs", "abs-readaloud-down") } returns
+            item("abs", "abs-readaloud-down", "ABS Readaloud Downloaded")
         coEvery { libraryObserver.getItem("abs", "ab-cached") } returns
             item("abs", "ab-cached", "ABS Audiobook Cached", ebookFormat = EbookFormat.Unsupported, hasAudio = true)
-        coEvery { libraryObserver.getItem("storyteller", "st-book") } returns item("storyteller", "st-book", "Storyteller Readaloud")
+        coEvery { libraryObserver.getItem("abs", "abs-readaloud-cached") } returns
+            item("abs", "abs-readaloud-cached", "ABS Readaloud Cached")
 
         val sourceRepository = mockk<SourceRepository>(relaxed = true)
         coEvery { sourceRepository.getById("abs") } returns source("abs", ServerType.AUDIOBOOKSHELF)
         coEvery { sourceRepository.getById("chitanka") } returns source("chitanka", ServerType.AUDIOBOOKSHELF)
         coEvery { sourceRepository.getById("storyteller") } returns source("storyteller", ServerType.STORYTELLER_SERVICE)
+
+        val readaloudLinkRepository = mockk<ReadaloudLinkRepository>(relaxed = true)
+        coEvery { readaloudLinkRepository.findByStorytellerBook("storyteller", "st-down") } returns listOf(
+            link("storyteller", "st-down", "abs", "abs-readaloud-down"),
+        )
+        coEvery { readaloudLinkRepository.findByStorytellerBook("storyteller", "st-book") } returns listOf(
+            link("storyteller", "st-book", "abs", "abs-readaloud-cached"),
+        )
 
         val sidecarStore = mockk<ReadaloudSidecarStore>(relaxed = true)
         every { sidecarStore.listCached() } returns listOf(
@@ -107,16 +120,23 @@ class DownloadsViewModelTest {
         val cacheSettingsStore = mockk<ContentCacheSettingsStore>(relaxed = true)
         every { cacheSettingsStore.autoClear } returns MutableStateFlow(ContentCacheSettingsStore.DEFAULT_AUTO_CLEAR)
 
-        val vm = DownloadsViewModel(downloadsRepo, libraryObserver, sourceRepository, sidecarStore, cacheSettingsStore)
+        val vm = DownloadsViewModel(
+            downloadsRepo,
+            libraryObserver,
+            sourceRepository,
+            readaloudLinkRepository,
+            sidecarStore,
+            cacheSettingsStore,
+        )
         advanceUntilIdle()
 
         val state = vm.uiState.value
         assertEquals(
-            listOf("ABS Downloaded", "Chitanka Downloaded", "ABS Audiobook Downloaded", "Storyteller Downloaded"),
+            listOf("ABS Downloaded", "Chitanka Downloaded", "ABS Audiobook Downloaded", "ABS Readaloud Downloaded"),
             state.downloadedItems.map { it.item.title },
         )
         assertEquals(
-            listOf("ABS Cached", "ABS Audiobook Cached", "Storyteller Readaloud"),
+            listOf("ABS Cached", "ABS Audiobook Cached", "ABS Readaloud Cached"),
             state.cachedItems.map { it.item.title },
         )
         assertEquals(
@@ -139,6 +159,49 @@ class DownloadsViewModelTest {
         assertEquals(ContentCacheSettingsStore.DEFAULT_AUTO_CLEAR, state.cacheAutoClear)
     }
 
+    @Test
+    fun `cached readaloud sidecar opens linked source item and removes storyteller sidecar`() = runTest(dispatcher) {
+        val downloadsRepo = mockk<DownloadsRepository>(relaxed = true)
+        every { downloadsRepo.getDownloadedArtifacts() } returns emptyList()
+        every { downloadsRepo.getCachedArtifacts() } returns emptyList()
+        every { downloadsRepo.sizeOf(any(), any()) } returns 0L
+
+        val libraryObserver = mockk<LibraryObserver>()
+        coEvery { libraryObserver.getItem("abs", "ebook") } returns item("abs", "ebook", "Linked Source Item")
+        val sourceRepository = mockk<SourceRepository>(relaxed = true)
+        val readaloudLinkRepository = mockk<ReadaloudLinkRepository>(relaxed = true)
+        coEvery { readaloudLinkRepository.findByStorytellerBook("storyteller", "sidecar-book") } returns listOf(
+            link("storyteller", "sidecar-book", "abs", "ebook"),
+        )
+        val sidecarStore = mockk<ReadaloudSidecarStore>(relaxed = true)
+        every { sidecarStore.listCached() } returns listOf(
+            ReadaloudSidecarStore.CachedSidecar("storyteller", "sidecar-book", 4096L),
+        )
+        val cacheSettingsStore = mockk<ContentCacheSettingsStore>(relaxed = true)
+        every { cacheSettingsStore.autoClear } returns MutableStateFlow(ContentCacheSettingsStore.DEFAULT_AUTO_CLEAR)
+
+        val vm = DownloadsViewModel(
+            downloadsRepo,
+            libraryObserver,
+            sourceRepository,
+            readaloudLinkRepository,
+            sidecarStore,
+            cacheSettingsStore,
+        )
+        advanceUntilIdle()
+
+        val entry = vm.uiState.value.cachedItems.single()
+        assertEquals("abs", entry.sourceId)
+        assertEquals("ebook", entry.item.id)
+        assertEquals(setOf(LocalMediaType.Readaloud), entry.mediaTypes)
+
+        vm.removeCachedItem(entry)
+        advanceUntilIdle()
+
+        verify { sidecarStore.remove("storyteller", "sidecar-book") }
+        coVerify(exactly = 0) { downloadsRepo.removeCached(any(), any()) }
+    }
+
     private fun source(id: String, serverType: ServerType) = Source(
         id = id,
         url = SourceUrl.parse("http://$id.local")!!,
@@ -146,5 +209,18 @@ class DownloadsViewModelTest {
         insecureConnectionAllowed = false,
         username = "user",
         serverType = serverType,
+    )
+
+    private fun link(
+        storytellerSourceId: String,
+        storytellerBookId: String,
+        absSourceId: String,
+        absLibraryItemId: String,
+    ) = ReadaloudLink(
+        storytellerSourceId = storytellerSourceId,
+        storytellerBookId = storytellerBookId,
+        absSourceId = absSourceId,
+        absLibraryItemId = absLibraryItemId,
+        userConfirmed = true,
     )
 }


### PR DESCRIPTION
## Summary
- Resolve readaloud sidecar and Storyteller readaloud artifacts through their confirmed Source-item link before building Downloads rows.
- Keep separate display and storage identities so tapping opens the linked Source item while removal deletes the correct cached/downloaded artifact.
- Ignore orphaned readaloud sidecars that no longer have a linked library item instead of surfacing a bogus service-item detail row.

## Tests
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :app:testDebugUnitTest --tests com.riffle.app.feature.downloads.DownloadsViewModelTest`

## Regression assertion
- `cached readaloud sidecar opens linked source item and removes storyteller sidecar` would fail if the row reverted to `(storytellerSourceId, storytellerBookId)` navigation because it asserts the cached row has `sourceId == "abs"` and `item.id == "ebook"`.
