### PR TITLE
fix(update): skip update check on dev builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       # KMP modules (core:common/models/domain/sources/net) have no `test` lifecycle
       # task — their JVM tests only run via `jvmTest`. `./gradlew test` alone silently
       # skipped all of them from the KMP conversion (#644) onward.
-      - run: ./gradlew test jvmTest
+      - run: ./gradlew test jvmTest -PversionName=0.0.0-ci
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@v7

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ build: wrapper ## Build the project
 
 .PHONY: test
 test: wrapper ## Run all unit tests
-	./gradlew test
+	./gradlew test -PversionName=0.0.0-ci
 
 .PHONY: lint
 lint: wrapper ## Run lint checks
@@ -83,7 +83,7 @@ lint: wrapper ## Run lint checks
 
 .PHONY: check
 check: wrapper ## Run build + lint + tests
-	./gradlew build lint test
+	./gradlew build lint test -PversionName=0.0.0-ci
 
 .PHONY: clean
 clean: ## Clean build outputs

--- a/app/src/main/kotlin/com/riffle/app/feature/update/StartupUpdateViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/update/StartupUpdateViewModel.kt
@@ -45,6 +45,7 @@ class StartupUpdateViewModel @Inject constructor(
     }
 
     fun checkNow() {
+        if (BuildConfig.VERSION_NAME.endsWith("-dev")) return
         if (_dialogState.value != null) return
         viewModelScope.launch {
             val autoEnabled = appUpdatePreferencesStore.autoUpdateEnabled.first()

--- a/app/src/main/kotlin/com/riffle/app/feature/update/StartupUpdateViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/update/StartupUpdateViewModel.kt
@@ -17,6 +17,10 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+// Dev builds produced outside the release pipeline carry a "-dev" suffix and never need an update
+// prompt — the developer is already running the latest code they built themselves.
+internal fun isDevVersionName(versionName: String): Boolean = versionName.endsWith("-dev")
+
 data class StartupUpdateDialogState(
     val releases: List<ReleaseInfo>,
     val update: AvailableUpdate,
@@ -45,7 +49,7 @@ class StartupUpdateViewModel @Inject constructor(
     }
 
     fun checkNow() {
-        if (BuildConfig.VERSION_NAME.endsWith("-dev")) return
+        if (isDevVersionName(BuildConfig.VERSION_NAME)) return
         if (_dialogState.value != null) return
         viewModelScope.launch {
             val autoEnabled = appUpdatePreferencesStore.autoUpdateEnabled.first()

--- a/app/src/test/kotlin/com/riffle/app/feature/update/StartupUpdateViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/update/StartupUpdateViewModelTest.kt
@@ -19,8 +19,10 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -286,5 +288,14 @@ class StartupUpdateViewModelTest {
 
         assertNull(vm.dialogState.value)
         assertEquals(0, prefs.ignoredVersionCode.first())
+    }
+
+    @Test
+    fun `isDevVersionName returns true for dash-dev suffix and false for real versions`() {
+        assertTrue(isDevVersionName("0.0.0-dev"))
+        assertTrue(isDevVersionName("1.2.3-dev"))
+        assertFalse(isDevVersionName("1.2.3"))
+        assertFalse(isDevVersionName("0.0.0-ci"))
+        assertFalse(isDevVersionName("1.0.0-rc1"))
     }
 }


### PR DESCRIPTION
## Summary

- Skip the startup update check when `BuildConfig.VERSION_NAME` ends with `"-dev"` — the fallback version name for local builds not produced by the release pipeline
- Extracts `isDevVersionName(versionName: String)` as an internal pure function so the predicate can be regression-tested independently of `BuildConfig`
- Wires `-PversionName=0.0.0-ci` into `make test` / `make check` and the CI unit-test step so the update-check logic is still exercised everywhere despite the guard

## Motivation

Running the app locally (via Android Studio Run or Debug, or any adb install of a dev build) triggered the "update available" modal on every cold start. Dev builds always carry `0.0.0-dev` as their version name, so the check is meaningless — the developer is already running the code they just built.

## Test plan

- [ ] `isDevVersionName` test covers `-dev`, release, `-ci`, and `-rc1` variants
- [ ] Existing `StartupUpdateViewModel` tests still pass (CI passes real version name; `make test` now does too)
- [ ] No modal on a locally-built APK; modal still appears on a release build