### PR TITLE
fix(library): show fixed-page progress in details

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -88,10 +88,11 @@ import com.riffle.app.feature.reader.TocPanel
 import com.riffle.app.ui.DefaultCoverPlaceholder
 import com.riffle.app.ui.isPhoneLandscape
 import com.riffle.app.ui.isTabletLayout
+import com.riffle.app.ui.source.asAuthHeader
 import com.riffle.core.models.EbookFormat
 import com.riffle.core.models.LibraryItem
 import kotlinx.coroutines.launch
-import com.riffle.app.ui.source.asAuthHeader
+import kotlin.math.roundToInt
 
 const val LIBRARY_ITEM_DETAIL_LEFT_PANE_TAG = "library_item_detail_left_pane"
 const val LIBRARY_ITEM_DETAIL_RIGHT_PANE_TAG = "library_item_detail_right_pane"
@@ -618,10 +619,10 @@ private fun PublicationFactsLine(
         }
         EbookFormat.Pdf -> (extractedPdfPageCount ?: item.pageCount)
             ?.takeIf { it > 0 }
-            ?.let { publicationPageCountText(EbookFormat.Pdf, it) }
+            ?.let { publicationPageCountText(it, item.readingProgress) }
         EbookFormat.Cbz -> item.pageCount
             ?.takeIf { it > 0 }
-            ?.let { publicationPageCountText(EbookFormat.Cbz, it) }
+            ?.let { publicationPageCountText(it, item.readingProgress) }
         EbookFormat.Unsupported -> null
     }
     // EPUB reading time and the extracted PDF page count arrive asynchronously, seconds after
@@ -656,13 +657,14 @@ internal fun ebookReadingTimeText(totalSec: Long, readingProgress: Float): Strin
     }
 }
 
-internal fun publicationPageCountText(format: EbookFormat, pageCount: Int): String {
-    val label = when (format) {
-        EbookFormat.Pdf -> "PDF"
-        EbookFormat.Cbz -> "Comic"
-        else -> "Ebook"
-    }
-    return "$label · $pageCount pages"
+internal fun publicationPageCountText(pageCount: Int, readingProgress: Float): String {
+    if (pageCount <= 0) return ""
+    if (!readingProgress.isFinite() || readingProgress <= 0f) return "$pageCount pages"
+
+    val pagesRead = (pageCount * readingProgress)
+        .roundToInt()
+        .coerceIn(1, pageCount)
+    return "$pagesRead of $pageCount pages read"
 }
 
 /** Total audiobook length on the detail screen, with remaining time when in progress (ADR 0029). */

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailPublicationFactsTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailPublicationFactsTest.kt
@@ -39,8 +39,13 @@ class LibraryItemDetailPublicationFactsTest {
     }
 
     @Test
-    fun `pdf page count is labelled by format`() {
-        assertEquals("PDF · 321 pages", publicationPageCountText(EbookFormat.Pdf, 321))
+    fun `fresh fixed-page item shows total page count without format prefix`() {
+        assertEquals("321 pages", publicationPageCountText(pageCount = 321, readingProgress = 0f))
+    }
+
+    @Test
+    fun `invalid fixed-page progress falls back to total page count`() {
+        assertEquals("321 pages", publicationPageCountText(pageCount = 321, readingProgress = Float.NaN))
     }
 
     @Test
@@ -50,8 +55,16 @@ class LibraryItemDetailPublicationFactsTest {
     }
 
     @Test
-    fun `comic page count is labelled by format`() {
-        assertEquals("Comic · 120 pages", publicationPageCountText(EbookFormat.Cbz, 120))
+    fun `in-progress fixed-page item shows pages read out of total`() {
+        assertEquals(
+            "40 of 120 pages read",
+            publicationPageCountText(pageCount = 120, readingProgress = 40f / 120f),
+        )
+    }
+
+    @Test
+    fun `finished fixed-page item shows all pages read`() {
+        assertEquals("120 of 120 pages read", publicationPageCountText(pageCount = 120, readingProgress = 1f))
     }
 
     @Test

--- a/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalog.kt
+++ b/core/catalog-komga/src/main/kotlin/com/riffle/core/catalog/komga/KomgaCatalog.kt
@@ -703,6 +703,7 @@ class KomgaCatalog(
         addedAt = parseIsoInstant(created),
         isbn = metadata.isbn,
         asin = null,
+        pageCount = media.pagesCount?.takeIf { it > 0 },
         readingProgress = null,
         updatedAt = parseIsoInstant(lastModified),
     )

--- a/core/catalog-komga/src/test/kotlin/com/riffle/core/catalog/komga/KomgaCatalogTest.kt
+++ b/core/catalog-komga/src/test/kotlin/com/riffle/core/catalog/komga/KomgaCatalogTest.kt
@@ -74,7 +74,7 @@ class KomgaCatalogTest {
             {
               "content": [
                 {"id":"B1","libraryId":"L1","name":"book.epub","media":{"mediaType":"application/epub+zip"},"metadata":{"title":"Book One","authors":[{"name":"Alice","role":"writer"}]}},
-                {"id":"B2","libraryId":"L1","name":"volume.cbz","media":{"mediaType":"application/x-cbz"},"metadata":{"title":"Vol 2","authors":[{"name":"Bob","role":"writer"}]}},
+                {"id":"B2","libraryId":"L1","name":"volume.cbz","media":{"mediaType":"application/x-cbz","pagesCount":120},"metadata":{"title":"Vol 2","authors":[{"name":"Bob","role":"writer"}]}},
                 {"id":"B3","libraryId":"L1","name":"doc.pdf","media":{"mediaType":"application/pdf"},"metadata":{"title":"PDF","authors":[]}}
               ],
               "totalPages":1,"totalElements":3,"first":true,"last":true,"empty":false
@@ -88,6 +88,7 @@ class KomgaCatalogTest {
         assertEquals("Alice", items[0].author)
         assertEquals(BookFormat.Epub, items[0].ebookFormat)
         assertEquals(BookFormat.Cbz, items[1].ebookFormat)
+        assertEquals(120, items[1].pageCount)
         assertEquals(BookFormat.Pdf, items[2].ebookFormat)
         val recorded = server.takeRequest()
         assertTrue(recorded.path!!.startsWith("/api/v1/books?library_id=L1"))

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogItem.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/CatalogItem.kt
@@ -28,6 +28,8 @@ data class CatalogItem(
     val addedAt: Long? = null,
     val isbn: String? = null,
     val asin: String? = null,
+    /** Total pages for fixed-page formats when the Source reports it. */
+    val pageCount: Int? = null,
     /**
      * Optional server-reported "how far through" fraction (0..1). Only populated by non-progress
      * paths that return items with server-side progress joined (e.g. some catalog list endpoints).

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -267,6 +267,7 @@ class LibraryRepositoryImpl @Inject constructor(
                         isbn = item.isbn,
                         asin = item.asin,
                         finishedAt = serverProgress?.finishedAt,
+                        pageCount = item.pageCount,
                     )
                 }
             libraryItemDao.replaceAllForLibrary(source.id, libraryId, entities)

--- a/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalog.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/localfiles/LocalFilesCatalog.kt
@@ -274,6 +274,7 @@ class LocalFilesCatalog(
         addedAt = addedAt,
         isbn = isbn,
         asin = asin,
+        pageCount = pageCount,
         readingProgress = readingProgress,
         updatedAt = null,
     )

--- a/core/data/src/main/kotlin/com/riffle/core/data/websource/WebSourceLibraryItemUpserter.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/websource/WebSourceLibraryItemUpserter.kt
@@ -78,6 +78,7 @@ class WebSourceLibraryItemUpserter @Inject constructor(
         addedAt = 0L,
         isbn = isbn,
         asin = asin,
+        pageCount = pageCount,
     )
 
     private fun BookFormat.toEbookFormat(): EbookFormat = when (this) {

--- a/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FakeLibraryItemDao.kt
@@ -87,6 +87,7 @@ internal class FakeLibraryItemDao : LibraryItemDao {
                     addedAt = metadata.addedAt,
                     isbn = metadata.isbn,
                     asin = metadata.asin,
+                    pageCount = metadata.pageCount,
                 )
             } else existing
         }

--- a/core/data/src/test/kotlin/com/riffle/core/data/websource/WebSourceLibraryItemUpserterTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/websource/WebSourceLibraryItemUpserterTest.kt
@@ -84,6 +84,19 @@ class WebSourceLibraryItemUpserterTest {
     }
 
     @Test
+    fun `first upsert preserves remote page count for fixed-page items`() = runTest {
+        val dao = InMemoryLibraryItemDao()
+        val upserter = WebSourceLibraryItemUpserter(dao)
+
+        upserter.upsert(
+            sourceId = "src-1",
+            item = catalogEpub().copy(ebookFormat = BookFormat.Cbz, pageCount = 120),
+        )
+
+        assertEquals(120, dao.getById("src-1", "text/12345-x")!!.pageCount)
+    }
+
+    @Test
     fun `audiobook item maps hasAudio true and libraryId to audio root`() = runTest {
         val dao = InMemoryLibraryItemDao()
         val upserter = WebSourceLibraryItemUpserter(dao)
@@ -253,6 +266,7 @@ class WebSourceLibraryItemUpserterTest {
                 isbn = metadata.isbn,
                 asin = metadata.asin,
                 finishedAt = metadata.finishedAt,
+                pageCount = metadata.pageCount,
                 // readingProgress intentionally NOT copied — updateMetadata excludes it (Room @Update).
             )
         }

--- a/core/database-api/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
+++ b/core/database-api/src/main/kotlin/com/riffle/core/database/LibraryItemDao.kt
@@ -216,6 +216,7 @@ data class LibraryItemMetadata(
     val isbn: String?,
     val asin: String?,
     val finishedAt: Long?,
+    val pageCount: Int?,
 ) {
     companion object {
         fun from(entity: LibraryItemEntity) = LibraryItemMetadata(
@@ -240,6 +241,7 @@ data class LibraryItemMetadata(
             isbn = entity.isbn,
             asin = entity.asin,
             finishedAt = entity.finishedAt,
+            pageCount = entity.pageCount,
         )
     }
 }


### PR DESCRIPTION
## Summary
- remove the format prefix from PDF/CBZ page-count facts in item details
- show fixed-page progress as pages read out of total when reading progress exists
- carry source-reported page counts through catalog and data metadata paths so remote CBZ totals reach details

## Test guardrail note
- Retired the old `pdf page count is labelled by format` and `comic page count is labelled by format` assertions because the requested behavior deliberately removes fixed-page format prefixes from item details. Replacement assertions cover format-neutral totals, invalid progress fallback, in-progress pages-read copy, and finished pages-read copy.

## Tests
- JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" java -classpath /Users/plamen.kmetski/conductor/workspaces/riffle/cancun-v2/gradle/wrapper/gradle-wrapper.jar org.gradle.wrapper.GradleWrapperMain :app:testDebugUnitTest --tests com.riffle.app.feature.library.LibraryItemDetailPublicationFactsTest
- JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" java -classpath /Users/plamen.kmetski/conductor/workspaces/riffle/cancun-v2/gradle/wrapper/gradle-wrapper.jar org.gradle.wrapper.GradleWrapperMain :core:catalog-komga:test --tests com.riffle.core.catalog.komga.KomgaCatalogTest :core:data:testDebugUnitTest --tests com.riffle.core.data.websource.WebSourceLibraryItemUpserterTest
- JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" java -classpath /Users/plamen.kmetski/conductor/workspaces/riffle/cancun-v2/gradle/wrapper/gradle-wrapper.jar org.gradle.wrapper.GradleWrapperMain lint riffleChecks
- git diff --check