### PR TITLE
fix(library): coalesce offline banner refreshes

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -174,6 +174,7 @@ class LibraryItemsViewModel @Inject constructor(
 
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+    private var refreshJob: Job? = null
 
     // The banner appears when the device has no network or when the last server refresh failed.
     val isOffline: StateFlow<Boolean> = combine(
@@ -293,9 +294,7 @@ class LibraryItemsViewModel @Inject constructor(
             if (server != null) {
                 authToken = tokenStorage.getToken(server.id) ?: ""
             }
-            val refreshJob = launch { refresh() }
-            launch { toReadRepository.refresh(libraryId) }
-            launch { playlistsRepository.refresh(libraryId) }
+            val refreshJob = launchRefresh()
             // Unblock the UI as soon as we have something meaningful to show:
             // either Room returns cached data quickly, or we wait for the network
             // refresh to complete so an empty state is known to be genuine.
@@ -314,9 +313,7 @@ class LibraryItemsViewModel @Inject constructor(
         // and the offline banner clears without requiring a manual lifecycle resume.
         viewModelScope.launch {
             connectivityObserver.isOnline.collectReconnects {
-                refresh()
-                toReadRepository.refresh(libraryId)
-                playlistsRepository.refresh(libraryId)
+                launchRefresh(clearStaleFailureIfOnline = true).join()
             }
         }
         // While a refresh is failing AND the device is online (i.e. server unreachable on an
@@ -332,10 +329,10 @@ class LibraryItemsViewModel @Inject constructor(
                         // Immediate retry covers cold-start transient failures (fast-fail
                         // "network unreachable" clears within milliseconds). Subsequent
                         // retries use the full interval for genuine server-down scenarios.
-                        runRefresh()
+                        launchRefresh().join()
                         while (true) {
                             delay(FAILED_REFRESH_RETRY_INTERVAL_MS)
-                            runRefresh()
+                            launchRefresh().join()
                         }
                     }
                 }
@@ -351,11 +348,26 @@ class LibraryItemsViewModel @Inject constructor(
      * doze/wake drift on ProcessLifecycleOwner ON_START (see ConnectivityObserverImpl) — no
      * explicit poke needed here. */
     fun onScreenResumed() {
-        refresh()
+        launchRefresh(clearStaleFailureIfOnline = true)
     }
 
     fun refresh() {
-        viewModelScope.launch { runRefresh() }
+        launchRefresh()
+    }
+
+    private fun launchRefresh(clearStaleFailureIfOnline: Boolean = false): Job {
+        if (clearStaleFailureIfOnline && connectivityObserver.isOnline.value) {
+            _refreshFailed.value = false
+        }
+        refreshJob?.takeIf { it.isActive }?.let { return it }
+        val job = viewModelScope.launch { runRefresh() }
+        refreshJob = job
+        job.invokeOnCompletion {
+            if (refreshJob === job) {
+                refreshJob = null
+            }
+        }
+        return job
     }
 
     private suspend fun runRefresh() = coroutineScope {

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -25,6 +25,7 @@ import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceUrl
 import com.riffle.core.data.ToReadRepository
 import com.riffle.core.domain.TokenStorage
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -808,7 +809,7 @@ class LibraryItemsViewModelTest {
     // --- periodic retry while refresh is failing ---
 
     private class CountingRefreshLibraryItems(
-        val refreshResult: () -> LibraryRefreshResult,
+        val refreshResult: suspend () -> LibraryRefreshResult,
         val onCall: () -> Unit = {},
     ) : com.riffle.core.domain.usecase.RefreshLibraryItems(
         com.riffle.app.testing.NoopLibraryRefresher,
@@ -823,6 +824,75 @@ class LibraryItemsViewModelTest {
         override suspend fun invoke(libraryId: String): LibraryRefreshResult {
             onCall(); return refreshResult()
         }
+    }
+
+    @Test
+    fun `reconnect and resume share an in-flight refresh`() = runTest {
+        val connectivity = FakeConnectivityObserver(online = false)
+        val refreshGate = CompletableDeferred<Unit>()
+        var refreshCount = 0
+        val vm = makeViewModel(
+            connectivityObserver = connectivity,
+            refreshLibraryItemsUseCase = CountingRefreshLibraryItems({
+                refreshGate.await()
+                LibraryRefreshResult.Success
+            }) { refreshCount++ },
+        )
+        backgroundScope.launch { vm.isOffline.collect {} }
+        testDispatcher.scheduler.runCurrent()
+        assertEquals(1, refreshCount)
+
+        connectivity.state.value = true
+        vm.onScreenResumed()
+        testDispatcher.scheduler.runCurrent()
+
+        assertEquals(
+            "Reconnect and ON_RESUME should join the already-running refresh, not start duplicates",
+            1,
+            refreshCount,
+        )
+
+        refreshGate.complete(Unit)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(false, vm.isOffline.value)
+        assertEquals(1, refreshCount)
+    }
+
+    @Test
+    fun `online resume clears stale offline banner before refresh completes`() = runTest {
+        val connectivity = FakeConnectivityObserver(online = false)
+        val refreshGate = CompletableDeferred<Unit>()
+        var failRefresh = true
+        val vm = makeViewModel(
+            connectivityObserver = connectivity,
+            refreshLibraryItemsUseCase = CountingRefreshLibraryItems({
+                if (failRefresh) {
+                    LibraryRefreshResult.NetworkError(RuntimeException("offline"))
+                } else {
+                    refreshGate.await()
+                    LibraryRefreshResult.Success
+                }
+            }),
+        )
+        backgroundScope.launch { vm.isOffline.collect {} }
+        testDispatcher.scheduler.runCurrent()
+        assertEquals(true, vm.isOffline.value)
+
+        failRefresh = false
+        connectivity.state.value = true
+        vm.onScreenResumed()
+        testDispatcher.scheduler.runCurrent()
+
+        assertEquals(
+            "A stale offline refresh failure should clear as soon as the device is online again",
+            false,
+            vm.isOffline.value,
+        )
+
+        refreshGate.complete(Unit)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(false, vm.isOffline.value)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Coalesce library-screen refresh triggers so reconnect, resume, retry, and manual refresh join one in-flight refresh instead of launching duplicate network batches.
- Clear a stale offline refresh failure immediately when the library screen resumes/reconnects and device connectivity is online, so the offline banner does not remain pinned while the refresh runs.
- Keep the existing connectivity observer, reconciliation predicate, and validated-network tracker behavior unchanged.

## Regression coverage
- `reconnect and resume share an in-flight refresh`: would fail if reconnect plus `ON_RESUME` started duplicate refreshes.
- `online resume clears stale offline banner before refresh completes`: would fail if `_refreshFailed` stayed true until a potentially slow refresh completed.
- Existing online-detection guards still pass: `ConnectivityReconcileTest`, `ValidatedNetworkTrackerTest`, `QualifyingNetworkTest`, `ConnectivityReconnectsTest`, and `ReconnectSyncKickerTest`.

## Tests
- `:core:data:testDebugUnitTest :core:domain:jvmTest :app:testDebugUnitTest --tests com.riffle.core.data.ConnectivityReconcileTest --tests com.riffle.core.data.ValidatedNetworkTrackerTest --tests com.riffle.core.data.QualifyingNetworkTest --tests com.riffle.core.domain.ConnectivityReconnectsTest --tests com.riffle.app.feature.library.LibraryItemsViewModelTest`
- `:app:testDebugUnitTest --tests com.riffle.app.sync.ReconnectSyncKickerTest`

Note: this workspace is missing `gradle/wrapper/gradle-wrapper.jar`, so local tests were launched through the wrapper jar from a neighboring Riffle workspace with this workspace as the working directory.