### PR TITLE
fix(readaloud): swallow FK constraint when source deleted mid-reconcile

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
@@ -13,6 +13,9 @@ import com.riffle.core.domain.MatchOutcome
 import com.riffle.core.domain.MatchableAbsItem
 import com.riffle.core.domain.MatchableStorytellerBook
 import com.riffle.core.domain.ReadaloudMatcher
+import com.riffle.core.logging.LogChannel
+import com.riffle.core.logging.Logger
+import com.riffle.core.logging.NoopLogger
 import com.riffle.core.models.ServerType
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -41,13 +44,15 @@ open class ReadaloudMatchingService(
     private val readaloudCandidateDao: ReadaloudCandidateDao,
     private val readaloudDismissalDao: ReadaloudDismissalDao,
     private val clock: () -> Long = System::currentTimeMillis,
+    private val logger: Logger = NoopLogger,
 ) : com.riffle.core.domain.ReadaloudLinkReconciler {
     @Inject constructor(
         libraryItemDao: LibraryItemDao,
         readaloudLinkDao: ReadaloudLinkDao,
         readaloudCandidateDao: ReadaloudCandidateDao,
         readaloudDismissalDao: ReadaloudDismissalDao,
-    ) : this(libraryItemDao, readaloudLinkDao, readaloudCandidateDao, readaloudDismissalDao, System::currentTimeMillis)
+        logger: Logger,
+    ) : this(libraryItemDao, readaloudLinkDao, readaloudCandidateDao, readaloudDismissalDao, System::currentTimeMillis, logger)
 
     override suspend fun reconcileLinks() {
         val storytellerBooks = libraryItemDao.listMatchableBySourceType(ServerType.STORYTELLER_SERVICE.name)
@@ -100,7 +105,7 @@ open class ReadaloudMatchingService(
                             return@forEach
                         }
                         // Either source may be concurrently deleted (race with source removal
-                        // in RefreshLibraryItems background scope). Skip silently — the next
+                        // in RefreshLibraryItems background scope). Log and skip — the next
                         // reconcile won't include the deleted source's books.
                         try {
                             readaloudLinkDao.upsert(
@@ -115,10 +120,13 @@ open class ReadaloudMatchingService(
                                     updatedAt = now,
                                 )
                             )
-                        } catch (_: SQLiteConstraintException) {
-                            return@forEach
+                            freshAutoSlots += slot
+                        } catch (e: SQLiteConstraintException) {
+                            logger.w(LogChannel.Readaloud, e) {
+                                "reconcileLinks upsert skipped — constraint violation for " +
+                                    "storytellerSourceId=${book.sourceId} absSourceId=${match.absServerUuid}"
+                            }
                         }
-                        freshAutoSlots += slot
                     }
 
                     is MatchOutcome.PendingReview -> {

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
@@ -1,5 +1,6 @@
 package com.riffle.core.data
 
+import android.database.sqlite.SQLiteConstraintException
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.MatchableItemRow
 import com.riffle.core.database.ReadaloudCandidateDao
@@ -98,18 +99,25 @@ open class ReadaloudMatchingService(
                             }
                             return@forEach
                         }
-                        readaloudLinkDao.upsert(
-                            ReadaloudLinkEntity(
-                                absSourceId = match.absServerUuid,
-                                absLibraryItemId = match.absLibraryItemId,
-                                storytellerSourceId = book.sourceId,
-                                storytellerBookId = book.itemId,
-                                state = ReadaloudLinkEntity.STATE_CONFIRMED,
-                                userConfirmed = false,
-                                createdAt = existing?.createdAt ?: now,
-                                updatedAt = now,
+                        // Either source may be concurrently deleted (race with source removal
+                        // in RefreshLibraryItems background scope). Skip silently — the next
+                        // reconcile won't include the deleted source's books.
+                        try {
+                            readaloudLinkDao.upsert(
+                                ReadaloudLinkEntity(
+                                    absSourceId = match.absServerUuid,
+                                    absLibraryItemId = match.absLibraryItemId,
+                                    storytellerSourceId = book.sourceId,
+                                    storytellerBookId = book.itemId,
+                                    state = ReadaloudLinkEntity.STATE_CONFIRMED,
+                                    userConfirmed = false,
+                                    createdAt = existing?.createdAt ?: now,
+                                    updatedAt = now,
+                                )
                             )
-                        )
+                        } catch (_: SQLiteConstraintException) {
+                            return@forEach
+                        }
                         freshAutoSlots += slot
                     }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -1,5 +1,6 @@
 package com.riffle.core.data
 
+import android.database.sqlite.SQLiteConstraintException
 import com.riffle.core.database.LastOpenedAtRow
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.LibraryItemEntity
@@ -309,6 +310,24 @@ class ReadaloudMatchingServiceTest {
     }
 
     @Test
+    fun `FK constraint on upsert is silently swallowed — source deleted mid-reconcile does not crash`() = runTest {
+        // Regression: reconcileLinks() fires on applicationScope and can race with source
+        // deletion. If the source is deleted between the listMatchable read and the upsert,
+        // Room throws SQLiteConstraintException (FK violation). The reconcile must complete
+        // normally; the stale link will simply not be written.
+        val items = StubLibraryItemDao(
+            storyteller = listOf(row("st-1", "42", isbn = "9780261103573")),
+            abs = listOf(row("abs-1", "ebook", isbn = "9780261103573")),
+        )
+        val links = FKFailingReadaloudLinkDao()
+
+        service(items, links).reconcileLinks()
+
+        // No crash — test reaching here proves the exception was swallowed.
+        assertTrue("no row written when FK throws", links.upserts.isEmpty())
+    }
+
+    @Test
     fun `stale candidates are cleared every pass`() = runTest {
         val items = StubLibraryItemDao(
             storyteller = listOf(row("st-1", "42", title = "Dune", author = "Frank Herbert")),
@@ -409,7 +428,14 @@ class ReadaloudMatchingServiceTest {
         override fun observeBySource(sourceId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
     }
 
-    private class RecordingReadaloudLinkDao : ReadaloudLinkDao {
+    /** Simulates the race where the source is deleted between the read and the upsert. */
+    private class FKFailingReadaloudLinkDao : RecordingReadaloudLinkDao() {
+        override suspend fun upsert(entity: ReadaloudLinkEntity) {
+            throw SQLiteConstraintException("FOREIGN KEY constraint failed (code 787)")
+        }
+    }
+
+    private open class RecordingReadaloudLinkDao : ReadaloudLinkDao {
         override suspend fun updateIdentityResult(absSourceId: String, absLibraryItemId: String, result: String) = Unit
         val upserts = mutableListOf<ReadaloudLinkEntity>()
         val deletions = mutableListOf<Pair<String, String>>()


### PR DESCRIPTION
## Problem

`SQLiteConstraintException: FOREIGN KEY constraint failed (code 787)` when removing a Storyteller config.

`reconcileLinks()` is launched fire-and-forget on `applicationScope` by `RefreshLibraryItems`. It races with `SourceRepository.remove()`: the Storyteller source row is deleted between `listMatchableBySourceType` (read) and `readaloudLinkDao.upsert` (write), so the FK on `storytellerSourceId → sources.id` fails.

## Fix

Wrap the `upsert` in a `try/catch (SQLiteConstraintException)`. On FK failure, log a warning via `LogChannel.Readaloud` and skip the link — the next reconcile pass won't include the deleted source's books, so the stale match self-corrects automatically.

Also moves `freshAutoSlots += slot` inside the try body (only reached on a successful upsert) and injects `Logger` so unexpected future constraint violations (NOT NULL, CHECK) produce a traceable log instead of disappearing silently.

## Test

`FKFailingReadaloudLinkDao` — a test double that throws `SQLiteConstraintException` on every upsert. Verifies that `reconcileLinks()` completes without crashing and writes nothing when the FK fires.