### PR TITLE
fix(reader): disarm resume restore on continuous touch

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousReaderViewSelectionInterceptTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousReaderViewSelectionInterceptTest.kt
@@ -52,6 +52,23 @@ class ContinuousReaderViewSelectionInterceptTest {
     }
 
     @Test
+    fun actionDown_notifiesUserTouchCallback() {
+        // Regression for sleep-resume scroll bounce: ContinuousReaderView is the visible scroll
+        // surface in Continuous mode, so its first touch must disarm ResumeRestorer before the
+        // resulting backward-scroll locator can be mistaken for Readium's post-resume clobber.
+        val v = view()
+        var touchCount = 0
+        val t = SystemClock.uptimeMillis()
+        val e = MotionEvent.obtain(t, t, MotionEvent.ACTION_DOWN, 100f, 100f, 0)
+        onMain {
+            v.onUserTouch = { touchCount++ }
+            v.dispatchTouchEvent(e)
+        }
+        e.recycle()
+        assertEquals(1, touchCount)
+    }
+
+    @Test
     fun normalReading_interceptsAsSoonAsHalfTouchSlopIsCrossed() {
         val v = view()
         down(v, 100f, 100f)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -117,6 +117,13 @@ internal class ContinuousReaderView @JvmOverloads constructor(
         set(value) { controller.readaloudAvailable = value }
 
     /**
+     * Fires on ACTION_DOWN for every touch on the continuous reader surface. Mirrors
+     * [ScrollBoundaryNavigationContainer.onUserTouch] for Readium-backed modes so the
+     * post-resume restore watcher is disarmed before a manual scroll emits a backward locator.
+     */
+    var onUserTouch: (() -> Unit)? = null
+
+    /**
      * Called on the main thread with (chapter href, selected text, evalJs) when the user taps
      * "Play". [evalJs] is the WebView's evaluateJavascript so the host can run geometry-based
      * sentence resolution before falling back to text matching.
@@ -411,6 +418,7 @@ internal class ContinuousReaderView @JvmOverloads constructor(
     // would never reach the controller and a latched backward intent would outlive the gesture.
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
         when (ev.actionMasked) {
+            MotionEvent.ACTION_DOWN -> onUserTouch?.invoke()
             MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> controller.onTouchUp()
         }
         return super.dispatchTouchEvent(ev)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -3048,6 +3048,7 @@ private fun EpubNavigatorView(
                         view.onFigureLongPress = { payload, anchorRect -> onFigureLongPress(payload, anchorRect) }
                         view.onSelectionEnded = { currentOnSelectionEnded() }
                         view.onSelectionActiveChanged = { active -> currentOnSelectionActiveChanged(active) }
+                        view.onUserTouch = { onUserInteracted() }
                         // Continuous-mode body-font probe (issue #484). Fires once per chapter
                         // load with the source book's computed body `font-family`; the VM caches
                         // it as the elided-view fallback and backfills legacy null-font rows.
@@ -3058,6 +3059,7 @@ private fun EpubNavigatorView(
                 update = {
                     it.annotationsAvailable = annotationsAvailable
                     it.readaloudAvailable = readaloudAvailable
+                    it.onUserTouch = { onUserInteracted() }
                 },
                 modifier = readerModifier,
             )

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousResumeTouchWiringTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousResumeTouchWiringTest.kt
@@ -1,0 +1,53 @@
+package com.riffle.app.feature.reader
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Regression guard for the sleep-resume scroll-bounce bug in Continuous mode.
+ *
+ * The behavioral state machine is covered by [com.riffle.app.feature.reader.session.ResumeRestorerTest]:
+ * after [com.riffle.app.feature.reader.session.ResumeRestorer.onUserInteracted], a backward locator
+ * must not be re-fired forward. This test pins the production wiring that Continuous used to miss:
+ * the visible [ContinuousReaderView] must emit the same ACTION_DOWN user-touch signal as the
+ * Readium-backed [ScrollBoundaryNavigationContainer].
+ */
+class ContinuousResumeTouchWiringTest {
+
+    @Test
+    fun `ContinuousReaderView disarms resume restore on touch down`() {
+        val source = resolveSource("ContinuousReaderView.kt").readText()
+
+        assertTrue(
+            "ContinuousReaderView must expose an onUserTouch callback",
+            source.contains("var onUserTouch: (() -> Unit)? = null"),
+        )
+        assertTrue(
+            "ACTION_DOWN must invoke onUserTouch before backward-scroll locator emissions arrive",
+            source.contains("MotionEvent.ACTION_DOWN -> onUserTouch?.invoke()"),
+        )
+    }
+
+    @Test
+    fun `EpubReaderScreen wires continuous touch to ViewModel user interaction`() {
+        val source = resolveSource("EpubReaderScreen.kt").readText()
+
+        assertTrue(
+            "Continuous AndroidView factory must wire onUserTouch to onUserInteracted",
+            source.contains("view.onUserTouch = { onUserInteracted() }"),
+        )
+        assertTrue(
+            "Continuous AndroidView update must refresh onUserTouch for reused views",
+            source.contains("it.onUserTouch = { onUserInteracted() }"),
+        )
+    }
+
+    private fun resolveSource(name: String): File {
+        val relative = "src/main/kotlin/com/riffle/app/feature/reader/$name"
+        val candidates = listOf(File(relative), File("app/$relative"))
+        return candidates.firstOrNull { it.exists() } ?: error(
+            "$name not found. Tried: ${candidates.map { it.absolutePath }}",
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add a first-touch callback to ContinuousReaderView so Continuous mode disarms the post-resume restore watcher before manual scroll locator emissions.
- Wire the Continuous AndroidView factory/update path to EpubReaderViewModel.onUserInteracted().
- Add JVM wiring coverage plus an instrumented ContinuousReaderView ACTION_DOWN assertion.

## Tests
- JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :app:testDebugUnitTest --tests "com.riffle.app.feature.reader.session.ResumeRestorerTest" --tests "com.riffle.app.feature.reader.ContinuousResumeTouchWiringTest"
- CLASS=com.riffle.app.feature.reader.ContinuousReaderViewSelectionInterceptTest make harness-test-class

## Regression assertion
- Reverting the callback dispatch flips `actionDown_notifiesUserTouchCallback` red at `assertEquals(1, touchCount)`.
