### PR TITLE
feat(reader): let auto theme follow app theme

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -197,10 +197,13 @@ User-controlled reading display settings. Scope varies by format:
 Formatting Preferences are per-device and Source-agnostic.
 
 ### Auto Theme
-A theme value that sits alongside Light, Dark, DarkDim, and Sepia in the [Formatting Preferences] theme picker. Selected like any other theme — globally as the default or per-book as an override — but resolves at render-time according to the [Theme Schedule]. The chip in the formatting panel uses a split day/night swatch. A book pinned to a concrete theme is unaffected; a book pinned to Auto follows the schedule.
+A theme value that sits alongside Light, Dark, DarkDim, and Sepia in the [Formatting Preferences] theme picker. Selected like any other theme — globally as the default or per-book as an override — but resolves at render-time according to the global Auto mode. The chip in the formatting panel uses a split swatch. A book pinned to a concrete theme is unaffected; a book pinned to Auto follows the global Auto mode.
+
+### Auto Theme Mode
+A global setting that controls how [Auto Theme] resolves. Modes: **Schedule** (the existing day/night clock behavior) and **App theme** (the reader picks from configurable light-app and dark-app reader themes according to the resolved app chrome; if the app theme is System, this follows the device dark-mode flag). Editable only on the full-screen Settings panel.
 
 ### Theme Schedule
-A global, user-configured pair of clock times and theme picks that drive [Auto Theme]. Four fields: day-start, night-start, day-theme, night-theme. Theme picks restricted to the four concrete themes. Interpreted on the device's local clock as two arcs on a 24-hour circle; the night arc may cross midnight. Defaults: 07:00, 21:00, Light, Dark. Applies uniformly to EPUB and PDF. Boundary crossings during an open reading session repaint live. Editable only on the full-screen Settings panel. See [ADR 0026].
+A global, user-configured pair of clock times and theme picks that drive [Auto Theme] when Auto mode is Schedule. Four fields: day-start, night-start, day-theme, night-theme. Theme picks restricted to the four concrete themes. Interpreted on the device's local clock as two arcs on a 24-hour circle; the night arc may cross midnight. Defaults: 07:00, 21:00, Light, Dark. Applies uniformly to EPUB and PDF. Boundary crossings during an open reading session repaint live. Editable only on the full-screen Settings panel. See [ADR 0026].
 
 ### EPUB CFI
 An EPUB Canonical Fragment Identifier — `epubcfi(/6/N!<docPath>)` pinpointing a location within an EPUB chapter. Two dialects: Readium (XPath-style) and epub.js (character-count, used by ABS). See [ADR 0013].

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Riffle lets you browse your library, read EPUB, PDF, and CBZ files, listen to au
 
 ### Reading Display
 - Rich formatting controls (themes, fonts, sizing, spacing, margins, justification)
-- Auto theme that switches between configured day and night themes on a global clock schedule
+- Auto theme that can follow configured app light/dark reader themes or switch between configured day/night themes on a global clock schedule
 - Paginated and continuous scroll modes, with landscape double-page spread
 - Per-book formatting overrides
 - Volume-key page navigation (with optional inverted direction)

--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderSettingsSectionsTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderSettingsSectionsTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.riffle.app.feature.reader.formatting.RenderCapabilities
+import com.riffle.core.domain.AutoReaderThemeMode
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.ReaderTheme
 import org.junit.Assert.assertFalse
@@ -68,7 +69,25 @@ class ReaderSettingsSectionsTest {
                 scheduleEditable = false,
             )
         }
-        composeTestRule.onNodeWithText("Edit the schedule in Settings → Display").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Edit Auto in Settings → Display").assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("Day starts at").assertCountEquals(0)
+    }
+
+    @Test
+    fun displaySection_appThemeAutoModeHidesScheduleEditor() {
+        composeTestRule.setContent {
+            DisplaySection(
+                prefs = FormattingPreferences().copy(
+                    theme = ReaderTheme.Auto,
+                    autoReaderThemeMode = AutoReaderThemeMode.AppTheme,
+                ),
+                onPrefsChange = {},
+                scheduleEditable = true,
+            )
+        }
+        composeTestRule.onNodeWithText("App theme").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Light app theme").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Dark app theme").assertIsDisplayed()
         composeTestRule.onAllNodesWithText("Day starts at").assertCountEquals(0)
     }
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/DisplaySection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/DisplaySection.kt
@@ -53,7 +53,14 @@ fun DisplaySection(
                         selected = prefs.theme == theme,
                         onClick = { onPrefsChange(prefs.copy(theme = theme)) },
                         label = { Text(theme.label()) },
-                        leadingIcon = { ThemeSwatch(theme, prefs.themeSchedule) },
+                        leadingIcon = {
+                            ThemeSwatch(
+                                theme = theme,
+                                schedule = prefs.themeSchedule,
+                                autoMode = prefs.autoReaderThemeMode,
+                                appThemeReaderThemes = prefs.appThemeReaderThemes,
+                            )
+                        },
                         modifier = Modifier.semantics { contentDescription = "${theme.label()} theme" },
                     )
                 }
@@ -64,19 +71,36 @@ fun DisplaySection(
                     selected = prefs.theme == ReaderTheme.Auto,
                     onClick = { onPrefsChange(prefs.copy(theme = ReaderTheme.Auto)) },
                     label = { Text(ReaderTheme.Auto.label()) },
-                    leadingIcon = { ThemeSwatch(ReaderTheme.Auto, prefs.themeSchedule) },
+                    leadingIcon = {
+                        ThemeSwatch(
+                            theme = ReaderTheme.Auto,
+                            schedule = prefs.themeSchedule,
+                            autoMode = prefs.autoReaderThemeMode,
+                            appThemeReaderThemes = prefs.appThemeReaderThemes,
+                        )
+                    },
                     modifier = Modifier.semantics { contentDescription = "${ReaderTheme.Auto.label()} theme" },
                 )
             }
             if (prefs.theme == ReaderTheme.Auto) {
                 Spacer(Modifier.height(12.dp))
                 if (scheduleEditable) {
-                    AutoScheduleControls(
+                    AutoThemeControls(
                         schedule = prefs.themeSchedule,
+                        autoMode = prefs.autoReaderThemeMode,
+                        appThemeReaderThemes = prefs.appThemeReaderThemes,
+                        onAutoModeChange = { onPrefsChange(prefs.copy(autoReaderThemeMode = it)) },
+                        onAppThemeReaderThemesChange = {
+                            onPrefsChange(prefs.copy(appThemeReaderThemes = it))
+                        },
                         onScheduleChange = { onPrefsChange(prefs.copy(themeSchedule = it)) },
                     )
                 } else {
-                    AutoScheduleSummaryCard(prefs.themeSchedule)
+                    AutoThemeSummaryCard(
+                        prefs.themeSchedule,
+                        prefs.autoReaderThemeMode,
+                        prefs.appThemeReaderThemes,
+                    )
                 }
             }
             Spacer(Modifier.height(20.dp))

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsControls.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsControls.kt
@@ -16,12 +16,16 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
@@ -46,6 +50,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import com.riffle.core.domain.AppThemeReaderThemes
+import com.riffle.core.domain.AutoReaderThemeMode
 import com.riffle.core.domain.ReaderFontFamily
 import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.ReaderTheme
@@ -54,9 +60,14 @@ import java.time.LocalTime
 import kotlin.math.roundToInt
 
 @Composable
-internal fun ThemeSwatch(theme: ReaderTheme, schedule: ThemeSchedule) {
+internal fun ThemeSwatch(
+    theme: ReaderTheme,
+    schedule: ThemeSchedule,
+    autoMode: AutoReaderThemeMode = AutoReaderThemeMode.Schedule,
+    appThemeReaderThemes: AppThemeReaderThemes = AppThemeReaderThemes(),
+) {
     if (theme == ReaderTheme.Auto) {
-        AutoThemeSwatch(schedule)
+        AutoThemeSwatch(schedule, autoMode, appThemeReaderThemes)
     } else {
         ConcreteThemeSwatch(theme)
     }
@@ -77,9 +88,19 @@ private fun ConcreteThemeSwatch(theme: ReaderTheme) {
 }
 
 @Composable
-private fun AutoThemeSwatch(schedule: ThemeSchedule) {
-    val day = schedule.dayTheme.palette
-    val night = schedule.nightTheme.palette
+private fun AutoThemeSwatch(
+    schedule: ThemeSchedule,
+    autoMode: AutoReaderThemeMode,
+    appThemeReaderThemes: AppThemeReaderThemes,
+) {
+    val day = when (autoMode) {
+        AutoReaderThemeMode.Schedule -> schedule.dayTheme
+        AutoReaderThemeMode.AppTheme -> appThemeReaderThemes.lightTheme
+    }.palette
+    val night = when (autoMode) {
+        AutoReaderThemeMode.Schedule -> schedule.nightTheme
+        AutoReaderThemeMode.AppTheme -> appThemeReaderThemes.darkTheme
+    }.palette
     val shape = RoundedCornerShape(percent = 50)
     Box(
         modifier = Modifier
@@ -202,9 +223,13 @@ private fun rememberAssetFontFamily(familyPrefix: String): FontFamily? {
 
 internal fun Float.round1() = (this * 10).roundToInt() / 10f
 
-// Read-only Auto-schedule summary for the in-reader Display tab, which cannot edit times.
+// Read-only Auto summary for the in-reader Display tab, which cannot edit global Auto settings.
 @Composable
-internal fun AutoScheduleSummaryCard(schedule: ThemeSchedule) {
+internal fun AutoThemeSummaryCard(
+    schedule: ThemeSchedule,
+    autoMode: AutoReaderThemeMode,
+    appThemeReaderThemes: AppThemeReaderThemes,
+) {
     Surface(
         shape = RoundedCornerShape(12.dp),
         color = MaterialTheme.colorScheme.surfaceVariant,
@@ -212,51 +237,161 @@ internal fun AutoScheduleSummaryCard(schedule: ThemeSchedule) {
         modifier = Modifier.fillMaxWidth(),
     ) {
         Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 11.dp)) {
-            Text(autoScheduleSummary(schedule), style = MaterialTheme.typography.bodyMedium)
+            Text(autoThemeSummary(schedule, autoMode, appThemeReaderThemes), style = MaterialTheme.typography.bodyMedium)
             Spacer(Modifier.height(2.dp))
-            Text(
-                "Edit the schedule in Settings → Display",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            Text("Edit Auto in Settings → Display", style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+internal fun AutoThemeControls(
+    schedule: ThemeSchedule,
+    autoMode: AutoReaderThemeMode,
+    appThemeReaderThemes: AppThemeReaderThemes,
+    onAutoModeChange: (AutoReaderThemeMode) -> Unit,
+    onAppThemeReaderThemesChange: (AppThemeReaderThemes) -> Unit,
+    onScheduleChange: (ThemeSchedule) -> Unit,
+) {
+    Column {
+        Text("Auto follows", style = MaterialTheme.typography.labelMedium)
+        AutoModeDropdown(
+            selected = autoMode,
+            onSelect = onAutoModeChange,
+        )
+        if (autoMode == AutoReaderThemeMode.Schedule) {
+            Spacer(Modifier.height(12.dp))
+            ScheduleThemeRow(
+                timeLabel = "Day starts at",
+                time = schedule.dayStart,
+                timeContentDescription = "Day start time",
+                onTimeChange = { onScheduleChange(schedule.copy(dayStart = it)) },
+                themeLabel = "Day theme",
+                theme = schedule.dayTheme,
+                themeContentDescription = "Day theme",
+                onThemeChange = { onScheduleChange(schedule.copy(dayTheme = it)) },
+            )
+            Spacer(Modifier.height(8.dp))
+            ScheduleThemeRow(
+                timeLabel = "Night starts at",
+                time = schedule.nightStart,
+                timeContentDescription = "Night start time",
+                onTimeChange = { onScheduleChange(schedule.copy(nightStart = it)) },
+                themeLabel = "Night theme",
+                theme = schedule.nightTheme,
+                themeContentDescription = "Night theme",
+                onThemeChange = { onScheduleChange(schedule.copy(nightTheme = it)) },
+            )
+        } else {
+            Spacer(Modifier.height(12.dp))
+            Text("Light app theme", style = MaterialTheme.typography.labelMedium)
+            ConcreteThemeDropdown(
+                selected = appThemeReaderThemes.lightTheme,
+                fieldContentDescription = "Light app reader theme",
+                onSelect = {
+                    onAppThemeReaderThemesChange(appThemeReaderThemes.copy(lightTheme = it))
+                },
+            )
+            Spacer(Modifier.height(8.dp))
+            Text("Dark app theme", style = MaterialTheme.typography.labelMedium)
+            ConcreteThemeDropdown(
+                selected = appThemeReaderThemes.darkTheme,
+                fieldContentDescription = "Dark app reader theme",
+                onSelect = {
+                    onAppThemeReaderThemesChange(appThemeReaderThemes.copy(darkTheme = it))
+                },
             )
         }
     }
 }
 
 @Composable
-internal fun AutoScheduleControls(
-    schedule: ThemeSchedule,
-    onScheduleChange: (ThemeSchedule) -> Unit,
+private fun ScheduleThemeRow(
+    timeLabel: String,
+    time: LocalTime,
+    timeContentDescription: String,
+    onTimeChange: (LocalTime) -> Unit,
+    themeLabel: String,
+    theme: ReaderTheme,
+    themeContentDescription: String,
+    onThemeChange: (ReaderTheme) -> Unit,
 ) {
-    Column {
-        Text("Day starts at", style = MaterialTheme.typography.labelMedium)
-        TimeField(
-            time = schedule.dayStart,
-            contentDescription = "Day start time",
-            onTimeChange = { onScheduleChange(schedule.copy(dayStart = it)) },
-        )
-        Spacer(Modifier.height(8.dp))
-        Text("Night starts at", style = MaterialTheme.typography.labelMedium)
-        TimeField(
-            time = schedule.nightStart,
-            contentDescription = "Night start time",
-            onTimeChange = { onScheduleChange(schedule.copy(nightStart = it)) },
-        )
-        Spacer(Modifier.height(12.dp))
-        Text("Day theme", style = MaterialTheme.typography.labelMedium)
-        ConcreteThemeDropdown(
-            selected = schedule.dayTheme,
-            fieldContentDescription = "Day theme",
-            onSelect = { onScheduleChange(schedule.copy(dayTheme = it)) },
-        )
-        Spacer(Modifier.height(8.dp))
-        Text("Night theme", style = MaterialTheme.typography.labelMedium)
-        ConcreteThemeDropdown(
-            selected = schedule.nightTheme,
-            fieldContentDescription = "Night theme",
-            onSelect = { onScheduleChange(schedule.copy(nightTheme = it)) },
-        )
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(timeLabel, style = MaterialTheme.typography.labelMedium)
+            TimeField(
+                time = time,
+                contentDescription = timeContentDescription,
+                onTimeChange = onTimeChange,
+            )
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(themeLabel, style = MaterialTheme.typography.labelMedium)
+            ConcreteThemeDropdown(
+                selected = theme,
+                fieldContentDescription = themeContentDescription,
+                onSelect = onThemeChange,
+            )
+        }
     }
+}
+
+@Composable
+private fun AutoModeDropdown(
+    selected: AutoReaderThemeMode,
+    onSelect: (AutoReaderThemeMode) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+    ) {
+        OutlinedTextField(
+            value = selected.label(),
+            onValueChange = {},
+            readOnly = true,
+            leadingIcon = { AutoModeIcon(selected) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor()
+                .semantics { contentDescription = "Auto theme mode" },
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            AutoReaderThemeMode.entries.forEach { mode ->
+                val label = mode.label()
+                DropdownMenuItem(
+                    text = { Text(label) },
+                    leadingIcon = { AutoModeIcon(mode) },
+                    onClick = {
+                        onSelect(mode)
+                        expanded = false
+                    },
+                    modifier = Modifier.semantics { contentDescription = "Auto follows $label" },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AutoModeIcon(mode: AutoReaderThemeMode) {
+    val imageVector = when (mode) {
+        AutoReaderThemeMode.Schedule -> Icons.Filled.Bedtime
+        AutoReaderThemeMode.AppTheme -> Icons.Filled.Home
+    }
+    Icon(
+        imageVector = imageVector,
+        contentDescription = null,
+        modifier = Modifier.size(18.dp),
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
 }
 
 @Composable

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsSummaries.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsSummaries.kt
@@ -1,6 +1,8 @@
 package com.riffle.app.feature.reader
 
 import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.domain.AppThemeReaderThemes
+import com.riffle.core.domain.AutoReaderThemeMode
 import com.riffle.core.domain.ReaderFontFamily
 import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.ReaderTheme
@@ -14,6 +16,11 @@ fun ReaderTheme.label(): String = when (this) {
     ReaderTheme.DarkDim -> "Dim"
     ReaderTheme.Sepia -> "Sepia"
     ReaderTheme.Auto -> "Auto"
+}
+
+fun AutoReaderThemeMode.label(): String = when (this) {
+    AutoReaderThemeMode.Schedule -> "Time based"
+    AutoReaderThemeMode.AppTheme -> "App theme"
 }
 
 fun ReaderFontFamily.label(): String = when (this) {
@@ -54,7 +61,12 @@ fun displaySummary(prefs: FormattingPreferences): String {
         ReaderOrientation.Continuous -> "Continuous"
     }
     val map = if (prefs.showChapterMap) "map on" else "map off"
-    return "${prefs.theme.label()} · $mode · $map"
+    val theme = if (prefs.theme == ReaderTheme.Auto) {
+        "Auto ${prefs.autoReaderThemeMode.label()}"
+    } else {
+        prefs.theme.label()
+    }
+    return "$theme · $mode · $map"
 }
 
 fun behaviorSummary(keepScreenOn: Boolean, volumeKeyNavigationEnabled: Boolean): String =
@@ -70,4 +82,14 @@ fun autoScheduleSummary(schedule: ThemeSchedule): String {
     fun t(time: LocalTime) = "%02d:%02d".format(time.hour, time.minute)
     return "Day ${t(schedule.dayStart)} · ${schedule.dayTheme.label()} → " +
         "Night ${t(schedule.nightStart)} · ${schedule.nightTheme.label()}"
+}
+
+fun autoThemeSummary(
+    schedule: ThemeSchedule,
+    autoMode: AutoReaderThemeMode,
+    appThemeReaderThemes: AppThemeReaderThemes = AppThemeReaderThemes(),
+): String = when (autoMode) {
+    AutoReaderThemeMode.Schedule -> autoScheduleSummary(schedule)
+    AutoReaderThemeMode.AppTheme -> "Light app · ${appThemeReaderThemes.lightTheme.label()} → " +
+        "Dark app · ${appThemeReaderThemes.darkTheme.label()}"
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/TypographyOverride.kt
@@ -89,6 +89,8 @@ internal val EXCLUDED_FROM_TYPOGRAPHY_OVERRIDES: Map<String, String> = mapOf(
     "showCurrentChapterLabel" to "UI affordance outside the reader content; no CSS implication.",
     "showReadingTimeEstimate" to "UI affordance outside the reader content; no CSS implication.",
     "themeSchedule" to "Schedule metadata used to derive the resolved theme at runtime; has no direct CSS implication.",
+    "autoReaderThemeMode" to "Auto-theme resolution mode metadata; the resolved concrete theme is applied through Readium's theme stylesheet, not a targeted CSS override.",
+    "appThemeReaderThemes" to "Light-app/dark-app Auto-theme mapping metadata; the resolved concrete theme is applied through Readium's theme stylesheet, not a targeted CSS override.",
     "autoScrollWpm" to "Auto-Scroll pace (words-per-minute); a kinetics setting consumed by AutoScrollController, not a CSS property.",
     "showAutoScroll" to "Settings toggle gating the reader top-bar Auto-Scroll icon; UI affordance, not a CSS property.",
     "cadenceWpm" to "Cadence pace (words-per-minute); a timing setting consumed by CadenceController/WpmTicker, not a CSS property.",

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -255,6 +255,7 @@ fun SettingsScreen(
         )
         SettingsPanel.Cadence -> CadenceSettingsPanel(
             prefs = globalFormatting,
+            appTheme = appTheme,
             onPrefsChange = viewModel::updateGlobalFormatting,
             onDismiss = { openPanel = null },
         )

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/panels/CadenceSettingsPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/panels/CadenceSettingsPanel.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
@@ -14,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.riffle.app.feature.reader.cadence.CadenceHeroIcon
 import com.riffle.app.feature.reader.swatchBackdropColor
+import com.riffle.core.domain.AppTheme
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.withResolvedTheme
 import java.time.LocalTime
@@ -30,10 +32,12 @@ import java.time.LocalTime
 @Composable
 fun CadenceSettingsPanel(
     prefs: FormattingPreferences,
+    appTheme: AppTheme = AppTheme.System,
     onPrefsChange: (FormattingPreferences) -> Unit,
     platformSupported: Boolean = true,
     onDismiss: () -> Unit,
 ) = DetailScaffold("Cadence", onDismiss) {
+    val systemInDark = isSystemInDarkTheme()
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.Center,
@@ -83,7 +87,7 @@ fun CadenceSettingsPanel(
         selected = prefs.cadenceHighlightColor,
         // Resolve Auto → concrete so the picker previews against the paper Readium is currently
         // painting, not the Light fallback the palette accessor uses when Auto slips through.
-        readerBackground = prefs.withResolvedTheme(LocalTime.now()).swatchBackdropColor,
+        readerBackground = prefs.withResolvedTheme(LocalTime.now(), appTheme, systemInDark).swatchBackdropColor,
         onSelectedChange = { onPrefsChange(prefs.copy(cadenceHighlightColor = it)) },
     )
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudSettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudSettingsScreen.kt
@@ -3,6 +3,7 @@ package com.riffle.app.feature.settings.readaloud
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -73,12 +74,16 @@ fun ReadaloudSettingsScreen(
     val readaloudSummaries by viewModel.readaloudSummaries.collectAsState()
     val readaloudPreferences by viewModel.readaloudPreferences.collectAsState()
     val formattingPreferences by viewModel.globalFormattingPreferences.collectAsState()
+    val appTheme by viewModel.appTheme.collectAsState()
+    val systemInDark = isSystemInDarkTheme()
     // Swatches must preview against the paper the reader draws, not the app's Material surface.
     // A dark-app / light-reader combo (or vice-versa) otherwise makes the swatches look nothing
     // like the highlight that lands on the page. The store persists Auto verbatim, so resolve to
     // the currently-scheduled concrete theme here — otherwise a night-schedule user opening
     // Settings during the dark arc would still see swatches on the Light fallback.
-    val readerBackground = formattingPreferences.withResolvedTheme(LocalTime.now()).swatchBackdropColor
+    val readerBackground = formattingPreferences
+        .withResolvedTheme(LocalTime.now(), appTheme, systemInDark)
+        .swatchBackdropColor
 
     val storyteller = servers.firstOrNull { it.serverType == ServerType.STORYTELLER_SERVICE }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderSettingsSummariesTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/ReaderSettingsSummariesTest.kt
@@ -1,6 +1,8 @@
 package com.riffle.app.feature.reader
 
 import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.domain.AppThemeReaderThemes
+import com.riffle.core.domain.AutoReaderThemeMode
 import com.riffle.core.domain.ReaderFontFamily
 import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.ReaderTheme
@@ -17,6 +19,8 @@ class ReaderSettingsSummariesTest {
         assertEquals("Light", ReaderTheme.Light.label())
         assertEquals("Dim", ReaderTheme.DarkDim.label())
         assertEquals("Auto", ReaderTheme.Auto.label())
+        assertEquals("Time based", AutoReaderThemeMode.Schedule.label())
+        assertEquals("App theme", AutoReaderThemeMode.AppTheme.label())
     }
 
     @Test fun fontLabels() {
@@ -54,6 +58,16 @@ class ReaderSettingsSummariesTest {
         assertEquals("Light · Paginated · map on", displaySummary(prefs))
     }
 
+    @Test fun displaySummaryShowsAutoMode() {
+        val prefs = defaults.copy(
+            theme = ReaderTheme.Auto,
+            autoReaderThemeMode = AutoReaderThemeMode.AppTheme,
+            orientation = ReaderOrientation.Horizontal,
+            showChapterMap = true,
+        )
+        assertEquals("Auto App theme · Paginated · map on", displaySummary(prefs))
+    }
+
     @Test fun displaySummaryScrollAndMapOff() {
         val prefs = defaults.copy(
             theme = ReaderTheme.Sepia,
@@ -86,5 +100,16 @@ class ReaderSettingsSummariesTest {
             nightTheme = ReaderTheme.Dark,
         )
         assertEquals("Day 07:00 · Light → Night 21:00 · Dark", autoScheduleSummary(schedule))
+    }
+
+    @Test fun autoThemeSummaryShowsAppThemeMode() {
+        val appThemeReaderThemes = AppThemeReaderThemes(
+            lightTheme = ReaderTheme.Sepia,
+            darkTheme = ReaderTheme.DarkDim,
+        )
+        assertEquals(
+            "Light app · Sepia → Dark app · Dim",
+            autoThemeSummary(ThemeSchedule(), AutoReaderThemeMode.AppTheme, appThemeReaderThemes),
+        )
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/AppearanceCoordinatorImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/AppearanceCoordinatorImpl.kt
@@ -1,8 +1,10 @@
 package com.riffle.core.data
 
 import com.riffle.core.domain.AppThemeStore
+import com.riffle.core.domain.AutoReaderThemeMode
 import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.resolveAutoReaderTheme
 import com.riffle.core.common.TimeProvider
 import com.riffle.core.domain.appearance.AppearanceCoordinator
 import com.riffle.core.domain.appearance.ChromeTheme
@@ -51,7 +53,7 @@ class AppearanceCoordinatorImpl(
     ) { appTheme, prefs, sysDark, _ ->
         val now = timeProvider.nowLocalTime()
         val resolvedReader = if (prefs.theme == ReaderTheme.Auto) {
-            prefs.themeSchedule.resolve(now)
+            prefs.resolveAutoReaderTheme(now, appTheme, sysDark)
         } else {
             prefs.theme
         }
@@ -76,7 +78,11 @@ class AppearanceCoordinatorImpl(
         // "Boundary crossings during an open reading session repaint live").
         scope.launch {
             formattingPreferencesStore.preferences
-                .map { it.themeSchedule to (it.theme == ReaderTheme.Auto) }
+                .map { prefs ->
+                    prefs.themeSchedule to
+                        (prefs.theme == ReaderTheme.Auto &&
+                            prefs.autoReaderThemeMode == AutoReaderThemeMode.Schedule)
+                }
                 .distinctUntilChanged()
                 .collectLatest { (schedule, autoActive) ->
                     if (!autoActive) return@collectLatest

--- a/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreImpl.kt
@@ -8,8 +8,10 @@ import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.riffle.core.data.di.FormattingPreferencesDataStore
+import com.riffle.core.domain.AppThemeReaderThemes
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.FormattingPreferencesStore
+import com.riffle.core.domain.AutoReaderThemeMode
 import com.riffle.core.models.HighlightColor
 import com.riffle.core.domain.ReaderFontFamily
 import com.riffle.core.domain.ReaderOrientation
@@ -53,6 +55,19 @@ class FormattingPreferencesStoreImpl @Inject constructor(
                 ?: FormattingPreferences.DEFAULT_CADENCE_HIGHLIGHT_COLOR,
             cadencePlatformSupported = prefs[KEY_CADENCE_PLATFORM_SUPPORTED]
                 ?: FormattingPreferences.DEFAULT_CADENCE_PLATFORM_SUPPORTED,
+            autoReaderThemeMode = prefs[KEY_AUTO_READER_THEME_MODE]
+                ?.let { runCatching { AutoReaderThemeMode.valueOf(it) }.getOrNull() }
+                ?: FormattingPreferences.DEFAULT_AUTO_READER_THEME_MODE,
+            appThemeReaderThemes = AppThemeReaderThemes(
+                lightTheme = prefs[KEY_APP_THEME_LIGHT_READER_THEME]
+                    ?.let { runCatching { ReaderTheme.valueOf(it) }.getOrNull() }
+                    ?.takeIf { it != ReaderTheme.Auto }
+                    ?: AppThemeReaderThemes.DEFAULT_LIGHT_THEME,
+                darkTheme = prefs[KEY_APP_THEME_DARK_READER_THEME]
+                    ?.let { runCatching { ReaderTheme.valueOf(it) }.getOrNull() }
+                    ?.takeIf { it != ReaderTheme.Auto }
+                    ?: AppThemeReaderThemes.DEFAULT_DARK_THEME,
+            ),
             themeSchedule = ThemeSchedule(
                 dayStart = prefs[KEY_SCHEDULE_DAY_START]?.let(::minuteOfDayToLocalTime)
                     ?: ThemeSchedule.DEFAULT_DAY_START,
@@ -90,6 +105,9 @@ class FormattingPreferencesStoreImpl @Inject constructor(
             prefs[KEY_CADENCE_WPM] = preferences.cadenceWpm
             prefs[KEY_SHOW_CADENCE] = preferences.showCadence
             prefs[KEY_CADENCE_HIGHLIGHT_COLOR] = preferences.cadenceHighlightColor.name
+            prefs[KEY_AUTO_READER_THEME_MODE] = preferences.autoReaderThemeMode.name
+            prefs[KEY_APP_THEME_LIGHT_READER_THEME] = preferences.appThemeReaderThemes.lightTheme.name
+            prefs[KEY_APP_THEME_DARK_READER_THEME] = preferences.appThemeReaderThemes.darkTheme.name
             prefs[KEY_SCHEDULE_DAY_START] = preferences.themeSchedule.dayStart.toMinuteOfDay()
             prefs[KEY_SCHEDULE_NIGHT_START] = preferences.themeSchedule.nightStart.toMinuteOfDay()
             prefs[KEY_SCHEDULE_DAY_THEME] = preferences.themeSchedule.dayTheme.name
@@ -126,6 +144,9 @@ class FormattingPreferencesStoreImpl @Inject constructor(
         val KEY_SHOW_CADENCE = booleanPreferencesKey("show_cadence")
         val KEY_CADENCE_HIGHLIGHT_COLOR = stringPreferencesKey("cadence_highlight_color")
         val KEY_CADENCE_PLATFORM_SUPPORTED = booleanPreferencesKey("cadence_platform_supported")
+        val KEY_AUTO_READER_THEME_MODE = stringPreferencesKey("auto_reader_theme_mode")
+        val KEY_APP_THEME_LIGHT_READER_THEME = stringPreferencesKey("app_theme_light_reader_theme")
+        val KEY_APP_THEME_DARK_READER_THEME = stringPreferencesKey("app_theme_dark_reader_theme")
         val KEY_SCHEDULE_DAY_START = intPreferencesKey("theme_schedule_day_start_minute_of_day")
         val KEY_SCHEDULE_NIGHT_START = intPreferencesKey("theme_schedule_night_start_minute_of_day")
         val KEY_SCHEDULE_DAY_THEME = stringPreferencesKey("theme_schedule_day_theme")

--- a/core/data/src/test/kotlin/com/riffle/core/data/AppearanceCoordinatorImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/AppearanceCoordinatorImplTest.kt
@@ -2,6 +2,8 @@ package com.riffle.core.data
 
 import com.riffle.core.domain.AppTheme
 import com.riffle.core.domain.AppThemeStore
+import com.riffle.core.domain.AppThemeReaderThemes
+import com.riffle.core.domain.AutoReaderThemeMode
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.ReaderTheme
@@ -122,6 +124,67 @@ class AppearanceCoordinatorImplTest {
         )
         try {
             assertEquals(ConcreteReaderTheme.Sepia, coord.resolved.value.readerTheme)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `reader Auto in app-theme mode follows forced app Dark`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+        val coord = AppearanceCoordinatorImpl(
+            appThemeStore = FakeAppThemeStore(AppTheme.Dark),
+            formattingPreferencesStore = FakeFormattingPreferencesStore(
+                FormattingPreferences(
+                    theme = ReaderTheme.Auto,
+                    autoReaderThemeMode = AutoReaderThemeMode.AppTheme,
+                    appThemeReaderThemes = AppThemeReaderThemes(
+                        lightTheme = ReaderTheme.Sepia,
+                        darkTheme = ReaderTheme.DarkDim,
+                    ),
+                    themeSchedule = ThemeSchedule(
+                        dayStart = LocalTime.of(7, 0),
+                        nightStart = LocalTime.of(21, 0),
+                        dayTheme = ReaderTheme.Sepia,
+                        nightTheme = ReaderTheme.DarkDim,
+                    ),
+                ),
+            ),
+            timeProvider = FakeTimeProvider(LocalTime.of(12, 0)),
+            scope = scope,
+        )
+        try {
+            assertEquals(ConcreteReaderTheme.DarkDim, coord.resolved.value.readerTheme)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `reader Auto in app-theme mode follows System app theme from systemDark flag`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+        val coord = AppearanceCoordinatorImpl(
+            appThemeStore = FakeAppThemeStore(AppTheme.System),
+            formattingPreferencesStore = FakeFormattingPreferencesStore(
+                FormattingPreferences(
+                    theme = ReaderTheme.Auto,
+                    autoReaderThemeMode = AutoReaderThemeMode.AppTheme,
+                    appThemeReaderThemes = AppThemeReaderThemes(
+                        lightTheme = ReaderTheme.Sepia,
+                        darkTheme = ReaderTheme.DarkDim,
+                    ),
+                ),
+            ),
+            timeProvider = FakeTimeProvider(LocalTime.of(12, 0)),
+            scope = scope,
+        )
+        try {
+            assertEquals(ConcreteReaderTheme.Sepia, coord.resolved.value.readerTheme)
+
+            coord.setSystemDark(true)
+            assertEquals(ConcreteReaderTheme.DarkDim, coord.resolved.value.readerTheme)
         } finally {
             scope.cancel()
         }

--- a/core/data/src/test/kotlin/com/riffle/core/data/FormattingPreferencesStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FormattingPreferencesStoreTest.kt
@@ -1,6 +1,13 @@
 package com.riffle.core.data
 
+import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.riffle.core.domain.AppThemeReaderThemes
+import com.riffle.core.domain.AutoReaderThemeMode
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.models.HighlightColor
 import com.riffle.core.domain.ReaderFontFamily
@@ -27,12 +34,13 @@ class FormattingPreferencesStoreTest {
     private val dispatcher = UnconfinedTestDispatcher()
     private val testScope = TestScope(dispatcher)
 
-    private fun buildStore() = FormattingPreferencesStoreImpl(
+    private fun buildDataStore(): DataStore<Preferences> =
         PreferenceDataStoreFactory.create(
             scope = testScope.backgroundScope,
             produceFile = { tmp.newFile("prefs.preferences_pb") },
         )
-    )
+
+    private fun buildStore() = FormattingPreferencesStoreImpl(buildDataStore())
 
     @Test
     fun `default preferences returned when DataStore is empty`() = testScope.runTest {
@@ -144,6 +152,51 @@ class FormattingPreferencesStoreTest {
         val store = buildStore()
         store.update(FormattingPreferences(theme = ReaderTheme.Auto))
         assertEquals(ReaderTheme.Auto, store.preferences.first().theme)
+    }
+
+    @Test
+    fun `legacy Auto schedule preferences load as time based Auto without losing schedule`() = testScope.runTest {
+        val dataStore = buildDataStore()
+        val schedule = ThemeSchedule(
+            dayStart = LocalTime.of(6, 30),
+            nightStart = LocalTime.of(19, 45),
+            dayTheme = ReaderTheme.Sepia,
+            nightTheme = ReaderTheme.DarkDim,
+        )
+        dataStore.edit { prefs ->
+            prefs[stringPreferencesKey("theme")] = ReaderTheme.Auto.name
+            prefs[intPreferencesKey("theme_schedule_day_start_minute_of_day")] =
+                schedule.dayStart.hour * 60 + schedule.dayStart.minute
+            prefs[intPreferencesKey("theme_schedule_night_start_minute_of_day")] =
+                schedule.nightStart.hour * 60 + schedule.nightStart.minute
+            prefs[stringPreferencesKey("theme_schedule_day_theme")] = schedule.dayTheme.name
+            prefs[stringPreferencesKey("theme_schedule_night_theme")] = schedule.nightTheme.name
+        }
+
+        val loaded = FormattingPreferencesStoreImpl(dataStore).preferences.first()
+
+        assertEquals(ReaderTheme.Auto, loaded.theme)
+        assertEquals(AutoReaderThemeMode.Schedule, loaded.autoReaderThemeMode)
+        assertEquals(schedule, loaded.themeSchedule)
+        assertEquals(AppThemeReaderThemes(), loaded.appThemeReaderThemes)
+    }
+
+    @Test
+    fun `auto reader theme mode round-trips through the DataStore`() = testScope.runTest {
+        val store = buildStore()
+        store.update(FormattingPreferences(autoReaderThemeMode = AutoReaderThemeMode.AppTheme))
+        assertEquals(AutoReaderThemeMode.AppTheme, store.preferences.first().autoReaderThemeMode)
+    }
+
+    @Test
+    fun `app theme reader themes round-trip through the DataStore`() = testScope.runTest {
+        val store = buildStore()
+        val appThemeReaderThemes = AppThemeReaderThemes(
+            lightTheme = ReaderTheme.Sepia,
+            darkTheme = ReaderTheme.DarkDim,
+        )
+        store.update(FormattingPreferences(appThemeReaderThemes = appThemeReaderThemes))
+        assertEquals(appThemeReaderThemes, store.preferences.first().appThemeReaderThemes)
     }
 
     @Test

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/BookFormattingOverrides.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/BookFormattingOverrides.kt
@@ -52,6 +52,8 @@ data class BookFormattingOverrides(
         // global through keeps the in-reader Auto resolution honouring the user's
         // configured day/night times instead of silently falling back to defaults.
         themeSchedule = global.themeSchedule,
+        autoReaderThemeMode = global.autoReaderThemeMode,
+        appThemeReaderThemes = global.appThemeReaderThemes,
         autoScrollWpm = autoScrollWpm ?: global.autoScrollWpm,
         showAutoScroll = global.showAutoScroll,
         cadenceWpm = cadenceWpm ?: global.cadenceWpm,

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/FormattingPreferences.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/FormattingPreferences.kt
@@ -17,6 +17,8 @@ data class FormattingPreferences(
     val showReadingTimeEstimate: Boolean = DEFAULT_SHOW_READING_TIME_ESTIMATE,
     val doublePageSpread: Boolean = DEFAULT_DOUBLE_PAGE_SPREAD,
     val justifyText: Boolean = DEFAULT_JUSTIFY_TEXT,
+    val autoReaderThemeMode: AutoReaderThemeMode = DEFAULT_AUTO_READER_THEME_MODE,
+    val appThemeReaderThemes: AppThemeReaderThemes = AppThemeReaderThemes(),
     val themeSchedule: ThemeSchedule = ThemeSchedule(),
     val autoScrollWpm: Int = DEFAULT_AUTO_SCROLL_WPM,
     val showAutoScroll: Boolean = DEFAULT_SHOW_AUTO_SCROLL,
@@ -49,14 +51,26 @@ data class FormattingPreferences(
         const val DEFAULT_CADENCE_PLATFORM_SUPPORTED: Boolean = true
         val DEFAULT_CADENCE_HIGHLIGHT_COLOR: HighlightColor = HighlightColor.YELLOW
         val DEFAULT_THEME: ReaderTheme = ReaderTheme.Light
+        val DEFAULT_AUTO_READER_THEME_MODE: AutoReaderThemeMode = AutoReaderThemeMode.Schedule
         val DEFAULT_FONT_FAMILY: ReaderFontFamily = ReaderFontFamily.Original
         val DEFAULT_ORIENTATION: ReaderOrientation = ReaderOrientation.Horizontal
     }
 }
 
 enum class ReaderTheme { Light, Dark, DarkDim, Sepia, Auto }
+enum class AutoReaderThemeMode { Schedule, AppTheme }
 enum class ReaderFontFamily { Original, Serif, SansSerif, Monospace, Literata, Merriweather, OpenDyslexic }
 enum class ReaderOrientation { Horizontal, Vertical, Continuous }
+
+data class AppThemeReaderThemes(
+    val lightTheme: ReaderTheme = DEFAULT_LIGHT_THEME,
+    val darkTheme: ReaderTheme = DEFAULT_DARK_THEME,
+) {
+    companion object {
+        val DEFAULT_LIGHT_THEME: ReaderTheme = ReaderTheme.Light
+        val DEFAULT_DARK_THEME: ReaderTheme = ReaderTheme.Dark
+    }
+}
 
 data class ThemeSchedule(
     val dayStart: LocalTime = DEFAULT_DAY_START,
@@ -101,4 +115,26 @@ data class ThemeSchedule(
 // run this at render-time so every downstream consumer (Readium mapper, palette,
 // chapter-rail backdrop) keeps reading `prefs.theme` and stays ignorant of Auto.
 fun FormattingPreferences.withResolvedTheme(now: LocalTime): FormattingPreferences =
-    if (theme == ReaderTheme.Auto) copy(theme = themeSchedule.resolve(now)) else this
+    withResolvedTheme(now, appTheme = AppTheme.System, systemInDark = false)
+
+fun FormattingPreferences.withResolvedTheme(
+    now: LocalTime,
+    appTheme: AppTheme,
+    systemInDark: Boolean,
+): FormattingPreferences =
+    if (theme == ReaderTheme.Auto) copy(theme = resolveAutoReaderTheme(now, appTheme, systemInDark)) else this
+
+fun FormattingPreferences.resolveAutoReaderTheme(
+    now: LocalTime,
+    appTheme: AppTheme,
+    systemInDark: Boolean,
+): ReaderTheme = when (autoReaderThemeMode) {
+    AutoReaderThemeMode.Schedule -> themeSchedule.resolve(now)
+    AutoReaderThemeMode.AppTheme -> if (appTheme.isDark(systemInDark)) {
+        appThemeReaderThemes.darkTheme.takeUnless { it == ReaderTheme.Auto }
+            ?: AppThemeReaderThemes.DEFAULT_DARK_THEME
+    } else {
+        appThemeReaderThemes.lightTheme.takeUnless { it == ReaderTheme.Auto }
+            ?: AppThemeReaderThemes.DEFAULT_LIGHT_THEME
+    }
+}

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/BookFormattingOverridesTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/BookFormattingOverridesTest.kt
@@ -149,6 +149,26 @@ class BookFormattingOverridesTest {
     }
 
     @Test
+    fun `applyTo always threads global autoReaderThemeMode (no per-book override)`() {
+        val globalWithAppThemeAuto = global.copy(autoReaderThemeMode = AutoReaderThemeMode.AppTheme)
+        val effective = BookFormattingOverrides(theme = ReaderTheme.Auto)
+            .applyTo(globalWithAppThemeAuto)
+        assertEquals(AutoReaderThemeMode.AppTheme, effective.autoReaderThemeMode)
+    }
+
+    @Test
+    fun `applyTo always threads global appThemeReaderThemes (no per-book override)`() {
+        val appThemeReaderThemes = AppThemeReaderThemes(
+            lightTheme = ReaderTheme.Sepia,
+            darkTheme = ReaderTheme.DarkDim,
+        )
+        val globalWithAppThemeAuto = global.copy(appThemeReaderThemes = appThemeReaderThemes)
+        val effective = BookFormattingOverrides(theme = ReaderTheme.Auto)
+            .applyTo(globalWithAppThemeAuto)
+        assertEquals(appThemeReaderThemes, effective.appThemeReaderThemes)
+    }
+
+    @Test
     fun `withChanges does not record a field when new equals previous`() {
         val previous = global
         val new = global.copy() // identical

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/FormattingPreferencesResolutionTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/FormattingPreferencesResolutionTest.kt
@@ -28,6 +28,7 @@ class FormattingPreferencesResolutionTest {
     fun `Auto with a custom schedule picks the custom night theme`() {
         val prefs = FormattingPreferences(
             theme = ReaderTheme.Auto,
+            autoReaderThemeMode = AutoReaderThemeMode.Schedule,
             themeSchedule = ThemeSchedule(
                 dayStart = LocalTime.of(7, 0),
                 nightStart = LocalTime.of(21, 0),
@@ -42,5 +43,55 @@ class FormattingPreferencesResolutionTest {
     @Test
     fun `default themeSchedule is the ThemeSchedule default`() {
         assertEquals(ThemeSchedule(), FormattingPreferences().themeSchedule)
+    }
+
+    @Test
+    fun `Auto in app-theme mode follows forced app Dark`() {
+        val prefs = FormattingPreferences(
+            theme = ReaderTheme.Auto,
+            autoReaderThemeMode = AutoReaderThemeMode.AppTheme,
+            appThemeReaderThemes = AppThemeReaderThemes(
+                lightTheme = ReaderTheme.Sepia,
+                darkTheme = ReaderTheme.DarkDim,
+            ),
+        )
+
+        assertEquals(
+            ReaderTheme.DarkDim,
+            prefs.withResolvedTheme(
+                now = LocalTime.of(12, 0),
+                appTheme = AppTheme.Dark,
+                systemInDark = false,
+            ).theme,
+        )
+    }
+
+    @Test
+    fun `Auto in app-theme mode follows System app theme from OS flag`() {
+        val prefs = FormattingPreferences(
+            theme = ReaderTheme.Auto,
+            autoReaderThemeMode = AutoReaderThemeMode.AppTheme,
+            appThemeReaderThemes = AppThemeReaderThemes(
+                lightTheme = ReaderTheme.Sepia,
+                darkTheme = ReaderTheme.DarkDim,
+            ),
+        )
+
+        assertEquals(
+            ReaderTheme.DarkDim,
+            prefs.withResolvedTheme(
+                now = LocalTime.of(12, 0),
+                appTheme = AppTheme.System,
+                systemInDark = true,
+            ).theme,
+        )
+        assertEquals(
+            ReaderTheme.Sepia,
+            prefs.withResolvedTheme(
+                now = LocalTime.of(12, 0),
+                appTheme = AppTheme.System,
+                systemInDark = false,
+            ).theme,
+        )
     }
 }


### PR DESCRIPTION
## Summary
- add a global Auto reading theme mode that can use either the existing day/night schedule or the resolved app light/dark theme
- add light-app and dark-app reader theme selections, while preserving existing schedule preferences for upgraded users
- update reader settings UI, summaries, swatches, and docs for the new Auto mode controls

## Tests
- ./gradlew :core:domain:jvmTest --tests com.riffle.core.domain.FormattingPreferencesResolutionTest --tests com.riffle.core.domain.BookFormattingOverridesTest :core:data:testDebugUnitTest --tests com.riffle.core.data.FormattingPreferencesStoreTest --tests com.riffle.core.data.AppearanceCoordinatorImplTest :app:testDebugUnitTest --tests com.riffle.app.feature.reader.ReaderSettingsSummariesTest --tests com.riffle.app.feature.reader.session.FormattingSessionTest
- make harness-test-class CLASS=com.riffle.app.feature.reader.ReaderSettingsSectionsTest
- ./gradlew :core:data:testDebugUnitTest --tests com.riffle.core.data.FormattingPreferencesStoreTest

Regression assertions that would fail if reverted: app-theme Auto resolves forced/system app dark to the configured dark reader theme; legacy Auto schedule keys load as Schedule mode with the original schedule intact; the settings UI hides schedule controls when App theme mode is selected.