### PR TITLE
fix(library): dispatch EPUB TOC extraction to Dispatchers.IO

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCase.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCase.kt
@@ -21,6 +21,8 @@ import org.readium.r2.shared.util.asset.AssetRetriever
 import org.readium.r2.shared.util.use
 import org.readium.r2.streamer.PublicationOpener
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 private const val READIUM_EPUB_POSITION_PAGE_LENGTH = 1024L
 
@@ -76,7 +78,7 @@ class ExtractEpubTocUseCase @Inject constructor(
     suspend operator fun invoke(item: LibraryItem): List<TocEntry> =
         extractDetails(item).tocEntries
 
-    suspend fun extractDetails(item: LibraryItem): Details {
+    suspend fun extractDetails(item: LibraryItem): Details = withContext(Dispatchers.IO) {
         // Use "unknown" when the server doesn't provide an inode (ABS < v2.36 omits
         // ebookFile.ino from the library-items list). The cache key still works; it
         // just won't auto-invalidate when the file is replaced on disk, which is an
@@ -100,12 +102,12 @@ class ExtractEpubTocUseCase @Inject constructor(
         // the cache forever — especially under the "unknown" inode key used for ABS < v2.36, where
         // the key never changes and there's no other invalidation trigger.
         if (matchingCachedEntries != null && matchingPositionCount != null && matchingEpubVersion != null) {
-            return Details(matchingCachedEntries, matchingPositionCount, matchingEpubVersion)
+            return@withContext Details(matchingCachedEntries, matchingPositionCount, matchingEpubVersion)
         }
 
         val opened = when (val r = epubRepository.openEpubForMetadata(item)) {
             is EpubOpenResult.Success -> r
-            else -> return Details(matchingCachedEntries.orEmpty(), matchingPositionCount, matchingEpubVersion)
+            else -> return@withContext Details(matchingCachedEntries.orEmpty(), matchingPositionCount, matchingEpubVersion)
         }
         val file = opened.epubFile
 
@@ -115,14 +117,14 @@ class ExtractEpubTocUseCase @Inject constructor(
             val extractedEpubVersion = EpubMetadataExtractor.extract(file).epubVersion ?: ""
 
             val url = AbsoluteUrl("file://${file.absolutePath}")
-                ?: return Details(matchingCachedEntries.orEmpty(), matchingPositionCount, matchingEpubVersion)
+                ?: return@withContext Details(matchingCachedEntries.orEmpty(), matchingPositionCount, matchingEpubVersion)
             val asset = when (val r = assetRetriever.retrieve(url)) {
                 is Try.Success -> r.value
-                is Try.Failure -> return Details(matchingCachedEntries.orEmpty(), matchingPositionCount, matchingEpubVersion)
+                is Try.Failure -> return@withContext Details(matchingCachedEntries.orEmpty(), matchingPositionCount, matchingEpubVersion)
             }
             val publication = when (val r = publicationOpener.open(asset, allowUserInteraction = false)) {
                 is Try.Success -> r.value
-                is Try.Failure -> return Details(matchingCachedEntries.orEmpty(), matchingPositionCount, matchingEpubVersion)
+                is Try.Failure -> return@withContext Details(matchingCachedEntries.orEmpty(), matchingPositionCount, matchingEpubVersion)
             }
 
             val details = publication.use {
@@ -152,7 +154,7 @@ class ExtractEpubTocUseCase @Inject constructor(
                     ),
                 )
             }
-            return details
+            details
         } finally {
             if (opened.temporary) file.delete()
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCase.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCase.kt
@@ -21,7 +21,7 @@ import org.readium.r2.shared.util.asset.AssetRetriever
 import org.readium.r2.shared.util.use
 import org.readium.r2.streamer.PublicationOpener
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
+import com.riffle.core.domain.DispatcherProvider
 import kotlinx.coroutines.withContext
 
 private const val READIUM_EPUB_POSITION_PAGE_LENGTH = 1024L
@@ -68,6 +68,7 @@ class ExtractEpubTocUseCase @Inject constructor(
     private val assetRetriever: AssetRetriever,
     private val tocRepository: TocRepository,
     private val publicationMetricsRepository: PublicationMetricsRepository,
+    private val dispatchers: DispatcherProvider,
 ) {
     data class Details(
         val tocEntries: List<TocEntry>,
@@ -78,7 +79,7 @@ class ExtractEpubTocUseCase @Inject constructor(
     suspend operator fun invoke(item: LibraryItem): List<TocEntry> =
         extractDetails(item).tocEntries
 
-    suspend fun extractDetails(item: LibraryItem): Details = withContext(Dispatchers.IO) {
+    suspend fun extractDetails(item: LibraryItem): Details = withContext(dispatchers.io) {
         // Use "unknown" when the server doesn't provide an inode (ABS < v2.36 omits
         // ebookFile.ino from the library-items list). The cache key still works; it
         // just won't auto-invalidate when the file is replaced on disk, which is an

--- a/app/src/test/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCaseCacheTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCaseCacheTest.kt
@@ -7,6 +7,7 @@ import com.riffle.core.domain.PublicationMetricsRepository
 import com.riffle.core.domain.TocRepository
 import com.riffle.core.models.EbookFormat
 import com.riffle.core.models.LibraryItem
+import com.riffle.core.domain.DefaultDispatcherProvider
 import com.riffle.core.models.TocEntry
 import io.mockk.coEvery
 import io.mockk.mockk
@@ -39,6 +40,7 @@ class ExtractEpubTocUseCaseCacheTest {
         assetRetriever = mockk<AssetRetriever>(),
         tocRepository = tocRepo,
         publicationMetricsRepository = metricsRepo,
+        dispatchers = DefaultDispatcherProvider,
     )
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCaseTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCaseTest.kt
@@ -23,6 +23,7 @@ import java.io.File
 import java.util.zip.CRC32
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
+import com.riffle.core.domain.DefaultDispatcherProvider
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -53,6 +54,7 @@ class ExtractEpubTocUseCaseTest {
         assetRetriever,
         tocRepository,
         publicationMetricsRepository,
+        DefaultDispatcherProvider,
     )
 
     private fun makeItem(isCached: Boolean = true, ebookFileIno: String? = "ino1") = LibraryItem(

--- a/app/src/test/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCaseTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/ExtractEpubTocUseCaseTest.kt
@@ -26,6 +26,7 @@ import java.util.zip.ZipOutputStream
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.readium.r2.shared.publication.Layout
@@ -292,5 +293,36 @@ class ExtractEpubTocUseCaseTest {
         } finally {
             unmockkStatic(Uri::class)
         }
+    }
+
+    @Test
+    fun `extractDetails dispatches to IO thread, not the calling coroutine thread`() = runTest {
+        // Regression: before the fix, extractDetails() ran on whatever dispatcher called it
+        // (typically Dispatchers.Main in the ViewModel). This blocked the main thread with
+        // synchronous ZipFile I/O and Readium parse work, causing jank during back navigation
+        // from the item detail screen opened by PR 710's readaloud-to-ABS redirect.
+        // The fix wraps extractDetails() in withContext(Dispatchers.IO). This test pins that
+        // dispatch by verifying the thread name inside openEpubForMetadata (the first blocking
+        // call on the cache-miss path) is a real IO pool thread, not the test scheduler thread.
+        val testThreadName = Thread.currentThread().name
+        var capturedThreadName: String? = null
+
+        coEvery { tocRepository.getCachedToc(any(), any()) } returns null
+        coEvery { publicationMetricsRepository.get(any(), any()) } returns null
+        coEvery { epubRepository.openEpubForMetadata(any()) } answers {
+            capturedThreadName = Thread.currentThread().name
+            EpubOpenResult.NetworkError(RuntimeException("no file"))
+        }
+
+        useCase.extractDetails(makeItem())
+
+        assertNotEquals(
+            "extractDetails must not run on the calling coroutine's thread",
+            testThreadName, capturedThreadName,
+        )
+        assertTrue(
+            "extractDetails must run on a Dispatchers.IO worker, got: $capturedThreadName",
+            capturedThreadName?.startsWith("DefaultDispatcher-worker") == true,
+        )
     }
 }


### PR DESCRIPTION
## Root cause

PR #710 redirected readaloud taps in Downloads to the linked ABS item instead of the Storyteller item. ABS items are EPUBs; Storyteller items are not. So after #710, opening item details from Downloads always triggers `extractEpubTocUseCase.extractDetails()` — which never ran for Storyteller items.

`extractDetails()` was launched in `viewModelScope` (inherits `Dispatchers.Main`) and did:
- `openEpubForMetadata` — potential network download on cache miss
- `assetRetriever.retrieve` + `publicationOpener.open` — Readium ZIP parsing
- `countEpubPositionsFromArchive` — blocking `ZipFile` I/O

Blocking the main thread with any of that work during or just after navigation caused the jank the user reported on back navigation.

## Fix

Wrap `ExtractEpubTocUseCase.extractDetails()` in `withContext(Dispatchers.IO)` so all I/O runs on a background thread regardless of the calling dispatcher. The cache-hit path (two DB reads, fast) also moves to IO, which is where Room runs its queries anyway.

## Test

Added `extractDetails dispatches to IO thread, not the calling coroutine thread` — records the thread name inside the `openEpubForMetadata` mock and asserts it's a `DefaultDispatcher-worker` thread. Flips red without the `withContext(Dispatchers.IO)` wrapper.