### PR TITLE
feat(gutenberg): add language filter

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt
@@ -24,13 +24,14 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.withResumed
+import com.riffle.core.models.SourceType
 import kotlinx.coroutines.yield
 import kotlinx.coroutines.withContext
 
 @Composable
 fun HomeScreen(
     onNavigateToAddSource: () -> Unit,
-    onNavigateToLibrary: (libraryId: String, libraryName: String) -> Unit,
+    onNavigateToLibrary: (sourceType: SourceType, libraryId: String, libraryName: String) -> Unit,
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
     var retryKey by remember { mutableIntStateOf(0) }
@@ -45,7 +46,9 @@ fun HomeScreen(
             showRetry = false
             when (dest) {
                 is HomeViewModel.StartDestination.AddSource -> onNavigateToAddSource()
-                is HomeViewModel.StartDestination.Library -> onNavigateToLibrary(dest.libraryId, dest.libraryName)
+                is HomeViewModel.StartDestination.Library -> {
+                    onNavigateToLibrary(dest.sourceType, dest.libraryId, dest.libraryName)
+                }
                 is HomeViewModel.StartDestination.NoLibraries -> showRetry = true
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeViewModel.kt
@@ -8,6 +8,7 @@ import com.riffle.core.domain.LibraryRefreshResult
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.usecase.RefreshLibraries
+import com.riffle.core.models.SourceType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
@@ -26,7 +27,11 @@ class HomeViewModel @Inject constructor(
     sealed class StartDestination {
         data object AddSource : StartDestination()
         data object NoLibraries : StartDestination()
-        data class Library(val libraryId: String, val libraryName: String) : StartDestination()
+        data class Library(
+            val sourceType: SourceType,
+            val libraryId: String,
+            val libraryName: String,
+        ) : StartDestination()
     }
 
     suspend fun getStartDestination(): StartDestination = withContext(dispatchers.io) {
@@ -55,6 +60,10 @@ class HomeViewModel @Inject constructor(
         val target = visible.firstOrNull { it.id == lastOpenedId }
             ?: visible.firstOrNull()
             ?: libraries.first()
-        StartDestination.Library(target.id, target.name)
+        StartDestination.Library(
+            sourceType = activeServer.type,
+            libraryId = target.id,
+            libraryName = target.name,
+        )
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.GridView
@@ -23,6 +24,8 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
 import com.riffle.app.ui.theme.RiffleIcons
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
@@ -62,6 +65,7 @@ import com.riffle.app.feature.source.websource.UnboundedCatalogGrid
 import com.riffle.app.feature.source.websource.UnboundedCoverGridZoomProvider
 import com.riffle.app.ui.DefaultCoverPlaceholder
 import com.riffle.app.ui.TabletContentWidthContainer
+import com.riffle.core.catalog.CatalogFacet
 import com.riffle.core.catalog.CatalogItem
 
 /**
@@ -207,6 +211,8 @@ private fun LibraryTabContent(
     val error by viewModel.error.collectAsState()
     val isPaging by viewModel.isPaging.collectAsState()
     val hasMore by viewModel.hasMore.collectAsState()
+    val languageFacets = remember(facets) { gutenbergLanguageFacets(facets) }
+    val topicFacets = remember(facets) { gutenbergTopicFacets(facets) }
 
     Column(modifier = Modifier.fillMaxSize()) {
         if (searchOpen) {
@@ -241,7 +247,7 @@ private fun LibraryTabContent(
                     } else null,
                 )
             }
-            if (facets.isNotEmpty()) {
+            if (topicFacets.isNotEmpty() || languageFacets.isNotEmpty()) {
                 item {
                     FilterChip(
                         selected = selectedFacet == null,
@@ -249,7 +255,16 @@ private fun LibraryTabContent(
                         label = { Text("All") },
                     )
                 }
-                items(facets, key = { it.key }) { facet ->
+                if (languageFacets.isNotEmpty()) {
+                    item {
+                        GutenbergLanguageFilterChip(
+                            languageFacets = languageFacets,
+                            selectedFacet = selectedFacet,
+                            onSelectFacet = viewModel::selectFacet,
+                        )
+                    }
+                }
+                items(topicFacets, key = { it.key }) { facet ->
                     FilterChip(
                         selected = selectedFacet == facet.key,
                         onClick = { viewModel.selectFacet(facet.key) },
@@ -295,6 +310,63 @@ private fun LibraryTabContent(
         }
     }
 }
+
+@Composable
+private fun GutenbergLanguageFilterChip(
+    languageFacets: List<CatalogFacet>,
+    selectedFacet: String?,
+    onSelectFacet: (String?) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val selectedLanguage = languageFacets.firstOrNull { it.key == selectedFacet }
+
+    Box {
+        FilterChip(
+            selected = selectedLanguage != null,
+            onClick = { expanded = true },
+            label = { Text("Language: ${selectedLanguage?.label ?: "Any"}") },
+            trailingIcon = {
+                Icon(
+                    Icons.Filled.ArrowDropDown,
+                    contentDescription = null,
+                    modifier = Modifier.size(FilterChipDefaults.IconSize),
+                )
+            },
+        )
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DropdownMenuItem(
+                text = { Text("Any") },
+                onClick = {
+                    onSelectFacet(null)
+                    expanded = false
+                },
+                leadingIcon = if (selectedLanguage == null) {
+                    { Icon(Icons.Filled.Check, contentDescription = null) }
+                } else null,
+            )
+            languageFacets.forEach { facet ->
+                DropdownMenuItem(
+                    text = { Text(facet.label) },
+                    onClick = {
+                        onSelectFacet(facet.key)
+                        expanded = false
+                    },
+                    leadingIcon = if (facet.key == selectedFacet) {
+                        { Icon(Icons.Filled.Check, contentDescription = null) }
+                    } else null,
+                )
+            }
+        }
+    }
+}
+
+internal fun gutenbergLanguageFacets(facets: List<CatalogFacet>): List<CatalogFacet> =
+    facets.filter { it.key.startsWith(GUTENBERG_LANGUAGE_FACET_PREFIX) }
+
+internal fun gutenbergTopicFacets(facets: List<CatalogFacet>): List<CatalogFacet> =
+    facets.filterNot { it.key.startsWith(GUTENBERG_LANGUAGE_FACET_PREFIX) }
+
+private const val GUTENBERG_LANGUAGE_FACET_PREFIX = "language:"
 
 @Composable
 private fun GutenbergHomeTab(

--- a/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.riffle.core.catalog.CatalogFacet
 import com.riffle.core.catalog.CatalogItem
 import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.FacetedSearchCapability
 import com.riffle.core.catalog.FacetSelection
 import com.riffle.core.data.websource.WebSourceItemGate
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
@@ -266,7 +267,18 @@ abstract class UnboundedBrowseViewModel(
         try {
             val q = _query.value.trim()
             val result = if (q.isNotEmpty()) {
-                catalog.search(rootId = rootId, query = q, page = 0, pageSize = pageSize)
+                val facet = _selectedFacet.value?.let { FacetSelection(it) }
+                if (catalog is FacetedSearchCapability) {
+                    catalog.search(
+                        rootId = rootId,
+                        query = q,
+                        page = 0,
+                        pageSize = pageSize,
+                        facet = facet,
+                    )
+                } else {
+                    catalog.search(rootId = rootId, query = q, page = 0, pageSize = pageSize)
+                }
             } else {
                 val facet = _selectedFacet.value?.let { FacetSelection(it) }
                 catalog.browse(rootId = rootId, page = 0, pageSize = pageSize, facet = facet)
@@ -297,7 +309,18 @@ abstract class UnboundedBrowseViewModel(
             val nextPage = currentPage + 1
             val q = _query.value.trim()
             val next = if (q.isNotEmpty()) {
-                catalog.search(rootId = rootId, query = q, page = nextPage, pageSize = pageSize)
+                val facet = _selectedFacet.value?.let { FacetSelection(it) }
+                if (catalog is FacetedSearchCapability) {
+                    catalog.search(
+                        rootId = rootId,
+                        query = q,
+                        page = nextPage,
+                        pageSize = pageSize,
+                        facet = facet,
+                    )
+                } else {
+                    catalog.search(rootId = rootId, query = q, page = nextPage, pageSize = pageSize)
+                }
             } else {
                 val facet = _selectedFacet.value?.let { FacetSelection(it) }
                 catalog.browse(rootId = rootId, page = nextPage, pageSize = pageSize, facet = facet)

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -39,6 +39,7 @@ import com.riffle.app.feature.library.LibrarySectionScreen
 import com.riffle.app.feature.library.LibrarySectionType
 import com.riffle.app.feature.library.SeriesDetailScreen
 import com.riffle.app.feature.navigation.HomeScreen
+import com.riffle.app.feature.navigation.HomeViewModel
 import com.riffle.app.feature.navigation.NavigationDrawerViewModel
 import com.riffle.app.feature.navigation.RiffleNavigationDrawer
 import com.riffle.app.feature.reader.EpubReaderScreen
@@ -151,6 +152,9 @@ internal fun libraryEntryRoute(sourceType: SourceType?, libraryId: String, libra
         ?.browseRoutePrefix
     return if (prefix != null) "$prefix/$libraryId/$encoded" else "library_items/$libraryId/$encoded"
 }
+
+internal fun libraryEntryRoute(destination: HomeViewModel.StartDestination.Library): String =
+    libraryEntryRoute(destination.sourceType, destination.libraryId, destination.libraryName)
 
 @Composable
 fun MainScreen(
@@ -286,9 +290,13 @@ fun MainScreen(
                     onNavigateToAddSource = {
                         navController.navigateAsRoot(ADD_SOURCE_TYPE_PICKER)
                     },
-                    onNavigateToLibrary = { libraryId, libraryName ->
+                    onNavigateToLibrary = { sourceType, libraryId, libraryName ->
                         viewModel.setActiveLibrary(libraryId)
-                        navController.navigateAsRoot(libraryEntryRoute(activeServer?.type, libraryId, libraryName))
+                        navController.navigateAsRoot(
+                            libraryEntryRoute(
+                                HomeViewModel.StartDestination.Library(sourceType, libraryId, libraryName),
+                            ),
+                        )
                     },
                 )
             }

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/HomeViewModelTest.kt
@@ -16,6 +16,7 @@ import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.models.Series
 import com.riffle.core.models.Source
 import com.riffle.core.domain.SourceRepository
+import com.riffle.core.models.SourceType
 import com.riffle.core.models.SourceUrl
 import java.io.IOException
 import kotlinx.coroutines.CompletableDeferred
@@ -50,12 +51,17 @@ class HomeViewModelTest {
     private val hiddenFlow = MutableStateFlow<Map<String, Set<String>>>(emptyMap())
     private val lastOpenedFlow = MutableStateFlow<Map<String, String>>(emptyMap())
 
-    private fun server(id: String, active: Boolean = false) = Source(
+    private fun server(
+        id: String,
+        active: Boolean = false,
+        type: SourceType = SourceType.ABS,
+    ) = Source(
         id = id,
         url = SourceUrl.parse("https://$id.example.com")!!,
         isActive = active,
         insecureConnectionAllowed = false,
         username = "",
+        type = type,
     )
 
     private fun library(id: String) = Library(id = id, name = id, mediaType = "book", isUnsupported = false)
@@ -152,7 +158,7 @@ class HomeViewModelTest {
 
         val result = makeVm().getStartDestination()
 
-        assertEquals(HomeViewModel.StartDestination.Library("lib-1", "lib-1"), result)
+        assertEquals(HomeViewModel.StartDestination.Library(SourceType.ABS, "lib-1", "lib-1"), result)
     }
 
     @Test
@@ -163,7 +169,17 @@ class HomeViewModelTest {
         val refresh = FakeRefreshLibraries(onRefresh = { librariesFlow.value = listOf(library("lib-1")) })
         val result = makeVm(refreshLibraries = refresh).getStartDestination()
 
-        assertEquals(HomeViewModel.StartDestination.Library("lib-1", "lib-1"), result)
+        assertEquals(HomeViewModel.StartDestination.Library(SourceType.ABS, "lib-1", "lib-1"), result)
+    }
+
+    @Test
+    fun `getStartDestination carries active source type for unbounded sources`() = runTest {
+        serversFlow.value = listOf(server("gut-1", active = true, type = SourceType.GUTENBERG))
+        librariesFlow.value = listOf(library("books"))
+
+        val result = makeVm().getStartDestination()
+
+        assertEquals(HomeViewModel.StartDestination.Library(SourceType.GUTENBERG, "books", "books"), result)
     }
 
     @Test
@@ -204,7 +220,7 @@ class HomeViewModelTest {
 
         val result = makeVm().getStartDestination()
 
-        assertEquals(HomeViewModel.StartDestination.Library("lib-2", "lib-2"), result)
+        assertEquals(HomeViewModel.StartDestination.Library(SourceType.ABS, "lib-2", "lib-2"), result)
     }
 
     @Test
@@ -216,7 +232,7 @@ class HomeViewModelTest {
 
         val result = makeVm().getStartDestination()
 
-        assertEquals(HomeViewModel.StartDestination.Library("lib-1", "lib-1"), result)
+        assertEquals(HomeViewModel.StartDestination.Library(SourceType.ABS, "lib-1", "lib-1"), result)
     }
 
     @Test
@@ -227,7 +243,7 @@ class HomeViewModelTest {
 
         val result = makeVm().getStartDestination()
 
-        assertEquals(HomeViewModel.StartDestination.Library("lib-1", "lib-1"), result)
+        assertEquals(HomeViewModel.StartDestination.Library(SourceType.ABS, "lib-1", "lib-1"), result)
     }
 
     // Pins the fix for the predictive-back burger-menu infinite loop: Compose Navigation 2.8+
@@ -280,7 +296,7 @@ class HomeViewModelTest {
 
         val result = makeVm().getStartDestination()
 
-        assertEquals(HomeViewModel.StartDestination.Library("lib-1", "lib-1"), result)
+        assertEquals(HomeViewModel.StartDestination.Library(SourceType.ABS, "lib-1", "lib-1"), result)
     }
 
     @Test
@@ -291,7 +307,7 @@ class HomeViewModelTest {
 
         val result = makeVm().getStartDestination()
 
-        assertEquals(HomeViewModel.StartDestination.Library("lib-2", "lib-2"), result)
+        assertEquals(HomeViewModel.StartDestination.Library(SourceType.ABS, "lib-2", "lib-2"), result)
     }
 
     // Pins the transient-RESUMED guard introduced to fix the burger-menu spinner flash.

--- a/app/src/test/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreenFilterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreenFilterTest.kt
@@ -1,0 +1,27 @@
+package com.riffle.app.feature.source.gutenberg
+
+import com.riffle.core.catalog.CatalogFacet
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GutenbergBrowseScreenFilterTest {
+
+    @Test
+    fun `language facets are separated from topic facets for dropdown rendering`() {
+        val facets = listOf(
+            CatalogFacet(key = "topic:fiction", label = "Fiction"),
+            CatalogFacet(key = "language:en", label = "English"),
+            CatalogFacet(key = "topic:history", label = "History"),
+            CatalogFacet(key = "language:fr", label = "French"),
+        )
+
+        assertEquals(
+            listOf("language:en", "language:fr"),
+            gutenbergLanguageFacets(facets).map { it.key },
+        )
+        assertEquals(
+            listOf("topic:fiction", "topic:history"),
+            gutenbergTopicFacets(facets).map { it.key },
+        )
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModelTest.kt
@@ -1,17 +1,24 @@
 package com.riffle.app.feature.source.gutenberg
 
 import androidx.lifecycle.SavedStateHandle
+import com.riffle.app.testing.FakeLibraryObserver
 import com.riffle.core.catalog.BookFormat
 import com.riffle.core.catalog.Catalog
+import com.riffle.core.catalog.CatalogFileHandle
+import com.riffle.core.catalog.CatalogFileStream
+import com.riffle.core.catalog.CatalogHealth
 import com.riffle.core.catalog.CatalogItem
 import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.CatalogRoot
+import com.riffle.core.catalog.FacetedSearchCapability
+import com.riffle.core.catalog.FacetSelection
+import com.riffle.core.catalog.SortKey
 import com.riffle.core.catalog.gutenberg.GutenbergCatalog
 import com.riffle.core.data.websource.WebSourceItemGate
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
 import com.riffle.core.domain.CoverGridDensityStore
-import com.riffle.app.testing.FakeLibraryObserver
-import com.riffle.core.models.Source
 import com.riffle.core.domain.SourceRepository
+import com.riffle.core.models.Source
 import com.riffle.core.models.SourceType
 import com.riffle.core.models.SourceUrl
 import io.mockk.coEvery
@@ -70,12 +77,12 @@ class GutenbergBrowseViewModelTest {
             coEvery { openItem(any(), any(), any(), any()) } returns WebSourceItemGate.Outcome.Fresh
         },
         upserter: WebSourceLibraryItemUpserter = mockk(relaxed = true),
-    ): Pair<GutenbergBrowseViewModel, WebSourceItemGate> {
-        val catalog = mockk<Catalog>(relaxed = true).also {
+        catalog: Catalog = mockk<Catalog>(relaxed = true).also {
             // Gutendex facets aren't relevant to openDetail; keep the init refresh cheap.
             coEvery { it.listFacets(any()) } returns emptyList()
             coEvery { it.browse(any(), any(), any(), any(), any()) } returns emptyList()
-        }
+        },
+    ): Pair<GutenbergBrowseViewModel, WebSourceItemGate> {
         val registry = mockk<CatalogRegistry>().also { coEvery { it.forSource(any()) } returns catalog }
         val handle = SavedStateHandle(mapOf("libraryId" to GutenbergCatalog.ROOT_BOOKS))
         val vm = GutenbergBrowseViewModel(
@@ -118,6 +125,21 @@ class GutenbergBrowseViewModelTest {
         coVerify(exactly = 0) { gate.openItem(any(), any(), any(), any()) }
     }
 
+    @Test
+    fun `search keeps the selected language facet when the catalog supports faceted search`() = runTest(dispatcher) {
+        val catalog = RecordingFacetedSearchCatalog()
+        val (vm, _) = makeVm(catalog = catalog)
+        advanceUntilIdle()
+
+        vm.selectFacet("language:fr")
+        advanceUntilIdle()
+        vm.onQueryChange("dumas")
+        advanceUntilIdle()
+
+        assertEquals(FacetSelection("language:fr"), catalog.lastSearchFacet)
+        assertEquals("dumas", catalog.lastSearchQuery)
+    }
+
     private fun fakeSourceRepo(active: Source?): SourceRepository = object : SourceRepository {
         override fun observeAll() = kotlinx.coroutines.flow.flowOf(listOfNotNull(active))
         override suspend fun getActive(): Source? = active
@@ -137,4 +159,56 @@ class GutenbergBrowseViewModelTest {
         }
 
     private fun emptyLibraryObserver() = FakeLibraryObserver()
+
+    private inner class RecordingFacetedSearchCatalog : Catalog, FacetedSearchCapability {
+        var lastSearchFacet: FacetSelection? = null
+        var lastSearchQuery: String? = null
+
+        override val sourceType: SourceType = SourceType.GUTENBERG
+
+        override suspend fun listRoots(): List<CatalogRoot> = emptyList()
+        override suspend fun browse(
+            rootId: String,
+            sort: SortKey,
+            page: Int,
+            pageSize: Int,
+            facet: FacetSelection?,
+        ): List<CatalogItem> = emptyList()
+
+        override suspend fun search(
+            rootId: String,
+            query: String,
+            page: Int,
+            pageSize: Int,
+        ): List<CatalogItem> = emptyList()
+
+        override suspend fun search(
+            rootId: String,
+            query: String,
+            page: Int,
+            pageSize: Int,
+            facet: FacetSelection?,
+        ): List<CatalogItem> {
+            lastSearchFacet = facet
+            lastSearchQuery = query
+            return emptyList()
+        }
+
+        override suspend fun getItem(itemId: String): CatalogItem? = null
+
+        override suspend fun fetchFile(itemId: String, format: BookFormat): CatalogFileHandle {
+            throw UnsupportedOperationException()
+        }
+
+        override suspend fun <T> withFileStream(
+            itemId: String,
+            format: BookFormat,
+            handleHint: String?,
+            block: suspend (CatalogFileStream) -> T,
+        ): T {
+            throw UnsupportedOperationException()
+        }
+
+        override suspend fun connectivityCheck(): CatalogHealth = CatalogHealth(isReachable = true)
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/navigation/DetailRouteEncodingTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/DetailRouteEncodingTest.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.navigation
 
+import com.riffle.app.feature.navigation.HomeViewModel
 import com.riffle.core.models.EbookFormat
 import com.riffle.core.models.LibraryItem
 import com.riffle.core.models.SourceType
@@ -106,6 +107,17 @@ class DetailRouteEncodingTest {
         // therefore renders an empty grid.
         val route = libraryEntryRoute(SourceType.GUTENBERG, "books", "Project Gutenberg")
         assertEquals("gutenberg_browse/books/Project+Gutenberg", route)
+    }
+
+    @Test
+    fun `home library destination for Gutenberg lands on gutenberg_browse`() {
+        val destination = HomeViewModel.StartDestination.Library(
+            sourceType = SourceType.GUTENBERG,
+            libraryId = "books",
+            libraryName = "Books",
+        )
+
+        assertEquals("gutenberg_browse/books/Books", libraryEntryRoute(destination))
     }
 
     @Test

--- a/core/catalog-gutenberg/src/main/kotlin/com/riffle/core/catalog/gutenberg/GutenbergCatalog.kt
+++ b/core/catalog-gutenberg/src/main/kotlin/com/riffle/core/catalog/gutenberg/GutenbergCatalog.kt
@@ -4,12 +4,13 @@ import com.riffle.core.catalog.BookFormat
 import com.riffle.core.catalog.Catalog
 import com.riffle.core.catalog.CatalogFacet
 import com.riffle.core.catalog.CatalogFileHandle
+import com.riffle.core.catalog.CatalogFileRetryPolicy
 import com.riffle.core.catalog.CatalogFileStream
 import com.riffle.core.catalog.CatalogHealth
 import com.riffle.core.catalog.CatalogItem
 import com.riffle.core.catalog.CatalogRoot
-import com.riffle.core.catalog.CatalogFileRetryPolicy
 import com.riffle.core.catalog.DownloadsCapability
+import com.riffle.core.catalog.FacetedSearchCapability
 import com.riffle.core.catalog.FacetSelection
 import com.riffle.core.catalog.OfflineBrowseCapability
 import com.riffle.core.catalog.ReadCapability
@@ -35,7 +36,8 @@ import java.net.URLEncoder
  * - Mandatory core: implemented.
  * - [OfflineBrowseCapability]: marker mixin — page-cache TTL logic lives in a wrapper repository
  *   layer (not this class).
- * - [DownloadsCapability], [ToReadListCapability], [ReadCapability]: yes.
+ * - [DownloadsCapability], [ToReadListCapability], [ReadCapability],
+ *   [FacetedSearchCapability]: yes.
  * - Absent: Series (Gutendex has bookshelves, not per-title series metadata), Collections,
  *   Playlists, Progress, ReadingSessions, Stats, Bookmarks, AudiobookMedia.
  */
@@ -49,7 +51,8 @@ class GutenbergCatalog(
     OfflineBrowseCapability,
     DownloadsCapability,
     ToReadListCapability,
-    ReadCapability {
+    ReadCapability,
+    FacetedSearchCapability {
 
     override val sourceType: SourceType = SourceType.GUTENBERG
 
@@ -62,14 +65,11 @@ class GutenbergCatalog(
     // ---- Facets -------------------------------------------------------------
 
     /**
-     * Chip strip contents: a curated list of top-level Gutendex topics that map cleanly onto
-     * `?topic=<label>` filters. Gutendex accepts topic as a case-insensitive substring match on
-     * subject/bookshelf, so these are stable — the site's underlying category taxonomy can be
-     * extended without breaking the chip. Kept small (10 entries) so the strip is scannable at
-     * a glance on a phone; power users can search instead.
+     * Chip strip contents: curated Gutendex topics and language filters. Kept small so the strip
+     * is scannable at a glance on a phone; power users can search instead.
      */
     override suspend fun listFacets(rootId: String): List<CatalogFacet> = when (rootId) {
-        ROOT_BOOKS -> DEFAULT_TOPICS
+        ROOT_BOOKS -> DEFAULT_FACETS
         else -> emptyList()
     }
 
@@ -95,16 +95,7 @@ class GutenbergCatalog(
     }
 
     internal fun browseUrlFor(facet: FacetSelection?, page: Int): String {
-        val pageNum = page + 1 // Gutendex pagination is 1-indexed.
-        val qs = buildList {
-            add("page=$pageNum")
-            facet?.key?.let { key ->
-                if (key.startsWith("topic:")) {
-                    add("topic=${URLEncoder.encode(key.removePrefix("topic:"), "UTF-8")}")
-                }
-            }
-        }.joinToString("&")
-        return "$apiBase/books/?$qs"
+        return booksUrl(page = page, facet = facet)
     }
 
     // ---- Search -------------------------------------------------------------
@@ -114,12 +105,28 @@ class GutenbergCatalog(
         query: String,
         page: Int,
         pageSize: Int,
+    ): List<CatalogItem> = search(
+        rootId = rootId,
+        query = query,
+        page = page,
+        pageSize = pageSize,
+        facet = null,
+    )
+
+    override suspend fun search(
+        rootId: String,
+        query: String,
+        page: Int,
+        pageSize: Int,
+        facet: FacetSelection?,
     ): List<CatalogItem> {
         if (rootId != ROOT_BOOKS) return emptyList()
         if (query.isBlank()) return emptyList()
-        val pageNum = page + 1
-        val url = "$apiBase/books/?page=$pageNum&search=" +
-            URLEncoder.encode(query.trim(), "UTF-8")
+        val url = booksUrl(
+            page = page,
+            facet = facet,
+            extraParams = listOf("search=${URLEncoder.encode(query.trim(), "UTF-8")}"),
+        )
         val body = http.getString(url)
         return GutenbergParser.parseListing(body).items
             .map { it.toCatalogItem() }
@@ -218,6 +225,33 @@ class GutenbergCatalog(
         return GutenbergParser.parseBook(body)
     }
 
+    private fun booksUrl(
+        page: Int,
+        facet: FacetSelection?,
+        extraParams: List<String> = emptyList(),
+    ): String {
+        val pageNum = page + 1 // Gutendex pagination is 1-indexed.
+        val qs = buildList {
+            add("page=$pageNum")
+            addAll(facetQueryParams(facet))
+            addAll(extraParams)
+        }.joinToString("&")
+        return "$apiBase/books/?$qs"
+    }
+
+    private fun facetQueryParams(facet: FacetSelection?): List<String> {
+        val key = facet?.key ?: return emptyList()
+        return when {
+            key.startsWith(TOPIC_PREFIX) -> {
+                listOf("topic=${URLEncoder.encode(key.removePrefix(TOPIC_PREFIX), "UTF-8")}")
+            }
+            key.startsWith(LANGUAGE_PREFIX) -> {
+                listOf("languages=${URLEncoder.encode(key.removePrefix(LANGUAGE_PREFIX), "UTF-8")}")
+            }
+            else -> emptyList()
+        }
+    }
+
     private fun GutenbergBookSummary.toCatalogItem(): CatalogItem = CatalogItem(
         id = id.toString(),
         rootId = ROOT_BOOKS,
@@ -254,6 +288,8 @@ class GutenbergCatalog(
 
     companion object {
         const val ROOT_BOOKS: String = "books"
+        private const val TOPIC_PREFIX: String = "topic:"
+        private const val LANGUAGE_PREFIX: String = "language:"
 
         /**
          * Curated topic facets. Gutendex accepts `topic=<label>` as a case-insensitive substring
@@ -261,17 +297,37 @@ class GutenbergCatalog(
          * against Project Gutenberg's Library-of-Congress subject taxonomy.
          */
         internal val DEFAULT_TOPICS: List<CatalogFacet> = listOf(
-            CatalogFacet(key = "topic:fiction", label = "Fiction", sortOrder = 1),
-            CatalogFacet(key = "topic:children", label = "Children's", sortOrder = 2),
-            CatalogFacet(key = "topic:history", label = "History", sortOrder = 3),
-            CatalogFacet(key = "topic:poetry", label = "Poetry", sortOrder = 4),
-            CatalogFacet(key = "topic:philosophy", label = "Philosophy", sortOrder = 5),
-            CatalogFacet(key = "topic:science", label = "Science", sortOrder = 6),
-            CatalogFacet(key = "topic:biography", label = "Biography", sortOrder = 7),
-            CatalogFacet(key = "topic:drama", label = "Drama", sortOrder = 8),
-            CatalogFacet(key = "topic:adventure", label = "Adventure", sortOrder = 9),
-            CatalogFacet(key = "topic:mystery", label = "Mystery", sortOrder = 10),
+            CatalogFacet(key = "${TOPIC_PREFIX}fiction", label = "Fiction", sortOrder = 1),
+            CatalogFacet(key = "${TOPIC_PREFIX}children", label = "Children's", sortOrder = 2),
+            CatalogFacet(key = "${TOPIC_PREFIX}history", label = "History", sortOrder = 3),
+            CatalogFacet(key = "${TOPIC_PREFIX}poetry", label = "Poetry", sortOrder = 4),
+            CatalogFacet(key = "${TOPIC_PREFIX}philosophy", label = "Philosophy", sortOrder = 5),
+            CatalogFacet(key = "${TOPIC_PREFIX}science", label = "Science", sortOrder = 6),
+            CatalogFacet(key = "${TOPIC_PREFIX}biography", label = "Biography", sortOrder = 7),
+            CatalogFacet(key = "${TOPIC_PREFIX}drama", label = "Drama", sortOrder = 8),
+            CatalogFacet(key = "${TOPIC_PREFIX}adventure", label = "Adventure", sortOrder = 9),
+            CatalogFacet(key = "${TOPIC_PREFIX}mystery", label = "Mystery", sortOrder = 10),
         )
+
+        /**
+         * Curated Gutendex language filters. The API accepts comma-separated ISO-639 two-letter
+         * codes in a `languages` query parameter; Riffle exposes one language at a time through
+         * the existing single-selection facet strip.
+         */
+        internal val DEFAULT_LANGUAGES: List<CatalogFacet> = listOf(
+            CatalogFacet(key = "${LANGUAGE_PREFIX}en", label = "English", sortOrder = 101),
+            CatalogFacet(key = "${LANGUAGE_PREFIX}fr", label = "French", sortOrder = 102),
+            CatalogFacet(key = "${LANGUAGE_PREFIX}de", label = "German", sortOrder = 103),
+            CatalogFacet(key = "${LANGUAGE_PREFIX}es", label = "Spanish", sortOrder = 104),
+            CatalogFacet(key = "${LANGUAGE_PREFIX}it", label = "Italian", sortOrder = 105),
+            CatalogFacet(key = "${LANGUAGE_PREFIX}pt", label = "Portuguese", sortOrder = 106),
+            CatalogFacet(key = "${LANGUAGE_PREFIX}nl", label = "Dutch", sortOrder = 107),
+            CatalogFacet(key = "${LANGUAGE_PREFIX}fi", label = "Finnish", sortOrder = 108),
+            CatalogFacet(key = "${LANGUAGE_PREFIX}sv", label = "Swedish", sortOrder = 109),
+            CatalogFacet(key = "${LANGUAGE_PREFIX}pl", label = "Polish", sortOrder = 110),
+        )
+
+        internal val DEFAULT_FACETS: List<CatalogFacet> = DEFAULT_TOPICS + DEFAULT_LANGUAGES
     }
 }
 

--- a/core/catalog-gutenberg/src/test/kotlin/com/riffle/core/catalog/gutenberg/GutenbergCatalogTest.kt
+++ b/core/catalog-gutenberg/src/test/kotlin/com/riffle/core/catalog/gutenberg/GutenbergCatalogTest.kt
@@ -68,7 +68,14 @@ class GutenbergCatalogTest {
     fun `listFacets returns the curated topic set for the books root`() = runTest {
         val facets = catalog.listFacets(GutenbergCatalog.ROOT_BOOKS)
         assertTrue("expected curated topics, got $facets", facets.isNotEmpty())
-        assertTrue(facets.all { it.key.startsWith("topic:") })
+        assertTrue(facets.any { it.key == "topic:fiction" })
+    }
+
+    @Test
+    fun `listFacets returns the curated language filters for the books root`() = runTest {
+        val facets = catalog.listFacets(GutenbergCatalog.ROOT_BOOKS)
+        assertTrue("English language facet missing from $facets", facets.any { it.key == "language:en" })
+        assertTrue("French language facet missing from $facets", facets.any { it.key == "language:fr" })
     }
 
     @Test
@@ -109,6 +116,19 @@ class GutenbergCatalogTest {
     }
 
     @Test
+    fun `browse threads the language facet into the query string`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("gutendex-books-page-1.json")))
+        catalog.browse(
+            rootId = GutenbergCatalog.ROOT_BOOKS,
+            page = 0,
+            pageSize = 32,
+            facet = FacetSelection("language:fr"),
+        )
+        val request = server.takeRequest()
+        assertTrue("expected languages=fr in ${request.path}", request.path?.contains("languages=fr") == true)
+    }
+
+    @Test
     fun `browse for a non-books root returns empty without hitting the network`() = runTest {
         val items = catalog.browse(rootId = "bogus", page = 0, pageSize = 32)
         assertTrue(items.isEmpty())
@@ -129,6 +149,22 @@ class GutenbergCatalogTest {
             "expected encoded query in $path",
             path.contains("search=jane+austen") || path.contains("search=jane%20austen"),
         )
+    }
+
+    @Test
+    fun `faceted search threads the language facet into the query string`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("gutendex-books-page-1.json")))
+        catalog.search(
+            rootId = GutenbergCatalog.ROOT_BOOKS,
+            query = "dumas",
+            page = 0,
+            pageSize = 32,
+            facet = FacetSelection("language:fr"),
+        )
+        val request = server.takeRequest()
+        val path = request.path.orEmpty()
+        assertTrue("expected search=dumas in $path", path.contains("search=dumas"))
+        assertTrue("expected languages=fr in $path", path.contains("languages=fr"))
     }
 
     @Test

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/FacetedSearchCapability.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/FacetedSearchCapability.kt
@@ -1,0 +1,15 @@
+package com.riffle.core.catalog
+
+/**
+ * Optional extension for Sources whose server can combine free-text search with the same
+ * server-side facets returned by [Catalog.listFacets].
+ */
+interface FacetedSearchCapability : CatalogCapability {
+    suspend fun search(
+        rootId: String,
+        query: String,
+        page: Int = 0,
+        pageSize: Int = 50,
+        facet: FacetSelection? = null,
+    ): List<CatalogItem>
+}


### PR DESCRIPTION
## Summary
- Add curated Project Gutenberg language facets backed by Gutendex `languages=` requests.
- Render Gutenberg languages as a dropdown chip inside the existing filter bar while keeping topic chips inline.
- Preserve the selected language facet during Gutenberg search and pagination.
- Carry source type through Home start routing so Gutenberg opens `gutenberg_browse`, not the generic library list.

## Tests
- Added catalog tests asserting `language:fr` emits `languages=fr` for browse and search.
- Added ViewModel coverage asserting selected language facets are forwarded during search.
- Added filter split coverage asserting language facets are separated for dropdown rendering.
- Added navigation coverage asserting an active Gutenberg start destination routes to `gutenberg_browse/books/Books`.

Specific assertions that fail if reverted: `languages=fr` must appear in Gutendex request paths, `FacetSelection("language:fr")` must reach faceted search, and a Gutenberg Home destination must produce `gutenberg_browse/books/Books`.

Local test execution was blocked in this workspace because no Java runtime is visible to Gradle (`Unable to locate a Java Runtime`).