### PR TITLE
feat(reader): orientation-aware volume key navigation

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/riffle/app/MainActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
+import android.view.Surface
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.SystemBarStyle
@@ -145,6 +146,11 @@ class MainActivity : FragmentActivity() {
             isPanelOpen = readerStateHolder.isPanelOpen,
             isAudioPlaying = readerStateHolder.isAudioPlaying,
             isAutoScrolling = autoScrollController.state.value.isAutoScrollActive,
+            volumeUpPointsRight = when (windowManager.defaultDisplay.rotation) {
+                Surface.ROTATION_270 -> true
+                Surface.ROTATION_90 -> false
+                else -> null
+            },
         )
         return when (action) {
             VolumeKeyAction.NavigateForward -> {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/VolumeKeyEventHandler.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/VolumeKeyEventHandler.kt
@@ -9,6 +9,8 @@ object VolumeKeyEventHandler {
         isPanelOpen: Boolean,
         isAudioPlaying: Boolean,
         isAutoScrolling: Boolean = false,
+        // null = portrait/ambiguous orientation — fall back to invertVolumeKeys preference.
+        volumeUpPointsRight: Boolean? = null,
     ): VolumeKeyAction {
         if (!isReaderActive) return VolumeKeyAction.PassThrough
         // While in-app audio is playing, the volume keys belong to system volume,
@@ -22,7 +24,13 @@ object VolumeKeyEventHandler {
         }
         if (!volumeNavEnabled) return VolumeKeyAction.PassThrough
         if (isPanelOpen) return VolumeKeyAction.Swallow
-        val goForward = if (invertVolumeKeys) !isVolumeDown else isVolumeDown
+        // In landscape, the physical direction of volume-up overrides the user preference;
+        // in portrait (null) the preference is used as-is.
+        val goForward = when (volumeUpPointsRight) {
+            true  -> !isVolumeDown
+            false -> isVolumeDown
+            null  -> if (invertVolumeKeys) !isVolumeDown else isVolumeDown
+        }
         return if (goForward) VolumeKeyAction.NavigateForward else VolumeKeyAction.NavigateBackward
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/VolumeKeyEventHandlerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/VolumeKeyEventHandlerTest.kt
@@ -14,6 +14,7 @@ class VolumeKeyEventHandlerTest {
         isPanelOpen: Boolean = false,
         isAudioPlaying: Boolean = false,
         isAutoScrolling: Boolean = false,
+        volumeUpPointsRight: Boolean? = null,
     ) = VolumeKeyEventHandler.handle(
         isVolumeDown = isVolumeDown,
         isReaderActive = isReaderActive,
@@ -22,6 +23,7 @@ class VolumeKeyEventHandlerTest {
         isPanelOpen = isPanelOpen,
         isAudioPlaying = isAudioPlaying,
         isAutoScrolling = isAutoScrolling,
+        volumeUpPointsRight = volumeUpPointsRight,
     )
 
     @Test
@@ -131,6 +133,37 @@ class VolumeKeyEventHandlerTest {
             VolumeKeyAction.PassThrough,
             handle(isVolumeDown = true, isAutoScrolling = true, isAudioPlaying = true),
         )
+    }
+
+    @Test
+    fun `volume-up navigates forward when it points right`() {
+        assertEquals(VolumeKeyAction.NavigateForward, handle(isVolumeDown = false, volumeUpPointsRight = true))
+        assertEquals(VolumeKeyAction.NavigateBackward, handle(isVolumeDown = true, volumeUpPointsRight = true))
+    }
+
+    @Test
+    fun `landscape direction overrides invert preference when volume-up points right`() {
+        assertEquals(VolumeKeyAction.NavigateForward, handle(isVolumeDown = false, invertVolumeKeys = true, volumeUpPointsRight = true))
+        assertEquals(VolumeKeyAction.NavigateBackward, handle(isVolumeDown = true, invertVolumeKeys = true, volumeUpPointsRight = true))
+    }
+
+    @Test
+    fun `volume-down navigates forward when volume-up points left`() {
+        assertEquals(VolumeKeyAction.NavigateForward, handle(isVolumeDown = true, volumeUpPointsRight = false))
+        assertEquals(VolumeKeyAction.NavigateBackward, handle(isVolumeDown = false, volumeUpPointsRight = false))
+    }
+
+    @Test
+    fun `landscape direction overrides invert preference when volume-up points left`() {
+        assertEquals(VolumeKeyAction.NavigateForward, handle(isVolumeDown = true, invertVolumeKeys = true, volumeUpPointsRight = false))
+        assertEquals(VolumeKeyAction.NavigateBackward, handle(isVolumeDown = false, invertVolumeKeys = true, volumeUpPointsRight = false))
+    }
+
+    @Test
+    fun `auto-scroll speed direction is not affected by orientation`() {
+        // Speed nudge always follows invertVolumeKeys, not spatial orientation
+        assertEquals(VolumeKeyAction.AutoScrollFaster, handle(isVolumeDown = false, isAutoScrolling = true, volumeUpPointsRight = true))
+        assertEquals(VolumeKeyAction.AutoScrollSlower, handle(isVolumeDown = true, isAutoScrolling = true, volumeUpPointsRight = true))
     }
 
 }


### PR DESCRIPTION
Make volume key page-turn direction follow the physical orientation of the device so navigation is spatially consistent in landscape mode.

## What changed

**`VolumeKeyEventHandler`** — accepts a new `volumeUpPointsRight: Boolean?` parameter (`null` = portrait/unambiguous, defer to `invertVolumeKeys` preference). When non-null it overrides the user preference with the spatial direction:
- `true` (volume-up points right) → volume-up = forward
- `false` (volume-up points left) → volume-up = backward

Auto-scroll speed nudge is intentionally unaffected — it always follows `invertVolumeKeys`.

**`MainActivity`** — maps `windowManager.defaultDisplay.rotation` to `volumeUpPointsRight` using `Surface.ROTATION_270`/`ROTATION_90` before the call. Android rotation-to-direction logic stays in the Android layer; the handler remains pure JVM.

## Tests

Five new test cases covering both landscape directions (with and without the `invertVolumeKeys` override) and auto-scroll immunity to orientation.