### PR TITLE
feat(settings): developer options as a root settings screen

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -44,7 +44,7 @@ import com.riffle.app.feature.settings.sections.AppBehaviorSection
 import com.riffle.app.feature.settings.sections.AppVersionSection
 import com.riffle.app.feature.settings.sections.AppearanceSection
 import com.riffle.app.feature.settings.sections.ComicsSection
-import com.riffle.app.feature.settings.sections.DiagnosticsSection
+import com.riffle.app.feature.settings.sections.DeveloperOptionsSection
 import com.riffle.app.feature.settings.sections.ListeningSection
 import com.riffle.app.feature.settings.sections.ReadaloudSection
 import com.riffle.app.feature.settings.sections.ReadingSection
@@ -72,11 +72,11 @@ fun SettingsScreen(
     onNavigateToAddLocalFolder: () -> Unit = {},
     onNavigateToReadaloudSettings: () -> Unit = {},
     onNavigateToAnnotationsSyncSettings: () -> Unit = {},
+    onNavigateToDeveloperOptions: () -> Unit = {},
     onNavigateToDebugLogs: () -> Unit = {},
     onNavigateToChangelog: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
-    val crashReports by viewModel.crashReports.collectAsState()
     val globalFormatting by viewModel.globalFormattingPreferences.collectAsState()
     val globalComicFormatting by viewModel.globalComicFormatting.collectAsState()
     val keepScreenOn by viewModel.keepScreenOn.collectAsState()
@@ -99,9 +99,7 @@ fun SettingsScreen(
     val rewindOnResumeSeconds by viewModel.rewindOnResumeSeconds.collectAsState()
     val annotationSyncRow by viewModel.annotationSyncRow.collectAsState()
     val developerModeEnabled by viewModel.developerModeEnabled.collectAsState()
-    val githubPat by viewModel.githubPat.collectAsState()
     val expandedServers = remember { mutableStateMapOf<String, Boolean>() }
-    val expandedCrashes = remember { mutableStateMapOf<String, Boolean>() }
     var openPanel by remember { mutableStateOf<SettingsPanel?>(null) }
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -218,14 +216,10 @@ fun SettingsScreen(
                 )
                 HorizontalDivider()
 
-                DiagnosticsSection(
-                    crashReports = crashReports,
-                    expandedCrashes = expandedCrashes,
-                    crashReportFiles = { viewModel.crashReportFiles() },
-                    onClearCrashReports = viewModel::clearCrashReports,
-                    onNavigateToDebugLogs = onNavigateToDebugLogs,
-                )
-                HorizontalDivider()
+                if (developerModeEnabled) {
+                    DeveloperOptionsSection(onOpen = onNavigateToDeveloperOptions)
+                    HorizontalDivider()
+                }
 
                 AppVersionSection(
                     installedVersionName = viewModel.installedVersionName,
@@ -236,9 +230,6 @@ fun SettingsScreen(
                     onSetAutoUpdateEnabled = viewModel::setAutoUpdateEnabled,
                     onNavigateToChangelog = onNavigateToChangelog,
                     onVersionTap = viewModel::onVersionTap,
-                    developerModeEnabled = developerModeEnabled,
-                    currentGithubPat = githubPat,
-                    onSaveGithubPat = viewModel::onSaveGithubPat,
                 )
                 HorizontalDivider()
             }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/developer/DeveloperOptionsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/developer/DeveloperOptionsScreen.kt
@@ -1,0 +1,81 @@
+package com.riffle.app.feature.settings.developer
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.riffle.app.feature.settings.SettingsSectionHeader
+import com.riffle.app.feature.settings.SettingsViewModel
+import com.riffle.app.feature.settings.sections.DiagnosticsSection
+import com.riffle.app.feature.settings.sections.GithubPatField
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DeveloperOptionsScreen(
+    onNavigateBack: () -> Unit,
+    onNavigateToDebugLogs: () -> Unit,
+    viewModel: SettingsViewModel,
+) {
+    val githubPat by viewModel.githubPat.collectAsState()
+    val crashReports by viewModel.crashReports.collectAsState()
+    val expandedCrashes = remember { mutableStateMapOf<String, Boolean>() }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Developer options") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            HorizontalDivider()
+            SettingsSectionHeader("GitHub PAT")
+            Text(
+                text = "Used to submit panel detection bug reports to the GitHub repository.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+            GithubPatField(
+                currentPat = githubPat,
+                onSaveGithubPat = viewModel::onSaveGithubPat,
+            )
+            HorizontalDivider()
+            DiagnosticsSection(
+                crashReports = crashReports,
+                expandedCrashes = expandedCrashes,
+                crashReportFiles = { viewModel.crashReportFiles() },
+                onClearCrashReports = viewModel::clearCrashReports,
+                onNavigateToDebugLogs = onNavigateToDebugLogs,
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/developer/DeveloperOptionsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/developer/DeveloperOptionsScreen.kt
@@ -1,31 +1,42 @@
 package com.riffle.app.feature.settings.developer
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import com.riffle.app.feature.settings.SettingsSectionHeader
 import com.riffle.app.feature.settings.SettingsViewModel
 import com.riffle.app.feature.settings.sections.DiagnosticsSection
-import com.riffle.app.feature.settings.sections.GithubPatField
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -72,10 +83,48 @@ fun DeveloperOptionsScreen(
             DiagnosticsSection(
                 crashReports = crashReports,
                 expandedCrashes = expandedCrashes,
-                crashReportFiles = { viewModel.crashReportFiles() },
+                crashReportFiles = viewModel::crashReportFiles,
                 onClearCrashReports = viewModel::clearCrashReports,
                 onNavigateToDebugLogs = onNavigateToDebugLogs,
             )
+        }
+    }
+}
+
+@Composable
+private fun GithubPatField(
+    currentPat: String,
+    onSaveGithubPat: (String) -> Unit,
+) {
+    var pat by remember { mutableStateOf(currentPat) }
+    var isSaved by remember { mutableStateOf(currentPat.isNotEmpty()) }
+
+    LaunchedEffect(currentPat) {
+        if (currentPat.isNotEmpty() && pat.isEmpty()) {
+            pat = currentPat
+            isSaved = true
+        }
+    }
+
+    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+        OutlinedTextField(
+            value = pat,
+            onValueChange = { pat = it; isSaved = false },
+            label = { Text("GitHub PAT (public_repo scope)") },
+            visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Button(
+                onClick = { onSaveGithubPat(pat); isSaved = true },
+                enabled = pat.isNotBlank() && !isSaved,
+            ) { Text("Save") }
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/sections/AppVersionSection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/sections/AppVersionSection.kt
@@ -30,9 +30,6 @@ internal fun AppVersionSection(
     onSetAutoUpdateEnabled: (Boolean) -> Unit,
     onNavigateToChangelog: () -> Unit,
     onVersionTap: () -> Unit = {},
-    developerModeEnabled: Boolean = false,
-    currentGithubPat: String = "",
-    onSaveGithubPat: (String) -> Unit = {},
 ) {
     SettingsSectionHeader("App version")
     val supporting = when (state) {
@@ -71,9 +68,6 @@ internal fun AppVersionSection(
             }
         },
     )
-    if (developerModeEnabled) {
-        DeveloperOptionsSection(currentPat = currentGithubPat, onSaveGithubPat = onSaveGithubPat)
-    }
     ListItem(
         headlineContent = { Text("Check for updates on startup") },
         trailingContent = {

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/sections/DeveloperOptionsSection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/sections/DeveloperOptionsSection.kt
@@ -1,75 +1,17 @@
 package com.riffle.app.feature.settings.sections
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Button
 import androidx.compose.material3.ListItem
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.unit.dp
 import com.riffle.app.feature.settings.DrillInChevron
-import com.riffle.app.feature.settings.SettingsSectionHeader
 
 @Composable
 internal fun DeveloperOptionsSection(onOpen: () -> Unit) {
-    SettingsSectionHeader("Developer options")
     ListItem(
         headlineContent = { Text("Developer options") },
         trailingContent = { DrillInChevron() },
         modifier = Modifier.clickable(onClick = onOpen),
     )
-}
-
-/** PAT input field used inside the Developer Options screen. */
-@Composable
-internal fun GithubPatField(
-    currentPat: String,
-    onSaveGithubPat: (String) -> Unit,
-) {
-    var pat by remember { mutableStateOf(currentPat) }
-    var isSaved by remember { mutableStateOf(currentPat.isNotEmpty()) }
-
-    LaunchedEffect(currentPat) {
-        if (currentPat.isNotEmpty() && pat.isEmpty()) {
-            pat = currentPat
-            isSaved = true
-        }
-    }
-
-    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-        OutlinedTextField(
-            value = pat,
-            onValueChange = { pat = it; isSaved = false },
-            label = { Text("GitHub PAT (public_repo scope)") },
-            visualTransformation = PasswordVisualTransformation(),
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
-            singleLine = true,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Button(
-                onClick = { onSaveGithubPat(pat); isSaved = true },
-                enabled = pat.isNotBlank() && !isSaved,
-            ) { Text("Save") }
-        }
-    }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/sections/DeveloperOptionsSection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/sections/DeveloperOptionsSection.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.settings.sections
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,7 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
-import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.ListItem
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,20 +22,28 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
+import com.riffle.app.feature.settings.DrillInChevron
 import com.riffle.app.feature.settings.SettingsSectionHeader
 
 @Composable
-internal fun DeveloperOptionsSection(
+internal fun DeveloperOptionsSection(onOpen: () -> Unit) {
+    SettingsSectionHeader("Developer options")
+    ListItem(
+        headlineContent = { Text("Developer options") },
+        trailingContent = { DrillInChevron() },
+        modifier = Modifier.clickable(onClick = onOpen),
+    )
+}
+
+/** PAT input field used inside the Developer Options screen. */
+@Composable
+internal fun GithubPatField(
     currentPat: String,
     onSaveGithubPat: (String) -> Unit,
 ) {
-    HorizontalDivider()
-    SettingsSectionHeader("Developer options")
     var pat by remember { mutableStateOf(currentPat) }
     var isSaved by remember { mutableStateOf(currentPat.isNotEmpty()) }
 
-    // When the StateFlow delivers the persisted PAT (starts empty, then emits the real value),
-    // seed the field only if the user hasn't typed anything yet.
     LaunchedEffect(currentPat) {
         if (currentPat.isNotEmpty() && pat.isEmpty()) {
             pat = currentPat

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -93,6 +93,7 @@ private const val ANNOTATIONS_SYNC_SETTINGS = "settings/annotation_sync"
 private const val CHANGELOG = "settings/changelog"
 private const val ANNOTATION_SYNC_MAINTENANCE = "settings/annotation_sync/maintenance"
 private const val DEBUG_LOGS = "settings/debug_logs"
+private const val DEVELOPER_OPTIONS = "settings/developer_options"
 private const val READALOUD_MATCHES = "readaloud_matches/{sourceId}?pairBookId={pairBookId}"
 private const val DOWNLOADS = "downloads"
 private const val LIBRARY_ITEMS = "library_items/{libraryId}/{libraryName}"
@@ -523,6 +524,7 @@ fun MainScreen(
                     onNavigateToAddLocalFolder = { navController.navigate(ADD_LOCAL_FILES) },
                     onNavigateToReadaloudSettings = { navController.navigate(READALOUD_SETTINGS) },
                     onNavigateToAnnotationsSyncSettings = { navController.navigate(ANNOTATIONS_SYNC_SETTINGS) },
+                    onNavigateToDeveloperOptions = { navController.navigate(DEVELOPER_OPTIONS) },
                     onNavigateToDebugLogs = { navController.navigate(DEBUG_LOGS) },
                     onNavigateToChangelog = { navController.navigate(CHANGELOG) },
                 )
@@ -580,6 +582,18 @@ fun MainScreen(
             composable(ANNOTATION_SYNC_MAINTENANCE) { backStackEntry ->
                 AnnotationSyncMaintenanceScreen(
                     onNavigateBack = { navController.popBackStackIfTop(backStackEntry) },
+                )
+            }
+            composable(DEVELOPER_OPTIONS) { backStackEntry ->
+                val settingsEntry = remember(backStackEntry) {
+                    navController.getBackStackEntry(SETTINGS)
+                }
+                val settingsVm: com.riffle.app.feature.settings.SettingsViewModel =
+                    hiltViewModel(settingsEntry)
+                com.riffle.app.feature.settings.developer.DeveloperOptionsScreen(
+                    onNavigateBack = { navController.popBackStackIfTop(backStackEntry) },
+                    onNavigateToDebugLogs = { navController.navigate(DEBUG_LOGS) },
+                    viewModel = settingsVm,
                 )
             }
             composable(DEBUG_LOGS) { backStackEntry ->


### PR DESCRIPTION
## Summary

- Developer options is now a dedicated drill-in screen in global settings, visible only when developer mode is enabled, positioned above App version
- GitHub PAT field (for submitting panel detection bug reports to GitHub) moves into the new screen with a short description: *"Used to submit panel detection bug reports to the GitHub repository."*
- Diagnostics section (debug logs + crash reports) moves into the new screen — no longer shown to regular users in the main list
- `AppVersionSection` loses its embedded developer options params (`developerModeEnabled`, `currentGithubPat`, `onSaveGithubPat`)

## Test plan

- [ ] Unlock developer mode (tap version row 7 times) — "Developer options" row appears above App version
- [ ] Tap Developer options → new screen opens with GitHub PAT field and diagnostics
- [ ] Save a PAT — persists across navigation
- [ ] Debug logs and crash reports work as before from the new location
- [ ] Without developer mode unlocked — no Developer options row; Diagnostics not accessible from main settings