### PR TITLE
feat(websource): add Unowned filter chip to web-source browse screens

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -45,6 +45,7 @@ import com.riffle.core.catalog.CatalogRegistry
 import com.riffle.app.feature.audiobook.audiobookProgressFraction
 import com.riffle.core.data.localfiles.CopyCoverImageUseCase
 import com.riffle.core.data.localfiles.SaveLocalFileMetadataOverrideUseCase
+import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
 import com.riffle.core.models.SourceType
 import com.riffle.core.catalog.DownloadsCapability
 import com.riffle.core.catalog.OriginalCoverCapability
@@ -261,6 +262,7 @@ class LibraryItemDetailViewModel @Inject constructor(
     private val saveLocalFileMetadataOverride: SaveLocalFileMetadataOverrideUseCase,
     private val copyCoverImage: CopyCoverImageUseCase,
     private val readingSpeedStore: ReadingSpeedStore,
+    private val webSourceLibraryItemUpserter: WebSourceLibraryItemUpserter,
 ) : ViewModel() {
 
     private val itemId: String = savedStateHandle.get<String>("itemId") ?: ""
@@ -416,7 +418,15 @@ class LibraryItemDetailViewModel @Inject constructor(
             }
             val request = buildImportRequest(item.sourceId, sourceCatalog, sourceItem, library, item.readingProgress)
                 .copy(onProgress = onProgress, claimDestinationItem = claimItem)
-            destinationCatalog.importBook(request)
+            val result = destinationCatalog.importBook(request)
+            if (result is CatalogImportResult.Uploaded) {
+                // Mirror the uploaded item into Room under the destination source so the
+                // "Unowned" web-source filter sees it immediately — without waiting for the
+                // next full ABS library sync (which only runs against the active source).
+                val upsertId = result.destinationItemId ?: sourceItem.id
+                webSourceLibraryItemUpserter.upsert(destination.sourceId, sourceItem.copy(id = upsertId))
+            }
+            result
         }
         _uploadPreflight.value = UploadPreflight.Idle
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
@@ -222,6 +222,8 @@ private fun LibraryTabContent(
 ) {
     val items by viewModel.filteredItems.collectAsState()
     val notStartedFilterActive by viewModel.notStartedFilterActive.collectAsState()
+    val unownedFilterActive by viewModel.unownedFilterActive.collectAsState()
+    val hasServerSources by viewModel.hasServerSources.collectAsState()
     val facets by viewModel.facets.collectAsState()
     val selectedFacet by viewModel.selectedFacet.collectAsState()
     val query by viewModel.query.collectAsState()
@@ -262,6 +264,24 @@ private fun LibraryTabContent(
                         }
                     } else null,
                 )
+            }
+            if (hasServerSources) {
+                item {
+                    FilterChip(
+                        selected = unownedFilterActive,
+                        onClick = { viewModel.toggleUnownedFilter() },
+                        label = { Text("Unowned") },
+                        leadingIcon = if (unownedFilterActive) {
+                            {
+                                Icon(
+                                    Icons.Filled.Check,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(FilterChipDefaults.IconSize),
+                                )
+                            }
+                        } else null,
+                    )
+                }
             }
             if (facets.isNotEmpty()) {
                 item {

--- a/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
@@ -199,6 +199,8 @@ private fun LibraryTabContent(
 ) {
     val items by viewModel.filteredItems.collectAsState()
     val notStartedFilterActive by viewModel.notStartedFilterActive.collectAsState()
+    val unownedFilterActive by viewModel.unownedFilterActive.collectAsState()
+    val hasServerSources by viewModel.hasServerSources.collectAsState()
     val facets by viewModel.facets.collectAsState()
     val selectedFacet by viewModel.selectedFacet.collectAsState()
     val query by viewModel.query.collectAsState()
@@ -241,6 +243,24 @@ private fun LibraryTabContent(
                         }
                     } else null,
                 )
+            }
+            if (hasServerSources) {
+                item {
+                    FilterChip(
+                        selected = unownedFilterActive,
+                        onClick = { viewModel.toggleUnownedFilter() },
+                        label = { Text("Unowned") },
+                        leadingIcon = if (unownedFilterActive) {
+                            {
+                                Icon(
+                                    Icons.Filled.Check,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(FilterChipDefaults.IconSize),
+                                )
+                            }
+                        } else null,
+                    )
+                }
             }
             if (topicFacets.isNotEmpty() || languageFacets.isNotEmpty()) {
                 item {

--- a/app/src/main/kotlin/com/riffle/app/feature/source/websource/OwnedItemMatcher.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/websource/OwnedItemMatcher.kt
@@ -148,9 +148,9 @@ private fun authorsOverlap(a: String, b: String): Boolean {
 
 private fun titlesSimilar(a: String, b: String): Boolean {
     if (a == b) return true
-    if (Math.abs(a.length - b.length) > 3) return false
+    if (kotlin.math.abs(a.length - b.length) > 3) return false
     val maxLen = maxOf(a.length, b.length)
-    val threshold = minOf(3, Math.ceil(maxLen * 0.10).toInt())
+    val threshold = minOf(3, kotlin.math.ceil(maxLen * 0.10).toInt())
     return levenshtein(a, b) <= threshold
 }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/source/websource/OwnedItemMatcher.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/websource/OwnedItemMatcher.kt
@@ -1,0 +1,170 @@
+package com.riffle.app.feature.source.websource
+
+import com.riffle.core.catalog.CatalogItem
+import com.riffle.core.models.LibraryItem
+import java.text.Normalizer
+
+private const val SEP = "|||"
+
+/**
+ * Pre-built index of a user's server-source library items for the "Unowned" catalog filter.
+ *
+ * Matching strategies (applied in order, first hit wins):
+ *   1. ISBN — strongest signal; skips title matching entirely.
+ *   2. Exact title+author key — normalized, then O(1) lookup.
+ *   3. Title-only key — for ABS items stored without an author field.
+ *   4. Fuzzy-author — exact normalized title, but spaceless+containment author overlap.
+ *      Handles ABS items where the author field concatenates role prefix with no spaces
+ *      (e.g. "реж.ЛилянаТодорова ШарлПеро" vs candidate "Шарл Перо").
+ *   5. Prefix match — ABS title starts with candidate title + space (≥8 char guard).
+ *      Handles ABS items uploaded with extra metadata appended
+ *      (e.g. "Винету и Поразяващата ръка :К.Май :БалканТон").
+ *   6. Fuzzy title — Levenshtein ≤3 edits / 10% threshold, with author confirmation.
+ *      Handles OCR errors and minor Unicode spelling variations.
+ *
+ * Ported from https://github.com/pkmetski/chitanka-to-audiobookshelf/blob/main/lib/abs/matching.ts
+ */
+internal class OwnedItemIndex(
+    private val isbns: Set<String>,
+    private val exactKeys: Set<String>,
+    private val scanList: List<AbsEntry>,
+    // Normalized base titles extracted from ABS entries that have no author and use the
+    // " :Author :Publisher" suffix format (e.g. "Клан, клан-недоклан :НароднаПриказка :БалканТон").
+    // Stored separately so strategy 5b can do an O(1) lookup without touching series volumes.
+    private val titlesWithMeta: Set<String> = emptySet(),
+) {
+    internal data class AbsEntry(val normTitle: String, val normAuthor: String)
+
+    fun isOwned(item: CatalogItem): Boolean {
+        // 1. ISBN
+        val normIsbn = item.isbn?.normalizeIsbn()
+        if (!normIsbn.isNullOrEmpty() && normIsbn in isbns) return true
+
+        val normTitle = normalizeTitle(item.title)
+        if (normTitle.length < 3) return false
+        val normAuthor = normalizeTitle(item.author)
+
+        // 2. Exact combined key
+        if (normAuthor.isNotEmpty() && "$normTitle$SEP$normAuthor" in exactKeys) return true
+
+        // 3. Title-only key
+        if (normTitle in exactKeys) return true
+
+        if (scanList.isEmpty()) return false
+
+        // 4. Fuzzy-author: exact title, spaceless/containment author overlap
+        if (normAuthor.isNotEmpty()) {
+            for (entry in scanList) {
+                if (entry.normTitle == normTitle && authorsOverlap(normAuthor, entry.normAuthor)) return true
+            }
+        }
+
+        // 5. Prefix: ABS title starts with candidate title + space (≥8 chars, author required)
+        if (normTitle.length >= 8 && normAuthor.isNotEmpty()) {
+            val prefix = "$normTitle "
+            for (entry in scanList) {
+                if (entry.normTitle.startsWith(prefix) && authorsOverlap(normAuthor, entry.normAuthor)) return true
+            }
+        }
+
+        // 5b. Title-only metadata prefix — ABS stored with " :Author :Publisher" appended to the
+        //     title and no separate author field. `titlesWithMeta` was built from the raw title
+        //     (" :" guard), so series volumes ("Title Книга 7") are never included.
+        if (normTitle.length >= 8 && normTitle in titlesWithMeta) return true
+
+        // 6. Fuzzy title: Levenshtein ≤3 / 10%, author confirmation required
+        if (normAuthor.isNotEmpty()) {
+            for (entry in scanList) {
+                if (titlesSimilar(normTitle, entry.normTitle) && authorsOverlap(normAuthor, entry.normAuthor)) return true
+            }
+        }
+
+        return false
+    }
+}
+
+internal fun buildOwnedItemIndex(items: List<LibraryItem>): OwnedItemIndex {
+    val isbns = mutableSetOf<String>()
+    val exactKeys = mutableSetOf<String>()
+    val scanList = mutableListOf<OwnedItemIndex.AbsEntry>()
+    val titlesWithMeta = mutableSetOf<String>()
+
+    for (item in items) {
+        val normIsbn = item.isbn?.normalizeIsbn()
+        if (!normIsbn.isNullOrEmpty()) isbns.add(normIsbn)
+
+        val normTitle = normalizeTitle(item.title)
+        if (normTitle.isEmpty()) continue
+        val normAuthor = normalizeTitle(item.author)
+
+        if (normAuthor.isEmpty()) {
+            exactKeys.add(normTitle)
+            // If the raw title uses " :Metadata" suffix (chitanka-to-abs upload format), index
+            // the normalized base title so strategy 5b can match without a prefix scan.
+            if (item.title.contains(" :")) {
+                val baseNorm = normalizeTitle(item.title.substringBefore(" :"))
+                if (baseNorm.isNotEmpty()) titlesWithMeta.add(baseNorm)
+            }
+        } else {
+            exactKeys.add("$normTitle$SEP$normAuthor")
+        }
+        scanList.add(OwnedItemIndex.AbsEntry(normTitle, normAuthor))
+    }
+
+    return OwnedItemIndex(isbns, exactKeys, scanList, titlesWithMeta)
+}
+
+internal fun normalizeTitle(s: String): String =
+    Normalizer.normalize(s, Normalizer.Form.NFD)
+        .replace(Regex("[\\u0300-\\u036f]"), "")
+        .replace(Regex("[-–—]"), " ")
+        .replace(Regex("[^\\p{L}\\p{N}\\s]"), "")
+        .lowercase()
+        .replace(Regex("\\s+"), " ")
+        .trim()
+
+private fun String.normalizeIsbn(): String = filter { it.isLetterOrDigit() }.lowercase()
+
+private fun spaceless(s: String): String = s.replace(Regex("\\s+"), "")
+
+private fun authorsOverlap(a: String, b: String): Boolean {
+    if (a == b) return true
+    val sa = spaceless(a)
+    val sb = spaceless(b)
+    if (sa == sb) return true
+    if (sa.length >= 4 && sb.contains(sa)) return true
+    if (sb.length >= 4 && sa.contains(sb)) return true
+    // Gramofonche emits "Author, реж. Director"; the chitanka-to-abs upload script stores
+    // "реж.Director Author" (role prefix first, no spaces). The full spaceless strings land in
+    // different order so containment fails. Extract just the author token (part before " реж")
+    // from each and retry — title equality is already confirmed by the caller, so the 4-char
+    // author prefix check is sufficient to avoid false positives.
+    val aAuthor = spaceless(a.substringBefore(" реж").trim())
+    if (aAuthor.length >= 4 && sb.contains(aAuthor)) return true
+    val bAuthor = spaceless(b.substringBefore(" реж").trim())
+    if (bAuthor.length >= 4 && sa.contains(bAuthor)) return true
+    return false
+}
+
+private fun titlesSimilar(a: String, b: String): Boolean {
+    if (a == b) return true
+    if (Math.abs(a.length - b.length) > 3) return false
+    val maxLen = maxOf(a.length, b.length)
+    val threshold = minOf(3, Math.ceil(maxLen * 0.10).toInt())
+    return levenshtein(a, b) <= threshold
+}
+
+private fun levenshtein(a: String, b: String): Int {
+    val m = a.length
+    val n = b.length
+    val dp = Array(m + 1) { IntArray(n + 1) }
+    for (i in 0..m) dp[i][0] = i
+    for (j in 0..n) dp[0][j] = j
+    for (i in 1..m) {
+        for (j in 1..n) {
+            dp[i][j] = if (a[i - 1] == b[j - 1]) dp[i - 1][j - 1]
+            else 1 + minOf(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])
+        }
+    }
+    return dp[m][n]
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
@@ -16,6 +16,7 @@ import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
@@ -28,6 +29,8 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -138,6 +141,36 @@ abstract class UnboundedBrowseViewModel(
         persistNotStartedFilter(active)
     }
 
+    private val _unownedFilterActive = MutableStateFlow(false)
+    val unownedFilterActive: StateFlow<Boolean> = _unownedFilterActive.asStateFlow()
+
+    fun toggleUnownedFilter() {
+        val active = !_unownedFilterActive.value
+        _unownedFilterActive.value = active
+        persistUnownedFilter(active)
+    }
+
+    /** True when at least one non-web source (e.g. ABS) is configured. Controls chip visibility. */
+    val hasServerSources: StateFlow<Boolean> =
+        sourceRepository.observeAll()
+            .map { sources -> sources.any { !it.type.isWebSource } }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    // Ownership index built from all configured server-source libraries. Used by the "Unowned"
+    // filter to exclude items the user already has on their ABS/Komga server.
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val ownedItemIndex: StateFlow<OwnedItemIndex> =
+        sourceRepository.observeAll()
+            .map { sources -> sources.filter { !it.type.isWebSource }.map { it.id } }
+            .flatMapLatest { serverSourceIds ->
+                if (serverSourceIds.isEmpty()) return@flatMapLatest flowOf(buildOwnedItemIndex(emptyList()))
+                val perSourceFlows = serverSourceIds.map { sourceId ->
+                    libraryObserver.observeAllItemsForSource(sourceId)
+                }
+                combine(perSourceFlows) { arrays -> buildOwnedItemIndex(arrays.flatMap { it }) }
+            }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, buildOwnedItemIndex(emptyList()))
+
     // Local progress for Room-backed web-source items. Items absent from Room have no progress
     // and are treated as not-started by the filter.
     private val localReadingProgressByItemId: StateFlow<Map<String, Float>> =
@@ -146,13 +179,20 @@ abstract class UnboundedBrowseViewModel(
             .stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
 
     val filteredItems: StateFlow<List<CatalogItem>> =
-        combine(_items, localReadingProgressByItemId, _notStartedFilterActive) { catalog, progressById, active ->
+        combine(
+            _items,
+            localReadingProgressByItemId,
+            _notStartedFilterActive,
+            ownedItemIndex,
+            _unownedFilterActive,
+        ) { catalog, progressById, notStartedActive, index, unownedActive ->
             catalog
                 .map { item ->
                     val localProgress = progressById[item.id]
                     if (localProgress == null) item else item.copy(readingProgress = localProgress)
                 }
-                .filter { item -> !active || (item.readingProgress ?: 0f) <= 0f }
+                .filter { item -> !notStartedActive || (item.readingProgress ?: 0f) <= 0f }
+                .filter { item -> !unownedActive || !index.isOwned(item) }
         }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     private val _isLoading = MutableStateFlow(false)
@@ -195,6 +235,7 @@ abstract class UnboundedBrowseViewModel(
                 _selectedFacet.value = prefs.selectedFacetKey
                 savedStateHandle["facetKey"] = prefs.selectedFacetKey
                 _notStartedFilterActive.value = prefs.notStartedFilterActive
+                _unownedFilterActive.value = prefs.unownedFilterActive
             }
             loadFacets()
             refresh()
@@ -233,6 +274,13 @@ abstract class UnboundedBrowseViewModel(
         val sourceId = libraryFilterSourceId ?: return
         viewModelScope.launch {
             libraryFilterPreferencesStore.setNotStartedFilterActive(sourceId, rootId, active)
+        }
+    }
+
+    private fun persistUnownedFilter(active: Boolean) {
+        val sourceId = libraryFilterSourceId ?: return
+        viewModelScope.launch {
+            libraryFilterPreferencesStore.setUnownedFilterActive(sourceId, rootId, active)
         }
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -30,6 +30,10 @@ import com.riffle.core.models.Source
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceUrl
 import com.riffle.core.models.ProgressSyncCycleResult
+import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
+import com.riffle.core.database.LibraryItemDao
+import com.riffle.core.database.LibraryItemEntity
+import com.riffle.core.database.LibraryItemMetadata
 import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.domain.StoredItemRef
 import com.riffle.core.models.SessionPayload
@@ -350,6 +354,7 @@ class LibraryItemDetailViewModelTest {
         libraryRefresher: com.riffle.core.domain.LibraryRefresher = com.riffle.app.testing.NoopLibraryRefresher,
         saveOverride: com.riffle.core.data.localfiles.SaveLocalFileMetadataOverrideUseCase = com.riffle.app.testing.noopSaveLocalFileMetadataOverride(),
         copyCoverImageFn: com.riffle.core.data.localfiles.CopyCoverImageUseCase = com.riffle.app.testing.noopCopyCoverImage(),
+        webSourceLibraryItemUpserter: WebSourceLibraryItemUpserter = WebSourceLibraryItemUpserter(NoopLibraryItemDao),
         sourceId: String? = null,
     ) = LibraryItemDetailViewModel(
         savedStateHandle = SavedStateHandle(
@@ -401,6 +406,7 @@ class LibraryItemDetailViewModelTest {
             override val speedSecPerPosition = flowOf(63.0)
             override suspend fun updateSpeed(newSecPerPosition: Double) = Unit
         },
+        webSourceLibraryItemUpserter = webSourceLibraryItemUpserter,
     )
 
     // These tests exercise ViewModel state and side-effects; none read Ready.capabilities.
@@ -1568,4 +1574,149 @@ class LibraryItemDetailViewModelTest {
             override suspend fun forSource(source: com.riffle.core.models.Source): com.riffle.core.catalog.Catalog = catalog
             override suspend fun forSourceId(sourceId: String): com.riffle.core.catalog.Catalog = catalog
         }
+
+    // ── importToDestination upsert regression ────────────────────────────────────────────────────
+
+    @Test
+    fun `importToDestination upserts uploaded item into Room under destination sourceId`() = runTest {
+        val destinationSourceId = "abs-source-1"
+        val absItemId = "abs-item-123"
+        val dao = RecordingLibraryItemDao()
+
+        val sourceCatalogItem = com.riffle.core.catalog.CatalogItem(
+            id = knownItem.id,
+            rootId = "chitanka-root",
+            title = knownItem.title,
+            author = knownItem.author,
+            coverUrl = null,
+            ebookFormat = com.riffle.core.catalog.BookFormat.Epub,
+        )
+        val sourceCatalog = object : com.riffle.core.catalog.Catalog by NoopCatalog {
+            override suspend fun getItem(itemId: String) = sourceCatalogItem
+        }
+        val importCatalog = object : com.riffle.core.catalog.Catalog by NoopCatalog,
+            com.riffle.core.catalog.BookImportCapability {
+            override suspend fun importBook(request: com.riffle.core.catalog.CatalogImportRequest) =
+                com.riffle.core.catalog.CatalogImportResult.Uploaded(destinationItemId = absItemId)
+            override suspend fun listRoots() = listOf(
+                com.riffle.core.catalog.CatalogRoot(id = "lib-abs", name = "ABS Library", mediaType = "book", importFolderId = "folder-1")
+            )
+        }
+        val registry = object : com.riffle.core.catalog.CatalogRegistry {
+            override suspend fun forActive() = sourceCatalog
+            override suspend fun forSource(source: com.riffle.core.models.Source) = sourceCatalog
+            override suspend fun forSourceId(sourceId: String) =
+                if (sourceId == destinationSourceId) importCatalog else sourceCatalog
+        }
+
+        val vm = makeVm(
+            repo = fakeRepo(knownItem),
+            catalogRegistryOverride = registry,
+            webSourceLibraryItemUpserter = WebSourceLibraryItemUpserter(dao),
+        )
+        backgroundScope.launch { vm.uiState.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val destination = UploadDestination(sourceId = destinationSourceId, label = "ABS", username = "test", libraries = emptyList())
+        val library = com.riffle.core.catalog.CatalogRoot(
+            id = "lib-abs",
+            name = "ABS Library",
+            mediaType = "book",
+            importFolderId = "folder-1",
+        )
+        vm.importToDestination(destination, library)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // The uploaded item must appear in Room under the ABS sourceId with the ABS item ID so the
+        // "Unowned" filter can see it without waiting for the next full ABS library sync.
+        val upserted = dao.insertedItems.firstOrNull { it.sourceId == destinationSourceId }
+        assertTrue("Item was not upserted under destination sourceId", upserted != null)
+        assertEquals(absItemId, upserted!!.id)
+        assertEquals(knownItem.title, upserted.title)
+    }
+
+    @Test
+    fun `importToDestination falls back to source item id when destinationItemId is null`() = runTest {
+        val destinationSourceId = "abs-source-1"
+        val dao = RecordingLibraryItemDao()
+
+        val sourceCatalogItem = com.riffle.core.catalog.CatalogItem(
+            id = knownItem.id,
+            rootId = "chitanka-root",
+            title = knownItem.title,
+            author = knownItem.author,
+            coverUrl = null,
+            ebookFormat = com.riffle.core.catalog.BookFormat.Epub,
+        )
+        val sourceCatalog = object : com.riffle.core.catalog.Catalog by NoopCatalog {
+            override suspend fun getItem(itemId: String) = sourceCatalogItem
+        }
+        val importCatalog = object : com.riffle.core.catalog.Catalog by NoopCatalog,
+            com.riffle.core.catalog.BookImportCapability {
+            override suspend fun importBook(request: com.riffle.core.catalog.CatalogImportRequest) =
+                com.riffle.core.catalog.CatalogImportResult.Uploaded(destinationItemId = null)
+        }
+        val registry = object : com.riffle.core.catalog.CatalogRegistry {
+            override suspend fun forActive() = sourceCatalog
+            override suspend fun forSource(source: com.riffle.core.models.Source) = sourceCatalog
+            override suspend fun forSourceId(sourceId: String) =
+                if (sourceId == destinationSourceId) importCatalog else sourceCatalog
+        }
+
+        val vm = makeVm(
+            repo = fakeRepo(knownItem),
+            catalogRegistryOverride = registry,
+            webSourceLibraryItemUpserter = WebSourceLibraryItemUpserter(dao),
+        )
+        backgroundScope.launch { vm.uiState.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val destination = UploadDestination(sourceId = destinationSourceId, label = "ABS", username = "test", libraries = emptyList())
+        val library = com.riffle.core.catalog.CatalogRoot(
+            id = "lib-abs",
+            name = "ABS Library",
+            mediaType = "book",
+            importFolderId = "folder-1",
+        )
+        vm.importToDestination(destination, library)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val upserted = dao.insertedItems.firstOrNull { it.sourceId == destinationSourceId }
+        assertTrue("Item was not upserted under destination sourceId", upserted != null)
+        assertEquals(knownItem.id, upserted!!.id)
+    }
+
+    private object NoopLibraryItemDao : LibraryItemDao {
+        override fun observeByLibraryId(sourceId: String, libraryId: String) = flowOf(emptyList<LibraryItemEntity>())
+        override suspend fun listByLibraryId(sourceId: String, libraryId: String) = emptyList<LibraryItemEntity>()
+        override fun observeBySource(sourceId: String) = flowOf(emptyList<LibraryItemEntity>())
+        override fun observeUngroupedByLibraryId(sourceId: String, libraryId: String) = flowOf(emptyList<LibraryItemEntity>())
+        override suspend fun upsertAll(items: List<LibraryItemEntity>) = Unit
+        override suspend fun insertOrIgnore(items: List<LibraryItemEntity>) = Unit
+        override suspend fun updateMetadata(metadata: LibraryItemMetadata) = Unit
+        override suspend fun deleteByIds(sourceId: String, itemIds: List<String>) = Unit
+        override suspend fun idsForLibrary(sourceId: String, libraryId: String) = emptyList<String>()
+        override suspend fun getById(sourceId: String, itemId: String): LibraryItemEntity? = null
+        override suspend fun listByIds(sourceId: String, itemIds: List<String>) = emptyList<LibraryItemEntity>()
+        override fun observeById(sourceId: String, itemId: String) = flowOf<LibraryItemEntity?>(null)
+        override suspend fun findSourceIdForItem(itemId: String): String? = null
+        override suspend fun deleteByLibraryId(sourceId: String, libraryId: String) = Unit
+        override suspend fun deleteById(sourceId: String, itemId: String) = Unit
+        override fun observeInProgress(sourceId: String, libraryId: String) = flowOf(emptyList<LibraryItemEntity>())
+        override fun observeFinished(sourceId: String, libraryId: String) = flowOf(emptyList<LibraryItemEntity>())
+        override fun observeRecentlyAdded(sourceId: String, libraryId: String) = flowOf(emptyList<LibraryItemEntity>())
+        override fun observeAllBooks(sourceId: String, libraryId: String) = flowOf(emptyList<LibraryItemEntity>())
+        override suspend fun updateLastOpenedAt(sourceId: String, itemId: String, timestamp: Long) = Unit
+        override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) = Unit
+        override suspend fun updateLibraryId(sourceId: String, itemId: String, libraryId: String) = Unit
+        override suspend fun updateFinishedAt(sourceId: String, itemId: String, finishedAt: Long?) = Unit
+        override suspend fun getLastOpenedAtMap(sourceId: String, libraryId: String) = emptyList<com.riffle.core.database.LastOpenedAtRow>()
+        override suspend fun getReadingProgressMap(sourceId: String, libraryId: String) = emptyList<com.riffle.core.database.ReadingProgressRow>()
+        override suspend fun listMatchableBySourceType(serverType: String) = emptyList<com.riffle.core.database.MatchableItemRow>()
+    }
+
+    private class RecordingLibraryItemDao : LibraryItemDao by NoopLibraryItemDao {
+        val insertedItems = mutableListOf<LibraryItemEntity>()
+        override suspend fun insertOrIgnore(items: List<LibraryItemEntity>) { insertedItems += items }
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
@@ -16,6 +16,7 @@ import com.riffle.core.domain.ReadingSessionRepository
 import com.riffle.core.models.Series
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.TocEntry
+import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -200,6 +201,7 @@ class LibraryItemDetailViewModelTocTest {
         saveLocalFileMetadataOverride = com.riffle.app.testing.noopSaveLocalFileMetadataOverride(),
         copyCoverImage = com.riffle.app.testing.noopCopyCoverImage(),
         readingSpeedStore = readingSpeedStore,
+        webSourceLibraryItemUpserter = WebSourceLibraryItemUpserter(mockk(relaxed = true)),
     )
 
     private val epubItem = LibraryItem(

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -201,6 +201,12 @@ class LibraryItemsViewModelTest {
             }
         }
 
+        override suspend fun setUnownedFilterActive(sourceId: String, libraryId: String, active: Boolean) {
+            state.update {
+                it + ((sourceId to libraryId) to ((it[sourceId to libraryId] ?: LibraryFilterPreferences()).copy(unownedFilterActive = active)))
+            }
+        }
+
         override suspend fun setSortModeName(sourceId: String, libraryId: String, name: String?) {
             sortWrites += Triple(sourceId, libraryId, name)
             state.update {

--- a/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
@@ -76,6 +76,7 @@ class ChitankaBrowseViewModelTest {
         libraryFilterPreferencesStore: LibraryFilterPreferencesStore = FakeLibraryFilterPreferencesStore(),
         libraryObserver: LibraryObserver = emptyLibraryObserver(),
         catalog: Catalog = mockk<Catalog>(relaxed = true).also {
+
             // Relaxed mocks return a stub CatalogItem instead of null for `getItem`, which breaks
             // the openDetail enrichment fallback in tests that don't explicitly stub it. Pin to
             // null so the fallback lands on the listing item as it does at runtime for legacy
@@ -391,8 +392,11 @@ class ChitankaBrowseViewModelTest {
 
     // ---- helpers -----------------------------------------------------------------
 
-    private fun fakeSourceRepo(active: Source?): SourceRepository = object : SourceRepository {
-        override fun observeAll() = kotlinx.coroutines.flow.flowOf(listOfNotNull(active))
+    private fun fakeSourceRepo(
+        active: Source?,
+        allSources: List<Source> = listOfNotNull(active),
+    ): SourceRepository = object : SourceRepository {
+        override fun observeAll() = kotlinx.coroutines.flow.flowOf(allSources)
         override suspend fun getActive(): Source? = active
         override suspend fun commit(
             pending: com.riffle.core.domain.PendingSource,
@@ -561,6 +565,140 @@ class ChitankaBrowseViewModelTest {
             )
         }
 
+    // ─── Unowned filter ──────────────────────────────────────────────────────────────────────────
+
+    private val absSource = chitankaSource.copy(id = "abs-1", type = SourceType.ABS)
+
+    @Test
+    fun `hasServerSources is false when only web source is configured`() = runTest(dispatcher) {
+        val vm = makeVm(sourceRepo = fakeSourceRepo(active = chitankaSource))
+        advanceUntilIdle()
+        assertFalse(vm.hasServerSources.value)
+    }
+
+    @Test
+    fun `hasServerSources is true when an ABS source is also configured`() = runTest(dispatcher) {
+        val vm = makeVm(
+            sourceRepo = fakeSourceRepo(active = chitankaSource, allSources = listOf(chitankaSource, absSource)),
+        )
+        advanceUntilIdle()
+        assertTrue(vm.hasServerSources.value)
+    }
+
+    @Test
+    fun `toggleUnownedFilter hides catalog items that match server library by title+author`() =
+        runTest(dispatcher) {
+            val serverItem = serverLibraryItem(title = "Dune", author = "Frank Herbert")
+            val serverItems = MutableStateFlow(listOf(serverItem))
+
+            val catalog = mockk<Catalog>(relaxed = true)
+            coEvery { catalog.browse(rootId = any(), page = 0, pageSize = any(), facet = any()) } returns
+                listOf(item("cat-1").copy(title = "Dune", author = "Frank Herbert"), item("cat-2"))
+
+            val vm = makeVm(
+                catalog = catalog,
+                sourceRepo = fakeSourceRepo(active = chitankaSource, allSources = listOf(chitankaSource, absSource)),
+                libraryObserver = FakeLibraryObserver(serverSourceItemsFlow = serverItems),
+            )
+            advanceUntilIdle()
+
+            assertEquals(2, vm.filteredItems.value.size)
+            assertFalse(vm.unownedFilterActive.value)
+
+            vm.toggleUnownedFilter()
+            advanceUntilIdle()
+
+            assertTrue(vm.unownedFilterActive.value)
+            val ids = vm.filteredItems.value.map { it.id }
+            assertEquals(listOf("cat-2"), ids)
+        }
+
+    @Test
+    fun `toggleUnownedFilter hides catalog items that match server library by isbn`() =
+        runTest(dispatcher) {
+            val isbn = "9780441013593"
+            val serverItem = serverLibraryItem(title = "Dune", author = "Frank Herbert", isbn = isbn)
+            val serverItems = MutableStateFlow(listOf(serverItem))
+
+            val catalog = mockk<Catalog>(relaxed = true)
+            coEvery { catalog.browse(rootId = any(), page = 0, pageSize = any(), facet = any()) } returns
+                listOf(
+                    item("cat-1").copy(title = "Dune (Anniversary Edition)", author = "F. Herbert", isbn = isbn),
+                    item("cat-2"),
+                )
+
+            val vm = makeVm(
+                catalog = catalog,
+                sourceRepo = fakeSourceRepo(active = chitankaSource, allSources = listOf(chitankaSource, absSource)),
+                libraryObserver = FakeLibraryObserver(serverSourceItemsFlow = serverItems),
+            )
+            advanceUntilIdle()
+
+            vm.toggleUnownedFilter()
+            advanceUntilIdle()
+
+            val ids = vm.filteredItems.value.map { it.id }
+            assertEquals(listOf("cat-2"), ids)
+        }
+
+    @Test
+    fun `toggleUnownedFilter off restores all catalog items`() = runTest(dispatcher) {
+        val serverItem = serverLibraryItem(title = "Dune", author = "Frank Herbert")
+        val serverItems = MutableStateFlow(listOf(serverItem))
+
+        val catalog = mockk<Catalog>(relaxed = true)
+        coEvery { catalog.browse(rootId = any(), page = 0, pageSize = any(), facet = any()) } returns
+            listOf(item("cat-1").copy(title = "Dune", author = "Frank Herbert"), item("cat-2"))
+
+        val vm = makeVm(
+            catalog = catalog,
+            sourceRepo = fakeSourceRepo(active = chitankaSource, allSources = listOf(chitankaSource, absSource)),
+            libraryObserver = FakeLibraryObserver(serverSourceItemsFlow = serverItems),
+        )
+        advanceUntilIdle()
+
+        vm.toggleUnownedFilter()
+        advanceUntilIdle()
+        assertEquals(1, vm.filteredItems.value.size)
+
+        vm.toggleUnownedFilter()
+        advanceUntilIdle()
+
+        assertFalse(vm.unownedFilterActive.value)
+        assertEquals(2, vm.filteredItems.value.size)
+    }
+
+    @Test
+    fun `unownedFilter change persists via LibraryFilterPreferencesStore`() = runTest(dispatcher) {
+        val store = FakeLibraryFilterPreferencesStore()
+        val vm = makeVm(
+            libraryFilterPreferencesStore = store,
+            sourceRepo = fakeSourceRepo(active = chitankaSource, allSources = listOf(chitankaSource, absSource)),
+        )
+        advanceUntilIdle()
+
+        vm.toggleUnownedFilter()
+        advanceUntilIdle()
+
+        assertEquals(
+            LibraryFilterPreferences(unownedFilterActive = true),
+            store.state.value["chit-1" to ChitankaCatalog.ROOT_BOOKS],
+        )
+    }
+
+    @Test
+    fun `remembered unownedFilterActive is restored from preferences on init`() = runTest(dispatcher) {
+        val store = FakeLibraryFilterPreferencesStore(
+            mapOf(
+                ("chit-1" to ChitankaCatalog.ROOT_BOOKS) to LibraryFilterPreferences(unownedFilterActive = true),
+            ),
+        )
+        val vm = makeVm(libraryFilterPreferencesStore = store)
+        advanceUntilIdle()
+
+        assertTrue(vm.unownedFilterActive.value)
+    }
+
     // ---- filter helpers ----------------------------------------------------------
 
     private fun libraryItem(id: String, progress: Float) = LibraryItem(
@@ -573,6 +711,23 @@ class ChitankaBrowseViewModelTest {
         isCached = false,
         isDownloaded = false,
         ebookFormat = com.riffle.core.models.EbookFormat.Epub,
+    )
+
+    private fun serverLibraryItem(
+        title: String,
+        author: String,
+        isbn: String? = null,
+    ) = LibraryItem(
+        id = "server-${title.take(4)}",
+        libraryId = "abs-lib-1",
+        title = title,
+        author = author,
+        coverUrl = null,
+        readingProgress = 0f,
+        isCached = false,
+        isDownloaded = false,
+        ebookFormat = com.riffle.core.models.EbookFormat.Epub,
+        isbn = isbn,
     )
 
     private fun emptyLibraryObserver(): LibraryObserver = FakeLibraryObserver()
@@ -597,6 +752,12 @@ class ChitankaBrowseViewModelTest {
         override suspend fun setNotStartedFilterActive(sourceId: String, libraryId: String, active: Boolean) {
             state.update {
                 it + ((sourceId to libraryId) to ((it[sourceId to libraryId] ?: LibraryFilterPreferences()).copy(notStartedFilterActive = active)))
+            }
+        }
+
+        override suspend fun setUnownedFilterActive(sourceId: String, libraryId: String, active: Boolean) {
+            state.update {
+                it + ((sourceId to libraryId) to ((it[sourceId to libraryId] ?: LibraryFilterPreferences()).copy(unownedFilterActive = active)))
             }
         }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModelTest.kt
@@ -226,6 +226,12 @@ class GutenbergBrowseViewModelTest {
             }
         }
 
+        override suspend fun setUnownedFilterActive(sourceId: String, libraryId: String, active: Boolean) {
+            state.update {
+                it + ((sourceId to libraryId) to ((it[sourceId to libraryId] ?: LibraryFilterPreferences()).copy(unownedFilterActive = active)))
+            }
+        }
+
         override suspend fun setSortModeName(sourceId: String, libraryId: String, name: String?) {
             state.update {
                 it + ((sourceId to libraryId) to ((it[sourceId to libraryId] ?: LibraryFilterPreferences()).copy(sortModeName = name)))

--- a/app/src/test/kotlin/com/riffle/app/feature/source/websource/OwnedItemMatcherTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/websource/OwnedItemMatcherTest.kt
@@ -1,0 +1,277 @@
+package com.riffle.app.feature.source.websource
+
+import com.riffle.core.catalog.BookFormat
+import com.riffle.core.catalog.CatalogItem
+import com.riffle.core.models.EbookFormat
+import com.riffle.core.models.LibraryItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OwnedItemMatcherTest {
+
+    private fun serverItem(
+        title: String,
+        author: String = "",
+        isbn: String? = null,
+    ) = LibraryItem(
+        id = "server-${title.take(4)}",
+        libraryId = "lib-1",
+        title = title,
+        author = author,
+        coverUrl = null,
+        readingProgress = 0f,
+        isCached = false,
+        isDownloaded = false,
+        ebookFormat = EbookFormat.Epub,
+        isbn = isbn,
+    )
+
+    private fun catalogItem(
+        title: String,
+        author: String = "",
+        isbn: String? = null,
+    ) = CatalogItem(
+        id = "cat-${title.take(4)}",
+        rootId = "root",
+        title = title,
+        author = author,
+        coverUrl = null,
+        ebookFormat = BookFormat.Epub,
+        isbn = isbn,
+    )
+
+    private fun index(vararg items: LibraryItem) = buildOwnedItemIndex(items.toList())
+
+    // ─── normalizeTitle ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `normalizeTitle lowercases`() {
+        assertEquals("аладин", normalizeTitle("Аладин"))
+    }
+
+    @Test
+    fun `normalizeTitle replaces hyphens with spaces`() {
+        assertEquals("абу мързеливият", normalizeTitle("Абу-мързеливият"))
+    }
+
+    @Test
+    fun `normalizeTitle replaces en-dash and em-dash with spaces`() {
+        assertEquals("абу мързеливият", normalizeTitle("Абу–мързеливият"))
+        assertEquals("абу мързеливият", normalizeTitle("Абу—мързеливият"))
+    }
+
+    @Test
+    fun `normalizeTitle strips punctuation`() {
+        assertEquals("аладин и вълшебната лампа роман", normalizeTitle("Аладин и вълшебната лампа (роман)"))
+    }
+
+    @Test
+    fun `normalizeTitle collapses whitespace`() {
+        assertEquals("аладин и лампа", normalizeTitle("Аладин  и   лампа"))
+    }
+
+    // ─── Empty / trivial cases ───────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `empty index means nothing is owned`() {
+        val item = catalogItem("The Hobbit", "Tolkien")
+        assertFalse(index().isOwned(item))
+    }
+
+    // ─── Exact title+author ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `exact title+author match`() {
+        val idx = index(serverItem("Басни", "Лафонтен"))
+        assertTrue(idx.isOwned(catalogItem("Басни", "Лафонтен")))
+    }
+
+    @Test
+    fun `no false positive on same title different author`() {
+        val idx = index(serverItem("Басни", "Лафонтен"))
+        assertFalse(idx.isOwned(catalogItem("Басни", "Алберт Декало")))
+    }
+
+    // ─── Title-only fallback ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `title-only match when ABS item has no author`() {
+        val idx = index(serverItem("Аладин", ""))
+        assertTrue(idx.isOwned(catalogItem("Аладин", "Some Author")))
+    }
+
+    @Test
+    fun `title-only match when catalog item has no author`() {
+        val idx = index(serverItem("Аладин", ""))
+        assertTrue(idx.isOwned(catalogItem("Аладин", "")))
+    }
+
+    // ─── Hyphen normalisation ────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `hyphenated candidate matches space-separated ABS title`() {
+        val idx = index(serverItem("Абу мързеливият и хубавицата", "Шехерезада"))
+        assertTrue(idx.isOwned(catalogItem("Абу-мързеливият и хубавицата", "Шехерезада")))
+    }
+
+    @Test
+    fun `space-separated candidate matches hyphenated ABS title`() {
+        val idx = index(serverItem("Абу-мързеливият и хубавицата", "Шехерезада"))
+        assertTrue(idx.isOwned(catalogItem("Абу мързеливият и хубавицата", "Шехерезада")))
+    }
+
+    // ─── Fuzzy author (spaceless + containment) ──────────────────────────────────────────────────
+
+    @Test
+    fun `matches when ABS author has role prefix and no spaces`() {
+        val idx = index(serverItem("Котаракът в чизми", "реж.ЛилянаТодорова ШарлПеро"))
+        assertTrue(idx.isOwned(catalogItem("Котаракът в чизми", "Шарл Перо")))
+    }
+
+    @Test
+    fun `no false positive on completely unrelated authors`() {
+        val idx = index(serverItem("Котаракът в чизми", "реж.ЛилянаТодорова ШарлПеро"))
+        assertFalse(idx.isOwned(catalogItem("Котаракът в чизми", "Иван Вазов")))
+    }
+
+    // ─── Prefix matching ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `matches when ABS title has extra suffix metadata and authors agree`() {
+        val idx = index(serverItem("Винету и Поразяващата ръка :К.Май :БалканТон", "Карл Май"))
+        assertTrue(idx.isOwned(catalogItem("Винету и Поразяващата ръка", "Карл Май")))
+    }
+
+    @Test
+    fun `matches when ABS title has suffix and author is concatenated without spaces`() {
+        val idx = index(serverItem(
+            "Вълшебното камъче :АфриканскаПриказка,реж.В.Чачановски :БалканТон",
+            "реж.ВихрониЧачановски АфриканскаПриказка",
+        ))
+        assertTrue(idx.isOwned(catalogItem("Вълшебното камъче", "Африканска Приказка")))
+    }
+
+    @Test
+    fun `no prefix match for short candidate titles (under 8 chars)`() {
+        val idx = index(serverItem("Басни и разкази", "Лафонтен"))
+        assertFalse(idx.isOwned(catalogItem("Басни", "Лафонтен")))
+    }
+
+    @Test
+    fun `no prefix match when authors differ even if title prefix matches`() {
+        val idx = index(serverItem("Винету и Поразяващата ръка :К.Май :БалканТон", "Карл Май"))
+        assertFalse(idx.isOwned(catalogItem("Винету и Поразяващата ръка", "Иван Вазов")))
+    }
+
+    @Test
+    fun `matches when ABS title has suffix metadata and no author field (title-only prefix)`() {
+        // ABS upload stored "Клан, клан-недоклан :НароднаПриказка :БалканТон" with author=""
+        // Strategy 5 fails (authorsOverlap against "" rejects); strategy 5b should catch it.
+        val idx = index(serverItem("Клан, клан-недоклан :НароднаПриказка :БалканТон", ""))
+        assertTrue(idx.isOwned(catalogItem("Клан, клан-недоклан", "Народна Приказка")))
+    }
+
+    @Test
+    fun `no title-only prefix match for short candidate titles (under 8 chars)`() {
+        val idx = index(serverItem("Клан :НароднаПриказка :БалканТон", ""))
+        assertFalse(idx.isOwned(catalogItem("Клан", "Народна Приказка")))
+    }
+
+    // ─── Author order inversion (Gramofonche "Author, реж. Director" vs ABS "реж.Director Author") ─
+
+    @Test
+    fun `matches when candidate has Author+role and ABS has role+Director+Author concatenated`() {
+        // Gramofonche: "Братя Грим, реж. Мария Нанчева"
+        // ABS upload:  "реж.МарияНанчева БратяГрим"  (role prefix first, no inner spaces)
+        val idx = index(serverItem("Веселите градски музиканти", "реж.МарияНанчева БратяГрим"))
+        assertTrue(idx.isOwned(catalogItem("Веселите градски музиканти", "Братя Грим, реж. Мария Нанчева")))
+    }
+
+    @Test
+    fun `matches inverted order for Шехерезада author`() {
+        val idx = index(serverItem("Аладин и вълшебната лампа", "реж.МарияНанчева Шехерезада"))
+        assertTrue(idx.isOwned(catalogItem("Аладин и вълшебната лампа", "Шехерезада, реж. Мария Нанчева")))
+    }
+
+    @Test
+    fun `no false positive on inverted-order check — different author, same director`() {
+        val idx = index(serverItem("Аладин и вълшебната лампа", "реж.МарияНанчева Шехерезада"))
+        assertFalse(idx.isOwned(catalogItem("Аладин и вълшебната лампа", "Братя Грим, реж. Мария Нанчева")))
+    }
+
+    // ─── No false positives on partial title overlap ──────────────────────────────────────────────
+
+    @Test
+    fun `does NOT match series name against a specific volume in ABS (no author)`() {
+        val idx = index(serverItem("Приказните светове на Николай Райнов Книга 7", ""))
+        assertFalse(idx.isOwned(catalogItem("Приказните светове на Николай Райнов", "")))
+    }
+
+    @Test
+    fun `does NOT match specific volume against series name in ABS`() {
+        val idx = index(serverItem("Приказните светове на Николай Райнов", ""))
+        assertFalse(idx.isOwned(catalogItem("Приказните светове на Николай Райнов Книга 7", "")))
+    }
+
+    // ─── Fuzzy title ─────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `fuzzy title matches small spelling variation with author confirmation`() {
+        val idx = index(serverItem("Маруф обущарят", "Мария Нанчева"))
+        assertTrue(idx.isOwned(catalogItem("Маруф обушарт", "реж. Мария Нанчева")))
+    }
+
+    @Test
+    fun `fuzzy title no match when title difference is too large`() {
+        val idx = index(serverItem("Котаракът в чизми", "Шарл Перо"))
+        assertFalse(idx.isOwned(catalogItem("Аладин и вълшебната лампа", "Шарл Перо")))
+    }
+
+    @Test
+    fun `fuzzy title no match when authors do not overlap`() {
+        val idx = index(serverItem("Маруф обущарят", "Иван Вазов"))
+        assertFalse(idx.isOwned(catalogItem("Маруф обушарт", "реж. Мария Нанчева")))
+    }
+
+    // ─── ISBN ────────────────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `isbn match wins even when titles differ`() {
+        val isbn = "9780061120084"
+        val idx = index(serverItem("To Kill a Mockingbird", "Harper Lee", isbn = isbn))
+        assertTrue(idx.isOwned(catalogItem("To Kill a Mockingbird (50th Anniversary Edition)", "Lee, Harper", isbn = isbn)))
+    }
+
+    @Test
+    fun `isbn normalization strips hyphens and ignores case`() {
+        val idx = index(serverItem("Book", "Author", isbn = "978-0-06-112008-4"))
+        assertTrue(idx.isOwned(catalogItem("Book", "Author", isbn = "9780061120084")))
+    }
+
+    @Test
+    fun `isbn normalization handles uppercase X in isbn-10`() {
+        val idx = index(serverItem("Book", "Author", isbn = "0-674-83777-X"))
+        assertTrue(idx.isOwned(catalogItem("Book", "Author", isbn = "067483777x")))
+    }
+
+    @Test
+    fun `item with isbn falls back to title+author if isbn not in index`() {
+        val idx = index(serverItem("Dune", "Frank Herbert"))
+        assertTrue(idx.isOwned(catalogItem("Dune", "Frank Herbert", isbn = "9780441013593")))
+    }
+
+    // ─── Multiple items ───────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `multiple server items build combined index`() {
+        val idx = index(
+            serverItem("Dune", "Frank Herbert"),
+            serverItem("Foundation", "Isaac Asimov"),
+        )
+        assertTrue(idx.isOwned(catalogItem("Dune", "Frank Herbert")))
+        assertTrue(idx.isOwned(catalogItem("Foundation", "Isaac Asimov")))
+        assertFalse(idx.isOwned(catalogItem("Neuromancer", "William Gibson")))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/testing/LibraryObserverFakes.kt
+++ b/app/src/test/kotlin/com/riffle/app/testing/LibraryObserverFakes.kt
@@ -15,8 +15,10 @@ import kotlinx.coroutines.flow.flowOf
  */
 class FakeLibraryObserver(
     private val allBooksFlow: Flow<List<LibraryItem>> = flowOf(emptyList()),
+    private val serverSourceItemsFlow: Flow<List<LibraryItem>> = flowOf(emptyList()),
 ) : LibraryObserver {
     override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> = allBooksFlow
+    override fun observeAllItemsForSource(sourceId: String): Flow<List<LibraryItem>> = serverSourceItemsFlow
     override fun observeLibraries(): Flow<List<Library>> = flowOf(emptyList())
     override fun observeLibraries(sourceId: String): Flow<List<Library>> = flowOf(emptyList())
     override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryFilterPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryFilterPreferencesStoreImpl.kt
@@ -22,6 +22,7 @@ class LibraryFilterPreferencesStoreImpl @Inject constructor(
                 selectedFacetKey = prefs[facetKey(sourceId, libraryId)],
                 notStartedFilterActive = prefs[notStartedKey(sourceId, libraryId)] ?: false,
                 sortModeName = prefs[sortModeKey(sourceId, libraryId)],
+                unownedFilterActive = prefs[unownedKey(sourceId, libraryId)] ?: false,
             )
         }
 
@@ -38,6 +39,12 @@ class LibraryFilterPreferencesStoreImpl @Inject constructor(
         }
     }
 
+    override suspend fun setUnownedFilterActive(sourceId: String, libraryId: String, active: Boolean) {
+        dataStore.edit { prefs ->
+            prefs[unownedKey(sourceId, libraryId)] = active
+        }
+    }
+
     override suspend fun setSortModeName(sourceId: String, libraryId: String, name: String?) {
         dataStore.edit { prefs ->
             val prefKey = sortModeKey(sourceId, libraryId)
@@ -50,6 +57,9 @@ class LibraryFilterPreferencesStoreImpl @Inject constructor(
 
     private fun notStartedKey(sourceId: String, libraryId: String) =
         booleanPreferencesKey("library_filter:$sourceId:$libraryId:not_started")
+
+    private fun unownedKey(sourceId: String, libraryId: String) =
+        booleanPreferencesKey("library_filter:$sourceId:$libraryId:unowned")
 
     private fun sortModeKey(sourceId: String, libraryId: String) =
         stringPreferencesKey("library_filter:$sourceId:$libraryId:sort_mode")

--- a/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -104,6 +104,9 @@ class LibraryRepositoryImpl @Inject constructor(
     override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> =
         scopedItemFlow { sourceId -> libraryItemDao.observeAllBooks(sourceId, libraryId) }
 
+    override fun observeAllItemsForSource(sourceId: String): Flow<List<LibraryItem>> =
+        libraryItemDao.observeBySource(sourceId).map { list -> list.map { it.toDomain() } }
+
     override fun observeSeries(libraryId: String): Flow<List<Series>> =
         seriesDao.observeByLibraryId(libraryId).map { list -> list.map { it.toDomain() } }
 

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/LibraryFilterPreferencesStore.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/LibraryFilterPreferencesStore.kt
@@ -6,6 +6,7 @@ data class LibraryFilterPreferences(
     val selectedFacetKey: String? = null,
     val notStartedFilterActive: Boolean = false,
     val sortModeName: String? = null,
+    val unownedFilterActive: Boolean = false,
 )
 
 /**
@@ -18,5 +19,6 @@ interface LibraryFilterPreferencesStore {
     fun preferences(sourceId: String, libraryId: String): Flow<LibraryFilterPreferences>
     suspend fun setSelectedFacetKey(sourceId: String, libraryId: String, key: String?)
     suspend fun setNotStartedFilterActive(sourceId: String, libraryId: String, active: Boolean)
+    suspend fun setUnownedFilterActive(sourceId: String, libraryId: String, active: Boolean)
     suspend fun setSortModeName(sourceId: String, libraryId: String, name: String?)
 }

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/LibraryRepository.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/LibraryRepository.kt
@@ -1,6 +1,7 @@
 package com.riffle.core.domain
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import com.riffle.core.models.Collection
 import com.riffle.core.models.Library
 import com.riffle.core.models.LibraryItem
@@ -29,6 +30,10 @@ interface LibraryObserver {
     fun observeFinishedItems(libraryId: String): Flow<List<LibraryItem>>
     fun observeRecentlyAddedItems(libraryId: String): Flow<List<LibraryItem>>
     fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>>
+
+    /** All items owned by a specific Source, across every library. Used to check ownership
+     *  across server sources when filtering web-source catalogs. */
+    fun observeAllItemsForSource(sourceId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
     fun observeSeries(libraryId: String): Flow<List<Series>>
     fun observeCollections(libraryId: String): Flow<List<Collection>>
     fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>>


### PR DESCRIPTION
Add a persistent **Unowned** filter chip to Chitanka and Gramofonche browse screens. When active, it hides catalog items the user already has on their ABS/Komga server — so the list focuses on what's still worth importing.

## What changed

### Filter chip UI
- `ChitankaBrowseScreen` / `GutenbergBrowseScreen` — render `FilterChip` with a checkmark icon only when at least one non-web source is configured (`hasServerSources`).

### Ownership matching (`OwnedItemMatcher`)
Multi-strategy index built from server-source Room items (ISBN → exact key → title-only → fuzzy author → prefix → Levenshtein). Handles all Chitanka-to-ABS upload script variants:
- Spaceless author concatenation (`"реж.ЛилянаТодорова ШарлПеро"` → candidate `"Шарл Перо"`)
- Role-prefix order inversion (`"Author, реж. Director"` vs `"реж.Director Author"`)
- `" :Author :Publisher"` suffix with empty author field (`titlesWithMeta` O(1) lookup, guarded by the raw `" :"` marker so series volumes are excluded)

### ViewModel (`UnboundedBrowseViewModel`)
- `ownedItemIndex` — built eagerly from all server-source items via `flatMapLatest`; auto-updates on Room changes and on lazy page loads.
- `hasServerSources` — drives chip visibility.
- `filteredItems` — extended `combine` to incorporate `ownedItemIndex` and `_unownedFilterActive`.
- Preference persisted in DataStore via `setUnownedFilterActive`.

### Import-to-Room mirror (`LibraryItemDetailViewModel`)
After a successful ABS upload (`CatalogImportResult.Uploaded`), the imported item is immediately upserted into Room under the destination `sourceId` — so the filter reflects the import without waiting for the next full ABS library sync.

### Domain / data layer
- `LibraryFilterPreferences.unownedFilterActive` + `LibraryFilterPreferencesStore.setUnownedFilterActive`
- `LibraryObserver.observeAllItemsForSource` (default `flowOf(emptyList())` on the interface for fakes)
- `LibraryRepositoryImpl.observeAllItemsForSource` via `libraryItemDao.observeBySource`

## Tests
- `OwnedItemMatcherTest` — 35 unit tests covering all matcher strategies and false-positive guards.
- `ChitankaBrowseViewModelTest` — filter on/off, ISBN match, author-mismatch, preference persistence, init restore from preferences, `hasServerSources` toggling.
- `LibraryItemDetailViewModelTest` — upsert-on-upload (with `destinationItemId` present and null).