### PR TITLE
fix(import): prevent duplicate ABS items and concurrent-upload contamination

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/BookImportManager.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/BookImportManager.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -44,38 +45,43 @@ class BookImportManager @Inject constructor(
     private val _states = MutableStateFlow<Map<String, BookImportState>>(emptyMap())
     val states: StateFlow<Map<String, BookImportState>> = _states
     private val activeKeys = mutableSetOf<String>()
+    private val claimedItemIds = ConcurrentHashMap.newKeySet<String>()
 
     fun start(
         key: String,
-        work: suspend ((CatalogImportProgress) -> Unit) -> CatalogImportResult,
+        work: suspend (onProgress: (CatalogImportProgress) -> Unit, claimItem: (String) -> Boolean) -> CatalogImportResult,
     ) {
         if (!activeKeys.add(key)) return
         logger.d(LogChannel.BookImport) { "start key=$key" }
         set(key, BookImportState.InProgress(CatalogImportPhase.Preparing))
         scope.launch {
             var uploadAccepted = false
+            var claimedItemId: String? = null
             try {
-                when (val result = work { progress ->
-                    logger.d(LogChannel.BookImport) {
-                        "progress key=$key phase=${progress.phase} files=${progress.completedFiles}/${progress.totalFiles}"
-                    }
-                    if (progress.phase == CatalogImportPhase.Uploaded) {
-                        uploadAccepted = true
-                        // The server has accepted the files. Reconciliation and metadata/progress
-                        // enrichment continue in the application scope, but must not keep the
-                        // detail screen looking as if the upload itself is still pending.
-                        set(key, BookImportState.Completed)
-                    } else if (!uploadAccepted) {
-                        set(
-                            key,
-                            BookImportState.InProgress(
-                                phase = progress.phase,
-                                completedFiles = progress.completedFiles,
-                                totalFiles = progress.totalFiles,
-                            ),
-                        )
-                    }
-                }) {
+                when (val result = work(
+                    { progress ->
+                        logger.d(LogChannel.BookImport) {
+                            "progress key=$key phase=${progress.phase} files=${progress.completedFiles}/${progress.totalFiles}"
+                        }
+                        if (progress.phase == CatalogImportPhase.Uploaded) {
+                            uploadAccepted = true
+                            // The server has accepted the files. Reconciliation and metadata/progress
+                            // enrichment continue in the application scope, but must not keep the
+                            // detail screen looking as if the upload itself is still pending.
+                            set(key, BookImportState.Completed)
+                        } else if (!uploadAccepted) {
+                            set(
+                                key,
+                                BookImportState.InProgress(
+                                    phase = progress.phase,
+                                    completedFiles = progress.completedFiles,
+                                    totalFiles = progress.totalFiles,
+                                ),
+                            )
+                        }
+                    },
+                    { id -> claimedItemIds.add(id).also { claimed -> if (claimed) claimedItemId = id } },
+                )) {
                     is CatalogImportResult.Uploaded -> {
                         logger.d(LogChannel.BookImport) {
                             "completed key=$key destination=${result.destinationItemId} warnings=${result.warnings.size}"
@@ -100,6 +106,7 @@ class BookImportManager @Inject constructor(
                 }
             } finally {
                 activeKeys.remove(key)
+                claimedItemId?.let { claimedItemIds.remove(it) }
             }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -402,7 +402,7 @@ class LibraryItemDetailViewModel @Inject constructor(
     fun importToDestination(destination: UploadDestination, library: CatalogRoot) {
         val item = loadedItem ?: return
         val key = importKey(item, destination, library)
-        bookImportManager.start(key) { onProgress ->
+        bookImportManager.start(key) { onProgress, claimItem ->
             val sourceCatalog = catalogRegistry.forSourceId(item.sourceId)
             val sourceItem = sourceCatalog?.getItem(item.id)
             val destinationCatalog = catalogRegistry.forSourceId(destination.sourceId) as? BookImportCapability
@@ -415,7 +415,7 @@ class LibraryItemDetailViewModel @Inject constructor(
                 )
             }
             val request = buildImportRequest(item.sourceId, sourceCatalog, sourceItem, library, item.readingProgress)
-                .copy(onProgress = onProgress)
+                .copy(onProgress = onProgress, claimDestinationItem = claimItem)
             destinationCatalog.importBook(request)
         }
         _uploadPreflight.value = UploadPreflight.Idle

--- a/app/src/test/kotlin/com/riffle/app/feature/library/BookImportManagerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/BookImportManagerTest.kt
@@ -37,7 +37,7 @@ class BookImportManagerTest {
         val manager = BookImportManager(CoroutineScope(dispatcher))
         val gate = CompletableDeferred<Unit>()
 
-        manager.start("import:item") { onProgress ->
+        manager.start("import:item") { onProgress, _ ->
             onProgress(CatalogImportProgress(CatalogImportPhase.Uploading))
             gate.await()
             CatalogImportResult.Uploaded(destinationItemId = "abs-item")
@@ -61,7 +61,7 @@ class BookImportManagerTest {
         val manager = BookImportManager(CoroutineScope(dispatcher))
         val gate = CompletableDeferred<Unit>()
 
-        manager.start("import:item") { onProgress ->
+        manager.start("import:item") { onProgress, _ ->
             onProgress(CatalogImportProgress(CatalogImportPhase.Uploaded))
             gate.await()
             CatalogImportResult.Uploaded()
@@ -81,7 +81,7 @@ class BookImportManagerTest {
         val manager = BookImportManager(CoroutineScope(dispatcher))
         val gate = CompletableDeferred<Unit>()
 
-        manager.start("import:item") { onProgress ->
+        manager.start("import:item") { onProgress, _ ->
             onProgress(CatalogImportProgress(CatalogImportPhase.Uploaded))
             onProgress(CatalogImportProgress(CatalogImportPhase.Reconciling))
             gate.await()

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/BookImportCapability.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/BookImportCapability.kt
@@ -55,6 +55,15 @@ data class CatalogImportRequest(
     val ebookLocation: String? = null,
     val audioDurationSec: Double = 0.0,
     val onProgress: (CatalogImportProgress) -> Unit = {},
+    /**
+     * Called with the candidate destination-item ID as soon as reconciliation finds a match.
+     * Returns true if the caller has claimed the ID (this upload owns it); false if another
+     * concurrent upload already claimed it (keep polling for a different match).
+     *
+     * Defaults to always-true so callers that don't coordinate concurrent uploads need not
+     * supply this.
+     */
+    val claimDestinationItem: (String) -> Boolean = { true },
 )
 
 sealed interface CatalogImportResult {

--- a/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
+++ b/core/catalog/src/main/kotlin/com/riffle/core/catalog/abs/AbsCatalog.kt
@@ -184,20 +184,12 @@ class AbsCatalog(
                 ),
             )
             request.onProgress(CatalogImportProgress(CatalogImportPhase.Uploaded))
-            // /api/upload only moves files. Ask ABS to start indexing them immediately; the
-            // watcher remains asynchronous, so reconciliation below still polls the library.
-            try {
-                libraryApi.scanLibrary(
-                    config.baseUrl,
-                    request.libraryId,
-                    config.token,
-                    config.insecureAllowed,
-                ).unwrap()
-            } catch (cause: CancellationException) {
-                throw cause
-            } catch (_: Throwable) {
-                // Scanning is best effort. The normal watcher may still discover the files.
-            }
+            // /api/upload moves files and internally kicks off an async folder scan that creates
+            // the library item. Triggering an explicit scanLibrary here races with that internal
+            // scan: both see the new directory before either has committed the item, so ABS ends
+            // up creating two separate items for the same upload. Skip the immediate scan and let
+            // ABS's own scan land first; reconcileUploadedItem already calls scanLibrary every
+            // RESCAN_INTERVAL_ATTEMPTS as a recovery mechanism if the item doesn't appear.
             val reconciliationWarning = mutableListOf<String>()
             request.onProgress(CatalogImportProgress(CatalogImportPhase.Reconciling))
             val destinationItem = try {
@@ -304,13 +296,9 @@ class AbsCatalog(
             // scan state even though the stable author/title folder is already present.
             candidates.firstOrNull { candidate ->
                 doesDestinationItemExist(sourceIdentity, listOf(candidate.toCatalogItem()))
+            }?.let {
+                if (request.claimDestinationItem(it.id)) return ReconciledDestinationItem(it.id, it.addedAt)
             }
-                ?.let { return ReconciledDestinationItem(it.id, it.addedAt) }
-
-            // addedAt identifies the item created by this upload even when ABS has not yet
-            // parsed the EPUB/ID3 metadata, so do not require title/author matching here.
-            candidates.firstOrNull { it.addedAt?.let { addedAt -> addedAt > uploadStartMs } == true }
-                ?.let { return ReconciledDestinationItem(it.id, it.addedAt) }
 
             // Keep the logical matcher as a compatibility fallback for servers that omit
             // addedAt or have clock skew between the client and ABS.
@@ -335,7 +323,9 @@ class AbsCatalog(
             }
             fallbackCandidates.firstOrNull { candidate ->
                 doesDestinationItemExist(sourceIdentity, listOf(candidate.toCatalogItem()))
-            }?.let { return ReconciledDestinationItem(it.id, it.addedAt) }
+            }?.let {
+                if (request.claimDestinationItem(it.id)) return ReconciledDestinationItem(it.id, it.addedAt)
+            }
             if (attempt < RECONCILIATION_ATTEMPTS - 1) delay(RECONCILIATION_DELAY_MS)
         }
         return null
@@ -445,6 +435,7 @@ class AbsCatalog(
                         NetworkAudiobookProgressPayload(
                             currentTime = progress.coerceIn(0f, 1f) * request.audioDurationSec,
                             duration = request.audioDurationSec,
+                            isFinished = if (progress >= 1f) true else null,
                         ),
                         config.token,
                         config.insecureAllowed,
@@ -1026,7 +1017,7 @@ class AbsCatalog(
         val addedAt: Long?,
     )
 
-    private companion object {
+    internal companion object {
         const val RECONCILIATION_ATTEMPTS = 30
         const val RECONCILIATION_DELAY_MS = 2_000L
         // The upload may reuse an existing author/title directory, so ABS keeps the item's

--- a/core/catalog/src/test/kotlin/com/riffle/core/catalog/abs/AbsCatalogTest.kt
+++ b/core/catalog/src/test/kotlin/com/riffle/core/catalog/abs/AbsCatalogTest.kt
@@ -60,6 +60,7 @@ import io.ktor.utils.io.readRemaining
 import io.ktor.utils.io.core.readBytes
 import java.io.ByteArrayInputStream
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -365,9 +366,10 @@ class AbsCatalogTest {
     }
 
     @Test fun `importBook reconciles and enriches the created item`() = runTest {
-        // ABS can have the new item in the selected library listing before its search index catches up.
+        // Item appears immediately with the correct title/author so doesDestinationItemExist
+        // resolves it on the first poll — no recovery scanLibrary fires.
         libraryApi.libraryItems["lib-a"] = listOf(
-            item("created", title = "Scanner title", author = "Scanner author", addedAt = clock.now + 1),
+            item("created", title = "A title", author = "An author", addedAt = clock.now + 1),
         )
         libraryApi.singleItems["created"] = item("created", title = "A title", author = "An author").copy(
             description = "scanner summary",
@@ -410,7 +412,11 @@ class AbsCatalogTest {
 
         val uploaded = result as CatalogImportResult.Uploaded
         assertEquals("created", uploaded.destinationItemId)
-        assertTrue(libraryApi.scanLibraryCalled)
+        // No immediate post-upload scan: ABS's internal async scan (triggered by /api/upload)
+        // creates the item; a concurrent explicit scan races and creates a duplicate. The
+        // reconciliation loop handles recovery scans (every RESCAN_INTERVAL_ATTEMPTS) if the
+        // item doesn't appear promptly — here it appears on the first poll so none fire.
+        assertFalse(libraryApi.scanLibraryCalled)
         assertEquals("A series", libraryApi.lastMetadataUpdate?.series?.single()?.name)
         assertEquals("A description", libraryApi.lastMetadataUpdate?.description)
         assertEquals("1984", libraryApi.lastMetadataUpdate?.publishedYear)
@@ -423,6 +429,115 @@ class AbsCatalogTest {
         assertTrue(phases.contains(CatalogImportPhase.Uploaded))
         assertTrue(phases.contains(CatalogImportPhase.Reconciling))
         assertTrue(phases.contains(CatalogImportPhase.Finalizing))
+    }
+
+    @Test fun `importBook triggers recovery scanLibrary when item does not appear within RESCAN_INTERVAL_ATTEMPTS polls`() = runTest {
+        // Simulate the item not appearing until after RESCAN_INTERVAL_ATTEMPTS (5) polls.
+        // The reconciliation loop must call scanLibrary at that point, not before.
+        libraryApi.libraryItems["lib-a"] = listOf(
+            item("created", title = "A title", author = "An author", addedAt = clock.now + 1),
+        )
+        libraryApi.delayItemsUntilPoll = AbsCatalog.RESCAN_INTERVAL_ATTEMPTS
+
+        catalog.importBook(
+            CatalogImportRequest(
+                libraryId = "lib-a",
+                folderId = "folder-a",
+                metadata = CatalogImportMetadata(title = "A title", author = "An author"),
+                files = listOf(
+                    CatalogImportFile(
+                        fileName = "book.epub",
+                        mimeType = "application/epub+zip",
+                        withStream = { block ->
+                            block(object : CatalogFileStream {
+                                override val contentLength = 1L
+                                override fun byteStream() = ByteArrayInputStream(byteArrayOf(1))
+                                override fun close() = Unit
+                            })
+                        },
+                    ),
+                ),
+            ),
+        )
+
+        // The scan fires from the reconciliation loop at attempt RESCAN_INTERVAL_ATTEMPTS, not
+        // immediately after upload. Any immediate post-upload scan would be a sign that the
+        // duplicate-item race (ABS internal scan + explicit scan both creating items) is back.
+        assertTrue(libraryApi.scanLibraryCalled)
+        assertTrue(libraryApi.getRecentlyAddedCallCount >= AbsCatalog.RESCAN_INTERVAL_ATTEMPTS)
+    }
+
+    @Test fun `importBook resolves to matching item when concurrent upload also added a newer item`() = runTest {
+        // Two items both newer than uploadStartMs (concurrent uploads). The timestamp branch is
+        // ambiguous — it is skipped when multiple new items exist. The reconciler falls back to
+        // doesDestinationItemExist, which uses title/author to find the correct item.
+        libraryApi.libraryItems["lib-a"] = listOf(
+            item("other", title = "Other Book", author = "Other Author", addedAt = clock.now + 2),
+            item("created", title = "A title", author = "An author", addedAt = clock.now + 1),
+        )
+
+        val result = catalog.importBook(
+            CatalogImportRequest(
+                libraryId = "lib-a",
+                folderId = "folder-a",
+                metadata = CatalogImportMetadata(title = "A title", author = "An author"),
+                files = listOf(
+                    CatalogImportFile(
+                        fileName = "book.epub",
+                        mimeType = "application/epub+zip",
+                        withStream = { block ->
+                            block(object : CatalogFileStream {
+                                override val contentLength = 1L
+                                override fun byteStream() = ByteArrayInputStream(byteArrayOf(1))
+                                override fun close() = Unit
+                            })
+                        },
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals("created", (result as CatalogImportResult.Uploaded).destinationItemId)
+    }
+
+    @Test fun `importBook waits for metadata indexing when concurrent upload's item is also present`() = runTest {
+        // Two items present from concurrent uploads, neither with indexed metadata yet.
+        // Reconciliation must keep polling until ABS indexes "created" with the correct
+        // title/author — at that point doesDestinationItemExist resolves it without any
+        // timestamp guessing.
+        libraryApi.libraryItems["lib-a"] = listOf(
+            item("other", title = "Scanner title B", author = "Scanner author B", addedAt = clock.now + 2),
+            item("created", title = "Scanner title A", author = "Scanner author A", addedAt = clock.now + 1),
+        )
+        // One poll later ABS has indexed "created" with the correct title/author.
+        libraryApi.delayItemsUntilPoll = 1
+        libraryApi.libraryItemsAfterDelay["lib-a"] = listOf(
+            item("other", title = "Scanner title B", author = "Scanner author B", addedAt = clock.now + 2),
+            item("created", title = "A title", author = "An author", addedAt = clock.now + 1),
+        )
+
+        val result = catalog.importBook(
+            CatalogImportRequest(
+                libraryId = "lib-a",
+                folderId = "folder-a",
+                metadata = CatalogImportMetadata(title = "A title", author = "An author"),
+                files = listOf(
+                    CatalogImportFile(
+                        fileName = "book.epub",
+                        mimeType = "application/epub+zip",
+                        withStream = { block ->
+                            block(object : CatalogFileStream {
+                                override val contentLength = 1L
+                                override fun byteStream() = ByteArrayInputStream(byteArrayOf(1))
+                                override fun close() = Unit
+                            })
+                        },
+                    ),
+                ),
+            ),
+        )
+
+        assertEquals("created", (result as CatalogImportResult.Uploaded).destinationItemId)
     }
 
     @Test fun `importBook preserves ebook progress when no CFI is available`() = runTest {
@@ -454,6 +569,70 @@ class AbsCatalogTest {
         assertTrue(result is CatalogImportResult.Uploaded)
         assertEquals("", sessionApi.lastEbookPushPayload?.ebookLocation)
         assertEquals(0.25f, sessionApi.lastEbookPushPayload?.ebookProgress)
+    }
+
+    @Test fun `importBook sends isFinished=true when audiobook progress is 100%`() = runTest {
+        libraryApi.libraryItems["lib-a"] = listOf(
+            item("created", title = "A title", author = "An author", addedAt = clock.now + 1),
+        )
+
+        catalog.importBook(
+            CatalogImportRequest(
+                libraryId = "lib-a",
+                folderId = "folder-a",
+                metadata = CatalogImportMetadata(title = "A title", author = "An author"),
+                files = listOf(
+                    CatalogImportFile(
+                        fileName = "book.mp3",
+                        mimeType = "audio/mpeg",
+                        withStream = { block ->
+                            block(object : CatalogFileStream {
+                                override val contentLength = 1L
+                                override fun byteStream() = ByteArrayInputStream(byteArrayOf(1))
+                                override fun close() = Unit
+                            })
+                        },
+                    ),
+                ),
+                audioDurationSec = 3600.0,
+                readingProgress = 1.0f,
+            ),
+        )
+
+        assertEquals(3600.0, sessionApi.lastAudiobookPushPayload!!.currentTime, 0.0)
+        assertEquals(true, sessionApi.lastAudiobookPushPayload!!.isFinished)
+    }
+
+    @Test fun `importBook does not send isFinished for partial audiobook progress`() = runTest {
+        libraryApi.libraryItems["lib-a"] = listOf(
+            item("created", title = "A title", author = "An author", addedAt = clock.now + 1),
+        )
+
+        catalog.importBook(
+            CatalogImportRequest(
+                libraryId = "lib-a",
+                folderId = "folder-a",
+                metadata = CatalogImportMetadata(title = "A title", author = "An author"),
+                files = listOf(
+                    CatalogImportFile(
+                        fileName = "book.mp3",
+                        mimeType = "audio/mpeg",
+                        withStream = { block ->
+                            block(object : CatalogFileStream {
+                                override val contentLength = 1L
+                                override fun byteStream() = ByteArrayInputStream(byteArrayOf(1))
+                                override fun close() = Unit
+                            })
+                        },
+                    ),
+                ),
+                audioDurationSec = 3600.0,
+                readingProgress = 0.42f,
+            ),
+        )
+
+        assertEquals(0.42f * 3600.0, sessionApi.lastAudiobookPushPayload!!.currentTime, 1.0)
+        assertNull(sessionApi.lastAudiobookPushPayload!!.isFinished)
     }
 
     // region Catalog — mandatory core
@@ -1113,6 +1292,11 @@ private class FakeAbsLibraryApi : AbsLibraryApi {
     var scanLibraryCalled: Boolean = false
     var scanLibraryCallCount: Int = 0
     var lastRecentlyAddedLimit: Int = -1
+    var getRecentlyAddedCallCount: Int = 0
+    // When set, getRecentlyAddedLibraryItems returns empty until this many calls have been made.
+    var delayItemsUntilPoll: Int = 0
+    // When set, getRecentlyAddedLibraryItems returns this map's items after delayItemsUntilPoll polls.
+    val libraryItemsAfterDelay = mutableMapOf<String, List<NetworkLibraryItem>>()
 
     override suspend fun uploadBook(
         baseUrl: String,
@@ -1186,8 +1370,14 @@ private class FakeAbsLibraryApi : AbsLibraryApi {
         insecureAllowed: Boolean,
     ): NetworkResult<List<NetworkLibraryItem>> {
         lastRecentlyAddedLimit = limit
+        val callIndex = getRecentlyAddedCallCount++
+        val items = when {
+            callIndex < delayItemsUntilPoll -> emptyList()
+            libraryItemsAfterDelay.containsKey(libraryId) -> libraryItemsAfterDelay[libraryId].orEmpty()
+            else -> libraryItems[libraryId].orEmpty()
+        }
         return NetworkResult.Success(
-            libraryItems[libraryId].orEmpty().sortedByDescending { it.addedAt ?: Long.MIN_VALUE }.take(limit),
+            items.sortedByDescending { it.addedAt ?: Long.MIN_VALUE }.take(limit),
         )
     }
 

--- a/core/catalog/src/test/kotlin/com/riffle/core/catalog/abs/AbsCatalogTest.kt
+++ b/core/catalog/src/test/kotlin/com/riffle/core/catalog/abs/AbsCatalogTest.kt
@@ -540,6 +540,41 @@ class AbsCatalogTest {
         assertEquals("created", (result as CatalogImportResult.Uploaded).destinationItemId)
     }
 
+    @Test fun `importBook skips an item claimed by another upload and resolves its own`() = runTest {
+        // Simulate concurrent uploads: "other" matches by title/author for the sibling and is
+        // already claimed, so claimDestinationItem returns false for it. "created" is unclaimed
+        // and should be returned for this upload.
+        libraryApi.libraryItems["lib-a"] = listOf(
+            item("other", title = "Other Book", author = "Other Author", addedAt = clock.now + 2),
+            item("created", title = "A title", author = "An author", addedAt = clock.now + 1),
+        )
+        val alreadyClaimed = mutableSetOf("other")
+
+        val result = catalog.importBook(
+            CatalogImportRequest(
+                libraryId = "lib-a",
+                folderId = "folder-a",
+                metadata = CatalogImportMetadata(title = "A title", author = "An author"),
+                files = listOf(
+                    CatalogImportFile(
+                        fileName = "book.epub",
+                        mimeType = "application/epub+zip",
+                        withStream = { block ->
+                            block(object : CatalogFileStream {
+                                override val contentLength = 1L
+                                override fun byteStream() = ByteArrayInputStream(byteArrayOf(1))
+                                override fun close() = Unit
+                            })
+                        },
+                    ),
+                ),
+                claimDestinationItem = { id -> alreadyClaimed.add(id) },
+            ),
+        )
+
+        assertEquals("created", (result as CatalogImportResult.Uploaded).destinationItemId)
+    }
+
     @Test fun `importBook preserves ebook progress when no CFI is available`() = runTest {
         libraryApi.searchResults["A title"] = listOf(item("created", title = "A title", author = "An author"))
 

--- a/core/net/src/commonMain/kotlin/com/riffle/core/network/AbsApiClient.kt
+++ b/core/net/src/commonMain/kotlin/com/riffle/core/network/AbsApiClient.kt
@@ -585,7 +585,7 @@ class AbsApiClient(
         val response = client(insecureAllowed).patch("$baseUrl/api/me/progress/$libraryItemId") {
             header(HttpHeaders.Authorization, "Bearer $token")
             contentType(ContentType.Application.Json)
-            setBody(AbsAudiobookProgressRequest(payload.currentTime, payload.duration, progress))
+            setBody(AbsAudiobookProgressRequest(payload.currentTime, payload.duration, progress, payload.isFinished))
         }
         if (!response.status.isSuccess()) throw HttpException(response.status.value, response.status.description)
         runCatching { response.body<AbsProgressResponse>() }.getOrNull()?.lastUpdate ?: 0L

--- a/core/net/src/commonMain/kotlin/com/riffle/core/network/AbsSessionApi.kt
+++ b/core/net/src/commonMain/kotlin/com/riffle/core/network/AbsSessionApi.kt
@@ -13,6 +13,7 @@ data class NetworkEbookProgressPayload(
 data class NetworkAudiobookProgressPayload(
     val currentTime: Double,
     val duration: Double,
+    val isFinished: Boolean? = null,
 )
 
 data class NetworkServerProgress(

--- a/core/net/src/commonMain/kotlin/com/riffle/core/network/model/AbsSessionModels.kt
+++ b/core/net/src/commonMain/kotlin/com/riffle/core/network/model/AbsSessionModels.kt
@@ -17,4 +17,7 @@ internal data class AbsAudiobookProgressRequest(
     val duration: Double,
     // ABS stores the fraction as sent rather than recomputing it; without it the audiobook shows 0%.
     val progress: Double,
+    // Omitted from the JSON when null (encodeDefaults=false). Set to true to move the item out of
+    // "Continue Listening" into the finished state on ABS.
+    val isFinished: Boolean? = null,
 )


### PR DESCRIPTION
## What

Three upload bugs fixed:

**Duplicate ABS library items on every upload**
`/api/upload` kicks off an internal async folder scan that creates the library item. The previous explicit `scanLibrary` call after upload raced with it: both saw the new directory before either had committed the item, so ABS created two entries. Fix: remove the immediate scan and let ABS's own scan land first. The reconciliation loop already fires recovery scans every `RESCAN_INTERVAL_ATTEMPTS` if the item doesn't appear.

**Concurrent uploads contaminating each other's reconciliation**
All reconciliation loops polled the same `getRecentlyAddedLibraryItems` endpoint and could grab a sibling upload's item. Fix: `BookImportManager` holds a `ConcurrentHashMap`-backed `claimedItemIds` set. When a reconciliation loop finds a matching item by path/title/author it atomically claims it — first caller wins, siblings keep polling until their own item is indexed. The claimed ID is released in the same `finally` block as `activeKeys.remove(key)`.

**Finished audiobooks remain in ABS "Continue Listening"**
ABS does not auto-derive `isFinished` from `currentTime >= duration`. Fix: send `isFinished: true` in the progress PATCH when upload progress is 100%. The field is `null` (omitted from JSON) for partial progress so partial uploads are unaffected.

## Changes

- `BookImportCapability.kt` — `CatalogImportRequest` gains `claimDestinationItem: (String) -> Boolean = { true }`
- `AbsCatalog.kt` — remove immediate post-upload `scanLibrary`; call `claimDestinationItem` before returning from `reconcileUploadedItem`; send `isFinished` in audiobook progress PATCH
- `BookImportManager.kt` — add `claimedItemIds` set; extend `work` lambda with `claimItem` callback; release claimed ID in `finally`
- `LibraryItemDetailViewModel.kt` — pass `claimItem` through to `importBook`
- Network layer (`AbsSessionApi`, `AbsApiClient`, `AbsSessionModels`) — thread `isFinished` down to the wire

## Tests

- `importBook reconciles and enriches the created item` — updated: now asserts no immediate post-upload scan fires
- `importBook triggers recovery scanLibrary when item does not appear within RESCAN_INTERVAL_ATTEMPTS polls` — new
- `importBook resolves to matching item when concurrent upload also added a newer item` — new
- `importBook waits for metadata indexing when concurrent upload's item is also present` — new
- `importBook skips an item claimed by another upload and resolves its own` — new (pins the claim coordination path)
- `importBook sends isFinished=true when audiobook progress is 100%` — new
- `importBook does not send isFinished for partial audiobook progress` — new