### PR TITLE
perf+fix(library/navigation): parallelize init I/O and fix drawer nav regression

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -325,9 +325,11 @@ class LibraryItemsViewModel @Inject constructor(
         viewModelScope.launch {
             val source = sourceRepository.getActive()
             if (source != null) {
-                authToken = tokenStorage.getToken(source.id) ?: ""
+                val tokenDeferred = async { tokenStorage.getToken(source.id) ?: "" }
+                val prefsDeferred = async { libraryFilterPreferencesStore.preferences(source.id, libraryId).first() }
+                authToken = tokenDeferred.await()
                 libraryFilterSourceId = source.id
-                val prefs = libraryFilterPreferencesStore.preferences(source.id, libraryId).first()
+                val prefs = prefsDeferred.await()
                 _notStartedFilterActive.value = prefs.notStartedFilterActive
                 _librarySortMode.value = prefs.sortModeName
                     ?.let { runCatching { LibrarySortMode.valueOf(it) }.getOrNull() }

--- a/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
@@ -228,6 +228,7 @@ abstract class UnboundedBrowseViewModel(
 
     init {
         viewModelScope.launch {
+            launch { loadFacets() }
             val source = sourceRepository.getActive()?.takeIf { it.type == sourceType }
             if (source != null) {
                 libraryFilterSourceId = source.id
@@ -237,7 +238,6 @@ abstract class UnboundedBrowseViewModel(
                 _notStartedFilterActive.value = prefs.notStartedFilterActive
                 _unownedFilterActive.value = prefs.unownedFilterActive
             }
-            loadFacets()
             refresh()
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -16,6 +16,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavType
@@ -284,14 +286,21 @@ fun MainScreen(
         },
         onDownloadsSelected = {
             scope.launch { drawerState.close() }
-            navController.navigate(DOWNLOADS)
+            if (navController.currentDestination?.route != DOWNLOADS) navController.navigate(DOWNLOADS)
         },
         onSettingsSelected = {
             scope.launch { drawerState.close() }
-            navController.navigate(SETTINGS)
+            if (navController.currentDestination?.route != SETTINGS) navController.navigate(SETTINGS)
         },
     ) {
-        NavHost(navController = navController, startDestination = HOME) {
+        NavHost(
+            navController = navController,
+            startDestination = HOME,
+            enterTransition = { EnterTransition.None },
+            exitTransition = { ExitTransition.None },
+            popEnterTransition = { EnterTransition.None },
+            popExitTransition = { ExitTransition.None },
+        ) {
             composable(HOME) {
                 HomeScreen(
                     onNavigateToAddSource = {

--- a/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/navigation/ShouldInterceptBackForDrawerTest.kt
@@ -275,3 +275,52 @@ class RouteBackCallbackGuardrailTest {
             File("app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt"),
         ).first { it.exists() }
 }
+
+/**
+ * Pins the fix for Downloads and Settings being re-added to the back stack when re-selected from
+ * the drawer while already on that screen.
+ *
+ * Previously both used a plain navController.navigate(DOWNLOADS/SETTINGS) with no guard, so
+ * tapping the drawer item while already on the screen pushed a duplicate entry. Back then had to
+ * be pressed once per duplicate before returning to the previous destination.
+ *
+ * The fix guards each navigate call with a currentDestination?.route check so re-selecting an
+ * already-top destination is a no-op. The assertions below flip red if either guard is removed.
+ *
+ * Note: `launchSingleTop = true` was intentionally NOT used — it still fires the enter animation
+ * on the existing composable in Navigation 2.9+, producing a bizarre re-enter animation when the
+ * destination is already the top of the stack.
+ */
+class DrawerNavigationDeduplicationTest {
+
+    @Test
+    fun `Downloads drawer navigation is guarded by route check`() {
+        assertNavCallHasRouteGuard("DOWNLOADS", "downloads")
+    }
+
+    @Test
+    fun `Settings drawer navigation is guarded by route check`() {
+        assertNavCallHasRouteGuard("SETTINGS", "settings")
+    }
+
+    private fun assertNavCallHasRouteGuard(constName: String, literal: String) {
+        val lines = locateMainScreenSource().readLines()
+        val idx = lines.indexOfFirst { line ->
+            "navigate($constName)" in line || "navigate(\"$literal\")" in line
+        }
+        assertTrue("$constName navigate call not found in MainScreen.kt", idx >= 0)
+        // The guard must appear on the same line or the immediately preceding line.
+        val window = lines.subList(maxOf(0, idx - 1), minOf(idx + 2, lines.size)).joinToString("\n")
+        assertTrue(
+            "navigate($constName) must be guarded by a currentDestination route check to prevent " +
+                "back-stack duplicates and spurious re-enter animations.\nFound:\n$window",
+            "currentDestination" in window,
+        )
+    }
+
+    private fun locateMainScreenSource(): File =
+        listOf(
+            File("src/main/kotlin/com/riffle/app/navigation/MainScreen.kt"),
+            File("app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt"),
+        ).first { it.exists() }
+}


### PR DESCRIPTION
## What changed

### perf: parallel DataStore reads on source/library switch

`feat(library): remember source library filters (#718)` introduced sequential DataStore reads in two ViewModel `init` blocks that run on every source/library switch (both VMs are recreated each time). The token read and the prefs read have no dependency on each other, but were chained sequentially, gating `launchRefresh()` behind two consecutive disk reads.

- **`LibraryItemsViewModel`**: fan out `getToken()` and `preferences().first()` with `async`/`await` so both run in parallel before the first data fetch fires.
- **`UnboundedBrowseViewModel`**: restore `loadFacets()` to a concurrent inner `launch` (it was already there before #718 inadvertently sequenced it). `refresh()` still awaits prefs because the persisted facet feeds the network request directly.

### fix: duplicate back-stack entries on drawer re-selection

Tapping Downloads (or Settings) from the drawer while already on that screen pushed a duplicate entry; Back had to be pressed once per duplicate before returning home.

Fix: guard each `navigate()` call with `currentDestination?.route != DEST` so re-selecting the already-top destination is a no-op.

`launchSingleTop = true` was intentionally NOT used — in Navigation 2.9+, it still fires the enter animation on the existing composable, producing a bizarre re-enter animation when you're already on the destination.

### fix: screen blink on every drawer navigation

Navigation 2.9.8's default crossfade renders the outgoing and incoming composables simultaneously at partial alpha, creating a ghost/blink on every transition.

Fix: set `EnterTransition.None`/`ExitTransition.None` on the `NavHost` for all four transition slots so navigation is an instant snap.

## Tests

- `DrawerNavigationDeduplicationTest` (two assertions) — flips red if either route guard is removed from `MainScreen.kt`.
- Existing `LibraryItemsViewModelTest` covers the VM init path; the I/O parallelisation changes only execution order, not observable output.