### PR TITLE
fix(websource): show progress in catalog grid

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
@@ -1,10 +1,8 @@
 package com.riffle.app.feature.source.chitanka
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -12,7 +10,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -48,13 +45,9 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import coil.compose.AsyncImage
 import com.riffle.app.feature.annotations.AnnotationsListScreen
 import com.riffle.app.feature.annotations.AnnotationsListViewModel
 import com.riffle.app.feature.library.HomeTabContent
@@ -62,9 +55,8 @@ import com.riffle.app.feature.library.LocalCoversAreSquare
 import com.riffle.app.feature.library.ToReadTabContent
 import com.riffle.app.feature.source.websource.UnboundedCatalogGrid
 import com.riffle.app.feature.source.websource.UnboundedCoverGridZoomProvider
-import com.riffle.app.ui.DefaultCoverPlaceholder
+import com.riffle.app.feature.source.websource.WebSourceCatalogItemCard
 import com.riffle.app.ui.TabletContentWidthContainer
-import com.riffle.core.catalog.CatalogItem
 import com.riffle.core.catalog.chitanka.ChitankaCatalog
 
 /**
@@ -313,7 +305,7 @@ private fun LibraryTabContent(
                         itemKey = { it.id },
                         coverCellSizeMultiplier = if (isAudioRoot) 4f / 3f else 1f,
                     ) { item ->
-                        CatalogItemCard(
+                        WebSourceCatalogItemCard(
                             item = item,
                             isAudio = isAudioRoot,
                             onClick = { viewModel.openDetail(item) },
@@ -379,49 +371,4 @@ private fun ChitankaAnnotationsTab(
         token = viewModel.authToken,
         onBookClick = onAnnotatedBookClick,
     )
-}
-
-@Composable
-private fun CatalogItemCard(
-    item: CatalogItem,
-    isAudio: Boolean,
-    onClick: () -> Unit,
-) {
-    Column(
-        modifier = Modifier.clickable(onClick = onClick),
-        verticalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        val ratio = if (isAudio) 1f else (2f / 3f)
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(ratio)
-                .clip(RoundedCornerShape(8.dp)),
-        ) {
-            DefaultCoverPlaceholder(isAudiobook = isAudio)
-            if (!item.coverUrl.isNullOrBlank()) {
-                AsyncImage(
-                    model = item.coverUrl,
-                    contentDescription = null,
-                    modifier = Modifier.fillMaxSize(),
-                )
-            }
-        }
-        Text(
-            item.title,
-            style = MaterialTheme.typography.bodySmall,
-            fontWeight = FontWeight.Medium,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-        )
-        if (item.author.isNotBlank()) {
-            Text(
-                item.author,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-    }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
@@ -1,10 +1,8 @@
 package com.riffle.app.feature.source.gutenberg
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -12,7 +10,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
@@ -50,23 +47,18 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import coil.compose.AsyncImage
 import com.riffle.app.feature.annotations.AnnotationsListScreen
 import com.riffle.app.feature.annotations.AnnotationsListViewModel
 import com.riffle.app.feature.library.HomeTabContent
 import com.riffle.app.feature.library.ToReadTabContent
 import com.riffle.app.feature.source.websource.UnboundedCatalogGrid
 import com.riffle.app.feature.source.websource.UnboundedCoverGridZoomProvider
-import com.riffle.app.ui.DefaultCoverPlaceholder
+import com.riffle.app.feature.source.websource.WebSourceCatalogItemCard
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.core.catalog.CatalogFacet
-import com.riffle.core.catalog.CatalogItem
 
 /**
  * Gutenberg Source screen. Distinct route ("gutenberg_browse/{libraryId}/{name}") from
@@ -300,8 +292,9 @@ private fun LibraryTabContent(
                         onCoverScaleChange = onCoverScaleChange,
                         itemKey = { it.id },
                     ) { item ->
-                        CatalogItemCard(
+                        WebSourceCatalogItemCard(
                             item = item,
+                            isAudio = false,
                             onClick = { viewModel.openDetail(item) },
                         )
                     }
@@ -419,47 +412,4 @@ private fun GutenbergAnnotationsTab(
         token = viewModel.authToken,
         onBookClick = onAnnotatedBookClick,
     )
-}
-
-@Composable
-private fun CatalogItemCard(
-    item: CatalogItem,
-    onClick: () -> Unit,
-) {
-    Column(
-        modifier = Modifier.clickable(onClick = onClick),
-        verticalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(2f / 3f)
-                .clip(RoundedCornerShape(8.dp)),
-        ) {
-            DefaultCoverPlaceholder(isAudiobook = false)
-            if (!item.coverUrl.isNullOrBlank()) {
-                AsyncImage(
-                    model = item.coverUrl,
-                    contentDescription = null,
-                    modifier = Modifier.fillMaxSize(),
-                )
-            }
-        }
-        Text(
-            item.title,
-            style = MaterialTheme.typography.bodySmall,
-            fontWeight = FontWeight.Medium,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-        )
-        if (item.author.isNotBlank()) {
-            Text(
-                item.author,
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
-    }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
@@ -138,15 +138,21 @@ abstract class UnboundedBrowseViewModel(
         persistNotStartedFilter(active)
     }
 
-    // IDs of Room-backed items that have been started (readingProgress > 0). Items absent from
-    // Room have no progress and are treated as not-started by the filter.
-    private val startedItemIds: StateFlow<Set<String>> = libraryObserver.observeAllBooks(rootId)
-        .map { books -> books.filter { it.readingProgress > 0f }.mapTo(HashSet()) { it.id } }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, emptySet())
+    // Local progress for Room-backed web-source items. Items absent from Room have no progress
+    // and are treated as not-started by the filter.
+    private val localReadingProgressByItemId: StateFlow<Map<String, Float>> =
+        libraryObserver.observeAllBooks(rootId)
+            .map { books -> books.associate { it.id to it.readingProgress } }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
 
     val filteredItems: StateFlow<List<CatalogItem>> =
-        combine(_items, startedItemIds, _notStartedFilterActive) { catalog, started, active ->
-            if (active) catalog.filter { it.id !in started } else catalog
+        combine(_items, localReadingProgressByItemId, _notStartedFilterActive) { catalog, progressById, active ->
+            catalog
+                .map { item ->
+                    val localProgress = progressById[item.id]
+                    if (localProgress == null) item else item.copy(readingProgress = localProgress)
+                }
+                .filter { item -> !active || (item.readingProgress ?: 0f) <= 0f }
         }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     private val _isLoading = MutableStateFlow(false)

--- a/app/src/main/kotlin/com/riffle/app/feature/source/websource/WebSourceCatalogItemCard.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/websource/WebSourceCatalogItemCard.kt
@@ -1,0 +1,79 @@
+package com.riffle.app.feature.source.websource
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.riffle.app.ui.DefaultCoverPlaceholder
+import com.riffle.core.catalog.CatalogItem
+
+@Composable
+internal fun WebSourceCatalogItemCard(
+    item: CatalogItem,
+    isAudio: Boolean,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.clickable(onClick = onClick),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        val ratio = if (isAudio) 1f else (2f / 3f)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(ratio)
+                .clip(RoundedCornerShape(8.dp)),
+        ) {
+            val progress = item.readingProgress ?: 0f
+            DefaultCoverPlaceholder(isAudiobook = isAudio)
+            if (!item.coverUrl.isNullOrBlank()) {
+                AsyncImage(
+                    model = item.coverUrl,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+            if (progress > 0f) {
+                LinearProgressIndicator(
+                    progress = { progress.coerceIn(0f, 1f) },
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .fillMaxWidth()
+                        .height(3.dp),
+                )
+            }
+        }
+        Text(
+            item.title,
+            style = MaterialTheme.typography.bodySmall,
+            fontWeight = FontWeight.Medium,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+        if (item.author.isNotBlank()) {
+            Text(
+                item.author,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
@@ -455,6 +455,33 @@ class ChitankaBrowseViewModelTest {
         }
 
     @Test
+    fun `catalog items include local reading progress from Room`() = runTest(dispatcher) {
+        val startedId = "text/started"
+        val notStartedId = "text/not-started"
+        val roomItems = MutableStateFlow(
+            listOf(
+                libraryItem(startedId, progress = 0.42f),
+                libraryItem(notStartedId, progress = 0f),
+            ),
+        )
+
+        val catalog = mockk<Catalog>(relaxed = true)
+        coEvery { catalog.browse(rootId = any(), page = 0, pageSize = any(), facet = any()) } returns
+            listOf(item(startedId), item(notStartedId), item("text/unseen"))
+
+        val vm = makeVm(
+            catalog = catalog,
+            libraryObserver = libraryObserverWithAllBooks(roomItems),
+        )
+        advanceUntilIdle()
+
+        val byId = vm.filteredItems.value.associateBy { it.id }
+        assertEquals(0.42f, byId.getValue(startedId).readingProgress ?: -1f)
+        assertEquals(0f, byId.getValue(notStartedId).readingProgress ?: -1f)
+        assertEquals(null, byId.getValue("text/unseen").readingProgress)
+    }
+
+    @Test
     fun `toggleNotStartedFilter off restores all catalog items`() = runTest(dispatcher) {
         val startedId = "text/444"
         val roomItems = MutableStateFlow(listOf(libraryItem(startedId, progress = 0.8f)))


### PR DESCRIPTION
## Summary
- hydrate unbounded web-source catalog items with local Room reading progress before filtering/rendering
- replace duplicated Chitanka/Gutenberg catalog cards with a shared web-source card that renders the progress strip
- add regression coverage for the catalog-item progress join

## Tests
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ANDROID_HOME="$HOME/Library/Android/sdk" java -classpath /Users/plamen.kmetski/conductor/workspaces/riffle/hyderabad/gradle/wrapper/gradle-wrapper.jar org.gradle.wrapper.GradleWrapperMain :app:testDebugUnitTest --tests 'com.riffle.app.feature.source.chitanka.ChitankaBrowseViewModelTest' --tests 'com.riffle.app.feature.source.gutenberg.GutenbergBrowseViewModelTest'`

## Regression assertion
- `catalog items include local reading progress from Room` asserts that a catalog item matching a Room row exposes `readingProgress == 0.42f`; reverting the progress join makes that value `null` and fails the test.