### PR TITLE
feat(library): remember source library filters

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -12,6 +12,7 @@ import com.riffle.core.models.Collection
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.collectReconnects
 import com.riffle.core.models.LibraryItem
+import com.riffle.core.domain.LibraryFilterPreferencesStore
 import com.riffle.core.domain.LibraryItemOfflineAvailability
 import com.riffle.core.domain.LibraryRefreshResult
 import com.riffle.core.domain.LibraryObserver
@@ -66,6 +67,7 @@ class LibraryItemsViewModel @Inject constructor(
     private val playlistsRepository: PlaylistsRepository,
     private val readaloudLinkRepository: com.riffle.core.domain.ReadaloudLinkRepository,
     private val coverGridDensityStore: com.riffle.core.domain.CoverGridDensityStore,
+    private val libraryFilterPreferencesStore: LibraryFilterPreferencesStore,
     private val annotationStore: AnnotationStore,
     private val audiobookBookmarkStore: AudiobookBookmarkStore,
     private val annotationsLibraryRepository: AnnotationsLibraryRepository,
@@ -213,9 +215,12 @@ class LibraryItemsViewModel @Inject constructor(
 
     private val _notStartedFilterActive = MutableStateFlow(false)
     val notStartedFilterActive: StateFlow<Boolean> = _notStartedFilterActive.asStateFlow()
+    private var libraryFilterSourceId: String? = null
 
     fun toggleNotStartedFilter() {
-        _notStartedFilterActive.value = !_notStartedFilterActive.value
+        val active = !_notStartedFilterActive.value
+        _notStartedFilterActive.value = active
+        persistNotStartedFilter(active)
     }
 
     private val _librarySortMode = MutableStateFlow(LibrarySortMode.ADDED_DESC)
@@ -223,6 +228,7 @@ class LibraryItemsViewModel @Inject constructor(
 
     fun setLibrarySortMode(mode: LibrarySortMode) {
         _librarySortMode.value = mode
+        persistLibrarySortMode(mode)
     }
 
     // Share the VM's already-stateIn'd source flows with the engine so we don't open a second
@@ -317,9 +323,15 @@ class LibraryItemsViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            val server = sourceRepository.getActive()
-            if (server != null) {
-                authToken = tokenStorage.getToken(server.id) ?: ""
+            val source = sourceRepository.getActive()
+            if (source != null) {
+                authToken = tokenStorage.getToken(source.id) ?: ""
+                libraryFilterSourceId = source.id
+                val prefs = libraryFilterPreferencesStore.preferences(source.id, libraryId).first()
+                _notStartedFilterActive.value = prefs.notStartedFilterActive
+                _librarySortMode.value = prefs.sortModeName
+                    ?.let { runCatching { LibrarySortMode.valueOf(it) }.getOrNull() }
+                    ?: LibrarySortMode.ADDED_DESC
             }
             val refreshJob = launchRefresh()
             // Unblock the UI as soon as we have something meaningful to show:
@@ -363,6 +375,20 @@ class LibraryItemsViewModel @Inject constructor(
                         }
                     }
                 }
+        }
+    }
+
+    private fun persistNotStartedFilter(active: Boolean) {
+        val sourceId = libraryFilterSourceId ?: return
+        viewModelScope.launch {
+            libraryFilterPreferencesStore.setNotStartedFilterActive(sourceId, libraryId, active)
+        }
+    }
+
+    private fun persistLibrarySortMode(mode: LibrarySortMode) {
+        val sourceId = libraryFilterSourceId ?: return
+        viewModelScope.launch {
+            libraryFilterPreferencesStore.setSortModeName(sourceId, libraryId, mode.name)
         }
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModel.kt
@@ -7,6 +7,7 @@ import com.riffle.core.catalog.chitanka.ChitankaCatalog
 import com.riffle.core.data.websource.WebSourceItemGate
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
 import com.riffle.core.domain.CoverGridDensityStore
+import com.riffle.core.domain.LibraryFilterPreferencesStore
 import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
@@ -29,6 +30,7 @@ class ChitankaBrowseViewModel @Inject constructor(
     libraryItemUpserter: WebSourceLibraryItemUpserter,
     webSourceItemGate: WebSourceItemGate,
     coverGridDensityStore: CoverGridDensityStore,
+    libraryFilterPreferencesStore: LibraryFilterPreferencesStore,
     libraryObserver: LibraryObserver,
 ) : UnboundedBrowseViewModel(
     savedStateHandle = savedStateHandle,
@@ -37,6 +39,7 @@ class ChitankaBrowseViewModel @Inject constructor(
     libraryItemUpserter = libraryItemUpserter,
     webSourceItemGate = webSourceItemGate,
     coverGridDensityStore = coverGridDensityStore,
+    libraryFilterPreferencesStore = libraryFilterPreferencesStore,
     libraryObserver = libraryObserver,
     sourceType = SourceType.CHITANKA,
     defaultRootId = ChitankaCatalog.ROOT_BOOKS,

--- a/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModel.kt
@@ -7,6 +7,7 @@ import com.riffle.core.catalog.gutenberg.GutenbergCatalog
 import com.riffle.core.data.websource.WebSourceItemGate
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
 import com.riffle.core.domain.CoverGridDensityStore
+import com.riffle.core.domain.LibraryFilterPreferencesStore
 import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
@@ -29,6 +30,7 @@ class GutenbergBrowseViewModel @Inject constructor(
     libraryItemUpserter: WebSourceLibraryItemUpserter,
     webSourceItemGate: WebSourceItemGate,
     coverGridDensityStore: CoverGridDensityStore,
+    libraryFilterPreferencesStore: LibraryFilterPreferencesStore,
     libraryObserver: LibraryObserver,
 ) : UnboundedBrowseViewModel(
     savedStateHandle = savedStateHandle,
@@ -37,6 +39,7 @@ class GutenbergBrowseViewModel @Inject constructor(
     libraryItemUpserter = libraryItemUpserter,
     webSourceItemGate = webSourceItemGate,
     coverGridDensityStore = coverGridDensityStore,
+    libraryFilterPreferencesStore = libraryFilterPreferencesStore,
     libraryObserver = libraryObserver,
     sourceType = SourceType.GUTENBERG,
     defaultRootId = GutenbergCatalog.ROOT_BOOKS,

--- a/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
@@ -11,6 +11,7 @@ import com.riffle.core.catalog.FacetSelection
 import com.riffle.core.data.websource.WebSourceItemGate
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
 import com.riffle.core.domain.CoverGridDensityStore
+import com.riffle.core.domain.LibraryFilterPreferencesStore
 import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
@@ -26,6 +27,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -68,6 +70,7 @@ abstract class UnboundedBrowseViewModel(
     private val libraryItemUpserter: WebSourceLibraryItemUpserter,
     private val webSourceItemGate: WebSourceItemGate,
     private val coverGridDensityStore: CoverGridDensityStore,
+    private val libraryFilterPreferencesStore: LibraryFilterPreferencesStore,
     private val libraryObserver: LibraryObserver,
     private val sourceType: SourceType,
     defaultRootId: String,
@@ -121,6 +124,7 @@ abstract class UnboundedBrowseViewModel(
 
     private val _selectedFacet = MutableStateFlow<String?>(savedStateHandle["facetKey"])
     val selectedFacet: StateFlow<String?> = _selectedFacet.asStateFlow()
+    private var libraryFilterSourceId: String? = null
 
     private val _items = MutableStateFlow<List<CatalogItem>>(emptyList())
     val items: StateFlow<List<CatalogItem>> = _items.asStateFlow()
@@ -129,7 +133,9 @@ abstract class UnboundedBrowseViewModel(
     val notStartedFilterActive: StateFlow<Boolean> = _notStartedFilterActive.asStateFlow()
 
     fun toggleNotStartedFilter() {
-        _notStartedFilterActive.value = !_notStartedFilterActive.value
+        val active = !_notStartedFilterActive.value
+        _notStartedFilterActive.value = active
+        persistNotStartedFilter(active)
     }
 
     // IDs of Room-backed items that have been started (readingProgress > 0). Items absent from
@@ -175,8 +181,18 @@ abstract class UnboundedBrowseViewModel(
     private var loadMoreJob: Job? = null
 
     init {
-        viewModelScope.launch { loadFacets() }
-        refresh()
+        viewModelScope.launch {
+            val source = sourceRepository.getActive()?.takeIf { it.type == sourceType }
+            if (source != null) {
+                libraryFilterSourceId = source.id
+                val prefs = libraryFilterPreferencesStore.preferences(source.id, rootId).first()
+                _selectedFacet.value = prefs.selectedFacetKey
+                savedStateHandle["facetKey"] = prefs.selectedFacetKey
+                _notStartedFilterActive.value = prefs.notStartedFilterActive
+            }
+            loadFacets()
+            refresh()
+        }
     }
 
     private suspend fun activeCatalog() =
@@ -192,10 +208,25 @@ abstract class UnboundedBrowseViewModel(
     fun selectFacet(key: String?) {
         _selectedFacet.value = key
         savedStateHandle["facetKey"] = key
+        persistSelectedFacet(key)
         facetDebounceJob?.cancel()
         facetDebounceJob = viewModelScope.launch {
             delay(facetDebounceMs)
             refresh()
+        }
+    }
+
+    private fun persistSelectedFacet(key: String?) {
+        val sourceId = libraryFilterSourceId ?: return
+        viewModelScope.launch {
+            libraryFilterPreferencesStore.setSelectedFacetKey(sourceId, rootId, key)
+        }
+    }
+
+    private fun persistNotStartedFilter(active: Boolean) {
+        val sourceId = libraryFilterSourceId ?: return
+        viewModelScope.launch {
+            libraryFilterPreferencesStore.setNotStartedFilterActive(sourceId, rootId, active)
         }
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -10,6 +10,8 @@ import com.riffle.core.models.EbookFormat
 import com.riffle.core.domain.EpubDownloadResult
 import com.riffle.core.domain.EpubOpenResult
 import com.riffle.core.domain.EpubRepository
+import com.riffle.core.domain.LibraryFilterPreferences
+import com.riffle.core.domain.LibraryFilterPreferencesStore
 import com.riffle.core.models.Library
 import com.riffle.core.models.LibraryItem
 import com.riffle.core.domain.BundleAudiobookSource
@@ -33,6 +35,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -150,10 +153,60 @@ class LibraryItemsViewModelTest {
         override suspend fun getSourceVersion(sourceId: String): String? = null
     }
 
+    private fun fakeActiveSourceRepo(sourceId: String = "src-1"): SourceRepository = object : SourceRepository {
+        private val source = Source(
+            id = sourceId,
+            url = SourceUrl.parse("https://example.com")!!,
+            isActive = true,
+            insecureConnectionAllowed = false,
+            username = "",
+            type = com.riffle.core.models.SourceType.ABS,
+        )
+
+        override fun observeAll(): Flow<List<Source>> = MutableStateFlow(listOf(source))
+        override suspend fun getActive(): Source? = source
+        override suspend fun commit(pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>) =
+            throw UnsupportedOperationException()
+        override suspend fun setActive(sourceId: String) {}
+        override suspend fun remove(sourceId: String) {}
+        override suspend fun getSourceVersion(sourceId: String): String? = null
+    }
+
     private fun fakeTokenStorage(): TokenStorage = object : TokenStorage {
         override suspend fun saveToken(sourceId: String, token: String) {}
         override suspend fun getToken(sourceId: String): String? = null
         override suspend fun deleteToken(sourceId: String) {}
+    }
+
+    private class FakeLibraryFilterPreferencesStore(
+        initial: Map<Pair<String, String>, LibraryFilterPreferences> = emptyMap(),
+    ) : LibraryFilterPreferencesStore {
+        val state = MutableStateFlow(initial)
+        val notStartedWrites = mutableListOf<Triple<String, String, Boolean>>()
+        val sortWrites = mutableListOf<Triple<String, String, String?>>()
+
+        override fun preferences(sourceId: String, libraryId: String): Flow<LibraryFilterPreferences> =
+            state.map { it[sourceId to libraryId] ?: LibraryFilterPreferences() }
+
+        override suspend fun setSelectedFacetKey(sourceId: String, libraryId: String, key: String?) {
+            state.update {
+                it + ((sourceId to libraryId) to ((it[sourceId to libraryId] ?: LibraryFilterPreferences()).copy(selectedFacetKey = key)))
+            }
+        }
+
+        override suspend fun setNotStartedFilterActive(sourceId: String, libraryId: String, active: Boolean) {
+            notStartedWrites += Triple(sourceId, libraryId, active)
+            state.update {
+                it + ((sourceId to libraryId) to ((it[sourceId to libraryId] ?: LibraryFilterPreferences()).copy(notStartedFilterActive = active)))
+            }
+        }
+
+        override suspend fun setSortModeName(sourceId: String, libraryId: String, name: String?) {
+            sortWrites += Triple(sourceId, libraryId, name)
+            state.update {
+                it + ((sourceId to libraryId) to ((it[sourceId to libraryId] ?: LibraryFilterPreferences()).copy(sortModeName = name)))
+            }
+        }
     }
 
     private fun fakeEpubRepo(): EpubRepository = object : EpubRepository {
@@ -235,6 +288,7 @@ class LibraryItemsViewModelTest {
             override val scale = kotlinx.coroutines.flow.flowOf(1f)
             override suspend fun setScale(value: Float) {}
         },
+        libraryFilterPreferencesStore: LibraryFilterPreferencesStore = FakeLibraryFilterPreferencesStore(),
         annotationStore: com.riffle.core.domain.AnnotationStore = fakeAnnotationStore(),
         audiobookBookmarkStore: com.riffle.core.domain.AudiobookBookmarkStore = fakeAudiobookBookmarkStore(),
         annotationsLibraryRepository: com.riffle.core.data.AnnotationsLibraryRepository = fakeAnnotationsLibraryRepository(),
@@ -261,6 +315,7 @@ class LibraryItemsViewModelTest {
         playlistsRepository = NoopPlaylistsRepository(),
         readaloudLinkRepository = readaloudLinkRepository,
         coverGridDensityStore = coverGridDensityStore,
+        libraryFilterPreferencesStore = libraryFilterPreferencesStore,
         annotationStore = annotationStore,
         audiobookBookmarkStore = audiobookBookmarkStore,
         annotationsLibraryRepository = annotationsLibraryRepository,
@@ -1168,6 +1223,45 @@ class LibraryItemsViewModelTest {
         vm.toggleNotStartedFilter()
         testDispatcher.scheduler.advanceUntilIdle()
         assertEquals(listOf(audiobook), vm.projection.value.allBooks)
+    }
+
+    @Test
+    fun `library filter preferences restore not-started and sort for the active source library`() = runTest {
+        val store = FakeLibraryFilterPreferencesStore(
+            mapOf(
+                ("src-1" to "lib-1") to LibraryFilterPreferences(
+                    notStartedFilterActive = true,
+                    sortModeName = LibrarySortMode.TITLE_DESC.name,
+                ),
+            ),
+        )
+        val vm = makeViewModel(
+            sourceRepository = fakeActiveSourceRepo("src-1"),
+            libraryFilterPreferencesStore = store,
+        )
+        backgroundScope.launch { vm.notStartedFilterActive.collect {} }
+        backgroundScope.launch { vm.librarySortMode.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(vm.notStartedFilterActive.value)
+        assertEquals(LibrarySortMode.TITLE_DESC, vm.librarySortMode.value)
+    }
+
+    @Test
+    fun `library filter changes persist under active source and library id`() = runTest {
+        val store = FakeLibraryFilterPreferencesStore()
+        val vm = makeViewModel(
+            sourceRepository = fakeActiveSourceRepo("src-1"),
+            libraryFilterPreferencesStore = store,
+        )
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.toggleNotStartedFilter()
+        vm.setLibrarySortMode(LibrarySortMode.AUTHOR_ASC)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf(Triple("src-1", "lib-1", true)), store.notStartedWrites)
+        assertEquals(listOf(Triple("src-1", "lib-1", LibrarySortMode.AUTHOR_ASC.name)), store.sortWrites)
     }
 
     // --- searchQuery persistence (issue #60) ---

--- a/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
@@ -5,9 +5,12 @@ import com.riffle.core.catalog.BookFormat
 import com.riffle.core.catalog.Catalog
 import com.riffle.core.catalog.CatalogItem
 import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.FacetSelection
 import com.riffle.core.catalog.chitanka.ChitankaCatalog
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
 import com.riffle.core.domain.CoverGridDensityStore
+import com.riffle.core.domain.LibraryFilterPreferences
+import com.riffle.core.domain.LibraryFilterPreferencesStore
 import com.riffle.app.testing.FakeLibraryObserver
 import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.models.LibraryItem
@@ -25,6 +28,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -68,6 +73,7 @@ class ChitankaBrowseViewModelTest {
         upserter: WebSourceLibraryItemUpserter = mockk(relaxed = true),
         sourceRepo: SourceRepository = fakeSourceRepo(chitankaSource),
         coverGridDensityStore: CoverGridDensityStore = fakeCoverGridDensityStore(),
+        libraryFilterPreferencesStore: LibraryFilterPreferencesStore = FakeLibraryFilterPreferencesStore(),
         libraryObserver: LibraryObserver = emptyLibraryObserver(),
         catalog: Catalog = mockk<Catalog>(relaxed = true).also {
             // Relaxed mocks return a stub CatalogItem instead of null for `getItem`, which breaks
@@ -95,6 +101,7 @@ class ChitankaBrowseViewModelTest {
             upserter,
             gate,
             coverGridDensityStore,
+            libraryFilterPreferencesStore,
             libraryObserver,
         )
     }
@@ -159,6 +166,7 @@ class ChitankaBrowseViewModelTest {
             mockk<WebSourceLibraryItemUpserter>(relaxed = true),
             gate,
             fakeCoverGridDensityStore(),
+            FakeLibraryFilterPreferencesStore(),
             emptyLibraryObserver(),
         )
         advanceUntilIdle()
@@ -191,6 +199,7 @@ class ChitankaBrowseViewModelTest {
             mockk<WebSourceLibraryItemUpserter>(relaxed = true),
             gate,
             fakeCoverGridDensityStore(),
+            FakeLibraryFilterPreferencesStore(),
             emptyLibraryObserver(),
         )
         advanceUntilIdle()
@@ -223,6 +232,7 @@ class ChitankaBrowseViewModelTest {
             upserter,
             gate,
             fakeCoverGridDensityStore(),
+            FakeLibraryFilterPreferencesStore(),
             emptyLibraryObserver(),
         )
         advanceUntilIdle()
@@ -467,6 +477,63 @@ class ChitankaBrowseViewModelTest {
         assertEquals(2, vm.filteredItems.value.size)
     }
 
+    @Test
+    fun `remembered filters are scoped separately for Chitanka and Gramofonche roots`() =
+        runTest(dispatcher) {
+            val store = FakeLibraryFilterPreferencesStore(
+                mapOf(
+                    ("chit-1" to ChitankaCatalog.ROOT_BOOKS) to LibraryFilterPreferences(
+                        selectedFacetKey = "genre:fantasy",
+                        notStartedFilterActive = true,
+                    ),
+                    ("chit-1" to ChitankaCatalog.ROOT_AUDIOBOOKS) to LibraryFilterPreferences(
+                        selectedFacetKey = "genre:audio",
+                        notStartedFilterActive = false,
+                    ),
+                ),
+            )
+            val catalog = mockk<Catalog>(relaxed = true)
+            coEvery { catalog.browse(rootId = any(), page = 0, pageSize = any(), facet = any()) } returns emptyList()
+
+            val vm = makeVm(
+                rootId = ChitankaCatalog.ROOT_AUDIOBOOKS,
+                catalog = catalog,
+                libraryFilterPreferencesStore = store,
+            )
+            advanceUntilIdle()
+
+            assertEquals("genre:audio", vm.selectedFacet.value)
+            assertFalse(vm.notStartedFilterActive.value)
+            coVerify {
+                catalog.browse(
+                    rootId = ChitankaCatalog.ROOT_AUDIOBOOKS,
+                    page = 0,
+                    pageSize = any(),
+                    facet = FacetSelection("genre:audio"),
+                )
+            }
+        }
+
+    @Test
+    fun `selectFacet and not-started changes persist for the active source library`() =
+        runTest(dispatcher) {
+            val store = FakeLibraryFilterPreferencesStore()
+            val vm = makeVm(libraryFilterPreferencesStore = store)
+            advanceUntilIdle()
+
+            vm.selectFacet("genre:history")
+            vm.toggleNotStartedFilter()
+            advanceUntilIdle()
+
+            assertEquals(
+                LibraryFilterPreferences(
+                    selectedFacetKey = "genre:history",
+                    notStartedFilterActive = true,
+                ),
+                store.state.value["chit-1" to ChitankaCatalog.ROOT_BOOKS],
+            )
+        }
+
     // ---- filter helpers ----------------------------------------------------------
 
     private fun libraryItem(id: String, progress: Float) = LibraryItem(
@@ -485,4 +552,31 @@ class ChitankaBrowseViewModelTest {
 
     private fun libraryObserverWithAllBooks(allBooks: Flow<List<LibraryItem>>): LibraryObserver =
         FakeLibraryObserver(allBooksFlow = allBooks)
+
+    private class FakeLibraryFilterPreferencesStore(
+        initial: Map<Pair<String, String>, LibraryFilterPreferences> = emptyMap(),
+    ) : LibraryFilterPreferencesStore {
+        val state = MutableStateFlow(initial)
+
+        override fun preferences(sourceId: String, libraryId: String): Flow<LibraryFilterPreferences> =
+            state.map { it[sourceId to libraryId] ?: LibraryFilterPreferences() }
+
+        override suspend fun setSelectedFacetKey(sourceId: String, libraryId: String, key: String?) {
+            state.update {
+                it + ((sourceId to libraryId) to ((it[sourceId to libraryId] ?: LibraryFilterPreferences()).copy(selectedFacetKey = key)))
+            }
+        }
+
+        override suspend fun setNotStartedFilterActive(sourceId: String, libraryId: String, active: Boolean) {
+            state.update {
+                it + ((sourceId to libraryId) to ((it[sourceId to libraryId] ?: LibraryFilterPreferences()).copy(notStartedFilterActive = active)))
+            }
+        }
+
+        override suspend fun setSortModeName(sourceId: String, libraryId: String, name: String?) {
+            state.update {
+                it + ((sourceId to libraryId) to ((it[sourceId to libraryId] ?: LibraryFilterPreferences()).copy(sortModeName = name)))
+            }
+        }
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModelTest.kt
@@ -17,6 +17,8 @@ import com.riffle.core.catalog.gutenberg.GutenbergCatalog
 import com.riffle.core.data.websource.WebSourceItemGate
 import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
 import com.riffle.core.domain.CoverGridDensityStore
+import com.riffle.core.domain.LibraryFilterPreferences
+import com.riffle.core.domain.LibraryFilterPreferencesStore
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.Source
 import com.riffle.core.models.SourceType
@@ -27,8 +29,12 @@ import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -77,6 +83,7 @@ class GutenbergBrowseViewModelTest {
             coEvery { openItem(any(), any(), any(), any()) } returns WebSourceItemGate.Outcome.Fresh
         },
         upserter: WebSourceLibraryItemUpserter = mockk(relaxed = true),
+        libraryFilterPreferencesStore: LibraryFilterPreferencesStore = FakeLibraryFilterPreferencesStore(),
         catalog: Catalog = mockk<Catalog>(relaxed = true).also {
             // Gutendex facets aren't relevant to openDetail; keep the init refresh cheap.
             coEvery { it.listFacets(any()) } returns emptyList()
@@ -92,6 +99,7 @@ class GutenbergBrowseViewModelTest {
             upserter,
             gate,
             fakeCoverGridDensityStore(),
+            libraryFilterPreferencesStore,
             emptyLibraryObserver(),
         )
         return vm to gate
@@ -140,6 +148,44 @@ class GutenbergBrowseViewModelTest {
         assertEquals("dumas", catalog.lastSearchQuery)
     }
 
+    @Test
+    fun `remembered language facet is used for initial Project Gutenberg browse`() = runTest(dispatcher) {
+        val store = FakeLibraryFilterPreferencesStore(
+            mapOf(
+                ("gut-1" to GutenbergCatalog.ROOT_BOOKS) to LibraryFilterPreferences(
+                    selectedFacetKey = "language:fr",
+                    notStartedFilterActive = true,
+                ),
+            ),
+        )
+        val catalog = RecordingFacetedSearchCatalog()
+        val (vm, _) = makeVm(catalog = catalog, libraryFilterPreferencesStore = store)
+        advanceUntilIdle()
+
+        assertEquals("language:fr", vm.selectedFacet.value)
+        assertEquals(true, vm.notStartedFilterActive.value)
+        assertEquals(FacetSelection("language:fr"), catalog.lastBrowseFacet)
+    }
+
+    @Test
+    fun `facet and not-started changes are persisted for Project Gutenberg`() = runTest(dispatcher) {
+        val store = FakeLibraryFilterPreferencesStore()
+        val (vm, _) = makeVm(libraryFilterPreferencesStore = store)
+        advanceUntilIdle()
+
+        vm.selectFacet("topic:history")
+        vm.toggleNotStartedFilter()
+        advanceUntilIdle()
+
+        assertEquals(
+            LibraryFilterPreferences(
+                selectedFacetKey = "topic:history",
+                notStartedFilterActive = true,
+            ),
+            store.state.value["gut-1" to GutenbergCatalog.ROOT_BOOKS],
+        )
+    }
+
     private fun fakeSourceRepo(active: Source?): SourceRepository = object : SourceRepository {
         override fun observeAll() = kotlinx.coroutines.flow.flowOf(listOfNotNull(active))
         override suspend fun getActive(): Source? = active
@@ -160,9 +206,37 @@ class GutenbergBrowseViewModelTest {
 
     private fun emptyLibraryObserver() = FakeLibraryObserver()
 
+    private class FakeLibraryFilterPreferencesStore(
+        initial: Map<Pair<String, String>, LibraryFilterPreferences> = emptyMap(),
+    ) : LibraryFilterPreferencesStore {
+        val state = MutableStateFlow(initial)
+
+        override fun preferences(sourceId: String, libraryId: String): Flow<LibraryFilterPreferences> =
+            state.map { it[sourceId to libraryId] ?: LibraryFilterPreferences() }
+
+        override suspend fun setSelectedFacetKey(sourceId: String, libraryId: String, key: String?) {
+            state.update {
+                it + ((sourceId to libraryId) to ((it[sourceId to libraryId] ?: LibraryFilterPreferences()).copy(selectedFacetKey = key)))
+            }
+        }
+
+        override suspend fun setNotStartedFilterActive(sourceId: String, libraryId: String, active: Boolean) {
+            state.update {
+                it + ((sourceId to libraryId) to ((it[sourceId to libraryId] ?: LibraryFilterPreferences()).copy(notStartedFilterActive = active)))
+            }
+        }
+
+        override suspend fun setSortModeName(sourceId: String, libraryId: String, name: String?) {
+            state.update {
+                it + ((sourceId to libraryId) to ((it[sourceId to libraryId] ?: LibraryFilterPreferences()).copy(sortModeName = name)))
+            }
+        }
+    }
+
     private inner class RecordingFacetedSearchCatalog : Catalog, FacetedSearchCapability {
         var lastSearchFacet: FacetSelection? = null
         var lastSearchQuery: String? = null
+        var lastBrowseFacet: FacetSelection? = null
 
         override val sourceType: SourceType = SourceType.GUTENBERG
 
@@ -173,7 +247,10 @@ class GutenbergBrowseViewModelTest {
             page: Int,
             pageSize: Int,
             facet: FacetSelection?,
-        ): List<CatalogItem> = emptyList()
+        ): List<CatalogItem> {
+            lastBrowseFacet = facet
+            return emptyList()
+        }
 
         override suspend fun search(
             rootId: String,

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryFilterPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryFilterPreferencesStoreImpl.kt
@@ -1,0 +1,56 @@
+package com.riffle.core.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.riffle.core.data.di.LibraryFilterPreferencesDataStore
+import com.riffle.core.domain.LibraryFilterPreferences
+import com.riffle.core.domain.LibraryFilterPreferencesStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class LibraryFilterPreferencesStoreImpl @Inject constructor(
+    @param:LibraryFilterPreferencesDataStore private val dataStore: DataStore<Preferences>,
+) : LibraryFilterPreferencesStore {
+
+    override fun preferences(sourceId: String, libraryId: String): Flow<LibraryFilterPreferences> =
+        dataStore.data.map { prefs ->
+            LibraryFilterPreferences(
+                selectedFacetKey = prefs[facetKey(sourceId, libraryId)],
+                notStartedFilterActive = prefs[notStartedKey(sourceId, libraryId)] ?: false,
+                sortModeName = prefs[sortModeKey(sourceId, libraryId)],
+            )
+        }
+
+    override suspend fun setSelectedFacetKey(sourceId: String, libraryId: String, key: String?) {
+        dataStore.edit { prefs ->
+            val prefKey = facetKey(sourceId, libraryId)
+            if (key == null) prefs.remove(prefKey) else prefs[prefKey] = key
+        }
+    }
+
+    override suspend fun setNotStartedFilterActive(sourceId: String, libraryId: String, active: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[notStartedKey(sourceId, libraryId)] = active
+        }
+    }
+
+    override suspend fun setSortModeName(sourceId: String, libraryId: String, name: String?) {
+        dataStore.edit { prefs ->
+            val prefKey = sortModeKey(sourceId, libraryId)
+            if (name == null) prefs.remove(prefKey) else prefs[prefKey] = name
+        }
+    }
+
+    private fun facetKey(sourceId: String, libraryId: String) =
+        stringPreferencesKey("library_filter:$sourceId:$libraryId:facet")
+
+    private fun notStartedKey(sourceId: String, libraryId: String) =
+        booleanPreferencesKey("library_filter:$sourceId:$libraryId:not_started")
+
+    private fun sortModeKey(sourceId: String, libraryId: String) =
+        stringPreferencesKey("library_filter:$sourceId:$libraryId:sort_mode")
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DataModule.kt
@@ -29,6 +29,10 @@ annotation class LibraryVisibilityPreferencesDataStore
 
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
+annotation class LibraryFilterPreferencesDataStore
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
 annotation class LocalToReadDataStore
 
 @Qualifier

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/LibraryFilterPreferencesDataStoreExt.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/LibraryFilterPreferencesDataStoreExt.kt
@@ -1,0 +1,9 @@
+package com.riffle.core.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+
+val Context.libraryFilterPreferencesDataStore: DataStore<Preferences>
+    by preferencesDataStore(name = "library_filter_preferences")

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/PreferencesModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/PreferencesModule.kt
@@ -9,6 +9,7 @@ import com.riffle.core.data.ContentCacheAccessStoreImpl
 import com.riffle.core.data.FormattingPreferencesStoreImpl
 import com.riffle.core.data.FormattingPreferencesStoreProviderImpl
 import com.riffle.core.data.LastOpenedLibraryStoreImpl
+import com.riffle.core.data.LibraryFilterPreferencesStoreImpl
 import com.riffle.core.data.LibraryOrderPreferencesStoreImpl
 import com.riffle.core.data.LibraryVisibilityPreferencesStoreImpl
 import com.riffle.core.data.ListeningPreferencesStoreImpl
@@ -25,6 +26,7 @@ import com.riffle.core.data.di.HighlightsFormattingPreferencesDataStore
 import com.riffle.core.data.di.HighlightColorPreferencesDataStore
 import com.riffle.core.data.di.HighlightsResumePreferencesDataStore
 import com.riffle.core.data.di.LastOpenedLibraryDataStore
+import com.riffle.core.data.di.LibraryFilterPreferencesDataStore
 import com.riffle.core.data.di.LibraryOrderPreferencesDataStore
 import com.riffle.core.data.di.LibraryVisibilityPreferencesDataStore
 import com.riffle.core.data.di.ListeningPreferencesDataStore
@@ -45,6 +47,7 @@ import com.riffle.core.data.di.formattingPreferencesHighlightsDataStore
 import com.riffle.core.data.di.highlightColorPreferencesDataStore
 import com.riffle.core.data.di.highlightsResumePreferencesDataStore
 import com.riffle.core.data.di.lastOpenedLibraryDataStore
+import com.riffle.core.data.di.libraryFilterPreferencesDataStore
 import com.riffle.core.data.di.libraryOrderPreferencesDataStore
 import com.riffle.core.data.di.libraryVisibilityPreferencesDataStore
 import com.riffle.core.data.di.listeningPreferencesDataStore
@@ -66,6 +69,7 @@ import com.riffle.core.models.FormattingScope
 import com.riffle.core.domain.HighlightColorPreferencesStore
 import com.riffle.core.domain.HighlightsResumeStore
 import com.riffle.core.domain.LastOpenedLibraryStore
+import com.riffle.core.domain.LibraryFilterPreferencesStore
 import com.riffle.core.domain.LibraryOrderPreferencesStore
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.ListeningPreferencesStore
@@ -113,6 +117,10 @@ abstract class PreferencesModule {
 
     @Binds
     @Singleton
+    abstract fun bindLibraryFilterPreferencesStore(impl: LibraryFilterPreferencesStoreImpl): LibraryFilterPreferencesStore
+
+    @Binds
+    @Singleton
     abstract fun bindLibraryOrderPreferencesStore(impl: LibraryOrderPreferencesStoreImpl): LibraryOrderPreferencesStore
 
     @Binds
@@ -154,6 +162,9 @@ abstract class PreferencesModule {
 
         @Provides @Singleton @LibraryVisibilityPreferencesDataStore
         fun provideLibraryVisibilityPreferencesDataStore(@ApplicationContext c: Context): DataStore<Preferences> = c.libraryVisibilityPreferencesDataStore
+
+        @Provides @Singleton @LibraryFilterPreferencesDataStore
+        fun provideLibraryFilterPreferencesDataStore(@ApplicationContext c: Context): DataStore<Preferences> = c.libraryFilterPreferencesDataStore
 
         @Provides @Singleton @LocalToReadDataStore
         fun provideLocalToReadDataStore(@ApplicationContext c: Context): DataStore<Preferences> = c.localToReadDataStore

--- a/core/data/src/test/kotlin/com/riffle/core/data/LibraryFilterPreferencesStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/LibraryFilterPreferencesStoreImplTest.kt
@@ -1,0 +1,97 @@
+package com.riffle.core.data
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.riffle.core.domain.LibraryFilterPreferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LibraryFilterPreferencesStoreImplTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private val testScope = TestScope(UnconfinedTestDispatcher())
+
+    private fun buildStore(fileName: String = "library_filter_preferences.preferences_pb") =
+        LibraryFilterPreferencesStoreImpl(
+            PreferenceDataStoreFactory.create(
+                scope = testScope.backgroundScope,
+                produceFile = { tmp.newFile(fileName) },
+            ),
+        )
+
+    @Test
+    fun `defaults are returned when no filters were saved`() = testScope.runTest {
+        assertEquals(LibraryFilterPreferences(), buildStore().preferences("src-1", "lib-1").first())
+    }
+
+    @Test
+    fun `facet not-started and sort round-trip per source library`() = testScope.runTest {
+        val store = buildStore()
+
+        store.setSelectedFacetKey("src-1", "lib-1", "language:fr")
+        store.setNotStartedFilterActive("src-1", "lib-1", true)
+        store.setSortModeName("src-1", "lib-1", "TITLE_DESC")
+
+        assertEquals(
+            LibraryFilterPreferences(
+                selectedFacetKey = "language:fr",
+                notStartedFilterActive = true,
+                sortModeName = "TITLE_DESC",
+            ),
+            store.preferences("src-1", "lib-1").first(),
+        )
+        assertEquals(LibraryFilterPreferences(), store.preferences("src-1", "lib-2").first())
+    }
+
+    @Test
+    fun `clearing selected facet removes only that field`() = testScope.runTest {
+        val store = buildStore()
+
+        store.setSelectedFacetKey("src-1", "lib-1", "topic:fiction")
+        store.setNotStartedFilterActive("src-1", "lib-1", true)
+        store.setSortModeName("src-1", "lib-1", "AUTHOR_ASC")
+        store.setSelectedFacetKey("src-1", "lib-1", null)
+
+        assertEquals(
+            LibraryFilterPreferences(
+                selectedFacetKey = null,
+                notStartedFilterActive = true,
+                sortModeName = "AUTHOR_ASC",
+            ),
+            store.preferences("src-1", "lib-1").first(),
+        )
+    }
+
+    @Test
+    fun `preferences persist across store instances`() {
+        val file = tmp.newFile("library_filter_preferences_round_trip.preferences_pb")
+
+        val writeScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        runBlocking {
+            LibraryFilterPreferencesStoreImpl(
+                PreferenceDataStoreFactory.create(scope = writeScope, produceFile = { file }),
+            ).setSelectedFacetKey("src-1", "lib-1", "genre:audio")
+        }
+        writeScope.cancel()
+
+        val readScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        val store = LibraryFilterPreferencesStoreImpl(
+            PreferenceDataStoreFactory.create(scope = readScope, produceFile = { file }),
+        )
+        assertEquals("genre:audio", runBlocking { store.preferences("src-1", "lib-1").first().selectedFacetKey })
+        readScope.cancel()
+    }
+}

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/LibraryFilterPreferencesStore.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/LibraryFilterPreferencesStore.kt
@@ -1,0 +1,22 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.flow.Flow
+
+data class LibraryFilterPreferences(
+    val selectedFacetKey: String? = null,
+    val notStartedFilterActive: Boolean = false,
+    val sortModeName: String? = null,
+)
+
+/**
+ * Device-local browse/filter state scoped to a concrete source library.
+ *
+ * The same source can expose multiple library roots (Chitanka books and Gramofonche audiobooks),
+ * so every key includes both ids. Values are display preferences, not synced content state.
+ */
+interface LibraryFilterPreferencesStore {
+    fun preferences(sourceId: String, libraryId: String): Flow<LibraryFilterPreferences>
+    suspend fun setSelectedFacetKey(sourceId: String, libraryId: String, key: String?)
+    suspend fun setNotStartedFilterActive(sourceId: String, libraryId: String, active: Boolean)
+    suspend fun setSortModeName(sourceId: String, libraryId: String, name: String?)
+}


### PR DESCRIPTION
## Summary
- Add a DataStore-backed filter preference store scoped by source id and library id.
- Restore and persist bounded-library All Books not-started and sort filters.
- Restore and persist unbounded source browse facets and not-started filters for Chitanka, Gramofonche, and Project Gutenberg roots.

## Tests
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ANDROID_HOME='/Users/plamen.kmetski/Library/Android/sdk' ./gradlew :core:data:testDebugUnitTest --tests 'com.riffle.core.data.LibraryFilterPreferencesStoreImplTest' :app:testDebugUnitTest --tests 'com.riffle.app.feature.library.LibraryItemsViewModelTest' --tests 'com.riffle.app.feature.source.chitanka.ChitankaBrowseViewModelTest' --tests 'com.riffle.app.feature.source.gutenberg.GutenbergBrowseViewModelTest'`

Regression assertions that would fail on revert: bounded libraries restore saved not-started/sort state and write changes under the active source/library ids; Chitanka and Gramofonche roots restore separate remembered facets; Project Gutenberg initial browse uses the remembered language facet; DataStore round-trips and clears facet values without losing other fields.