### PR TITLE
feat(comics): add WrongPanelOrder issue type to panel detection reporter

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportSheet.kt
@@ -105,6 +105,19 @@ internal fun PanelReportSheet(
                 }
             }
 
+            val labelPaint = remember {
+                android.graphics.Paint().apply {
+                    color = android.graphics.Color.WHITE
+                    textSize = 36f
+                    isFakeBoldText = true
+                    textAlign = android.graphics.Paint.Align.CENTER
+                    setShadowLayer(3f, 1f, 1f, android.graphics.Color.BLACK)
+                }
+            }
+            val orderedIndexMap = remember(state.orderedPanelIndices) {
+                state.orderedPanelIndices.withIndex().associate { (pos, idx) -> idx to pos }
+            }
+
             var canvasSize by remember { mutableStateOf(IntSize.Zero) }
             // Panel coordinates are in the original image space (pagePanels.imageWidth × imageHeight).
             // Use imageWidth/imageHeight (not mask.width/height) as the reference so rectangles
@@ -168,10 +181,7 @@ internal fun PanelReportSheet(
                                     val ix = (offset.x / scaleX).toInt().coerceIn(0, mask.width - 1)
                                     val iy = (offset.y / scaleY).toInt().coerceIn(0, mask.height - 1)
                                     if (orderMode) {
-                                        val panelIndex = viewModel.detectedPanels.indexOfFirst { p ->
-                                            ix in p.x until p.right && iy in p.y until p.bottom
-                                        }
-                                        if (panelIndex >= 0) viewModel.addOrRemoveOrderedPanel(panelIndex)
+                                        viewModel.tapForOrder(ix, iy)
                                     } else {
                                         viewModel.onTap(tappedImageX = ix, tappedImageY = iy)
                                     }
@@ -188,8 +198,8 @@ internal fun PanelReportSheet(
 
                     // Detected panels
                     viewModel.detectedPanels.forEachIndexed { i, p ->
-                        val orderPos = state.orderedPanelIndices.indexOf(i)
-                        val isOrdered = orderPos >= 0
+                        val orderPos = orderedIndexMap[i]
+                        val isOrdered = orderPos != null
                         val selected = state.tappedPanelIndex == i
                         drawRect(
                             color = when {
@@ -201,20 +211,13 @@ internal fun PanelReportSheet(
                             size = Size(p.width * scaleX, p.height * scaleY),
                             style = Stroke(width = if (selected || isOrdered) 3f else 1.5f),
                         )
-                        if (isOrdered) {
+                        if (orderPos != null) {
                             drawIntoCanvas { canvas ->
-                                val paint = android.graphics.Paint().apply {
-                                    color = android.graphics.Color.WHITE
-                                    textSize = 36f
-                                    isFakeBoldText = true
-                                    textAlign = android.graphics.Paint.Align.CENTER
-                                    setShadowLayer(3f, 1f, 1f, android.graphics.Color.BLACK)
-                                }
                                 canvas.nativeCanvas.drawText(
                                     "${orderPos + 1}",
                                     (p.x + p.width / 2f) * scaleX,
-                                    (p.y + p.height / 2f) * scaleY + paint.textSize / 2f - paint.descent(),
-                                    paint,
+                                    (p.y + p.height / 2f) * scaleY + labelPaint.textSize / 2f - labelPaint.descent(),
+                                    labelPaint,
                                 )
                             }
                         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportSheet.kt
@@ -39,6 +39,8 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.IntSize
@@ -63,6 +65,7 @@ internal fun PanelReportSheet(
         state.failureType == PanelDetectionFailureType.SplitPanel
     val drawsRectangle = state.failureType == PanelDetectionFailureType.MissedPanel ||
         state.failureType == PanelDetectionFailureType.SplitPanel
+    val orderMode = state.failureType == PanelDetectionFailureType.WrongPanelOrder
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(
@@ -124,6 +127,12 @@ internal fun PanelReportSheet(
                 }
                 Text(hint, style = androidx.compose.material3.MaterialTheme.typography.bodySmall)
             }
+            if (orderMode) {
+                Text(
+                    "Tap panels in the correct reading order. Tap a numbered panel to reset from that point.",
+                    style = androidx.compose.material3.MaterialTheme.typography.bodySmall,
+                )
+            }
 
             Box(
                 modifier = Modifier
@@ -131,7 +140,7 @@ internal fun PanelReportSheet(
                     .aspectRatio(mask.width.toFloat() / mask.height.toFloat())
                     .border(1.dp, Color.Gray)
                     .onSizeChanged { canvasSize = it }
-                    .pointerInput(drawMode, state.failureType, canvasSize) {
+                    .pointerInput(drawMode, orderMode, state.failureType, canvasSize) {
                         if (drawMode) {
                             detectDragGestures(
                                 onDragStart = { offset -> dragStart = offset; dragCurrent = offset },
@@ -156,10 +165,16 @@ internal fun PanelReportSheet(
                         } else {
                             detectTapGestures { offset ->
                                 if (scaleX > 0f && scaleY > 0f) {
-                                    viewModel.onTap(
-                                        tappedImageX = (offset.x / scaleX).toInt().coerceIn(0, mask.width - 1),
-                                        tappedImageY = (offset.y / scaleY).toInt().coerceIn(0, mask.height - 1),
-                                    )
+                                    val ix = (offset.x / scaleX).toInt().coerceIn(0, mask.width - 1)
+                                    val iy = (offset.y / scaleY).toInt().coerceIn(0, mask.height - 1)
+                                    if (orderMode) {
+                                        val panelIndex = viewModel.detectedPanels.indexOfFirst { p ->
+                                            ix in p.x until p.right && iy in p.y until p.bottom
+                                        }
+                                        if (panelIndex >= 0) viewModel.addOrRemoveOrderedPanel(panelIndex)
+                                    } else {
+                                        viewModel.onTap(tappedImageX = ix, tappedImageY = iy)
+                                    }
                                 }
                             }
                         }
@@ -173,13 +188,36 @@ internal fun PanelReportSheet(
 
                     // Detected panels
                     viewModel.detectedPanels.forEachIndexed { i, p ->
+                        val orderPos = state.orderedPanelIndices.indexOf(i)
+                        val isOrdered = orderPos >= 0
                         val selected = state.tappedPanelIndex == i
                         drawRect(
-                            color = if (selected) Color.Red else Color.Blue,
+                            color = when {
+                                isOrdered -> Color(0xFFFF9800)
+                                selected -> Color.Red
+                                else -> Color.Blue
+                            },
                             topLeft = Offset(p.x * scaleX, p.y * scaleY),
                             size = Size(p.width * scaleX, p.height * scaleY),
-                            style = Stroke(width = if (selected) 3f else 1.5f),
+                            style = Stroke(width = if (selected || isOrdered) 3f else 1.5f),
                         )
+                        if (isOrdered) {
+                            drawIntoCanvas { canvas ->
+                                val paint = android.graphics.Paint().apply {
+                                    color = android.graphics.Color.WHITE
+                                    textSize = 36f
+                                    isFakeBoldText = true
+                                    textAlign = android.graphics.Paint.Align.CENTER
+                                    setShadowLayer(3f, 1f, 1f, android.graphics.Color.BLACK)
+                                }
+                                canvas.nativeCanvas.drawText(
+                                    "${orderPos + 1}",
+                                    (p.x + p.width / 2f) * scaleX,
+                                    (p.y + p.height / 2f) * scaleY + paint.textSize / 2f - paint.descent(),
+                                    paint,
+                                )
+                            }
+                        }
                     }
 
                     // Tap marker (non-draw mode)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModel.kt
@@ -22,6 +22,7 @@ data class PanelReportUiState(
     val tappedPanelIndex: Int? = null,
     val drawnPanels: List<PanelRegion> = emptyList(),
     val drawnBoundaries: List<PanelBoundaryLine> = emptyList(),
+    val orderedPanelIndices: List<Int> = emptyList(),
     val submitting: Boolean = false,
     val submittedIssueUrl: String? = null,
     val error: String? = null,
@@ -41,7 +42,15 @@ class PanelReportViewModel(
     val state: StateFlow<PanelReportUiState> = _state.asStateFlow()
 
     fun setFailureType(type: PanelDetectionFailureType) {
-        _state.update { it.copy(failureType = type, error = null, drawnPanels = emptyList(), drawnBoundaries = emptyList()) }
+        _state.update { it.copy(failureType = type, error = null, drawnPanels = emptyList(), drawnBoundaries = emptyList(), orderedPanelIndices = emptyList()) }
+    }
+
+    fun addOrRemoveOrderedPanel(panelIndex: Int) {
+        _state.update { s ->
+            val existing = s.orderedPanelIndices.indexOf(panelIndex)
+            val updated = if (existing >= 0) s.orderedPanelIndices.take(existing) else s.orderedPanelIndices + panelIndex
+            s.copy(orderedPanelIndices = updated)
+        }
     }
 
     fun setNotes(notes: String) {
@@ -106,6 +115,7 @@ class PanelReportViewModel(
                 tappedPanelIndex = s.tappedPanelIndex,
                 drawnPanels = s.drawnPanels,
                 drawnBoundaries = s.drawnBoundaries,
+                expectedPanelOrder = s.orderedPanelIndices.takeIf { it.isNotEmpty() },
             )
             repository.submit(report, maskPng).fold(
                 onSuccess = { url -> _state.update { it.copy(submitting = false, submittedIssueUrl = url) } },

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModel.kt
@@ -58,11 +58,17 @@ class PanelReportViewModel(
     }
 
     fun onTap(tappedImageX: Int, tappedImageY: Int) {
-        val panelIndex = detectedPanels.indexOfFirst { p ->
-            tappedImageX in p.x until p.right && tappedImageY in p.y until p.bottom
-        }.takeIf { it >= 0 }
+        val panelIndex = panelIndexAt(tappedImageX, tappedImageY).takeIf { it >= 0 }
         _state.update { it.copy(tappedX = tappedImageX, tappedY = tappedImageY, tappedPanelIndex = panelIndex) }
     }
+
+    fun tapForOrder(ix: Int, iy: Int) {
+        val panelIndex = panelIndexAt(ix, iy)
+        if (panelIndex >= 0) addOrRemoveOrderedPanel(panelIndex)
+    }
+
+    private fun panelIndexAt(x: Int, y: Int): Int =
+        detectedPanels.indexOfFirst { p -> x in p.x until p.right && y in p.y until p.bottom }
 
     fun addDrawnPanel(x1: Int, y1: Int, x2: Int, y2: Int) {
         val left = minOf(x1, x2).coerceIn(0, imageWidth - 1)

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModelTest.kt
@@ -112,6 +112,61 @@ class PanelReportViewModelTest {
     }
 
     @Test
+    fun `tapping panel in WrongPanelOrder mode appends its index to orderedPanelIndices`() = runTest {
+        val panels = listOf(
+            PanelRegion(x = 0, y = 0, width = 100, height = 100),
+            PanelRegion(x = 100, y = 0, width = 100, height = 100),
+        )
+        val vm = makeVm(panels = panels)
+        vm.setFailureType(PanelDetectionFailureType.WrongPanelOrder)
+        vm.addOrRemoveOrderedPanel(1)
+        vm.addOrRemoveOrderedPanel(0)
+        assertEquals(listOf(1, 0), vm.state.value.orderedPanelIndices)
+    }
+
+    @Test
+    fun `re-tapping an already-ordered panel truncates sequence from that point`() = runTest {
+        val panels = List(3) { i -> PanelRegion(x = i * 100, y = 0, width = 100, height = 100) }
+        val vm = makeVm(panels = panels)
+        vm.setFailureType(PanelDetectionFailureType.WrongPanelOrder)
+        vm.addOrRemoveOrderedPanel(2)
+        vm.addOrRemoveOrderedPanel(0)
+        vm.addOrRemoveOrderedPanel(1)
+        // re-tap panel 0 (at position 1 in the sequence) → truncate to [2]
+        vm.addOrRemoveOrderedPanel(0)
+        assertEquals(listOf(2), vm.state.value.orderedPanelIndices)
+    }
+
+    @Test
+    fun `setFailureType clears orderedPanelIndices`() = runTest {
+        val panels = List(2) { i -> PanelRegion(x = i * 100, y = 0, width = 100, height = 100) }
+        val vm = makeVm(panels = panels)
+        vm.setFailureType(PanelDetectionFailureType.WrongPanelOrder)
+        vm.addOrRemoveOrderedPanel(0)
+        vm.setFailureType(PanelDetectionFailureType.FalsePanel)
+        assertTrue(vm.state.value.orderedPanelIndices.isEmpty())
+    }
+
+    @Test
+    fun `submit passes orderedPanelIndices as expectedPanelOrder`() = runTest {
+        var capturedReport: PanelDetectionReport? = null
+        val repo = object : PanelReportRepository {
+            override suspend fun submit(report: PanelDetectionReport, maskPng: ByteArray): Result<String> {
+                capturedReport = report
+                return Result.success("https://github.com/pkmetski/riffle/issues/1")
+            }
+        }
+        val panels = List(2) { i -> PanelRegion(x = i * 100, y = 0, width = 100, height = 100) }
+        val vm = makeVm(panels = panels, repository = repo)
+        vm.setFailureType(PanelDetectionFailureType.WrongPanelOrder)
+        vm.addOrRemoveOrderedPanel(1)
+        vm.addOrRemoveOrderedPanel(0)
+        vm.submit(maskPng = ByteArray(0))
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(listOf(1, 0), capturedReport?.expectedPanelOrder)
+    }
+
+    @Test
     fun `setFailureType clears drawn panels and boundaries`() = runTest {
         val vm = makeVm()
         vm.addDrawnPanel(0, 0, 50, 50)

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModelTest.kt
@@ -112,6 +112,28 @@ class PanelReportViewModelTest {
     }
 
     @Test
+    fun `tapForOrder on a panel region appends that panel to orderedPanelIndices`() = runTest {
+        val panels = listOf(
+            PanelRegion(x = 0, y = 0, width = 100, height = 100),
+            PanelRegion(x = 100, y = 0, width = 100, height = 100),
+        )
+        val vm = makeVm(panels = panels)
+        vm.setFailureType(PanelDetectionFailureType.WrongPanelOrder)
+        vm.tapForOrder(ix = 150, iy = 50)  // inside panel 1
+        vm.tapForOrder(ix = 50, iy = 50)   // inside panel 0
+        assertEquals(listOf(1, 0), vm.state.value.orderedPanelIndices)
+    }
+
+    @Test
+    fun `tapForOrder outside all panels does nothing`() = runTest {
+        val panels = listOf(PanelRegion(x = 0, y = 0, width = 100, height = 100))
+        val vm = makeVm(panels = panels)
+        vm.setFailureType(PanelDetectionFailureType.WrongPanelOrder)
+        vm.tapForOrder(ix = 500, iy = 500)
+        assertTrue(vm.state.value.orderedPanelIndices.isEmpty())
+    }
+
+    @Test
     fun `tapping panel in WrongPanelOrder mode appends its index to orderedPanelIndices`() = runTest {
         val panels = listOf(
             PanelRegion(x = 0, y = 0, width = 100, height = 100),

--- a/core/data/src/main/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepository.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepository.kt
@@ -180,6 +180,11 @@ class GitHubPanelReportRepository(
             appendLine("**Notes:** ${report.notes}")
             appendLine()
         }
+        val order = report.expectedPanelOrder
+        if (order != null) {
+            appendLine("**Expected panel order:** $order")
+            appendLine()
+        }
         appendLine("**Detected panels:**")
         report.detectedPanels.forEachIndexed { i, p ->
             appendLine("- [$i] x=${p.x} y=${p.y} w=${p.width} h=${p.height}")

--- a/core/data/src/test/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepositoryTest.kt
@@ -94,6 +94,29 @@ class GitHubPanelReportRepositoryTest {
     }
 
     @Test
+    fun `issue body contains expected panel order when WrongPanelOrder report submitted`() = runTest {
+        server.enqueue(MockResponse().setBody("""{"sha":"blob-sha-123"}""").setResponseCode(201))
+        server.enqueue(MockResponse().setBody("""{"object":{"sha":"commit-abc"}}""").setResponseCode(200))
+        server.enqueue(MockResponse().setBody("""{"tree":{"sha":"tree-xyz"}}""").setResponseCode(200))
+        server.enqueue(MockResponse().setBody("""{"sha":"new-tree-sha"}""").setResponseCode(201))
+        server.enqueue(MockResponse().setBody("""{"sha":"new-commit-sha"}""").setResponseCode(201))
+        server.enqueue(MockResponse().setBody("""{"ref":"refs/heads/panel-reports"}""").setResponseCode(200))
+        server.enqueue(MockResponse().setBody("""{"html_url":"https://github.com/pkmetski/riffle/issues/99"}""").setResponseCode(201))
+
+        val reportWithOrder = fakeReport.copy(
+            failureType = PanelDetectionFailureType.WrongPanelOrder,
+            expectedPanelOrder = listOf(1, 0),
+        )
+        repo().submit(reportWithOrder, ByteArray(0))
+
+        val requests = (1..7).map { server.takeRequest() }
+        val issueBody = requests[6].body.readUtf8()
+        val parsedBody = Json { ignoreUnknownKeys = true }
+            .parseToJsonElement(issueBody).jsonObject["body"]?.jsonPrimitive?.content ?: ""
+        assertTrue("body contains expected order", parsedBody.contains("[1, 0]"))
+    }
+
+    @Test
     fun `submit returns failure when API call fails`() = runTest {
         server.enqueue(MockResponse().setResponseCode(401).setBody("""{"message":"Bad credentials"}"""))
 

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetectionFailureType.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetectionFailureType.kt
@@ -7,4 +7,5 @@ enum class PanelDetectionFailureType(val label: String) {
     FalsePanel("False panel"),
     FellBackToFullPage("Fell back to full page"),
     CutPanelCutOff("Panel cut off"),
+    WrongPanelOrder("Wrong panel order"),
 }

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetectionReport.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetectionReport.kt
@@ -20,4 +20,5 @@ data class PanelDetectionReport(
     val tappedPanelIndex: Int?,
     val drawnPanels: List<PanelRegion> = emptyList(),
     val drawnBoundaries: List<PanelBoundaryLine> = emptyList(),
+    val expectedPanelOrder: List<Int>? = null,
 )


### PR DESCRIPTION
## Summary

- Adds `WrongPanelOrder` to `PanelDetectionFailureType` — a new failure type for reporting panels shown in the wrong reading order
- The user taps detected panels in their expected reading sequence; each panel gets an orange border and a numbered badge (1, 2, 3…); re-tapping a numbered panel truncates the sequence from that point
- `PanelDetectionReport` gains `expectedPanelOrder: List<Int>?` carrying the ordered panel indices
- The GitHub issue body includes `**Expected panel order:**` when set

## Test plan

- [ ] `PanelReportViewModelTest`: 6 new tests covering `tapForOrder` routing, `addOrRemoveOrderedPanel` append/truncate, `setFailureType` clears `orderedPanelIndices`, and `submit` passes the order to the repo
- [ ] `GitHubPanelReportRepositoryTest`: 1 new test verifying the expected order appears in the issue body