### PR TITLE
fix(reader): prevent continuous-mode images from shrinking to zero via vh feedback loop

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjector.kt
@@ -154,8 +154,16 @@ internal object ContinuousStyleInjector {
         val beforeBlock = buildString {
             append("\n<link rel=\"stylesheet\" type=\"text/css\" href=\"$CSS_BASE/ReadiumCSS-before.css\"/>\n")
             // Match Readium's overflow fix so scroll layout behaves identically.
+            // Also override --RS__maxMediaHeight to break the vh feedback loop that collapses
+            // images in continuous mode. Each ChapterWebView is sized to its full content height,
+            // so window.innerHeight = chapter height (not the visible screen), making 1vh
+            // proportional to the chapter. ReadiumCSS's max-height: 95vh !important then drives
+            // image height → chapter height → vh → image height in a converging cycle that
+            // shrinks tall images toward zero. Setting none removes the cap; images remain
+            // bounded by max-width: 100% from the same ReadiumCSS rule.
             append("<style>:root[style], :root { overflow: visible !important; }")
-            append(":root[style] > body, :root > body { overflow: visible !important; }</style>\n")
+            append(":root[style] > body, :root > body { overflow: visible !important; }")
+            append(":root { --RS__maxMediaHeight: none; }</style>\n")
             if (!hasAuthorStyles) {
                 append("<link rel=\"stylesheet\" type=\"text/css\" href=\"$CSS_BASE/ReadiumCSS-default.css\"/>\n")
             }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ContinuousStyleInjectorTest.kt
@@ -184,6 +184,27 @@ class ContinuousStyleInjectorTest {
     }
 
     @Test
+    fun `injectInto overrides RS maxMediaHeight to none to prevent vh feedback loop`() {
+        // ReadiumCSS-before.css caps images at max-height: 95vh !important. In continuous
+        // mode each ChapterWebView height = full chapter content height, so window.innerHeight
+        // = chapter height (not the visible screen). This creates a feedback loop where image
+        // height → chapter height → vh → image height collapses toward zero each iteration.
+        // Overriding --RS__maxMediaHeight to none breaks the loop; max-width: 100% still applies.
+        val out = ContinuousStyleInjector.injectInto(sampleHtml, FormattingPreferences())
+        assertTrue(
+            "--RS__maxMediaHeight must be overridden to none to prevent the vh feedback loop",
+            out.contains("--RS__maxMediaHeight: none"),
+        )
+        // The override must appear after ReadiumCSS-before.css (to win the cascade at equal
+        // specificity via document order) and before ReadiumCSS-after.css.
+        val beforeCssIdx = out.indexOf("ReadiumCSS-before.css")
+        val overrideIdx = out.indexOf("--RS__maxMediaHeight: none")
+        val afterCssIdx = out.indexOf("ReadiumCSS-after.css")
+        assertTrue("override after ReadiumCSS-before.css in document order", overrideIdx > beforeCssIdx)
+        assertTrue("override before ReadiumCSS-after.css", overrideIdx < afterCssIdx)
+    }
+
+    @Test
     fun `injectInto adds default-css only when chapter has no author styles`() {
         val withStyles = "<html><head><style>p{}</style></head><body></body></html>"
         val without = "<html><head><title>t</title></head><body></body></html>"


### PR DESCRIPTION
## Summary

- ReadiumCSS-before.css caps all images at `max-height: 95vh !important`. In continuous mode each `ChapterWebView` is sized to its full chapter content height, so `window.innerHeight` = chapter height (not the visible screen). This makes `1vh` proportional to the chapter height.
- This creates a converging feedback loop: image height → drives chapter height → drives `window.innerHeight` → drives `95vh` → constrains image height back down. Each `onHeightMeasured` cycle multiplies image height by ~0.95, collapsing images toward zero when they are the dominant content — visible on map-heavy chapters like The Martian's opening pages.
- Fix: inject `:root { --RS__maxMediaHeight: none; }` in the continuous-mode style block immediately after `ReadiumCSS-before.css`, winning the cascade at equal specificity via document order. `max-height: var(--RS__maxMediaHeight) !important` resolves to `max-height: none !important`, breaking the loop. Images remain bounded by `max-width: 100%`.

## Test plan

- [ ] `ContinuousStyleInjectorTest.injectInto overrides RS maxMediaHeight to none to prevent vh feedback loop` — pins the override is present and positioned after before.css/before after.css
- [ ] Open The Martian (or any image-heavy EPUB) in continuous mode and verify the maps render at full width without shrinking during load
- [ ] Confirm paginated and vertical modes are unaffected (fix is only in `ContinuousStyleInjector.injectInto`)