### PR TITLE
fix(sources): prevent source removal FK crashes

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
@@ -2,8 +2,6 @@ package com.riffle.core.data
 
 import com.riffle.core.data.credentialed.CredentialedSourceInstaller
 import com.riffle.core.data.credentialed.toDomain
-import com.riffle.core.database.LibraryDao
-import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.SourceDao
 import com.riffle.core.domain.CommitSourceResult
 import com.riffle.core.domain.PendingSource
@@ -31,8 +29,6 @@ class SourceRepositoryImpl @Inject constructor(
     private val tokenStorage: TokenStorage,
     private val serverInfoApi: AbsServerInfoApi,
     private val komgaServerInfoApi: KomgaServerInfoApi,
-    private val libraryDao: LibraryDao,
-    private val libraryItemDao: LibraryItemDao,
     private val filesCleaner: SourceFilesCleaner,
     // Provider (not direct injection) breaks the SourceRepository ↔ ReadaloudSidecarStore Hilt
     // cycle: the sidecar store needs SourceRepository to look up per-source credentials, and the
@@ -70,13 +66,10 @@ class SourceRepositoryImpl @Inject constructor(
     }
 
     override suspend fun remove(sourceId: String) {
-        // Cascade: clear per-library items + the libraries themselves + the token + the source row.
-        // For Storyteller sources this purges the synthetic Readaloud library and its books;
-        // for ABS sources it cleans up real libraries and their items. ReadaloudLinks cross-source
-        // cleanup belongs to #36 (matching slice) — until that lands the count of links is 0.
-        libraryDao.libraryIdsForSource(sourceId).forEach { libraryItemDao.deleteByLibraryId(sourceId, it) }
-        libraryDao.deleteBySourceId(sourceId)
-        dao.deleteById(sourceId)
+        // Keep Room cleanup atomic. Some user databases have accumulated rows in source-scoped
+        // caches and cross-source readaloud tables; deleting the source row through one graph
+        // cleanup avoids FK failures and leaves no partial source removal behind.
+        dao.deleteSourceGraph(sourceId)
         tokenStorage.deleteToken(sourceId)
         tokenStorage.deletePassword(sourceId)
         // The file stores live outside Room, so the FK cascade above doesn't touch them — purge the

--- a/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/SourceRepositoryTest.kt
@@ -66,6 +66,7 @@ class ServerRepositoryTest {
 
     private class FakeServerDao(initial: List<SourceEntity>) : SourceDao {
         val store = initial.toMutableList()
+        val graphDeletedSourceIds = mutableListOf<String>()
         override fun observeAll() = flowOf(store.toList())
         override suspend fun getActive() = store.firstOrNull { it.isActive }
         override suspend fun getById(id: String): SourceEntity? = store.firstOrNull { it.id == id }
@@ -83,6 +84,36 @@ class ServerRepositoryTest {
             return toInsert
         }
         override suspend fun deleteById(id: String) { store.removeAll { it.id == id } }
+        override suspend fun deleteReadaloudLinksForSource(id: String) = Unit
+        override suspend fun deleteReadaloudCandidatesForSource(id: String) = Unit
+        override suspend fun deleteReadaloudDismissalsForSource(id: String) = Unit
+        override suspend fun deleteSeriesForSource(id: String) = Unit
+        override suspend fun deleteSeriesItemsForSource(id: String) = Unit
+        override suspend fun deleteCollectionsForSource(id: String) = Unit
+        override suspend fun deleteCollectionItemsForSource(id: String) = Unit
+        override suspend fun deletePlaylistItemsForSource(id: String) = Unit
+        override suspend fun deletePlaylistsForSource(id: String) = Unit
+        override suspend fun deleteReadingPositionsForSource(id: String) = Unit
+        override suspend fun deleteBookFormattingPreferencesForSource(id: String) = Unit
+        override suspend fun deleteAnnotationsForSource(id: String) = Unit
+        override suspend fun deleteReadaloudResumePositionsForSource(id: String) = Unit
+        override suspend fun deleteAudioPlaybackPreferencesForSource(id: String) = Unit
+        override suspend fun deleteAudiobookPositionsForSource(id: String) = Unit
+        override suspend fun deleteAudiobookBookmarksForSource(id: String) = Unit
+        override suspend fun deleteTocCacheForSource(id: String) = Unit
+        override suspend fun deleteAudiobookChapterCacheForSource(id: String) = Unit
+        override suspend fun deleteLocalFilesFileFoldersForSource(id: String) = Unit
+        override suspend fun deleteLocalFilesFilesForSource(id: String) = Unit
+        override suspend fun deleteLocalFilesFoldersForSource(id: String) = Unit
+        override suspend fun deleteLocalFileMetadataOverridesForSource(id: String) = Unit
+        override suspend fun deleteRemoteItemFreshnessForSource(id: String) = Unit
+        override suspend fun deletePublicationMetricsCacheForSource(id: String) = Unit
+        override suspend fun deleteLibraryItemsForSource(id: String) = Unit
+        override suspend fun deleteLibrariesForSource(id: String) = Unit
+        override suspend fun deleteSourceGraph(id: String) {
+            graphDeletedSourceIds += id
+            deleteById(id)
+        }
         override suspend fun setAbsUserId(id: String, absUserId: String) {
             store.replaceAll { if (it.id == id) it.copy(absUserId = absUserId) else it }
         }
@@ -205,7 +236,7 @@ class ServerRepositoryTest {
         serverInfoApi: AbsServerInfoApi,
         libraryApi: AbsLibraryApi,
         libraryDao: LibraryDao,
-        libraryItemDao: com.riffle.core.database.LibraryItemDao,
+        @Suppress("UNUSED_PARAMETER") libraryItemDao: com.riffle.core.database.LibraryItemDao,
         visibilityStore: LibraryVisibilityPreferencesStore,
         filesCleaner: SourceFilesCleaner,
         sidecarCache: com.riffle.core.domain.ReadaloudSidecarCache = fakeSidecarCache(),
@@ -238,8 +269,6 @@ class ServerRepositoryTest {
             tokenStorage = tokens,
             serverInfoApi = serverInfoApi,
             komgaServerInfoApi = fakeKomgaServerInfoApi,
-            libraryDao = libraryDao,
-            libraryItemDao = libraryItemDao,
             filesCleaner = filesCleaner,
             sidecarCache = sidecarCacheProvider,
             installer = installer,
@@ -611,6 +640,7 @@ class ServerRepositoryTest {
             dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner()
         )
         repo.remove("srv-1")
+        assertEquals(listOf("srv-1"), dao.graphDeletedSourceIds)
         assertTrue("token not deleted", tokens.tokens.isEmpty())
         assertNull("entity not deleted from store", dao.getActive())
     }
@@ -668,57 +698,38 @@ class ServerRepositoryTest {
     }
 
     @Test
-    fun `remove cascades libraries and library_items for a Storyteller source`() = runTest {
+    fun `remove delegates Storyteller source Room cleanup to source graph delete`() = runTest {
         val entity = SourceEntity("st-1", "http://media-source:8001", true, false, username = "plamen", serverType = "STORYTELLER_SERVICE")
         val dao = fakeDao(entity)
         val tokens = fakeTokenStorage()
         tokens.tokens["st-1"] = "tok-st"
-        val libDao = fakeLibraryDao()
-        val libraryId = SourceRepositoryImpl.readaloudLibraryId("st-1")
-        libDao.rows["st-1"] = mutableListOf(LibraryEntity(libraryId, "Readalouds", "readaloud", "st-1"))
-        val itemDao = fakeLibraryItemDao()
-        itemDao.seed(libraryId, listOf(
-            com.riffle.core.database.LibraryItemEntity("st-1", "1385738337074647", libraryId, "The Martian", "Andy Weir", null, 0f, addedAt = 0L),
-            com.riffle.core.database.LibraryItemEntity("st-1", "99", libraryId, "Dune", "Frank Herbert", null, 0f, addedAt = 0L),
-        ))
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
         val repo = buildRepo(
-            dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, itemDao, fakeVisibilityStore(), fakeFilesCleaner()
+            dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner()
         )
 
         repo.remove("st-1")
 
+        assertEquals(listOf("st-1"), dao.graphDeletedSourceIds)
         assertEquals("source entity not deleted", 0, dao.allCount())
         assertTrue("token not deleted", tokens.tokens.isEmpty())
-        assertTrue("library rows not cleared", libDao.allEntities().isEmpty())
-        assertTrue("library_items not deleted via deleteByLibraryId", itemDao.deletedLibraryIds.contains(libraryId))
-        assertTrue("library items remain after removal", itemDao.itemsFor(libraryId).isEmpty())
     }
 
     @Test
-    fun `remove cascades libraries and library_items for an ABS source`() = runTest {
+    fun `remove delegates ABS source Room cleanup to source graph delete`() = runTest {
         val entity = SourceEntity("abs-1", "https://abs.example.com", true, false, username = "u")
         val dao = fakeDao(entity)
         val tokens = fakeTokenStorage()
         tokens.tokens["abs-1"] = "tok"
-        val libDao = fakeLibraryDao()
-        libDao.rows["abs-1"] = mutableListOf(
-            LibraryEntity("lib-1", "Books", "book", "abs-1"),
-            LibraryEntity("lib-2", "Audiobooks", "book", "abs-1"),
-        )
-        val itemDao = fakeLibraryItemDao()
-        itemDao.seed("lib-1", listOf(com.riffle.core.database.LibraryItemEntity("s1", "i-1", "lib-1", "Dune", "Herbert", null, 0f, addedAt = 0L)))
-        itemDao.seed("lib-2", listOf(com.riffle.core.database.LibraryItemEntity("s1", "i-2", "lib-2", "Foundation", "Asimov", null, 0f, addedAt = 0L)))
         val absApi = AbsApi { _, _, _, _ -> error("not called") }
         val repo = buildRepo(
-            dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, libDao, itemDao, fakeVisibilityStore(), fakeFilesCleaner()
+            dao, tokens, absApi, storytellerApiNotCalled, fakeServerInfoApi, libsApiNotCalled, fakeLibraryDao(), fakeLibraryItemDao(), fakeVisibilityStore(), fakeFilesCleaner()
         )
 
         repo.remove("abs-1")
 
+        assertEquals(listOf("abs-1"), dao.graphDeletedSourceIds)
         assertEquals(0, dao.allCount())
-        assertTrue(libDao.allEntities().isEmpty())
-        assertEquals(setOf("lib-1", "lib-2"), itemDao.deletedLibraryIds.toSet())
     }
 
     @Test

--- a/core/data/src/test/kotlin/com/riffle/core/data/credentialed/CredentialedSourceInstallerOrderingTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/credentialed/CredentialedSourceInstallerOrderingTest.kt
@@ -116,6 +116,32 @@ class CredentialedSourceInstallerOrderingTest {
             return source.copy(isActive = true)
         }
         override suspend fun deleteById(id: String) { order += "deleteById" }
+        override suspend fun deleteReadaloudLinksForSource(id: String) = Unit
+        override suspend fun deleteReadaloudCandidatesForSource(id: String) = Unit
+        override suspend fun deleteReadaloudDismissalsForSource(id: String) = Unit
+        override suspend fun deleteSeriesForSource(id: String) = Unit
+        override suspend fun deleteSeriesItemsForSource(id: String) = Unit
+        override suspend fun deleteCollectionsForSource(id: String) = Unit
+        override suspend fun deleteCollectionItemsForSource(id: String) = Unit
+        override suspend fun deletePlaylistItemsForSource(id: String) = Unit
+        override suspend fun deletePlaylistsForSource(id: String) = Unit
+        override suspend fun deleteReadingPositionsForSource(id: String) = Unit
+        override suspend fun deleteBookFormattingPreferencesForSource(id: String) = Unit
+        override suspend fun deleteAnnotationsForSource(id: String) = Unit
+        override suspend fun deleteReadaloudResumePositionsForSource(id: String) = Unit
+        override suspend fun deleteAudioPlaybackPreferencesForSource(id: String) = Unit
+        override suspend fun deleteAudiobookPositionsForSource(id: String) = Unit
+        override suspend fun deleteAudiobookBookmarksForSource(id: String) = Unit
+        override suspend fun deleteTocCacheForSource(id: String) = Unit
+        override suspend fun deleteAudiobookChapterCacheForSource(id: String) = Unit
+        override suspend fun deleteLocalFilesFileFoldersForSource(id: String) = Unit
+        override suspend fun deleteLocalFilesFilesForSource(id: String) = Unit
+        override suspend fun deleteLocalFilesFoldersForSource(id: String) = Unit
+        override suspend fun deleteLocalFileMetadataOverridesForSource(id: String) = Unit
+        override suspend fun deleteRemoteItemFreshnessForSource(id: String) = Unit
+        override suspend fun deletePublicationMetricsCacheForSource(id: String) = Unit
+        override suspend fun deleteLibraryItemsForSource(id: String) = Unit
+        override suspend fun deleteLibrariesForSource(id: String) = Unit
         override suspend fun setAbsUserId(id: String, absUserId: String) { order += "setAbsUserId" }
     }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesSourceInstallerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/localfiles/LocalFilesSourceInstallerTest.kt
@@ -108,6 +108,32 @@ class LocalFilesSourceInstallerTest {
         override suspend fun getByType(type: String): SourceEntity? =
             rows.values.firstOrNull { it.type == type }
         override suspend fun deleteById(id: String) { rows.remove(id) }
+        override suspend fun deleteReadaloudLinksForSource(id: String) = Unit
+        override suspend fun deleteReadaloudCandidatesForSource(id: String) = Unit
+        override suspend fun deleteReadaloudDismissalsForSource(id: String) = Unit
+        override suspend fun deleteSeriesForSource(id: String) = Unit
+        override suspend fun deleteSeriesItemsForSource(id: String) = Unit
+        override suspend fun deleteCollectionsForSource(id: String) = Unit
+        override suspend fun deleteCollectionItemsForSource(id: String) = Unit
+        override suspend fun deletePlaylistItemsForSource(id: String) = Unit
+        override suspend fun deletePlaylistsForSource(id: String) = Unit
+        override suspend fun deleteReadingPositionsForSource(id: String) = Unit
+        override suspend fun deleteBookFormattingPreferencesForSource(id: String) = Unit
+        override suspend fun deleteAnnotationsForSource(id: String) = Unit
+        override suspend fun deleteReadaloudResumePositionsForSource(id: String) = Unit
+        override suspend fun deleteAudioPlaybackPreferencesForSource(id: String) = Unit
+        override suspend fun deleteAudiobookPositionsForSource(id: String) = Unit
+        override suspend fun deleteAudiobookBookmarksForSource(id: String) = Unit
+        override suspend fun deleteTocCacheForSource(id: String) = Unit
+        override suspend fun deleteAudiobookChapterCacheForSource(id: String) = Unit
+        override suspend fun deleteLocalFilesFileFoldersForSource(id: String) = Unit
+        override suspend fun deleteLocalFilesFilesForSource(id: String) = Unit
+        override suspend fun deleteLocalFilesFoldersForSource(id: String) = Unit
+        override suspend fun deleteLocalFileMetadataOverridesForSource(id: String) = Unit
+        override suspend fun deleteRemoteItemFreshnessForSource(id: String) = Unit
+        override suspend fun deletePublicationMetricsCacheForSource(id: String) = Unit
+        override suspend fun deleteLibraryItemsForSource(id: String) = Unit
+        override suspend fun deleteLibrariesForSource(id: String) = Unit
         override suspend fun setAbsUserId(id: String, absUserId: String) {
             rows[id]?.let { rows[id] = it.copy(absUserId = absUserId) }
         }

--- a/core/data/src/test/kotlin/com/riffle/core/data/websource/SingletonWebSourceInstallerTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/websource/SingletonWebSourceInstallerTest.kt
@@ -148,6 +148,32 @@ class SingletonWebSourceInstallerTest {
         override suspend fun getByType(type: String): SourceEntity? =
             rows.values.firstOrNull { it.type == type }
         override suspend fun deleteById(id: String) { rows.remove(id) }
+        override suspend fun deleteReadaloudLinksForSource(id: String) = Unit
+        override suspend fun deleteReadaloudCandidatesForSource(id: String) = Unit
+        override suspend fun deleteReadaloudDismissalsForSource(id: String) = Unit
+        override suspend fun deleteSeriesForSource(id: String) = Unit
+        override suspend fun deleteSeriesItemsForSource(id: String) = Unit
+        override suspend fun deleteCollectionsForSource(id: String) = Unit
+        override suspend fun deleteCollectionItemsForSource(id: String) = Unit
+        override suspend fun deletePlaylistItemsForSource(id: String) = Unit
+        override suspend fun deletePlaylistsForSource(id: String) = Unit
+        override suspend fun deleteReadingPositionsForSource(id: String) = Unit
+        override suspend fun deleteBookFormattingPreferencesForSource(id: String) = Unit
+        override suspend fun deleteAnnotationsForSource(id: String) = Unit
+        override suspend fun deleteReadaloudResumePositionsForSource(id: String) = Unit
+        override suspend fun deleteAudioPlaybackPreferencesForSource(id: String) = Unit
+        override suspend fun deleteAudiobookPositionsForSource(id: String) = Unit
+        override suspend fun deleteAudiobookBookmarksForSource(id: String) = Unit
+        override suspend fun deleteTocCacheForSource(id: String) = Unit
+        override suspend fun deleteAudiobookChapterCacheForSource(id: String) = Unit
+        override suspend fun deleteLocalFilesFileFoldersForSource(id: String) = Unit
+        override suspend fun deleteLocalFilesFilesForSource(id: String) = Unit
+        override suspend fun deleteLocalFilesFoldersForSource(id: String) = Unit
+        override suspend fun deleteLocalFileMetadataOverridesForSource(id: String) = Unit
+        override suspend fun deleteRemoteItemFreshnessForSource(id: String) = Unit
+        override suspend fun deletePublicationMetricsCacheForSource(id: String) = Unit
+        override suspend fun deleteLibraryItemsForSource(id: String) = Unit
+        override suspend fun deleteLibrariesForSource(id: String) = Unit
         override suspend fun setAbsUserId(id: String, absUserId: String) {
             rows[id]?.let { rows[id] = it.copy(absUserId = absUserId) }
         }

--- a/core/database-api/src/main/kotlin/com/riffle/core/database/SourceDao.kt
+++ b/core/database-api/src/main/kotlin/com/riffle/core/database/SourceDao.kt
@@ -54,6 +54,115 @@ interface SourceDao {
     @Query("DELETE FROM sources WHERE id = :id")
     suspend fun deleteById(id: String)
 
+    @Query("DELETE FROM readaloud_links WHERE storytellerSourceId = :id OR absSourceId = :id")
+    suspend fun deleteReadaloudLinksForSource(id: String)
+
+    @Query("DELETE FROM readaloud_candidates WHERE storytellerSourceId = :id OR absSourceId = :id")
+    suspend fun deleteReadaloudCandidatesForSource(id: String)
+
+    @Query("DELETE FROM readaloud_dismissals WHERE storytellerSourceId = :id OR absSourceId = :id")
+    suspend fun deleteReadaloudDismissalsForSource(id: String)
+
+    @Query("DELETE FROM series WHERE id IN (SELECT seriesId FROM series_items WHERE sourceId = :id)")
+    suspend fun deleteSeriesForSource(id: String)
+
+    @Query("DELETE FROM series_items WHERE sourceId = :id")
+    suspend fun deleteSeriesItemsForSource(id: String)
+
+    @Query("DELETE FROM collections WHERE id IN (SELECT collectionId FROM collection_items WHERE sourceId = :id)")
+    suspend fun deleteCollectionsForSource(id: String)
+
+    @Query("DELETE FROM collection_items WHERE sourceId = :id")
+    suspend fun deleteCollectionItemsForSource(id: String)
+
+    @Query("DELETE FROM playlist_items WHERE sourceId = :id")
+    suspend fun deletePlaylistItemsForSource(id: String)
+
+    @Query("DELETE FROM playlists WHERE sourceId = :id")
+    suspend fun deletePlaylistsForSource(id: String)
+
+    @Query("DELETE FROM reading_positions WHERE sourceId = :id")
+    suspend fun deleteReadingPositionsForSource(id: String)
+
+    @Query("DELETE FROM book_formatting_preferences WHERE sourceId = :id")
+    suspend fun deleteBookFormattingPreferencesForSource(id: String)
+
+    @Query("DELETE FROM annotations WHERE sourceId = :id")
+    suspend fun deleteAnnotationsForSource(id: String)
+
+    @Query("DELETE FROM readaloud_resume_positions WHERE sourceId = :id")
+    suspend fun deleteReadaloudResumePositionsForSource(id: String)
+
+    @Query("DELETE FROM audio_playback_preferences WHERE sourceId = :id")
+    suspend fun deleteAudioPlaybackPreferencesForSource(id: String)
+
+    @Query("DELETE FROM audiobook_positions WHERE sourceId = :id")
+    suspend fun deleteAudiobookPositionsForSource(id: String)
+
+    @Query("DELETE FROM audiobook_bookmarks WHERE sourceId = :id")
+    suspend fun deleteAudiobookBookmarksForSource(id: String)
+
+    @Query("DELETE FROM toc_cache WHERE sourceId = :id")
+    suspend fun deleteTocCacheForSource(id: String)
+
+    @Query("DELETE FROM audiobook_chapter_cache WHERE sourceId = :id")
+    suspend fun deleteAudiobookChapterCacheForSource(id: String)
+
+    @Query("DELETE FROM local_files_file_folders WHERE sourceId = :id")
+    suspend fun deleteLocalFilesFileFoldersForSource(id: String)
+
+    @Query("DELETE FROM local_files_files WHERE sourceId = :id")
+    suspend fun deleteLocalFilesFilesForSource(id: String)
+
+    @Query("DELETE FROM local_files_folders WHERE sourceId = :id")
+    suspend fun deleteLocalFilesFoldersForSource(id: String)
+
+    @Query("DELETE FROM local_file_metadata_overrides WHERE sourceId = :id")
+    suspend fun deleteLocalFileMetadataOverridesForSource(id: String)
+
+    @Query("DELETE FROM remote_item_freshness WHERE sourceId = :id")
+    suspend fun deleteRemoteItemFreshnessForSource(id: String)
+
+    @Query("DELETE FROM publication_metrics_cache WHERE sourceId = :id")
+    suspend fun deletePublicationMetricsCacheForSource(id: String)
+
+    @Query("DELETE FROM library_items WHERE sourceId = :id")
+    suspend fun deleteLibraryItemsForSource(id: String)
+
+    @Query("DELETE FROM libraries WHERE sourceId = :id")
+    suspend fun deleteLibrariesForSource(id: String)
+
+    @Transaction
+    suspend fun deleteSourceGraph(id: String) {
+        deleteReadaloudLinksForSource(id)
+        deleteReadaloudCandidatesForSource(id)
+        deleteReadaloudDismissalsForSource(id)
+        deleteSeriesForSource(id)
+        deleteSeriesItemsForSource(id)
+        deleteCollectionsForSource(id)
+        deleteCollectionItemsForSource(id)
+        deletePlaylistItemsForSource(id)
+        deletePlaylistsForSource(id)
+        deleteReadingPositionsForSource(id)
+        deleteBookFormattingPreferencesForSource(id)
+        deleteAnnotationsForSource(id)
+        deleteReadaloudResumePositionsForSource(id)
+        deleteAudioPlaybackPreferencesForSource(id)
+        deleteAudiobookPositionsForSource(id)
+        deleteAudiobookBookmarksForSource(id)
+        deleteTocCacheForSource(id)
+        deleteAudiobookChapterCacheForSource(id)
+        deleteLocalFilesFileFoldersForSource(id)
+        deleteLocalFilesFilesForSource(id)
+        deleteLocalFilesFoldersForSource(id)
+        deleteLocalFileMetadataOverridesForSource(id)
+        deleteRemoteItemFreshnessForSource(id)
+        deletePublicationMetricsCacheForSource(id)
+        deleteLibraryItemsForSource(id)
+        deleteLibrariesForSource(id)
+        deleteById(id)
+    }
+
     @Query("UPDATE sources SET absUserId = :absUserId WHERE id = :id")
     suspend fun setAbsUserId(id: String, absUserId: String)
 }

--- a/core/database/src/androidTest/kotlin/com/riffle/core/database/SourceDaoDeleteGraphTest.kt
+++ b/core/database/src/androidTest/kotlin/com/riffle/core/database/SourceDaoDeleteGraphTest.kt
@@ -1,0 +1,101 @@
+package com.riffle.core.database
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SourceDaoDeleteGraphTest {
+    private lateinit var db: RiffleDatabase
+
+    @Before
+    fun setUp() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        db = Room.inMemoryDatabaseBuilder(context, RiffleDatabase::class.java).build()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun deleteSourceGraphRemovesAbsSourceRowsWithoutForeignKeyFailure() = runTest {
+        seedAbsSourceGraph()
+
+        db.sourceDao().deleteSourceGraph(ABS_SOURCE_ID)
+
+        assertEquals(0, count("sources", "id = '$ABS_SOURCE_ID'"))
+        assertEquals(0, count("libraries", "sourceId = '$ABS_SOURCE_ID'"))
+        assertEquals(0, count("library_items", "sourceId = '$ABS_SOURCE_ID'"))
+        assertEquals(0, count("reading_positions", "sourceId = '$ABS_SOURCE_ID'"))
+        assertEquals(0, count("book_formatting_preferences", "sourceId = '$ABS_SOURCE_ID'"))
+        assertEquals(0, count("annotations", "sourceId = '$ABS_SOURCE_ID'"))
+        assertEquals(0, count("playlists", "sourceId = '$ABS_SOURCE_ID'"))
+        assertEquals(0, count("playlist_items", "sourceId = '$ABS_SOURCE_ID'"))
+        assertEquals(0, count("publication_metrics_cache", "sourceId = '$ABS_SOURCE_ID'"))
+        assertEquals(0, count("readaloud_links", "absSourceId = '$ABS_SOURCE_ID'"))
+        assertEquals(0, count("readaloud_candidates", "absSourceId = '$ABS_SOURCE_ID'"))
+        assertEquals(0, count("readaloud_dismissals", "absSourceId = '$ABS_SOURCE_ID'"))
+        assertEquals(1, count("sources", "id = '$OTHER_SOURCE_ID'"))
+        assertEquals(1, count("publication_metrics_cache", "sourceId = '$OTHER_SOURCE_ID'"))
+    }
+
+    private suspend fun seedAbsSourceGraph() {
+        db.sourceDao().upsert(SourceEntity(ABS_SOURCE_ID, "https://abs.example.invalid", true, false, "u"))
+        db.sourceDao().upsert(SourceEntity(STORYTELLER_SOURCE_ID, "https://storyteller.example.invalid", false, false, "u", "STORYTELLER_SERVICE"))
+        db.sourceDao().upsert(SourceEntity(OTHER_SOURCE_ID, "https://other.example.invalid", false, false, "u"))
+
+        sql("INSERT INTO libraries (id, name, mediaType, sourceId, isUnsupported) VALUES ('lib-1', 'Books', 'book', '$ABS_SOURCE_ID', 0)")
+        sql("INSERT INTO library_items (sourceId, id, libraryId, title, author, coverUrl, readingProgress, ebookFormat, hasAudio, audioDurationSec, genres, addedAt) VALUES ('$ABS_SOURCE_ID', 'item-1', 'lib-1', 'Title', 'Author', NULL, 0.25, 'epub', 1, 123.0, '', 10)")
+        sql("INSERT INTO reading_positions (sourceId, itemId, cfi, localUpdatedAt, lastSyncedAt) VALUES ('$ABS_SOURCE_ID', 'item-1', 'epubcfi(/6/4!/4/1:0)', 20, 10)")
+        sql("INSERT INTO book_formatting_preferences (sourceId, itemId, scope, fontSize) VALUES ('$ABS_SOURCE_ID', 'item-1', 'FullBook', 1.0)")
+        db.annotationDao().upsertAll(
+            listOf(
+                AnnotationEntity(
+                    id = "ann-1",
+                    sourceId = ABS_SOURCE_ID,
+                    itemId = "item-1",
+                    type = AnnotationEntity.TYPE_HIGHLIGHT,
+                    cfi = "epubcfi(/6/4!/4/1:0,/1:0,/1:5)",
+                    textSnippet = "text",
+                    chapterHref = "chapter.xhtml",
+                    createdAt = 1,
+                    updatedAt = 1,
+                    originDeviceId = "device",
+                    lastModifiedByDeviceId = "device",
+                )
+            )
+        )
+        sql("INSERT INTO playlists (id, sourceId, rootId, name, bookCount) VALUES ('playlist-1', '$ABS_SOURCE_ID', 'lib-1', 'Queue', 1)")
+        sql("INSERT INTO playlist_items (playlistId, sourceId, itemId, orderIndex) VALUES ('playlist-1', '$ABS_SOURCE_ID', 'item-1', 0)")
+        sql("INSERT INTO publication_metrics_cache (sourceId, itemId, ebookFileIno, totalPositions, pageCount, cachedAt, epubVersion) VALUES ('$ABS_SOURCE_ID', 'item-1', 'ino-1', 100, NULL, 30, '3')")
+        sql("INSERT INTO publication_metrics_cache (sourceId, itemId, ebookFileIno, totalPositions, pageCount, cachedAt, epubVersion) VALUES ('$OTHER_SOURCE_ID', 'other-item', 'ino-2', 50, NULL, 30, '3')")
+        sql("INSERT INTO readaloud_links (absSourceId, absLibraryItemId, storytellerSourceId, storytellerBookId, state, userConfirmed, createdAt, updatedAt, identityResult) VALUES ('$ABS_SOURCE_ID', 'item-1', '$STORYTELLER_SOURCE_ID', 'st-book-1', '${ReadaloudLinkEntity.STATE_CONFIRMED}', 1, 1, 1, '${ReadaloudLinkEntity.IDENTITY_UNKNOWN}')")
+        sql("INSERT INTO readaloud_candidates (storytellerSourceId, storytellerBookId, absSourceId, absLibraryItemId, score) VALUES ('$STORYTELLER_SOURCE_ID', 'st-book-1', '$ABS_SOURCE_ID', 'item-1', 0.9)")
+        sql("INSERT INTO readaloud_dismissals (storytellerSourceId, storytellerBookId, scope, absSourceId, absLibraryItemId) VALUES ('$STORYTELLER_SOURCE_ID', 'st-book-1', '${ReadaloudDismissalEntity.SCOPE_CANDIDATE}', '$ABS_SOURCE_ID', 'item-1')")
+    }
+
+    private fun sql(statement: String) {
+        db.openHelper.writableDatabase.execSQL(statement)
+    }
+
+    private fun count(table: String, where: String): Int {
+        db.openHelper.writableDatabase.query("SELECT COUNT(*) FROM $table WHERE $where").use { cursor ->
+            cursor.moveToFirst()
+            return cursor.getInt(0)
+        }
+    }
+
+    private companion object {
+        const val ABS_SOURCE_ID = "abs-1"
+        const val STORYTELLER_SOURCE_ID = "storyteller-1"
+        const val OTHER_SOURCE_ID = "abs-2"
+    }
+}


### PR DESCRIPTION
## Summary
- Route source removal through a transactional Room graph cleanup before deleting the `sources` row.
- Clear source-scoped caches and cross-source readaloud rows for the removed source, so existing and future FK-protected rows are handled in one DAO-owned cleanup path.
- Add a Room regression test covering ABS source removal with library items, playlists, annotations, readaloud rows, and publication metrics.

## Test-claim changes
- Retired the repository-level claims that `SourceRepositoryImpl.remove` directly deletes `libraries` / `library_items` for ABS and Storyteller sources.
- Replacement claim: the repository delegates all Room cleanup to `SourceDao.deleteSourceGraph`, and the real Room schema test verifies the full graph can be removed without an FK failure.

## Tests
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :core:data:testDebugUnitTest --tests com.riffle.core.data.ServerRepositoryTest`
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :core:database:compileDebugAndroidTestKotlin`
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :core:database-api:compileDebugKotlin :core:database:compileDebugKotlin`
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew checkTestGuardrails`

Regression assertion: `SourceDaoDeleteGraphTest.deleteSourceGraphRemovesAbsSourceRowsWithoutForeignKeyFailure` fails if source removal no longer clears the Room source graph before deleting the source row.
