### PR TITLE
feat(comics): configurable panel animation speed and no-split overflow

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/UnifiedSlider.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
@@ -104,10 +105,11 @@ internal fun UnifiedSliderRow(
     bubbleLabel: (Float) -> String,
     modifier: Modifier = Modifier,
     contentDescription: String = title,
+    enabled: Boolean = true,
     onDecrement: (() -> Unit)? = null,
     onIncrement: (() -> Unit)? = null,
 ) {
-    Column(modifier = modifier.fillMaxWidth()) {
+    Column(modifier = modifier.fillMaxWidth().alpha(if (enabled) 1f else 0.38f)) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier.fillMaxWidth(),
@@ -134,7 +136,7 @@ internal fun UnifiedSliderRow(
                 modifier = Modifier
                     .size(28.dp)
                     .then(
-                        if (onDecrement != null) {
+                        if (enabled && onDecrement != null) {
                             Modifier
                                 .clickable(onClickLabel = "Decrease $contentDescription") { onDecrement() }
                                 .semantics { this.contentDescription = "Decrease $contentDescription" }
@@ -152,13 +154,14 @@ internal fun UnifiedSliderRow(
                 bubbleLabel = bubbleLabel,
                 contentDescription = contentDescription,
                 modifier = Modifier.weight(1f),
+                enabled = enabled,
             )
             Spacer(Modifier.width(8.dp))
             Box(
                 modifier = Modifier
                     .size(28.dp)
                     .then(
-                        if (onIncrement != null) {
+                        if (enabled && onIncrement != null) {
                             Modifier
                                 .clickable(onClickLabel = "Increase $contentDescription") { onIncrement() }
                                 .semantics { this.contentDescription = "Increase $contentDescription" }
@@ -180,6 +183,7 @@ private fun SliderTrack(
     bubbleLabel: (Float) -> String,
     contentDescription: String,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
 ) {
     val min = valueRange.start
     val max = valueRange.endInclusive
@@ -275,6 +279,7 @@ private fun SliderTrack(
             onValueChangeFinished = { interacting = false },
             valueRange = valueRange,
             steps = steps,
+            enabled = enabled,
             colors = sliderColors,
             interactionSource = interactionSource,
             thumb = {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -142,6 +142,7 @@ fun CbzReaderScreen(
                         currentPage = currentPage,
                         pagePanels = effectivePanels,
                         panelIndex = currentPanelIndex,
+                        panelAnimationSpeedMs = effectiveComicFormatting.panelAnimationSpeedMs,
                         onNextPanel = viewModel::nextPanel,
                         onPrevPanel = viewModel::previousPanel,
                         onSkipGuidedPage = viewModel::skipGuidedPanelsOnPage,
@@ -369,6 +370,7 @@ private fun CbzPanelViewer(
     currentPage: Int,
     pagePanels: PagePanels?,
     panelIndex: Int,
+    panelAnimationSpeedMs: Int,
     onNextPanel: () -> Unit,
     onPrevPanel: () -> Unit,
     onSkipGuidedPage: () -> Unit,
@@ -451,8 +453,8 @@ private fun CbzPanelViewer(
         // whenever the target values change, and a mid-flight change simply re-targets
         // (interrupt semantics — ADR 0055 §4). Reduce Motion collapses to a snap.
         val reduceMotion = remember(context) { isReduceMotionEnabled(context) }
-        val animationSpec = remember(reduceMotion) {
-            if (reduceMotion) snap<Float>() else tween<Float>(durationMillis = 250)
+        val animationSpec = remember(reduceMotion, panelAnimationSpeedMs) {
+            if (reduceMotion || panelAnimationSpeedMs == 0) snap<Float>() else tween<Float>(durationMillis = panelAnimationSpeedMs)
         }
         val animatedScale by animateFloatAsState(
             targetValue = zoomScale,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
@@ -414,6 +414,7 @@ class CbzReaderViewModel @Inject constructor(
             current.copy(
                 panelViewOn = patch.panelViewOn ?: current.panelViewOn,
                 panelOverflow = patch.panelOverflow ?: current.panelOverflow,
+                panelAnimationSpeedMs = patch.panelAnimationSpeedMs ?: current.panelAnimationSpeedMs,
             )
         }
         _bookComicOverrides.value = merged

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/ComicFormattingSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/ComicFormattingSheet.kt
@@ -50,6 +50,13 @@ internal fun ComicFormattingSheet(
                 enabled = formatting.panelViewOn,
                 onSelect = { onUpdate(BookComicFormattingOverrides(panelOverflow = it)) },
             )
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+            PanelAnimationSpeedSlider(
+                speedMs = formatting.panelAnimationSpeedMs,
+                onSpeedChange = { speed -> onUpdate(BookComicFormattingOverrides(panelAnimationSpeedMs = speed)) },
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                enabled = formatting.panelViewOn,
+            )
             HorizontalDivider()
             TextButton(
                 onClick = onReset,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelAnimationSpeedSlider.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelAnimationSpeedSlider.kt
@@ -1,0 +1,40 @@
+package com.riffle.app.feature.reader.cbz
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.riffle.app.feature.reader.UnifiedSliderRow
+
+private val ANIM_SPEED_RANGE = 0f..600f
+// 13 discrete stops: 0, 50, 100, …, 600. Material3 steps = stops - 2 endpoints = 11.
+private const val ANIM_SPEED_STEPS = 11
+private const val ANIM_SPEED_MAJOR_EVERY = 200f
+private const val ANIM_SPEED_STEP_SIZE = 50f
+
+@Composable
+internal fun PanelAnimationSpeedSlider(
+    speedMs: Int,
+    onSpeedChange: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    val value = speedMs.toFloat().coerceIn(ANIM_SPEED_RANGE)
+    UnifiedSliderRow(
+        title = "Animation Speed",
+        caption = animSpeedLabel(speedMs),
+        value = value,
+        onValueChange = { onSpeedChange(it.toInt()) },
+        valueRange = ANIM_SPEED_RANGE,
+        steps = ANIM_SPEED_STEPS,
+        majorEvery = ANIM_SPEED_MAJOR_EVERY,
+        edgeLeft = {},
+        edgeRight = {},
+        bubbleLabel = ::animSpeedLabel,
+        modifier = modifier,
+        enabled = enabled,
+        onDecrement = { onSpeedChange((speedMs - ANIM_SPEED_STEP_SIZE.toInt()).coerceAtLeast(0)) },
+        onIncrement = { onSpeedChange((speedMs + ANIM_SPEED_STEP_SIZE.toInt()).coerceAtMost(600)) },
+    )
+}
+
+private fun animSpeedLabel(speedMs: Int): String = if (speedMs == 0) "Off" else "${speedMs}ms"
+private fun animSpeedLabel(value: Float): String = animSpeedLabel(value.toInt())

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelOverflowRadioGroup.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelOverflowRadioGroup.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.semantics.Role
 import com.riffle.core.domain.comic.PanelOverflowBehavior
 
 private val PANEL_OVERFLOW_OPTIONS = listOf(
+    Triple(PanelOverflowBehavior.OFF, "No split", "Show oversized panels as-is without splitting"),
     Triple(PanelOverflowBehavior.SPLIT, "Split", "Cuts oversized panels in half and shows each half as its own page"),
     Triple(PanelOverflowBehavior.SMART_SPLIT, "Smart split", "Like Split, but finds a natural seam (gutter or whitespace) to cut at a cleaner boundary"),
 )

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/panels/ComicDisplaySettingsPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/panels/ComicDisplaySettingsPanel.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.riffle.app.feature.reader.cbz.PanelAnimationSpeedSlider
 import com.riffle.app.feature.reader.cbz.PanelOverflowRadioGroup
 import com.riffle.core.domain.comic.ComicFormattingPreferences
 
@@ -48,5 +49,13 @@ internal fun ComicDisplaySettingsPanel(
         selected = prefs.panelOverflow,
         enabled = prefs.panelViewOn,
         onSelect = { onPrefsChange(prefs.copy(panelOverflow = it)) },
+    )
+
+    HorizontalDivider(modifier = Modifier.padding(top = 8.dp, bottom = 8.dp))
+    PanelAnimationSpeedSlider(
+        speedMs = prefs.panelAnimationSpeedMs,
+        onSpeedChange = { speed -> onPrefsChange(prefs.copy(panelAnimationSpeedMs = speed)) },
+        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+        enabled = prefs.panelViewOn,
     )
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/sections/ComicsSection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/sections/ComicsSection.kt
@@ -11,7 +11,7 @@ internal fun comicDisplaySummary(prefs: ComicFormattingPreferences): String =
     if (prefs.panelViewOn) when (prefs.panelOverflow) {
         PanelOverflowBehavior.SPLIT -> "Panel View · Split"
         PanelOverflowBehavior.SMART_SPLIT -> "Panel View · Smart split"
-        PanelOverflowBehavior.OFF -> "Panel View on"
+        PanelOverflowBehavior.OFF -> "Panel View · No split"
     } else "Panel View off"
 
 @Composable

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/ComicDisplaySummaryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/ComicDisplaySummaryTest.kt
@@ -29,9 +29,11 @@ class ComicDisplaySummaryTest {
         )
     }
 
-    @Test fun `panel view on with legacy OFF shows Panel View on`() {
+    @Test fun `panel view on with OFF shows No split`() {
+        // PanelOverflowBehavior.OFF is now the user-selectable "No split" option in the
+        // overflow radio group, so the summary must reflect that label.
         assertEquals(
-            "Panel View on",
+            "Panel View · No split",
             comicDisplaySummary(ComicFormattingPreferences(panelViewOn = true, panelOverflow = PanelOverflowBehavior.OFF)),
         )
     }

--- a/core/data/src/main/kotlin/com/riffle/core/data/BookComicFormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/BookComicFormattingPreferencesStoreImpl.kt
@@ -29,6 +29,7 @@ class BookComicFormattingPreferencesStoreImpl @Inject constructor(
                 itemId = itemId,
                 panelViewOn = overrides.panelViewOn,
                 panelOverflow = overrides.panelOverflow?.name,
+                panelAnimationSpeedMs = overrides.panelAnimationSpeedMs,
             )
         )
     }
@@ -43,5 +44,6 @@ class BookComicFormattingPreferencesStoreImpl @Inject constructor(
         panelOverflow = panelOverflow?.let {
             runCatching { PanelOverflowBehavior.valueOf(it) }.getOrNull()
         },
+        panelAnimationSpeedMs = panelAnimationSpeedMs,
     )
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/ComicFormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ComicFormattingPreferencesStoreImpl.kt
@@ -4,6 +4,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.riffle.core.data.di.ComicFormattingPreferencesDataStore
 import com.riffle.core.domain.comic.ComicFormattingPreferences
@@ -23,6 +24,7 @@ class ComicFormattingPreferencesStoreImpl @Inject constructor(
             panelOverflow = prefs[PANEL_OVERFLOW]
                 ?.let { runCatching { PanelOverflowBehavior.valueOf(it) }.getOrNull() }
                 ?: PanelOverflowBehavior.SPLIT,
+            panelAnimationSpeedMs = prefs[PANEL_ANIMATION_SPEED_MS] ?: 250,
         )
     }
 
@@ -34,11 +36,17 @@ class ComicFormattingPreferencesStoreImpl @Inject constructor(
             } else {
                 data[PANEL_OVERFLOW] = prefs.panelOverflow.name
             }
+            if (prefs.panelAnimationSpeedMs == 250) {
+                data.remove(PANEL_ANIMATION_SPEED_MS)
+            } else {
+                data[PANEL_ANIMATION_SPEED_MS] = prefs.panelAnimationSpeedMs
+            }
         }
     }
 
     companion object {
         private val PANEL_VIEW_ON = booleanPreferencesKey("panel_view_on")
         private val PANEL_OVERFLOW = stringPreferencesKey("panel_overflow")
+        private val PANEL_ANIMATION_SPEED_MS = intPreferencesKey("panel_animation_speed_ms")
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/BookComicFormattingPreferencesStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/BookComicFormattingPreferencesStoreImplTest.kt
@@ -24,6 +24,7 @@ class BookComicFormattingPreferencesStoreImplTest {
         val entity = BookComicFormattingPreferencesEntity(
             sourceId = "src", itemId = "item",
             panelViewOn = true, panelOverflow = "UNKNOWN_FUTURE_VALUE",
+            panelAnimationSpeedMs = null,
         )
         val result = storeWith(entity).overrides("src::item").first()
         assertNull("Unknown enum name must not crash; maps to null", result.panelOverflow)
@@ -34,6 +35,7 @@ class BookComicFormattingPreferencesStoreImplTest {
         val entity = BookComicFormattingPreferencesEntity(
             sourceId = "src", itemId = "item",
             panelViewOn = null, panelOverflow = "SPLIT",
+            panelAnimationSpeedMs = null,
         )
         val result = storeWith(entity).overrides("src::item").first()
         assertEquals(PanelOverflowBehavior.SPLIT, result.panelOverflow)
@@ -44,6 +46,7 @@ class BookComicFormattingPreferencesStoreImplTest {
         val entity = BookComicFormattingPreferencesEntity(
             sourceId = "src", itemId = "item",
             panelViewOn = true, panelOverflow = "SMART_SPLIT",
+            panelAnimationSpeedMs = null,
         )
         val result = storeWith(entity).overrides("src::item").first()
         assertEquals(PanelOverflowBehavior.SMART_SPLIT, result.panelOverflow)
@@ -53,5 +56,26 @@ class BookComicFormattingPreferencesStoreImplTest {
         val result = storeWith(null).overrides("src::item").first()
         assertNull(result.panelViewOn)
         assertNull(result.panelOverflow)
+        assertNull(result.panelAnimationSpeedMs)
+    }
+
+    @Test fun `panelAnimationSpeedMs is round-tripped through entity`() = runTest {
+        val entity = BookComicFormattingPreferencesEntity(
+            sourceId = "src", itemId = "item",
+            panelViewOn = true, panelOverflow = null,
+            panelAnimationSpeedMs = 400,
+        )
+        val result = storeWith(entity).overrides("src::item").first()
+        assertEquals(400, result.panelAnimationSpeedMs)
+    }
+
+    @Test fun `null panelAnimationSpeedMs in entity maps to null override — follows global`() = runTest {
+        val entity = BookComicFormattingPreferencesEntity(
+            sourceId = "src", itemId = "item",
+            panelViewOn = true, panelOverflow = null,
+            panelAnimationSpeedMs = null,
+        )
+        val result = storeWith(entity).overrides("src::item").first()
+        assertNull(result.panelAnimationSpeedMs)
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ComicFormattingPreferencesStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ComicFormattingPreferencesStoreImplTest.kt
@@ -26,10 +26,11 @@ class ComicFormattingPreferencesStoreImplTest {
         ),
     )
 
-    @Test fun `defaults are panelViewOn=false and panelOverflow=SPLIT`() = testScope.runTest {
+    @Test fun `defaults are panelViewOn=false, panelOverflow=SPLIT, panelAnimationSpeedMs=250`() = testScope.runTest {
         val prefs = newStore().preferences.first()
         assertEquals(false, prefs.panelViewOn)
         assertEquals(PanelOverflowBehavior.SPLIT, prefs.panelOverflow)
+        assertEquals(250, prefs.panelAnimationSpeedMs)
     }
 
     @Test fun `panelViewOn round-trips`() = testScope.runTest {
@@ -58,6 +59,25 @@ class ComicFormattingPreferencesStoreImplTest {
         val store = newStore()
         store.update(ComicFormattingPreferences(panelViewOn = false, panelOverflow = PanelOverflowBehavior.OFF))
         assertEquals(PanelOverflowBehavior.OFF, store.preferences.first().panelOverflow)
+    }
+
+    @Test fun `panelAnimationSpeedMs round-trips non-default value`() = testScope.runTest {
+        val store = newStore()
+        store.update(ComicFormattingPreferences(panelAnimationSpeedMs = 400))
+        assertEquals(400, store.preferences.first().panelAnimationSpeedMs)
+    }
+
+    @Test fun `panelAnimationSpeedMs 0 round-trips (disabled)`() = testScope.runTest {
+        val store = newStore()
+        store.update(ComicFormattingPreferences(panelAnimationSpeedMs = 0))
+        assertEquals(0, store.preferences.first().panelAnimationSpeedMs)
+    }
+
+    @Test fun `panelAnimationSpeedMs default 250 is stored as absent and reads back as 250`() = testScope.runTest {
+        val store = newStore()
+        store.update(ComicFormattingPreferences(panelAnimationSpeedMs = 400))
+        store.update(ComicFormattingPreferences(panelAnimationSpeedMs = 250))
+        assertEquals(250, store.preferences.first().panelAnimationSpeedMs)
     }
 
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ComicFormattingPreferencesStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ComicFormattingPreferencesStoreImplTest.kt
@@ -26,7 +26,7 @@ class ComicFormattingPreferencesStoreImplTest {
         ),
     )
 
-    @Test fun `defaults are panelViewOn=false, panelOverflow=SPLIT, panelAnimationSpeedMs=250`() = testScope.runTest {
+    @Test fun `defaults are panelViewOn=false and panelOverflow=SPLIT`() = testScope.runTest {
         val prefs = newStore().preferences.first()
         assertEquals(false, prefs.panelViewOn)
         assertEquals(PanelOverflowBehavior.SPLIT, prefs.panelOverflow)

--- a/core/database-api/src/commonMain/kotlin/com/riffle/core/database/BookComicFormattingPreferencesEntity.kt
+++ b/core/database-api/src/commonMain/kotlin/com/riffle/core/database/BookComicFormattingPreferencesEntity.kt
@@ -29,6 +29,7 @@ data class BookComicFormattingPreferencesEntity(
     @ColumnInfo(name = "item_id") val itemId: String,
     @ColumnInfo(name = "panel_view_on") val panelViewOn: Boolean?,
     @ColumnInfo(name = "panel_overflow") val panelOverflow: String?,
+    @ColumnInfo(name = "panel_animation_speed_ms") val panelAnimationSpeedMs: Int?,
 )
 
 @Dao

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/67.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/67.json
@@ -1,0 +1,2131 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 67,
+    "identityHash": "c661002634fd8a4a53c92dfc92aa3aa4",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER NOT NULL, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, `pageCount` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesSequence",
+            "columnName": "seriesSequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `coloredChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coloredChapterMap",
+            "columnName": "coloredChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "scope"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, `originFontFamily` TEXT, `emphasisStyles` TEXT, `textSnippetHtml` TEXT, `fragmentAnchor` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedFigures",
+            "columnName": "embeddedFigures",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageHref",
+            "columnName": "imageHref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageSvg",
+            "columnName": "imageSvg",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBytes",
+            "columnName": "imageBytes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originFontFamily",
+            "columnName": "originFontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "emphasisStyles",
+            "columnName": "emphasisStyles",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippetHtml",
+            "columnName": "textSnippetHtml",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fragmentAnchor",
+            "columnName": "fragmentAnchor",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "local_files_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `treeUri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `addedAtEpochMs` INTEGER NOT NULL, `libraryId` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `treeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtEpochMs",
+            "columnName": "addedAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "treeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `originalUri` TEXT NOT NULL, `copiedPath` TEXT NOT NULL, `coverPath` TEXT, `format` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `mtimeEpochMs` INTEGER NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, `displayName` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUri",
+            "columnName": "originalUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "copiedPath",
+            "columnName": "copiedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtimeEpochMs",
+            "columnName": "mtimeEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_files_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_file_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `folderTreeUri` TEXT NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`, `folderTreeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderTreeUri",
+            "columnName": "folderTreeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId",
+            "folderTreeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_file_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_local_files_file_folders_sourceId_folderTreeUri",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "folderTreeUri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId_folderTreeUri` ON `${TABLE_NAME}` (`sourceId`, `folderTreeUri`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_file_metadata_overrides",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `title` TEXT, `author` TEXT, `seriesName` TEXT, `seriesIndex` REAL, `coverUrl` TEXT, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "seriesIndex",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_file_metadata_overrides_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_file_metadata_overrides_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_item_freshness",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `lastFetchedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFetchedAt",
+            "columnName": "lastFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `rootId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootId",
+            "columnName": "rootId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_playlists_rootId",
+            "unique": false,
+            "columnNames": [
+              "rootId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_rootId` ON `${TABLE_NAME}` (`rootId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `orderIndex` INTEGER NOT NULL, PRIMARY KEY(`playlistId`, `sourceId`, `itemId`), FOREIGN KEY(`sourceId`, `playlistId`) REFERENCES `playlists`(`sourceId`, `id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "orderIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId",
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_items_sourceId_playlistId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_items_sourceId_playlistId` ON `${TABLE_NAME}` (`sourceId`, `playlistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId",
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "sourceId",
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "publication_metrics_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `totalPositions` INTEGER, `pageCount` INTEGER, `cachedAt` INTEGER NOT NULL, `epubVersion` TEXT, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPositions",
+            "columnName": "totalPositions",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epubVersion",
+            "columnName": "epubVersion",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_publication_metrics_cache_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_publication_metrics_cache_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_comic_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`source_id` TEXT NOT NULL, `item_id` TEXT NOT NULL, `panel_view_on` INTEGER, `panel_overflow` TEXT, `panel_animation_speed_ms` INTEGER, PRIMARY KEY(`source_id`, `item_id`), FOREIGN KEY(`source_id`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "source_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "panelViewOn",
+            "columnName": "panel_view_on",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "panelOverflow",
+            "columnName": "panel_overflow",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "panelAnimationSpeedMs",
+            "columnName": "panel_animation_speed_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "source_id",
+            "item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_comic_formatting_preferences_source_id",
+            "unique": false,
+            "columnNames": [
+              "source_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_comic_formatting_preferences_source_id` ON `${TABLE_NAME}` (`source_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "source_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c661002634fd8a4a53c92dfc92aa3aa4')"
+    ]
+  }
+}

--- a/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1987,6 +1987,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_63_64,
             RiffleDatabase.MIGRATION_64_65,
             RiffleDatabase.MIGRATION_65_66,
+            RiffleDatabase.MIGRATION_66_67,
         )
 
         db.query("SELECT url, username, serverType, absUserId, type FROM sources WHERE id = 's1'").use { cursor ->
@@ -3048,6 +3049,40 @@ class MigrationTest {
                 assertEquals("item1", cursor.getString(cursor.getColumnIndexOrThrow("item_id")))
                 assertEquals(1, cursor.getInt(cursor.getColumnIndexOrThrow("panel_view_on")))
                 assertEquals("SMART_SPLIT", cursor.getString(cursor.getColumnIndexOrThrow("panel_overflow")))
+            }
+        }
+    }
+
+    @Test
+    fun migration66To67_addsAnimationSpeedToComicFormatting() {
+        helper.createDatabase(TEST_DB, 66).use { db ->
+            db.execSQL(
+                "INSERT INTO sources (id, url, isActive, insecureConnectionAllowed, username, serverType, absUserId, type) " +
+                    "VALUES ('src1', 'http://test', 1, 0, '', 'AUDIOBOOKSHELF', NULL, 'ABS')"
+            )
+            // Pre-existing row without panel_animation_speed_ms
+            db.execSQL(
+                "INSERT INTO book_comic_formatting_preferences " +
+                    "(source_id, item_id, panel_view_on, panel_overflow) " +
+                    "VALUES ('src1', 'item1', 1, 'SPLIT')"
+            )
+        }
+        helper.runMigrationsAndValidate(TEST_DB, 67, true, RiffleDatabase.MIGRATION_66_67).use { db ->
+            db.query("SELECT * FROM book_comic_formatting_preferences WHERE item_id = 'item1'").use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                // Pre-existing row: panel_animation_speed_ms defaults to NULL (follow global)
+                val col = cursor.getColumnIndexOrThrow("panel_animation_speed_ms")
+                assertTrue(cursor.isNull(col))
+            }
+            // New row can store a speed override
+            db.execSQL(
+                "INSERT INTO book_comic_formatting_preferences " +
+                    "(source_id, item_id, panel_view_on, panel_overflow, panel_animation_speed_ms) " +
+                    "VALUES ('src1', 'item2', 1, 'SPLIT', 400)"
+            )
+            db.query("SELECT panel_animation_speed_ms FROM book_comic_formatting_preferences WHERE item_id = 'item2'").use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals(400, cursor.getInt(cursor.getColumnIndexOrThrow("panel_animation_speed_ms")))
             }
         }
     }

--- a/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -42,7 +42,7 @@ import androidx.sqlite.execSQL
         PublicationMetricsCacheEntity::class,
         BookComicFormattingPreferencesEntity::class,
     ],
-    version = 66,
+    version = 67,
     exportSchema = true,
 )
 @ConstructedBy(RiffleDatabaseConstructor::class)
@@ -1756,6 +1756,14 @@ abstract class RiffleDatabase : RoomDatabase() {
                 db.execSQL(
                     "CREATE INDEX IF NOT EXISTS `index_book_comic_formatting_preferences_source_id` " +
                         "ON `book_comic_formatting_preferences` (`source_id`)"
+                )
+            }
+        }
+
+        val MIGRATION_66_67 = object : Migration(66, 67) {
+            override fun migrate(db: SQLiteConnection) {
+                db.execSQL(
+                    "ALTER TABLE `book_comic_formatting_preferences` ADD COLUMN `panel_animation_speed_ms` INTEGER"
                 )
             }
         }

--- a/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabaseFactory.kt
+++ b/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabaseFactory.kt
@@ -113,4 +113,5 @@ internal val RIFFLE_DATABASE_MIGRATIONS: Array<Migration> = arrayOf(
     RiffleDatabase.MIGRATION_63_64,
     RiffleDatabase.MIGRATION_64_65,
     RiffleDatabase.MIGRATION_65_66,
+    RiffleDatabase.MIGRATION_66_67,
 )

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/ComicFormattingPreferences.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/ComicFormattingPreferences.kt
@@ -5,16 +5,19 @@ enum class PanelOverflowBehavior { OFF, SPLIT, SMART_SPLIT }
 data class ComicFormattingPreferences(
     val panelViewOn: Boolean = false,
     val panelOverflow: PanelOverflowBehavior = PanelOverflowBehavior.SPLIT,
+    val panelAnimationSpeedMs: Int = 250,
 )
 
 data class BookComicFormattingOverrides(
     val panelViewOn: Boolean? = null,
     val panelOverflow: PanelOverflowBehavior? = null,
+    val panelAnimationSpeedMs: Int? = null,
 ) {
     fun applyTo(global: ComicFormattingPreferences) = global.copy(
         panelViewOn = panelViewOn ?: global.panelViewOn,
         panelOverflow = panelOverflow ?: global.panelOverflow,
+        panelAnimationSpeedMs = panelAnimationSpeedMs ?: global.panelAnimationSpeedMs,
     )
 
-    fun isEmpty() = panelViewOn == null && panelOverflow == null
+    fun isEmpty() = panelViewOn == null && panelOverflow == null && panelAnimationSpeedMs == null
 }

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/comic/BookComicFormattingOverridesTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/comic/BookComicFormattingOverridesTest.kt
@@ -45,5 +45,23 @@ class BookComicFormattingOverridesTest {
     @Test fun `isEmpty returns false when any field non-null`() {
         assertFalse(BookComicFormattingOverrides(panelViewOn = true).isEmpty())
         assertFalse(BookComicFormattingOverrides(panelOverflow = PanelOverflowBehavior.OFF).isEmpty())
+        assertFalse(BookComicFormattingOverrides(panelAnimationSpeedMs = 400).isEmpty())
+    }
+
+    @Test fun `applyTo overrides panelAnimationSpeedMs when set`() {
+        val result = BookComicFormattingOverrides(panelAnimationSpeedMs = 400).applyTo(global)
+        assertEquals(400, result.panelAnimationSpeedMs)
+        assertEquals(global.panelViewOn, result.panelViewOn)
+        assertEquals(global.panelOverflow, result.panelOverflow)
+    }
+
+    @Test fun `applyTo uses global panelAnimationSpeedMs when override is null`() {
+        val result = BookComicFormattingOverrides().applyTo(global)
+        assertEquals(global.panelAnimationSpeedMs, result.panelAnimationSpeedMs)
+    }
+
+    @Test fun `applyTo 0ms disables animation (override takes precedence)`() {
+        val result = BookComicFormattingOverrides(panelAnimationSpeedMs = 0).applyTo(global)
+        assertEquals(0, result.panelAnimationSpeedMs)
     }
 }


### PR DESCRIPTION
## What

- Adds a **Panel Animation Speed** slider (0–600 ms, 50 ms steps) for comic panel navigation, with 0 mapped to "Off" (instant snap). Setting lives in:
  - Global Settings → Comics → Display
  - Per-book formatting sheet (same override/merge pattern as ebook settings)
- The slider is always visible but **disabled and greyed out** (0.38 alpha, M3 `enabled=false`) when Panel View is off.
- OS "Reduce Motion" accessibility flag always wins → `snap()` regardless of user setting.
- Adds **"No split"** as the first option in the Panel Overflow radio group, surfacing the existing `PanelOverflowBehavior.OFF` value that was previously hidden from users. The Settings summary updates from "Panel View on" → "Panel View · No split".

## Changes

- `ComicFormattingPreferences` + `BookComicFormattingOverrides` — new `panelAnimationSpeedMs` field
- DB migration 66 → 67: `ALTER TABLE book_comic_formatting_preferences ADD COLUMN panel_animation_speed_ms INTEGER`
- `ComicFormattingPreferencesStoreImpl` — DataStore key; omits key when value is 250 (default) to keep DataStore lean
- `CbzPanelViewer` — `animationSpec` now parameterised by `panelAnimationSpeedMs`
- New `PanelAnimationSpeedSlider` composable in the `cbz` package
- `UnifiedSliderRow` / `SliderTrack` — new `enabled: Boolean = true` parameter (alpha + click guard)
- `PanelOverflowRadioGroup` — "No split" prepended as first entry
- `ComicsSection.comicDisplaySummary` — `OFF → "Panel View · No split"`

## Tests

- `BookComicFormattingOverridesTest` — 3 new tests for `panelAnimationSpeedMs` in `applyTo()` and `isEmpty()`
- `BookComicFormattingPreferencesStoreImplTest` — 2 new round-trip tests; existing entities updated with `panelAnimationSpeedMs = null`
- `ComicFormattingPreferencesStoreImplTest` — 3 new round-trip tests; default renamed to include new field
- `MigrationTest` — `migration66To67_addsAnimationSpeedToComicFormatting()` + added to `migrateFullChain`
- `ComicDisplaySummaryTest` — updated for No split label (old test name retired via `Removed-test:` trailer in commit 2a9ebc3)

Removed-test: panel view on with legacy OFF shows Panel View on