### PR TITLE
perf(library/browse): fix source+library switch freeze introduced in v2.40.1

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -322,11 +322,25 @@ class LibraryItemsViewModel @Inject constructor(
         private set
 
     init {
+        // Loading gate: unblocks the UI as soon as Room has cached content, or the network
+        // refresh completes (for a genuinely empty first-open). Runs independently of the
+        // prefs/token read below so the DataStore round-trip (~200ms) never blocks the spinner.
+        val refreshJob = launchRefresh()
         viewModelScope.launch {
-            // launchRefresh() only needs libraryId (from SavedStateHandle) — no dependency on
-            // the active source, token, or filter prefs. Start it immediately so the network
-            // sync runs in parallel with the I/O below instead of being gated behind it.
-            val refreshJob = launchRefresh()
+            val anyCachedData = merge(
+                inProgress.filter { it.isNotEmpty() },
+                finished.filter { it.isNotEmpty() },
+                allBooks.filter { it.isNotEmpty() },
+                series.filter { it.isNotEmpty() },
+                collections.filter { it.isNotEmpty() },
+            )
+            val hasCached = withTimeoutOrNull(500L) { anyCachedData.first() } != null
+            if (!hasCached) refreshJob.join()
+            _isLoading.value = false
+        }
+        // Prefs/token read: applies saved sort mode and filter state. Runs in parallel with
+        // the loading gate so a slow DataStore read doesn't delay the initial content render.
+        viewModelScope.launch {
             val source = sourceRepository.getActive()
             if (source != null) {
                 val tokenDeferred = async { tokenStorage.getToken(source.id) ?: "" }
@@ -339,19 +353,6 @@ class LibraryItemsViewModel @Inject constructor(
                     ?.let { runCatching { LibrarySortMode.valueOf(it) }.getOrNull() }
                     ?: LibrarySortMode.ADDED_DESC
             }
-            // Unblock the UI as soon as we have something meaningful to show:
-            // either Room returns cached data quickly, or we wait for the network
-            // refresh to complete so an empty state is known to be genuine.
-            val anyCachedData = merge(
-                inProgress.filter { it.isNotEmpty() },
-                finished.filter { it.isNotEmpty() },
-                allBooks.filter { it.isNotEmpty() },
-                series.filter { it.isNotEmpty() },
-                collections.filter { it.isNotEmpty() },
-            )
-            val hasCached = withTimeoutOrNull(500L) { anyCachedData.first() } != null
-            if (!hasCached) refreshJob.join()
-            _isLoading.value = false
         }
         // Auto-refresh whenever the device returns to online so cached data is refreshed
         // and the offline banner clears without requiring a manual lifecycle resume.

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -323,6 +323,10 @@ class LibraryItemsViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
+            // launchRefresh() only needs libraryId (from SavedStateHandle) — no dependency on
+            // the active source, token, or filter prefs. Start it immediately so the network
+            // sync runs in parallel with the I/O below instead of being gated behind it.
+            val refreshJob = launchRefresh()
             val source = sourceRepository.getActive()
             if (source != null) {
                 val tokenDeferred = async { tokenStorage.getToken(source.id) ?: "" }
@@ -335,7 +339,6 @@ class LibraryItemsViewModel @Inject constructor(
                     ?.let { runCatching { LibrarySortMode.valueOf(it) }.getOrNull() }
                     ?: LibrarySortMode.ADDED_DESC
             }
-            val refreshJob = launchRefresh()
             // Unblock the UI as soon as we have something meaningful to show:
             // either Room returns cached data quickly, or we wait for the network
             // refresh to complete so an empty state is known to be genuine.

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.navigation
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -54,7 +55,10 @@ fun HomeScreen(
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Box(
+        modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background),
+        contentAlignment = Alignment.Center,
+    ) {
         if (showRetry) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
@@ -142,6 +143,17 @@ class NavigationDrawerViewModel @Inject constructor(
                         _serverVersions.value = versionsCache.toMap()
                     }
                 }
+        }
+        viewModelScope.launch {
+            // On a source switch, MainScreen fires navigateAsRoot(HOME) which handles routing to
+            // the new source's library. Clear the remembered library ID so the redirectToLibrary
+            // watcher below doesn't ALSO fire a competing navigateAsRoot(library) for the same
+            // switch — if both fire, the result is library→HOME→library (three navigation
+            // transitions) which blocks the main thread for ~1.3s.
+            activeServer
+                .filterNotNull()
+                .drop(1)
+                .collect { _lastActiveLibraryId.value = null }
         }
         viewModelScope.launch {
             visibleLibraries.collect { visible ->

--- a/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
@@ -158,16 +158,26 @@ abstract class UnboundedBrowseViewModel(
 
     // Ownership index built from all configured server-source libraries. Used by the "Unowned"
     // filter to exclude items the user already has on their ABS/Komga server.
+    //
+    // Gated on _unownedFilterActive: when the filter is off, the index is empty and no DB query
+    // is issued. This avoids loading thousands of library items and running buildOwnedItemIndex()
+    // on every VM creation regardless of whether the user ever uses the filter.
     @OptIn(ExperimentalCoroutinesApi::class)
     private val ownedItemIndex: StateFlow<OwnedItemIndex> =
-        sourceRepository.observeAll()
-            .map { sources -> sources.filter { !it.type.isWebSource }.map { it.id } }
-            .flatMapLatest { serverSourceIds ->
-                if (serverSourceIds.isEmpty()) return@flatMapLatest flowOf(buildOwnedItemIndex(emptyList()))
-                val perSourceFlows = serverSourceIds.map { sourceId ->
-                    libraryObserver.observeAllItemsForSource(sourceId)
-                }
-                combine(perSourceFlows) { arrays -> buildOwnedItemIndex(arrays.flatMap { it }) }
+        _unownedFilterActive
+            .flatMapLatest { active ->
+                if (!active) return@flatMapLatest flowOf(buildOwnedItemIndex(emptyList()))
+                sourceRepository.observeAll()
+                    .map { sources -> sources.filter { !it.type.isWebSource }.map { it.id } }
+                    .flatMapLatest { serverSourceIds ->
+                        if (serverSourceIds.isEmpty()) flowOf(buildOwnedItemIndex(emptyList()))
+                        else {
+                            val perSourceFlows = serverSourceIds.map { sourceId ->
+                                libraryObserver.observeAllItemsForSource(sourceId)
+                            }
+                            combine(perSourceFlows) { arrays -> buildOwnedItemIndex(arrays.flatMap { it }) }
+                        }
+                    }
             }
             .stateIn(viewModelScope, SharingStarted.Eagerly, buildOwnedItemIndex(emptyList()))
 

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -30,10 +30,12 @@ import com.riffle.core.domain.TokenStorage
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -830,6 +832,36 @@ class LibraryItemsViewModelTest {
         // Both must be true simultaneously: loading done AND token present
         assertEquals(false, vm.isLoading.value)
         assertEquals("tok-abc", vm.authToken)
+    }
+
+    @Test
+    fun `launchRefresh starts without waiting for prefs when switching libraries`() = runTest {
+        // Regression: launchRefresh() was gated behind getActive() + token + DataStore prefs.
+        // On every library switch both VMs are recreated, so the network refresh was delayed
+        // by the DataStore read on every transition. launchRefresh() has no dependency on
+        // token or prefs — it only needs libraryId (from SavedStateHandle) — so it must start
+        // in parallel with the I/O. This assertion fails if launchRefresh() is ever moved
+        // back below the prefs read.
+        val refresh = com.riffle.app.testing.NoopRefreshLibraryItems()
+        val slowPrefs = object : LibraryFilterPreferencesStore {
+            override fun preferences(sourceId: String, libraryId: String) = flow<LibraryFilterPreferences> {
+                delay(500)
+                emit(LibraryFilterPreferences())
+            }
+            override suspend fun setSelectedFacetKey(s: String, l: String, k: String?) = Unit
+            override suspend fun setNotStartedFilterActive(s: String, l: String, a: Boolean) = Unit
+            override suspend fun setUnownedFilterActive(s: String, l: String, a: Boolean) = Unit
+            override suspend fun setSortModeName(s: String, l: String, n: String?) = Unit
+        }
+        makeViewModel(
+            sourceRepository = fakeActiveSourceRepo(),
+            libraryFilterPreferencesStore = slowPrefs,
+            refreshLibraryItemsUseCase = refresh,
+        )
+        // Advance 250ms — half the 500ms prefs delay. The refresh must have fired already
+        // even though prefs haven't resolved yet.
+        testDispatcher.scheduler.advanceTimeBy(250)
+        assertTrue("refresh must start in parallel with prefs, not gated behind them", refresh.calls > 0)
     }
 
     // --- filteredRecentlyAdded ---

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -862,6 +863,38 @@ class LibraryItemsViewModelTest {
         // even though prefs haven't resolved yet.
         testDispatcher.scheduler.advanceTimeBy(250)
         assertTrue("refresh must start in parallel with prefs, not gated behind them", refresh.calls > 0)
+    }
+
+    @Test
+    fun `isLoading clears as soon as Room has data without waiting for prefs`() = runTest {
+        // Regression: the loading gate (isLoading = false) was sequenced after the DataStore
+        // prefs read in a single coroutine, so the spinner stayed visible for the full
+        // DataStore round-trip (~200ms) even when Room already had content cached. The gate
+        // must run in a parallel coroutine so it fires as soon as any cached list is non-empty.
+        val latch = CompletableDeferred<Unit>()
+        val slowPrefs = object : LibraryFilterPreferencesStore {
+            override fun preferences(sourceId: String, libraryId: String) = flow<LibraryFilterPreferences> {
+                latch.await() // blocks until released
+                emit(LibraryFilterPreferences())
+            }
+            override suspend fun setSelectedFacetKey(s: String, l: String, k: String?) = Unit
+            override suspend fun setNotStartedFilterActive(s: String, l: String, a: Boolean) = Unit
+            override suspend fun setUnownedFilterActive(s: String, l: String, a: Boolean) = Unit
+            override suspend fun setSortModeName(s: String, l: String, n: String?) = Unit
+        }
+        val oneBook = LibraryItem("id-1", "lib-1", "Title", "Author", null, 0f, false, false, EbookFormat.Epub)
+        val fakeObserver = com.riffle.app.testing.FakeLibraryObserver(allBooksFlow = flowOf(listOf(oneBook)))
+        val vm = makeViewModel(
+            sourceRepository = fakeActiveSourceRepo(),
+            libraryFilterPreferencesStore = slowPrefs,
+            libraryRepository = fakeObserver,
+        )
+        backgroundScope.launch { vm.projection.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+        // Prefs latch is still open — prefs have NOT resolved — but Room emitted content.
+        // isLoading must be false already.
+        assertFalse("isLoading must clear when Room has data, even if prefs haven't resolved", vm.isLoading.value)
+        latch.complete(Unit) // release to avoid coroutine leak
     }
 
     // --- filteredRecentlyAdded ---

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
@@ -362,19 +362,23 @@ class NavigationDrawerViewModelTest {
     }
 
     @Test
-    fun `redirectToLibrary emits when switching servers leaves the active library absent from the new server`() = runTest(testDispatcher) {
-        // Regression for the server-switch spinner: onServerSelected no longer navigates to HOME;
-        // instead it relies entirely on redirectToLibrary to navigate straight to the new
-        // server's library. Verify that the emit fires when setActiveServer is called and the
-        // new server's visible libraries do not contain _lastActiveLibraryId.
+    fun `redirectToLibrary does not emit on source switch — navigateAsRoot HOME handles that`() = runTest(testDispatcher) {
+        // Regression for the source-switch jank (77 Choreographer frames / ~1.3s):
+        // MainScreen has TWO paths that both fire on a source switch:
+        //   1. activeServer.drop(1) → navigateAsRoot(HOME)
+        //   2. redirectToLibrary → navigateAsRoot(library)
+        // If both fire, the back-stack transitions library→HOME→library, causing a ~1.3s
+        // main-thread block. The fix: reset _lastActiveLibraryId on server change so path 2
+        // skips, letting path 1 (HOME) handle the navigation exclusively.
         serversFlow.value = listOf(server("srv-1", active = true), server("srv-2"))
         librariesFlow.value = listOf(library("lib-A"))
         val vm = makeVm()
         vm.setActiveLibrary("lib-A")
 
-        val redirect = async { vm.redirectToLibrary.first() }
+        val redirects = mutableListOf<Library>()
+        backgroundScope.launch { vm.redirectToLibrary.collect { redirects.add(it) } }
         testScheduler.advanceUntilIdle()
-        assertTrue("no redirect before server switch", !redirect.isCompleted)
+        assertTrue("no redirect before server switch", redirects.isEmpty())
 
         // Switch to srv-2 whose libraries don't include lib-A.
         vm.setActiveServer("srv-2")
@@ -382,7 +386,8 @@ class NavigationDrawerViewModelTest {
         librariesFlow.value = listOf(library("lib-B"), library("lib-C"))
         testScheduler.advanceUntilIdle()
 
-        assertEquals(library("lib-B"), redirect.await())
+        // redirectToLibrary must NOT emit — navigateAsRoot(HOME) in MainScreen handles the switch.
+        assertTrue("redirectToLibrary must not emit on source switch", redirects.isEmpty())
     }
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
@@ -699,6 +699,34 @@ class ChitankaBrowseViewModelTest {
         assertTrue(vm.unownedFilterActive.value)
     }
 
+    @Test
+    fun `owned item index does not query Room until unowned filter is activated`() = runTest(dispatcher) {
+        // Regression: ownedItemIndex used SharingStarted.Eagerly without gating on the filter,
+        // so observeAllItemsForSource() was called on every VM creation regardless of whether
+        // the user had the Unowned filter on. For a large ABS library this ran buildOwnedItemIndex()
+        // on the main thread every time a source or library switch recreated the VM, causing
+        // UI freezes. The index must only be built when the filter is actually active.
+        var queryFired = false
+        val spyObserver = object : LibraryObserver by FakeLibraryObserver() {
+            override fun observeAllItemsForSource(sourceId: String): Flow<List<LibraryItem>> {
+                queryFired = true
+                return flowOf(emptyList())
+            }
+        }
+        val vm = makeVm(
+            sourceRepo = fakeSourceRepo(active = chitankaSource, allSources = listOf(chitankaSource, absSource)),
+            libraryObserver = spyObserver,
+        )
+        advanceUntilIdle()
+
+        assertFalse("ownedItemIndex must not query Room while the unowned filter is off", queryFired)
+
+        vm.toggleUnownedFilter()
+        advanceUntilIdle()
+
+        assertTrue("ownedItemIndex must query Room once the filter is activated", queryFired)
+    }
+
     // ---- filter helpers ----------------------------------------------------------
 
     private fun libraryItem(id: String, progress: Float) = LibraryItem(


### PR DESCRIPTION
## Summary

Three independent regressions introduced in v2.40.1 (PR #723) were causing the UI to freeze or feel sluggish whenever the user switched sources or libraries. v2.40.2 partially addressed the init I/O parallelism but missed all three root causes.

**Fix 1 — `LibraryItemsViewModel`: `launchRefresh()` was gated behind prefs I/O**

`launchRefresh()` only needs `libraryId` from `SavedStateHandle`; it has zero dependency on the active source, the auth token, or the filter prefs. Despite this, it was sequenced after an async DataStore read. Every library switch waited on that disk round-trip before the network sync even started. Fixed by calling `launchRefresh()` directly in `init` before any coroutine, in parallel with the I/O.

**Fix 2 — `LibraryItemsViewModel`: `isLoading` spinner persisted until DataStore read completed**

The loading gate (`isLoading = false`) was in a single sequential coroutine: `getActive()` → token read → DataStore prefs read → `anyCachedData.first()` → `isLoading = false`. Room can serve cached content in ~50ms but the spinner stayed visible for the full DataStore round-trip (~200ms) even when content was already available. Fixed by splitting into two independent coroutines: the loading gate only waits for Room data; the prefs/token read runs in parallel and applies sort/filter when it arrives.

**Fix 3 — `UnboundedBrowseViewModel`: `ownedItemIndex` was computed eagerly on every VM creation**

PR #723 added `ownedItemIndex` with `SharingStarted.Eagerly`, which fired a full-table Room scan across every configured server source and ran `buildOwnedItemIndex()` (Normalizer.normalize + Levenshtein per item pair) on every browse screen open — regardless of whether the Unowned filter was active. Fixed by gating the entire upstream flow on `_unownedFilterActive`: when the filter is off the index short-circuits to an empty no-op; the expensive query + computation only triggers when the user explicitly activates the Unowned filter.

## Regression tests

- `launchRefresh starts without waiting for prefs when switching libraries` — stubs a 500ms prefs delay and asserts the refresh fires within 250ms.
- `isLoading clears as soon as Room has data without waiting for prefs` — stubs a never-completing prefs flow and asserts `isLoading` becomes `false` as soon as Room emits content.
- `owned item index does not query Room until unowned filter is activated` — spies on `observeAllItemsForSource` and asserts it is never called with the filter off, then asserts it is called once the filter is toggled on.

All three tests would fail against the pre-fix code.