### PR TITLE
perf(comics): cache CBZ thumbnail bitmaps and prewarm on open

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/cbz/CbzThumbnailStripTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/cbz/CbzThumbnailStripTest.kt
@@ -3,6 +3,9 @@ package com.riffle.app.feature.reader.cbz
 import android.graphics.Bitmap
 import android.util.LruCache
 import androidx.activity.ComponentActivity
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -85,10 +88,10 @@ class CbzThumbnailStripTest {
     }
 
     /**
-     * Regression: when thumbnails are decoded and stored in a shared cache, re-composing
-     * the strip with the same cache must not trigger additional openStream calls.
-     * This covers the immersive-mode toggle case: strip exits → composable removed →
-     * strip re-enters → composable recreated with the same hoisted cache → no re-decode.
+     * Regression: when thumbnails are decoded and stored in a shared cache, removing and
+     * re-adding the strip (immersive-mode toggle) must not trigger additional openStream calls.
+     *
+     * Uses state-driven visibility toggle — `setContent` can only be called once per test.
      */
     @Test
     fun shared_cache_survives_strip_recomposition_without_redecoding() {
@@ -97,36 +100,33 @@ class CbzThumbnailStripTest {
         val stubBitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
         repeat(5) { cache.put(it, stubBitmap) }
 
-        // First composition
+        var showStrip by mutableStateOf(true)
+
         composeTestRule.setContent {
-            CbzThumbnailStrip(
-                currentPage = 0,
-                pageCount = source.pageCount,
-                imageSource = source,
-                onSeek = {},
-                thumbnailCache = cache,
-            )
+            if (showStrip) {
+                CbzThumbnailStrip(
+                    currentPage = 0,
+                    pageCount = source.pageCount,
+                    imageSource = source,
+                    onSeek = {},
+                    thumbnailCache = cache,
+                )
+            }
         }
         composeTestRule.waitForIdle()
 
-        // Second composition with the same cache (simulates immersive toggle re-entry)
-        composeTestRule.setContent {
-            CbzThumbnailStrip(
-                currentPage = 0,
-                pageCount = source.pageCount,
-                imageSource = source,
-                onSeek = {},
-                thumbnailCache = cache,
-            )
-        }
+        // Simulate immersive toggle: strip exits then re-enters
+        showStrip = false
+        composeTestRule.waitForIdle()
+        showStrip = true
         composeTestRule.waitForIdle()
 
         assertEquals(
-            "openStream must not be called on second composition when cache is still populated",
+            "openStream must not be called after toggle when cache is still populated",
             0,
             source.openStreamCallCount,
         )
-        assertTrue("Cache must still hold all entries after recomposition", cache.size() == 5)
+        assertTrue("Cache must still hold all entries after toggle", cache.size() == 5)
     }
 
     /**

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/cbz/CbzThumbnailStripTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/cbz/CbzThumbnailStripTest.kt
@@ -146,8 +146,11 @@ class CbzThumbnailStripTest {
         val stub = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
         val decoded = mutableListOf<Int>()
 
+        // startPage=50 puts it in the middle: each offset produces TWO candidates (+offset and
+        // -offset). Without an inner-loop capacity check the last outer iteration can load both
+        // candidates and push loaded to capacity+1, evicting the startPage entry from the LruCache.
         prewarmThumbnailCache(
-            startPage = 0,
+            startPage = 50,
             pageCount = 200,
             cache = cache,
         ) { index ->
@@ -164,6 +167,10 @@ class CbzThumbnailStripTest {
             "cache must hold exactly [capacity] entries — no eviction occurred",
             capacity,
             cache.size(),
+        )
+        assertTrue(
+            "startPage must still be in cache — inner-loop overshoot must not evict it",
+            cache.get(50) != null,
         )
     }
 

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/cbz/CbzThumbnailStripTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/cbz/CbzThumbnailStripTest.kt
@@ -128,6 +128,79 @@ class CbzThumbnailStripTest {
         )
         assertTrue("Cache must still hold all entries after recomposition", cache.size() == 5)
     }
+
+    /**
+     * Regression for the capacity-cap guard in [prewarmThumbnailCache].
+     *
+     * Without the guard, a 200-page comic filling a 50-entry cache would loop through all 200
+     * pages, evicting earlier entries along the way. The reading neighbourhood (pages near the
+     * opening page) would be gone by the time the loop finished — reproducing the
+     * "cache lost on page turn" bug even though the prewarmer ran successfully.
+     *
+     * With the guard the cache must never exceed [LruCache.maxSize] regardless of [pageCount].
+     */
+    @Test
+    fun prewarm_respects_cache_capacity_and_never_evicts_loaded_entries() {
+        val capacity = 10
+        val cache = LruCache<Int, Bitmap>(capacity)
+        val stub = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+        val decoded = mutableListOf<Int>()
+
+        prewarmThumbnailCache(
+            startPage = 0,
+            pageCount = 200,
+            cache = cache,
+        ) { index ->
+            decoded += index
+            stub
+        }
+
+        assertEquals(
+            "prewarm must stop after cache is full — never decode beyond capacity",
+            capacity,
+            decoded.size,
+        )
+        assertEquals(
+            "cache must hold exactly [capacity] entries — no eviction occurred",
+            capacity,
+            cache.size(),
+        )
+    }
+
+    /**
+     * Regression for proximity-ordered preloading: pages closest to the opening position
+     * must be decoded before distant pages. Without this ordering, a large comic would fill
+     * the cache with pages the user will never see before loading the visible neighbourhood.
+     */
+    @Test
+    fun prewarm_decodes_nearby_pages_before_distant_pages() {
+        val cache = LruCache<Int, Bitmap>(20)
+        val stub = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+        val decoded = mutableListOf<Int>()
+
+        prewarmThumbnailCache(
+            startPage = 50,
+            pageCount = 200,
+            cache = cache,
+        ) { index ->
+            decoded += index
+            stub
+        }
+
+        // The first two decoded pages must be the start page itself (offset=0) and its
+        // immediate neighbour at offset=1 (51 decoded before 49 because listOf picks +offset first).
+        assertEquals("first decoded page must be startPage", 50, decoded[0])
+        assertEquals("second decoded page must be startPage+1", 51, decoded[1])
+        assertEquals("third decoded page must be startPage-1", 49, decoded[2])
+
+        // Every decoded page must be within [capacity] hops of startPage — confirming that
+        // the loop never jumps to a distant page while nearby pages are still uncached.
+        val maxDistance = decoded.maxOf { Math.abs(it - 50) }
+        assertTrue(
+            "all decoded pages must be near startPage; farthest was $maxDistance",
+            maxDistance <= 10,
+        )
+    }
 }
 
 /**

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/cbz/CbzThumbnailStripTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/cbz/CbzThumbnailStripTest.kt
@@ -1,11 +1,16 @@
 package com.riffle.app.feature.reader.cbz
 
+import android.graphics.Bitmap
+import android.util.LruCache
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.atomic.AtomicInteger
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,6 +49,85 @@ class CbzThumbnailStripTest {
 
         assertEquals(3, lastSeek)
     }
+
+    /**
+     * Regression for the shared bitmap cache: when a pre-populated LruCache is passed in,
+     * thumbnails must not call openStream at all (cache hit → skip decode).
+     * Without the fix, every CbzThumbnail composable independently calls decodeSampledBitmap
+     * regardless of whether a sibling already decoded the same page.
+     */
+    @Test
+    fun prePopulated_cache_prevents_any_openStream_call() {
+        val source = CountingCbzImageSource(validPngBytes(), pageCount = 5)
+        val cache = LruCache<Int, Bitmap>(50)
+
+        // Populate the cache manually for all 5 pages with a 1×1 bitmap.
+        val stubBitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+        repeat(5) { cache.put(it, stubBitmap) }
+
+        composeTestRule.setContent {
+            CbzThumbnailStrip(
+                currentPage = 0,
+                pageCount = source.pageCount,
+                imageSource = source,
+                onSeek = {},
+                thumbnailCache = cache,
+            )
+        }
+
+        composeTestRule.waitForIdle()
+
+        assertEquals(
+            "openStream must not be called when cache is pre-populated",
+            0,
+            source.openStreamCallCount,
+        )
+    }
+
+    /**
+     * Regression: when thumbnails are decoded and stored in a shared cache, re-composing
+     * the strip with the same cache must not trigger additional openStream calls.
+     * This covers the immersive-mode toggle case: strip exits → composable removed →
+     * strip re-enters → composable recreated with the same hoisted cache → no re-decode.
+     */
+    @Test
+    fun shared_cache_survives_strip_recomposition_without_redecoding() {
+        val source = CountingCbzImageSource(validPngBytes(), pageCount = 5)
+        val cache = LruCache<Int, Bitmap>(50)
+        val stubBitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+        repeat(5) { cache.put(it, stubBitmap) }
+
+        // First composition
+        composeTestRule.setContent {
+            CbzThumbnailStrip(
+                currentPage = 0,
+                pageCount = source.pageCount,
+                imageSource = source,
+                onSeek = {},
+                thumbnailCache = cache,
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        // Second composition with the same cache (simulates immersive toggle re-entry)
+        composeTestRule.setContent {
+            CbzThumbnailStrip(
+                currentPage = 0,
+                pageCount = source.pageCount,
+                imageSource = source,
+                onSeek = {},
+                thumbnailCache = cache,
+            )
+        }
+        composeTestRule.waitForIdle()
+
+        assertEquals(
+            "openStream must not be called on second composition when cache is still populated",
+            0,
+            source.openStreamCallCount,
+        )
+        assertTrue("Cache must still hold all entries after recomposition", cache.size() == 5)
+    }
 }
 
 /**
@@ -54,4 +138,25 @@ class CbzThumbnailStripTest {
 private class FakeCbzImageSource(override val pageCount: Int) : CbzImageSource {
     override fun imageBytes(pageIndex: Int): ByteArray = ByteArray(0)
     override fun openStream(pageIndex: Int): java.io.InputStream = ByteArray(0).inputStream()
+}
+
+private class CountingCbzImageSource(
+    private val bytes: ByteArray,
+    override val pageCount: Int,
+) : CbzImageSource {
+    private val _openStreamCallCount = AtomicInteger(0)
+    val openStreamCallCount: Int get() = _openStreamCallCount.get()
+
+    override fun imageBytes(pageIndex: Int) = bytes
+    override fun openStream(pageIndex: Int): java.io.InputStream {
+        _openStreamCallCount.incrementAndGet()
+        return bytes.inputStream()
+    }
+}
+
+private fun validPngBytes(): ByteArray {
+    val bmp = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+    val baos = ByteArrayOutputStream()
+    bmp.compress(Bitmap.CompressFormat.PNG, 100, baos)
+    return baos.toByteArray()
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -245,21 +245,11 @@ fun CbzReaderScreen(
             LaunchedEffect(effectiveThumbnailSource) {
                 delay(2_000)
                 val startPage = currentPage
-                val capacity = thumbnailCache.maxSize()
+                val source = effectiveThumbnailSource
+                val pageCount = ready.pageCount
                 withContext(Dispatchers.IO) {
-                    var loaded = 0
-                    for (offset in 0..ready.pageCount) {
-                        if (loaded >= capacity) break
-                        for (candidate in listOf(startPage + offset, startPage - offset).distinct()) {
-                            if (candidate in 0 until ready.pageCount && thumbnailCache.get(candidate) == null) {
-                                runCatching {
-                                    decodeSampledBitmap(effectiveThumbnailSource, candidate, MAX_THUMB_DIMENSION)
-                                }.getOrNull()?.let {
-                                    thumbnailCache.put(candidate, it)
-                                    loaded++
-                                }
-                            }
-                        }
+                    prewarmThumbnailCache(startPage, pageCount, thumbnailCache) { index ->
+                        runCatching { decodeSampledBitmap(source, index, MAX_THUMB_DIMENSION) }.getOrNull()
                     }
                 }
             }
@@ -756,4 +746,35 @@ internal fun cbzPageGestureAction(pointerCount: Int, scale: Float): CbzPageGestu
     pointerCount >= 2 -> CbzPageGestureAction.Zoom
     pointerCount == 1 && scale > 1f -> CbzPageGestureAction.PanZoomed
     else -> CbzPageGestureAction.Ignore
+}
+
+/**
+ * Fills [cache] with decoded thumbnails, radiating outward from [startPage].
+ *
+ * Stops as soon as [cache] is full — loading beyond capacity would evict nearby entries
+ * and leave the reading neighbourhood uncached (the "cache lost on page turn" bug).
+ *
+ * [decode] is called with a page index and must return a [Bitmap] or null on failure.
+ * Production callers pass `{ decodeSampledBitmap(source, it, MAX_THUMB_DIMENSION) }`.
+ * Tests pass a stub that creates a cheap 1×1 Bitmap.
+ */
+internal fun prewarmThumbnailCache(
+    startPage: Int,
+    pageCount: Int,
+    cache: LruCache<Int, Bitmap>,
+    decode: (Int) -> Bitmap?,
+) {
+    val capacity = cache.maxSize()
+    var loaded = 0
+    for (offset in 0..pageCount) {
+        if (loaded >= capacity) break
+        for (candidate in listOf(startPage + offset, startPage - offset).distinct()) {
+            if (candidate in 0 until pageCount && cache.get(candidate) == null) {
+                decode(candidate)?.let {
+                    cache.put(candidate, it)
+                    loaded++
+                }
+            }
+        }
+    }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -2,6 +2,7 @@ package com.riffle.app.feature.reader.cbz
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.util.LruCache
 import android.view.WindowManager
 import android.provider.Settings
 import androidx.compose.animation.AnimatedVisibility
@@ -17,25 +18,16 @@ import androidx.compose.foundation.gestures.calculatePan
 import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.MoreVert
@@ -74,10 +66,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import coil.compose.AsyncImage
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
-import coil.size.Size as CoilSize
 import androidx.compose.ui.graphics.asImageBitmap
 import com.riffle.app.feature.reader.ChapterMapOverlay
 import com.riffle.app.feature.reader.VolumeNavEvent
@@ -92,6 +82,7 @@ import com.riffle.core.domain.comic.panel.PanelBinaryMask
 import com.riffle.core.domain.comic.panel.PanelFitTransform
 import com.riffle.core.domain.comic.panel.PanelSource
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -240,6 +231,38 @@ fun CbzReaderScreen(
         if (ready != null) {
             var chapterMapContentPx by remember { mutableStateOf(0) }
             val density = LocalDensity.current
+            val effectiveThumbnailSource = ready.thumbnailSource ?: ready.imageSource
+            // Cache scoped to the book session — survives immersive mode toggles so thumbnails
+            // that were decoded before entering immersive are served instantly on re-exit.
+            val thumbnailCache = remember(effectiveThumbnailSource) { LruCache<Int, Bitmap>(50) }
+
+            // Pre-warm the cache ~2 s after the comic opens so the initial page render
+            // claims the full IO budget first. Radiates outward from the current reading
+            // position so the pages the user is most likely to scroll to are cached first.
+            // Stops once the cache is full — loading beyond capacity evicts earlier entries
+            // and leaves the reading neighbourhood uncached.
+            // Keyed only on effectiveThumbnailSource — runs once per book, not per page turn.
+            LaunchedEffect(effectiveThumbnailSource) {
+                delay(2_000)
+                val startPage = currentPage
+                val capacity = thumbnailCache.maxSize()
+                withContext(Dispatchers.IO) {
+                    var loaded = 0
+                    for (offset in 0..ready.pageCount) {
+                        if (loaded >= capacity) break
+                        for (candidate in listOf(startPage + offset, startPage - offset).distinct()) {
+                            if (candidate in 0 until ready.pageCount && thumbnailCache.get(candidate) == null) {
+                                runCatching {
+                                    decodeSampledBitmap(effectiveThumbnailSource, candidate, MAX_THUMB_DIMENSION)
+                                }.getOrNull()?.let {
+                                    thumbnailCache.put(candidate, it)
+                                    loaded++
+                                }
+                            }
+                        }
+                    }
+                }
+            }
 
             // Thumbnail strip — animated, sits above the chapter map
             AnimatedVisibility(
@@ -257,7 +280,8 @@ fun CbzReaderScreen(
                     CbzThumbnailStrip(
                         currentPage = currentPage,
                         pageCount = ready.pageCount,
-                        imageSource = ready.thumbnailSource ?: ready.imageSource,
+                        imageSource = effectiveThumbnailSource,
+                        thumbnailCache = thumbnailCache,
                         onSeek = { viewModel.jumpToPage(it) },
                     )
                 }
@@ -663,90 +687,6 @@ private fun CbzPanelPeekOverlay(
     }
 }
 
-@Composable
-internal fun CbzThumbnailStrip(
-    currentPage: Int,
-    pageCount: Int,
-    imageSource: CbzImageSource,
-    onSeek: (Int) -> Unit,
-) {
-    val listState = rememberLazyListState()
-
-    LaunchedEffect(currentPage) {
-        val viewport = listState.layoutInfo.viewportEndOffset - listState.layoutInfo.viewportStartOffset
-        val leading = if (viewport > 0) -(viewport / 2) else 0
-        listState.animateScrollToItem(currentPage, scrollOffset = leading)
-    }
-
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.9f))
-            .padding(vertical = 8.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Text(
-            text = "${currentPage + 1} / $pageCount",
-            color = MaterialTheme.colorScheme.onSurface,
-        )
-        LazyRow(
-            state = listState,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 4.dp)
-                .testTag("cbz_thumbnail_strip"),
-            contentPadding = PaddingValues(horizontal = 12.dp),
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            items(pageCount) { index ->
-                CbzThumbnail(
-                    imageSource = imageSource,
-                    pageIndex = index,
-                    isCurrent = index == currentPage,
-                    onClick = { onSeek(index) },
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun CbzThumbnail(
-    imageSource: CbzImageSource,
-    pageIndex: Int,
-    isCurrent: Boolean,
-    onClick: () -> Unit,
-) {
-    val context = LocalContext.current
-    val bitmap by produceState<Bitmap?>(initialValue = null, key1 = pageIndex, key2 = imageSource) {
-        value = withContext(Dispatchers.IO) {
-            runCatching { decodeSampledBitmap(imageSource, pageIndex, MAX_THUMB_DIMENSION) }.getOrNull()
-        }
-    }
-    val borderColor = if (isCurrent) MaterialTheme.colorScheme.primary else Color.Transparent
-    Box(
-        modifier = Modifier
-            .size(width = 88.dp, height = 120.dp)
-            .background(Color(0xFF1A1A1A), RoundedCornerShape(2.dp))
-            .border(width = 2.dp, color = borderColor, shape = RoundedCornerShape(2.dp))
-            .clickable { onClick() }
-            .testTag("cbz_thumb_$pageIndex"),
-    ) {
-        val currentBitmap = bitmap
-        if (currentBitmap != null) {
-            AsyncImage(
-                model = ImageRequest.Builder(context)
-                    .data(currentBitmap)
-                    .size(CoilSize(264, 360))
-                    .crossfade(false)
-                    .build(),
-                contentDescription = null,
-                modifier = Modifier.fillMaxSize(),
-            )
-        }
-    }
-}
-
 private enum class TapZone { Left, Center, Right }
 
 /**
@@ -771,7 +711,6 @@ internal enum class CbzPageGestureAction { Ignore, Zoom, PanZoomed }
 // Large BMPs can exceed 274MB decoded. Subsample to this max dimension to keep the Bitmap
 // allocation under the app heap limit.
 private const val MAX_PAGE_DIMENSION = 4096
-private const val MAX_THUMB_DIMENSION = 256
 
 internal fun calculateInSampleSize(width: Int, height: Int, maxDimension: Int): Int {
     var sampleSize = 1

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -766,9 +766,9 @@ internal fun prewarmThumbnailCache(
 ) {
     val capacity = cache.maxSize()
     var loaded = 0
-    for (offset in 0..pageCount) {
-        if (loaded >= capacity) break
+    outer@ for (offset in 0..pageCount) {
         for (candidate in listOf(startPage + offset, startPage - offset).distinct()) {
+            if (loaded >= capacity) break@outer
             if (candidate in 0 until pageCount && cache.get(candidate) == null) {
                 decode(candidate)?.let {
                     cache.put(candidate, it)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzThumbnailStrip.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzThumbnailStrip.kt
@@ -1,0 +1,137 @@
+package com.riffle.app.feature.reader.cbz
+
+import android.graphics.Bitmap
+import android.util.LruCache
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import coil.size.Size as CoilSize
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+internal const val MAX_THUMB_DIMENSION = 256
+
+@Composable
+internal fun CbzThumbnailStrip(
+    currentPage: Int,
+    pageCount: Int,
+    imageSource: CbzImageSource,
+    onSeek: (Int) -> Unit,
+    thumbnailCache: LruCache<Int, Bitmap>? = null,
+) {
+    val cache = thumbnailCache ?: remember(imageSource) { LruCache(50) }
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(currentPage) {
+        val viewport = listState.layoutInfo.viewportEndOffset - listState.layoutInfo.viewportStartOffset
+        val leading = if (viewport > 0) -(viewport / 2) else 0
+        listState.animateScrollToItem(currentPage, scrollOffset = leading)
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.9f))
+            .padding(vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "${currentPage + 1} / $pageCount",
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+        LazyRow(
+            state = listState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 4.dp)
+                .testTag("cbz_thumbnail_strip"),
+            contentPadding = PaddingValues(horizontal = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            items(pageCount) { index ->
+                CbzThumbnail(
+                    imageSource = imageSource,
+                    pageIndex = index,
+                    isCurrent = index == currentPage,
+                    onClick = { onSeek(index) },
+                    thumbnailCache = cache,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CbzThumbnail(
+    imageSource: CbzImageSource,
+    pageIndex: Int,
+    isCurrent: Boolean,
+    onClick: () -> Unit,
+    thumbnailCache: LruCache<Int, Bitmap>,
+) {
+    val context = LocalContext.current
+    val bitmap by produceState<Bitmap?>(
+        initialValue = thumbnailCache.get(pageIndex),
+        key1 = pageIndex,
+        key2 = imageSource,
+    ) {
+        if (value == null) {
+            val decoded = withContext(Dispatchers.IO) {
+                runCatching { decodeSampledBitmap(imageSource, pageIndex, MAX_THUMB_DIMENSION) }.getOrNull()
+            }
+            if (decoded != null) {
+                thumbnailCache.put(pageIndex, decoded)
+                value = decoded
+            }
+        }
+    }
+    val borderColor = if (isCurrent) MaterialTheme.colorScheme.primary else Color.Transparent
+    Box(
+        modifier = Modifier
+            .size(width = 88.dp, height = 120.dp)
+            .background(Color(0xFF1A1A1A), RoundedCornerShape(2.dp))
+            .border(width = 2.dp, color = borderColor, shape = RoundedCornerShape(2.dp))
+            .clickable { onClick() }
+            .testTag("cbz_thumb_$pageIndex"),
+    ) {
+        val currentBitmap = bitmap
+        if (currentBitmap != null) {
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(currentBitmap)
+                    .size(CoilSize(264, 360))
+                    .crossfade(false)
+                    .build(),
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,6 +101,7 @@ tasks.register("checkRiffleInfraSeams") {
             // migrate once the reader layer routes through DispatcherProvider.
             "app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt",
             "app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt",
+            "app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzThumbnailStrip.kt",
             // ---- Grandfathered when CI enforcement of these lints was turned on (the custom
             // checks were wired into `check`, which no CI job ran — drift below accumulated
             // unenforced). Same sweep-follow-up rationale as the blocks above.


### PR DESCRIPTION
## Summary

- **Shared LruCache hoisted above AnimatedVisibility** so the cache survives immersive-mode toggles — thumbnails that were decoded before entering immersive are served instantly on re-exit (previously: every show/hide cleared all decoded bitmaps)
- **`produceState` initialValue from cache** so any thumbnail already in the cache renders without waiting for a coroutine round-trip
- **Screen-level prewarmer** fires 2 s after the comic opens (yielding IO to the initial page render), radiating outward from the current page so the reading neighbourhood is warm before the user scrolls the strip
- **Capacity guard inside inner loop** (`break@outer` when `loaded >= capacity`) prevents the prewarmer from pushing more entries than the LruCache can hold, which would silently evict the start-page entry just decoded — reproducing the "cache lost on page turn" regression
- **`CbzThumbnailStrip` extracted** to its own file (`CbzThumbnailStrip.kt`) for separation of concerns
- **`prewarmThumbnailCache`** extracted to a top-level `internal` function so it can be called from both the `LaunchedEffect` and instrumentation tests without a Compose harness

## Tests

- `prePopulated_cache_prevents_any_openStream_call` — flips red if the cache hit check is removed from `CbzThumbnail`
- `shared_cache_survives_strip_recomposition_without_redecoding` — covers the immersive-mode toggle case
- `prewarm_respects_cache_capacity_and_never_evicts_loaded_entries` — flips red if the inner-loop capacity guard is removed; uses `startPage=50` (middle of 200 pages) to trigger the two-candidate-per-offset overshoot
- `prewarm_decodes_nearby_pages_before_distant_pages` — pins radial traversal order so nearby pages are always cached first