### PR TITLE
fix(library): keep series covers visible offline

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -180,6 +180,7 @@ fun LibraryItemsScreen(
     val toReadItems = projection.toRead
     val annotationResults = projection.annotations
     val audiobookBookmarkResults = projection.audiobookBookmarks
+    val seriesCoverUrls by viewModel.seriesCoverUrls.collectAsState()
     val collectionCoverUrls by viewModel.collectionCoverUrls.collectAsState()
     val isOffline by viewModel.isOffline.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
@@ -310,6 +311,7 @@ fun LibraryItemsScreen(
                     filteredItems = filteredUngroupedItems,
                     annotationResults = annotationResults,
                     audiobookBookmarkResults = audiobookBookmarkResults,
+                    seriesCoverUrls = seriesCoverUrls,
                     token = viewModel.authToken,
                     onSeriesSelected = onSeriesSelected,
                     onCollectionSelected = onCollectionSelected,
@@ -354,6 +356,7 @@ fun LibraryItemsScreen(
                         items = series,
                         isLoading = isLoading,
                         token = viewModel.authToken,
+                        seriesCoverUrls = seriesCoverUrls,
                         onSeriesSelected = onSeriesSelected,
                         onCoverScaleChange = onCoverScaleChange,
                     )
@@ -397,6 +400,7 @@ private fun SearchResultsContent(
     filteredItems: List<LibraryItem>,
     annotationResults: List<AnnotationSearchResult>,
     audiobookBookmarkResults: List<AudiobookBookmarkSearchResult>,
+    seriesCoverUrls: Map<String, String>,
     token: String,
     onSeriesSelected: (Series) -> Unit,
     onCollectionSelected: (Collection) -> Unit,
@@ -422,7 +426,12 @@ private fun SearchResultsContent(
         if (filteredSeries.isNotEmpty()) {
             item { SectionHeader("Series") }
             items(filteredSeries, key = { "series_${it.id}" }) { s ->
-                SearchSeriesRow(series = s, token = token, onClick = { onSeriesSelected(s) })
+                SearchSeriesRow(
+                    series = s,
+                    token = token,
+                    coverUrl = seriesCoverUrls[s.id],
+                    onClick = { onSeriesSelected(s) },
+                )
             }
         }
         if (filteredCollections.isNotEmpty()) {
@@ -523,6 +532,7 @@ fun BookSectionGrid(
 fun SeriesSectionGrid(
     items: List<Series>,
     token: String,
+    seriesCoverUrls: Map<String, String> = emptyMap(),
     onSeriesSelected: (Series) -> Unit,
     onSeeMore: (() -> Unit)? = null,
 ) {
@@ -543,7 +553,12 @@ fun SeriesSectionGrid(
                 SeeMoreTile(overflowCount = overflowCount, onClick = onSeeMore)
             } else {
                 val s = preview[index]
-                SeriesCoverTile(series = s, token = token, onClick = { onSeriesSelected(s) })
+                SeriesCoverTile(
+                    series = s,
+                    token = token,
+                    coverUrl = seriesCoverUrls[s.id],
+                    onClick = { onSeriesSelected(s) },
+                )
             }
         }
     }
@@ -737,8 +752,10 @@ fun BookCoverTile(
 fun SeriesCoverTile(
     series: Series,
     token: String,
+    coverUrl: String? = null,
     onClick: () -> Unit,
 ) {
+    val resolvedCoverUrl = coverUrl ?: series.coverUrl
     Column(modifier = Modifier.clickable(onClick = onClick)) {
         Box(
             modifier = Modifier
@@ -749,10 +766,10 @@ fun SeriesCoverTile(
             DefaultCoverPlaceholder(isAudiobook = false, modifier = Modifier.fillMaxSize())
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
-                    .data(series.coverUrl)
+                    .data(resolvedCoverUrl)
                     .addHeader("Authorization", token.asAuthHeader())
                     .crossfade(true)
-                    .instrumentCover("series", series.id, series.coverUrl)
+                    .instrumentCover("series", series.id, resolvedCoverUrl)
                     .build(),
                 contentDescription = series.name,
                 contentScale = ContentScale.Crop,
@@ -875,7 +892,8 @@ fun SeeMoreTile(overflowCount: Int, onClick: () -> Unit) {
 // --- Search result rows (kept for search mode) ---
 
 @Composable
-private fun SearchSeriesRow(series: Series, token: String, onClick: () -> Unit) {
+private fun SearchSeriesRow(series: Series, token: String, coverUrl: String? = null, onClick: () -> Unit) {
+    val resolvedCoverUrl = coverUrl ?: series.coverUrl
     Surface(
         modifier = Modifier
             .fillMaxWidth()
@@ -888,7 +906,7 @@ private fun SearchSeriesRow(series: Series, token: String, onClick: () -> Unit) 
                 DefaultCoverPlaceholder(isAudiobook = false, modifier = Modifier.fillMaxSize())
                 AsyncImage(
                     model = ImageRequest.Builder(LocalContext.current)
-                        .data(series.coverUrl)
+                        .data(resolvedCoverUrl)
                         .addHeader("Authorization", token.asAuthHeader())
                         .crossfade(true)
                         .build(),
@@ -1557,6 +1575,7 @@ private fun SeriesTabContent(
     items: List<Series>,
     isLoading: Boolean,
     token: String,
+    seriesCoverUrls: Map<String, String>,
     onSeriesSelected: (Series) -> Unit,
     onCoverScaleChange: (Float) -> Unit = {},
 ) {
@@ -1584,7 +1603,12 @@ private fun SeriesTabContent(
         }
         items(items, key = { it.id }) { s ->
             Box(modifier = Modifier.padding(4.dp)) {
-                SeriesCoverTile(series = s, token = token, onClick = { onSeriesSelected(s) })
+                SeriesCoverTile(
+                    series = s,
+                    token = token,
+                    coverUrl = seriesCoverUrls[s.id],
+                    onClick = { onSeriesSelected(s) },
+                )
             }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -183,6 +183,33 @@ class LibraryItemsViewModel @Inject constructor(
         !online || refreshFailed
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
 
+    /**
+     * Representative member cover per Series. The persisted `series.coverUrl` can point at a
+     * source-specific series-thumbnail endpoint that was never cached; member item rows are the
+     * same source of cover URLs used by the series-detail grid, so they survive stale series rows.
+     * Offline mode prefers a locally-available member so the chosen URL is the one most likely to
+     * already exist in Coil's disk cache.
+     */
+    val seriesCoverUrls: StateFlow<Map<String, String>> = series
+        .map { rows -> rows.map { it.id } }
+        .distinctUntilChanged()
+        .flatMapLatest { ids ->
+            if (ids.isEmpty()) {
+                flowOf(emptyMap())
+            } else {
+                combine(
+                    ids.map { id ->
+                        combine(libraryObserver.observeSeriesItems(id), isOffline) { items, offline ->
+                            id to representativeSeriesCoverUrl(items, offline)
+                        }
+                    },
+                ) { pairs ->
+                    pairs.mapNotNull { (id, coverUrl) -> coverUrl?.let { id to it } }.toMap()
+                }
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyMap())
+
     private val _notStartedFilterActive = MutableStateFlow(false)
     val notStartedFilterActive: StateFlow<Boolean> = _notStartedFilterActive.asStateFlow()
 
@@ -371,8 +398,23 @@ class LibraryItemsViewModel @Inject constructor(
         _refreshFailed.value = results.any { it is LibraryRefreshResult.NetworkError }
     }
 
+    private fun representativeSeriesCoverUrl(
+        items: List<LibraryItem>,
+        offline: Boolean,
+    ): String? {
+        val preferred = if (offline) {
+            items.filter { offlineAvailability.isAvailableOffline(it) }
+        } else {
+            items
+        }
+        return firstNonBlankCoverUrl(preferred) ?: firstNonBlankCoverUrl(items)
+    }
+
     private companion object {
         const val FAILED_REFRESH_RETRY_INTERVAL_MS = 10_000L
         const val KEY_SEARCH_QUERY = "searchQuery"
     }
 }
+
+private fun firstNonBlankCoverUrl(items: List<LibraryItem>): String? =
+    items.firstNotNullOfOrNull { it.coverUrl?.takeIf { url -> url.isNotBlank() } }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -461,6 +461,65 @@ class LibraryItemsViewModelTest {
         assertEquals(listOf(collection("Fantasy")), vm.collections.value)
     }
 
+    // --- seriesCoverUrls derivation ---
+
+    @Test
+    fun `seriesCoverUrls uses member item cover instead of stale series cover`() = runTest {
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.seriesCoverUrls.collect {} }
+        val stale = series("Fables").copy(coverUrl = "https://komga/api/v1/series/S1/thumbnail")
+        seriesFlow.value = listOf(stale)
+        seriesItemsBySeriesId.getOrPut(stale.id) { MutableStateFlow(emptyList()) }.value =
+            listOf(item("Fables Issue", "Writer", coverUrl = "https://komga/api/v1/books/B1/thumbnail"))
+
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            mapOf(stale.id to "https://komga/api/v1/books/B1/thumbnail"),
+            vm.seriesCoverUrls.value,
+        )
+    }
+
+    @Test
+    fun `seriesCoverUrls skips items with null or blank cover URLs`() = runTest {
+        val vm = makeViewModel()
+        backgroundScope.launch { vm.seriesCoverUrls.collect {} }
+        val ser = series("Mixed")
+        seriesFlow.value = listOf(ser)
+        seriesItemsBySeriesId.getOrPut(ser.id) { MutableStateFlow(emptyList()) }.value = listOf(
+            item("A", "X", coverUrl = null),
+            item("B", "X", coverUrl = ""),
+            item("C", "X", coverUrl = "   "),
+            item("D", "X", coverUrl = "https://komga/api/v1/books/D/thumbnail"),
+        )
+
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(mapOf(ser.id to "https://komga/api/v1/books/D/thumbnail"), vm.seriesCoverUrls.value)
+    }
+
+    @Test
+    fun `seriesCoverUrls prefers offline-available member cover while offline`() = runTest {
+        val vm = makeViewModel(
+            connectivityObserver = FakeConnectivityObserver(online = false),
+            epubRepository = fakeEpubRepoWithDownloads(setOf("id-Downloaded")),
+        )
+        backgroundScope.launch { vm.seriesCoverUrls.collect {} }
+        val ser = series("Arc")
+        seriesFlow.value = listOf(ser)
+        seriesItemsBySeriesId.getOrPut(ser.id) { MutableStateFlow(emptyList()) }.value = listOf(
+            item("Remote", "X", coverUrl = "https://komga/api/v1/books/remote/thumbnail"),
+            item("Downloaded", "X", coverUrl = "https://komga/api/v1/books/downloaded/thumbnail"),
+        )
+
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            mapOf(ser.id to "https://komga/api/v1/books/downloaded/thumbnail"),
+            vm.seriesCoverUrls.value,
+        )
+    }
+
     // --- collectionCoverUrls derivation ---
 
     @Test

--- a/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalog.kt
+++ b/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalog.kt
@@ -416,7 +416,11 @@ class KomgaCatalog(
                     id = s.id,
                     rootId = s.libraryId,
                     name = s.metadata.title?.takeIf { it.isNotBlank() } ?: s.name,
-                    coverUrl = apiUrl("series/${s.id}/thumbnail"),
+                    // Share the book-card cache key so a cached single-book series keeps its
+                    // cover offline even if /series/{id}/thumbnail was never persisted by Coil.
+                    coverUrl = entries.firstOrNull()
+                        ?.let { apiUrl("books/${it.itemId}/thumbnail") }
+                        ?: apiUrl("series/${s.id}/thumbnail"),
                     bookCount = s.booksCount.takeIf { it > 0 } ?: entries.size,
                     items = entries,
                 )

--- a/core/catalog-komga/src/test/kotlin/com/riffle/core/catalog/komga/KomgaCatalogTest.kt
+++ b/core/catalog-komga/src/test/kotlin/com/riffle/core/catalog/komga/KomgaCatalogTest.kt
@@ -190,6 +190,32 @@ class KomgaCatalogTest {
         assertNull(items[2].addedAt)
     }
 
+    @Test fun `listSeries uses first book thumbnail as cover cache key`() = runTest {
+        server.enqueue(MockResponse().setBody("""
+            {
+              "content": [
+                {"id":"B1","libraryId":"L1","seriesId":"S1","name":"one.cbz","number":1,
+                 "media":{"mediaType":"application/x-cbz"},"metadata":{"title":"One","authors":[]}}
+              ],
+              "totalPages":1,"totalElements":1,"first":true,"last":true,"empty":false
+            }
+        """.trimIndent()))
+        server.enqueue(MockResponse().setBody("""
+            {
+              "content": [
+                {"id":"S1","libraryId":"L1","name":"Series One","booksCount":1,"metadata":{"title":"Series One"}}
+              ],
+              "totalPages":1,"totalElements":1,"first":true,"last":true,"empty":false
+            }
+        """.trimIndent()))
+
+        val series = catalog.listSeries("L1")
+
+        assertEquals(1, series.size)
+        val baseUrl = server.url("/").toString().trimEnd('/')
+        assertEquals("$baseUrl/api/v1/books/B1/thumbnail", series[0].coverUrl)
+    }
+
     @Test fun `parseIsoInstant handles null blank and malformed strings`() {
         assertNull(KomgaCatalog.parseIsoInstant(null))
         assertNull(KomgaCatalog.parseIsoInstant(""))


### PR DESCRIPTION
## Summary
- derive series cover URLs from member item rows so stale series thumbnail rows do not blank offline
- prefer offline-available member covers when the device is offline
- align Komga series cover URLs with book thumbnail cache keys on future refreshes

## Tests
- `:app:testDebugUnitTest --tests com.riffle.app.feature.library.LibraryItemsViewModelTest`
- `:core:catalog-komga:test --tests com.riffle.core.catalog.komga.KomgaCatalogTest`

## Regression assertions
- `seriesCoverUrls` uses a member item cover instead of a stale `series.coverUrl`
- `seriesCoverUrls` prefers an offline-available member cover while offline
- Komga `listSeries` stores `/api/v1/books/{id}/thumbnail` as the series cover cache key
