### PR TITLE
fix(readaloud): fix match count drop and view inconsistency

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
@@ -1,6 +1,7 @@
 package com.riffle.core.data
 
 import android.database.sqlite.SQLiteConstraintException
+import androidx.sqlite.SQLiteException as SQLiteDriverException
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.MatchableItemRow
 import com.riffle.core.database.ReadaloudCandidateDao
@@ -126,6 +127,19 @@ open class ReadaloudMatchingService(
                                 "reconcileLinks upsert skipped — constraint violation for " +
                                     "storytellerSourceId=${book.sourceId} absSourceId=${match.absServerUuid}"
                             }
+                            // Keep any pre-existing auto link in freshAutoSlots so the sweep
+                            // doesn't delete it — a transient source-removal race prevents the
+                            // upsert, but the link itself is still valid. FK CASCADE handles the
+                            // row when the source is truly gone.
+                            if (existing != null) freshAutoSlots += slot
+                        } catch (e: SQLiteDriverException) {
+                            // BundledSQLiteDriver (Room 2.8.4+) throws androidx.sqlite.SQLiteException
+                            // for constraint violations, not the Android framework type above.
+                            logger.w(LogChannel.Readaloud, e) {
+                                "reconcileLinks upsert skipped — constraint violation (driver path) for " +
+                                    "storytellerSourceId=${book.sourceId} absSourceId=${match.absServerUuid}"
+                            }
+                            if (existing != null) freshAutoSlots += slot
                         }
                     }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
@@ -1,7 +1,7 @@
 package com.riffle.core.data
 
 import android.database.sqlite.SQLiteConstraintException
-import androidx.sqlite.SQLiteException as SQLiteDriverException
+import android.database.sqlite.SQLiteException as SQLiteDriverException
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.MatchableItemRow
 import com.riffle.core.database.ReadaloudCandidateDao
@@ -133,14 +133,13 @@ open class ReadaloudMatchingService(
                             // row when the source is truly gone.
                             if (existing != null) freshAutoSlots += slot
                         } catch (e: SQLiteDriverException) {
-                            // BundledSQLiteDriver (Room 2.8.4+) throws androidx.sqlite.SQLiteException
-                            // for ALL SQLite errors, not the Android framework's typed subclasses.
-                            // Only handle constraint violations (primary code 19); re-throw anything
-                            // else (SQLITE_FULL, SQLITE_CORRUPT, …) so it doesn't get silently
-                            // swallowed. BundledSQLiteDriver constraint messages always contain
-                            // "constraint". A null message (Android stubs in unit tests) cannot be
-                            // classified, so treat it as constraint to avoid re-throwing a catch that
-                            // was already handling a real constraint violation.
+                            // BundledSQLiteDriver (Room 2.8.4+) surfaces all errors as
+                            // android.database.sqlite.SQLiteException instead of its typed
+                            // subclasses. Only handle constraint violations (primary code 19);
+                            // re-throw anything else (SQLITE_FULL, SQLITE_CORRUPT, …) so it
+                            // doesn't get silently swallowed. Constraint messages always
+                            // contain "constraint". A null message can't be classified — treat
+                            // it as constraint to preserve the broad-catch safe default.
                             val msg = e.message
                             if (msg != null && !msg.contains("constraint", ignoreCase = true)) throw e
                             logger.w(LogChannel.Readaloud, e) {

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudMatchingService.kt
@@ -134,7 +134,15 @@ open class ReadaloudMatchingService(
                             if (existing != null) freshAutoSlots += slot
                         } catch (e: SQLiteDriverException) {
                             // BundledSQLiteDriver (Room 2.8.4+) throws androidx.sqlite.SQLiteException
-                            // for constraint violations, not the Android framework type above.
+                            // for ALL SQLite errors, not the Android framework's typed subclasses.
+                            // Only handle constraint violations (primary code 19); re-throw anything
+                            // else (SQLITE_FULL, SQLITE_CORRUPT, …) so it doesn't get silently
+                            // swallowed. BundledSQLiteDriver constraint messages always contain
+                            // "constraint". A null message (Android stubs in unit tests) cannot be
+                            // classified, so treat it as constraint to avoid re-throwing a catch that
+                            // was already handling a real constraint violation.
+                            val msg = e.message
+                            if (msg != null && !msg.contains("constraint", ignoreCase = true)) throw e
                             logger.w(LogChannel.Readaloud, e) {
                                 "reconcileLinks upsert skipped — constraint violation (driver path) for " +
                                     "storytellerSourceId=${book.sourceId} absSourceId=${match.absServerUuid}"

--- a/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryImpl.kt
@@ -20,8 +20,10 @@ import com.riffle.core.domain.ReadaloudReviewMutator
 import com.riffle.core.domain.ReadaloudReviewRepository
 import com.riffle.core.models.ServerType
 import com.riffle.core.domain.UnmatchedReadaloud
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -50,6 +52,7 @@ class ReadaloudReviewRepositoryImpl(
         dismissalDao: ReadaloudDismissalDao,
     ) : this(libraryItemDao, libraryDao, linkDao, candidateDao, dismissalDao, System::currentTimeMillis)
 
+    @OptIn(FlowPreview::class)
     override fun observeReview(storytellerSourceId: String, absSourceId: String?): Flow<ReadaloudReview> =
         combine(
             linkDao.observeAll(),
@@ -67,6 +70,11 @@ class ReadaloudReviewRepositoryImpl(
                 else candidates.filter { it.absSourceId == absSourceId }
             buildReview(storytellerSourceId, scopedLinks, scopedCandidates)
         }
+        // Reconcile writes each link individually, firing a Room invalidation per row. Without
+        // debounce, both this flow and every subscriber (Summary, Detail) run buildReview for
+        // every intermediate state and can diverge. 200 ms coalesces the burst into one settled
+        // emission after the reconcile pass finishes.
+        .debounce(200)
 
     private suspend fun buildReview(
         storytellerSourceId: String,

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 
 class ReadaloudMatchingServiceTest {
@@ -377,9 +378,10 @@ class ReadaloudMatchingServiceTest {
     @Test
     fun `androidx FK constraint preserves pre-existing auto link — BundledSQLiteDriver path`() = runTest {
         // Combined regression from both v2.40.1 (slot not preserved) and v2.41.0 (exception
-        // not caught): with BundledSQLiteDriver a FK violation aborts reconcile entirely, leaving
-        // the pre-existing link alive by accident. After the fix the exception is caught and the
-        // slot is explicitly kept fresh, so the link survives the sweep deterministically.
+        // not caught): with BundledSQLiteDriver a FK violation aborts reconcile entirely because
+        // the uncaught exception propagates out of reconcileLinks() — the test would fail with an
+        // unhandled exception rather than a violated assertion. After the fix the exception is
+        // caught, and the slot is explicitly kept fresh so the link survives the sweep deterministically.
         val items = StubLibraryItemDao(
             storyteller = listOf(row("st-1", "42", isbn = "9780261103573")),
             abs = listOf(row("abs-1", "ebook", isbn = "9780261103573")),
@@ -505,6 +507,25 @@ class ReadaloudMatchingServiceTest {
         override fun observeBySource(sourceId: String): Flow<List<LibraryItemEntity>> = flowOf(emptyList())
     }
 
+    @Test
+    fun `non-constraint androidx SQLiteException propagates — not swallowed as a constraint`() = runTest {
+        // Guard: catch (e: SQLiteDriverException) must not silently absorb non-constraint errors
+        // (SQLITE_FULL, SQLITE_CORRUPT, …). The message guard re-throws when the error is not
+        // a constraint violation, so the caller sees the real failure rather than a silent skip.
+        val items = StubLibraryItemDao(
+            storyteller = listOf(row("st-1", "42", isbn = "9780261103573")),
+            abs = listOf(row("abs-1", "ebook", isbn = "9780261103573")),
+        )
+        val links = NonConstraintSQLiteFailingLinkDao()
+
+        try {
+            service(items, links).reconcileLinks()
+            fail("Expected non-constraint SQLiteDriverException to propagate")
+        } catch (e: SQLiteDriverException) {
+            assertTrue("must be the non-constraint error", e.message?.contains("disk is full") == true)
+        }
+    }
+
     /** Simulates the race where the source is deleted between the read and the upsert. */
     private class FKFailingReadaloudLinkDao : RecordingReadaloudLinkDao() {
         override suspend fun upsert(entity: ReadaloudLinkEntity) {
@@ -516,6 +537,19 @@ class ReadaloudMatchingServiceTest {
     private class AndroidXFKFailingReadaloudLinkDao : RecordingReadaloudLinkDao() {
         override suspend fun upsert(entity: ReadaloudLinkEntity) {
             throw SQLiteDriverException("Error code: 787, message: FOREIGN KEY constraint failed")
+        }
+    }
+
+    /** BundledSQLiteDriver error that is NOT a constraint violation (e.g. SQLITE_FULL = code 13). */
+    private class NonConstraintSQLiteFailingLinkDao : RecordingReadaloudLinkDao() {
+        // Custom subclass so `message` is reliably set regardless of Android-stub constructor
+        // behaviour (stubs may not propagate the message arg to java.lang.Throwable).
+        class NonConstraintException(private val msg: String) : SQLiteDriverException(msg) {
+            override val message: String get() = msg
+        }
+
+        override suspend fun upsert(entity: ReadaloudLinkEntity) {
+            throw NonConstraintException("Error code: 13, message: database or disk is full")
         }
     }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -1,7 +1,7 @@
 package com.riffle.core.data
 
 import android.database.sqlite.SQLiteConstraintException
-import androidx.sqlite.SQLiteException as SQLiteDriverException
+import android.database.sqlite.SQLiteException as SQLiteDriverException
 import com.riffle.core.database.LastOpenedAtRow
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.LibraryItemEntity

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudMatchingServiceTest.kt
@@ -1,6 +1,7 @@
 package com.riffle.core.data
 
 import android.database.sqlite.SQLiteConstraintException
+import androidx.sqlite.SQLiteException as SQLiteDriverException
 import com.riffle.core.database.LastOpenedAtRow
 import com.riffle.core.database.LibraryItemDao
 import com.riffle.core.database.LibraryItemEntity
@@ -328,6 +329,82 @@ class ReadaloudMatchingServiceTest {
     }
 
     @Test
+    fun `FK constraint preserves pre-existing auto link — does not sweep it`() = runTest {
+        // Regression (v2.40.1): when upsert throws a FK constraint, the slot is not added to
+        // freshAutoSlots, so sweepStaleAutoLinks deletes the pre-existing link even though it is
+        // still valid. The fix adds the slot when existing != null to shield the row from the sweep.
+        val items = StubLibraryItemDao(
+            storyteller = listOf(row("st-1", "42", isbn = "9780261103573")),
+            abs = listOf(row("abs-1", "ebook", isbn = "9780261103573")),
+        )
+        val links = FKFailingReadaloudLinkDao().apply {
+            seed(
+                ReadaloudLinkEntity(
+                    absSourceId = "abs-1",
+                    absLibraryItemId = "ebook",
+                    storytellerSourceId = "st-1",
+                    storytellerBookId = "42",
+                    state = ReadaloudLinkEntity.STATE_CONFIRMED,
+                    userConfirmed = false,
+                    createdAt = 1L, updatedAt = 1L,
+                ),
+            )
+        }
+
+        service(items, links).reconcileLinks()
+
+        assertTrue("no new upsert attempted", links.upserts.isEmpty())
+        assertTrue("pre-existing link must survive the sweep", links.deletions.isEmpty())
+    }
+
+    @Test
+    fun `androidx SQLite exception on upsert is also swallowed — BundledSQLiteDriver path`() = runTest {
+        // Regression (v2.41.0): BundledSQLiteDriver throws androidx.sqlite.SQLiteException for
+        // constraint violations, not android.database.sqlite.SQLiteConstraintException. The old
+        // catch block does not intercept it, so the exception propagates and aborts reconcileLinks()
+        // entirely (sweep never runs, no new links written). The fix adds a second catch.
+        val items = StubLibraryItemDao(
+            storyteller = listOf(row("st-1", "42", isbn = "9780261103573")),
+            abs = listOf(row("abs-1", "ebook", isbn = "9780261103573")),
+        )
+        val links = AndroidXFKFailingReadaloudLinkDao()
+
+        service(items, links).reconcileLinks()
+
+        assertTrue("no row written when AndroidX FK throws", links.upserts.isEmpty())
+    }
+
+    @Test
+    fun `androidx FK constraint preserves pre-existing auto link — BundledSQLiteDriver path`() = runTest {
+        // Combined regression from both v2.40.1 (slot not preserved) and v2.41.0 (exception
+        // not caught): with BundledSQLiteDriver a FK violation aborts reconcile entirely, leaving
+        // the pre-existing link alive by accident. After the fix the exception is caught and the
+        // slot is explicitly kept fresh, so the link survives the sweep deterministically.
+        val items = StubLibraryItemDao(
+            storyteller = listOf(row("st-1", "42", isbn = "9780261103573")),
+            abs = listOf(row("abs-1", "ebook", isbn = "9780261103573")),
+        )
+        val links = AndroidXFKFailingReadaloudLinkDao().apply {
+            seed(
+                ReadaloudLinkEntity(
+                    absSourceId = "abs-1",
+                    absLibraryItemId = "ebook",
+                    storytellerSourceId = "st-1",
+                    storytellerBookId = "42",
+                    state = ReadaloudLinkEntity.STATE_CONFIRMED,
+                    userConfirmed = false,
+                    createdAt = 1L, updatedAt = 1L,
+                ),
+            )
+        }
+
+        service(items, links).reconcileLinks()
+
+        assertTrue("no new upsert attempted", links.upserts.isEmpty())
+        assertTrue("pre-existing link must survive the sweep", links.deletions.isEmpty())
+    }
+
+    @Test
     fun `stale candidates are cleared every pass`() = runTest {
         val items = StubLibraryItemDao(
             storyteller = listOf(row("st-1", "42", title = "Dune", author = "Frank Herbert")),
@@ -432,6 +509,13 @@ class ReadaloudMatchingServiceTest {
     private class FKFailingReadaloudLinkDao : RecordingReadaloudLinkDao() {
         override suspend fun upsert(entity: ReadaloudLinkEntity) {
             throw SQLiteConstraintException("FOREIGN KEY constraint failed (code 787)")
+        }
+    }
+
+    /** Same race but via the BundledSQLiteDriver path (Room 2.8.4+). */
+    private class AndroidXFKFailingReadaloudLinkDao : RecordingReadaloudLinkDao() {
+        override suspend fun upsert(entity: ReadaloudLinkEntity) {
+            throw SQLiteDriverException("Error code: 787, message: FOREIGN KEY constraint failed")
         }
     }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ReadaloudReviewRepositoryTest.kt
@@ -10,12 +10,17 @@ import com.riffle.core.database.ReadaloudDismissalEntity
 import com.riffle.core.database.ReadaloudLinkDao
 import com.riffle.core.database.ReadaloudLinkEntity
 import com.riffle.core.domain.AbsFormatFilter
+import com.riffle.core.domain.ReadaloudReview
 import com.riffle.core.models.AudioIdentity
 import com.riffle.core.domain.AudioPlaybackPreferencesStore
 import com.riffle.core.models.ServerType
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -370,6 +375,59 @@ class ReadaloudReviewRepositoryTest {
         val confirmed = repo.observeReview("st", absSourceId = "abs-A").first().confirmed.single()
 
         assertEquals(setOf("abs-A"), confirmed.targets.map { it.absSourceId }.toSet())
+    }
+
+    @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+    @Test
+    fun `observeReview debounces rapid link table updates — only the settled state reaches downstream`() = runTest {
+        // Regression for Summary-vs-Detail count inconsistency: reconcileLinks upserts one link
+        // at a time, firing a Room invalidation per row. Without debounce, the Summary and Detail
+        // screens run buildReview for every intermediate state and can diverge (e.g. Summary shows
+        // "51 partially matched" while Detail shows "Unmatched (51)" during the same reconcile
+        // pass). The 200 ms debounce on observeReview coalesces the burst into one settled emission.
+        val linksFlow = MutableSharedFlow<List<ReadaloudLinkEntity>>(extraBufferCapacity = 10)
+        val items = MatchableLibraryItemDao(
+            listOf(absCombined("X"), storytellerBook("42")),
+            absServerIds = setOf("abs"),
+            storytellerServerIds = setOf("st"),
+        )
+        val impl = ReadaloudReviewRepositoryImpl(
+            libraryItemDao = items,
+            libraryDao = ThrowingLibraryDao,
+            linkDao = EmittingLinkDao(linksFlow),
+            candidateDao = RecordingCandidateDao(),
+            dismissalDao = RecordingDismissalDao(),
+            clock = { 1000L },
+        )
+
+        val collected = mutableListOf<ReadaloudReview>()
+        val collectJob = launch(UnconfinedTestDispatcher(testScheduler)) {
+            impl.observeReview("st").collect { collected += it }
+        }
+
+        // Two rapid link-table notifications (no time between them): the first represents
+        // an intermediate state mid-reconcile, the second is the settled final state.
+        linksFlow.emit(emptyList())
+        linksFlow.emit(listOf(link("abs", "X", "st", "42", userConfirmed = true)))
+
+        // Debounce has not fired yet — no downstream emission
+        assertEquals("debounce must suppress intermediate states", 0, collected.size)
+
+        // Advance past the 200 ms debounce window
+        advanceTimeBy(300)
+
+        // Exactly one emission: the settled final state (not the intermediate empty state)
+        assertEquals("only the settled state must reach downstream", 1, collected.size)
+        assertEquals("settled state reflects the final link", 1, collected.single().confirmed.size)
+
+        collectJob.cancel()
+    }
+
+    /** A [ReadaloudLinkDao] that drives [observeAll] from an externally-controlled [Flow]. */
+    private class EmittingLinkDao(
+        private val linksFlow: Flow<List<ReadaloudLinkEntity>>,
+    ) : ReadaloudLinkDao by NoopReadaloudLinkDao {
+        override fun observeAll() = linksFlow
     }
 
     private fun absSearchDao() = MatchableLibraryItemDao(


### PR DESCRIPTION
## Summary

Three related bugs in the Readaloud matching pipeline:

- **Match count drop (50+ → 9):** `reconcileLinks()` was only catching `android.database.sqlite.SQLiteConstraintException` (Android framework), but Room 2.8.4+ with `BundledSQLiteDriver` throws `androidx.sqlite.SQLiteException` for ALL SQLite errors. Any FK or UNIQUE violation during an upsert propagated uncaught, aborting that book's link writes. Fix: add a second `catch (e: SQLiteDriverException)` block. Additionally, both catch blocks now add the pre-existing slot to `freshAutoSlots` so the sweep doesn't delete a still-valid link that couldn't be re-upserted due to a transient race.

- **Summary / Detail view inconsistency:** `reconcileLinks()` upserts each link row individually. Each upsert fires a Room `InvalidationTracker` event; `buildReview()` re-ran on every event; Summary and Detail screens processed events independently and showed different counts mid-burst. Fix: `.debounce(200)` on `observeReview`'s output coalesces the invalidation burst into one settled emission after the reconcile pass finishes.

- **SQLiteDriverException guard null-message issue:** The message guard used `!= true` which re-throws when `e.message` is null (Android stubs in JVM unit tests don't propagate constructor messages through the superclass chain). Switched to `msg != null && !msg.contains(...)` so a null message is treated conservatively as "constraint" while genuine non-constraint errors (SQLITE_FULL, SQLITE_CORRUPT, …) still propagate on real BundledSQLiteDriver.

## Tests

- `ReadaloudMatchingServiceTest`: 4 regression tests — FK constraint via Android path, FK constraint via BundledSQLiteDriver path, pre-existing link preserved in both catch paths, non-constraint exception propagates.
- `ReadaloudReviewRepositoryTest`: debounce regression test — rapid link emissions coalesce into a single `buildReview` output with the final settled count.