### PR TITLE
feat(comics): share reader theme controls

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderSettingsSectionsTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderSettingsSectionsTest.kt
@@ -1,21 +1,30 @@
 package com.riffle.app.feature.reader
 
 import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertLeftPositionInRootIsEqualTo
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.riffle.app.feature.reader.cbz.ComicDisplaySection
 import com.riffle.app.feature.reader.formatting.RenderCapabilities
 import com.riffle.core.domain.AutoReaderThemeMode
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.comic.ComicFormattingPreferences
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -127,6 +136,37 @@ class ReaderSettingsSectionsTest {
             .performClick()
         composeTestRule.runOnIdle {
             assertFalse(updated!!.coloredChapterMap)
+        }
+    }
+
+    @Test
+    fun comicDisplaySection_backgroundThemeIncludesAutoThemeChip() {
+        var selected: ReaderTheme? = null
+        composeTestRule.setContent {
+            Column(Modifier.padding(horizontal = 24.dp)) {
+                ComicDisplaySection(
+                    prefs = ComicFormattingPreferences(backgroundTheme = ReaderTheme.Dark),
+                    onBackgroundThemeChange = { selected = it },
+                    onPanelViewChange = {},
+                    onPanelOverflowChange = {},
+                    onPanelAnimationSpeedChange = {},
+                    onShowReadingProgressChange = {},
+                    onShowPageNumbersChange = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Background").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Background").assertLeftPositionInRootIsEqualTo(24.dp)
+        composeTestRule.onNodeWithText("Auto").assertIsDisplayed()
+        composeTestRule.onAllNodesWithText("Dim").assertCountEquals(0)
+        composeTestRule.onNodeWithContentDescription("Sepia theme").performClick()
+        composeTestRule.runOnIdle {
+            assertEquals(ReaderTheme.Sepia, selected)
+        }
+        composeTestRule.onNodeWithContentDescription("Auto theme").performClick()
+        composeTestRule.runOnIdle {
+            assertEquals(ReaderTheme.Auto, selected)
         }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/DisplaySection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/DisplaySection.kt
@@ -48,46 +48,16 @@ fun DisplaySection(
         // Theme
         if (capabilities.supportsTheme) {
             Text(stringResource(R.string.ui_theme), style = MaterialTheme.typography.labelMedium)
-            val concreteThemes = listOf(ReaderTheme.Light, ReaderTheme.Dark, ReaderTheme.DarkDim, ReaderTheme.Sepia)
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                concreteThemes.forEach { theme ->
-                    val label = theme.localizedLabel()
-                    val themeContentDescription = stringResource(R.string.ui_theme_named, label)
-                    FilterChip(
-                        selected = prefs.theme == theme,
-                        onClick = { onPrefsChange(prefs.copy(theme = theme)) },
-                        label = { Text(label) },
-                        leadingIcon = {
-                            ThemeSwatch(
-                                theme = theme,
-                                schedule = prefs.themeSchedule,
-                                autoMode = prefs.autoReaderThemeMode,
-                                appThemeReaderThemes = prefs.appThemeReaderThemes,
-                            )
-                        },
-                        modifier = Modifier.semantics { contentDescription = themeContentDescription },
-                    )
-                }
-            }
-            Spacer(Modifier.height(4.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                val autoLabel = ReaderTheme.Auto.localizedLabel()
-                val autoThemeContentDescription = stringResource(R.string.ui_theme_named, autoLabel)
-                FilterChip(
-                    selected = prefs.theme == ReaderTheme.Auto,
-                    onClick = { onPrefsChange(prefs.copy(theme = ReaderTheme.Auto)) },
-                    label = { Text(autoLabel) },
-                    leadingIcon = {
-                        ThemeSwatch(
-                            theme = ReaderTheme.Auto,
-                            schedule = prefs.themeSchedule,
-                            autoMode = prefs.autoReaderThemeMode,
-                            appThemeReaderThemes = prefs.appThemeReaderThemes,
-                        )
-                    },
-                    modifier = Modifier.semantics { contentDescription = autoThemeContentDescription },
-                )
-            }
+            ThemeChipRows(
+                selected = prefs.theme,
+                onSelect = { onPrefsChange(prefs.copy(theme = it)) },
+                schedule = prefs.themeSchedule,
+                autoMode = prefs.autoReaderThemeMode,
+                appThemeReaderThemes = prefs.appThemeReaderThemes,
+                includeAuto = true,
+                labelForTheme = { it.localizedLabel() },
+                contentDescriptionForTheme = { _, label -> stringResource(R.string.ui_theme_named, label) },
+            )
             if (prefs.theme == ReaderTheme.Auto) {
                 Spacer(Modifier.height(12.dp))
                 if (scheduleEditable) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsControls.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsControls.kt
@@ -61,22 +61,25 @@ import com.riffle.core.domain.ThemeSchedule
 import java.time.LocalTime
 import kotlin.math.roundToInt
 
+internal enum class ThemeSwatchStyle { TextPreview, BackgroundOnly }
+
 @Composable
 internal fun ThemeSwatch(
     theme: ReaderTheme,
     schedule: ThemeSchedule,
     autoMode: AutoReaderThemeMode = AutoReaderThemeMode.Schedule,
     appThemeReaderThemes: AppThemeReaderThemes = AppThemeReaderThemes(),
+    style: ThemeSwatchStyle = ThemeSwatchStyle.TextPreview,
 ) {
     if (theme == ReaderTheme.Auto) {
         AutoThemeSwatch(schedule, autoMode, appThemeReaderThemes)
     } else {
-        ConcreteThemeSwatch(theme)
+        ConcreteThemeSwatch(theme, style)
     }
 }
 
 @Composable
-private fun ConcreteThemeSwatch(theme: ReaderTheme) {
+private fun ConcreteThemeSwatch(theme: ReaderTheme, style: ThemeSwatchStyle) {
     val palette = theme.palette
     Box(
         modifier = Modifier
@@ -85,7 +88,9 @@ private fun ConcreteThemeSwatch(theme: ReaderTheme) {
             .border(1.dp, palette.foreground, RoundedCornerShape(percent = 50)),
         contentAlignment = Alignment.Center,
     ) {
-        Text("A", color = palette.foreground, style = MaterialTheme.typography.labelSmall)
+        if (style == ThemeSwatchStyle.TextPreview) {
+            Text("A", color = palette.foreground, style = MaterialTheme.typography.labelSmall)
+        }
     }
 }
 
@@ -195,6 +200,83 @@ internal fun FontChipRow(
             )
         }
     }
+}
+
+@Composable
+internal fun ThemeChipRows(
+    selected: ReaderTheme,
+    onSelect: (ReaderTheme) -> Unit,
+    schedule: ThemeSchedule = ThemeSchedule(),
+    autoMode: AutoReaderThemeMode = AutoReaderThemeMode.Schedule,
+    appThemeReaderThemes: AppThemeReaderThemes = AppThemeReaderThemes(),
+    includeAuto: Boolean,
+    swatchStyle: ThemeSwatchStyle = ThemeSwatchStyle.TextPreview,
+    concreteThemes: List<ReaderTheme> = listOf(ReaderTheme.Light, ReaderTheme.Dark, ReaderTheme.DarkDim, ReaderTheme.Sepia),
+    labelForTheme: @Composable (ReaderTheme) -> String = { it.label() },
+    contentDescriptionForTheme: @Composable (ReaderTheme, String) -> String = { _, label -> "$label theme" },
+) {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        concreteThemes.forEach { theme ->
+            val label = labelForTheme(theme)
+            ThemeChip(
+                theme = theme,
+                label = label,
+                contentDescription = contentDescriptionForTheme(theme, label),
+                selected = selected == theme,
+                onSelect = onSelect,
+                schedule = schedule,
+                autoMode = autoMode,
+                appThemeReaderThemes = appThemeReaderThemes,
+                swatchStyle = swatchStyle,
+            )
+        }
+    }
+    if (includeAuto) {
+        Spacer(Modifier.height(4.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            val label = labelForTheme(ReaderTheme.Auto)
+            ThemeChip(
+                theme = ReaderTheme.Auto,
+                label = label,
+                contentDescription = contentDescriptionForTheme(ReaderTheme.Auto, label),
+                selected = selected == ReaderTheme.Auto,
+                onSelect = onSelect,
+                schedule = schedule,
+                autoMode = autoMode,
+                appThemeReaderThemes = appThemeReaderThemes,
+                swatchStyle = swatchStyle,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ThemeChip(
+    theme: ReaderTheme,
+    label: String,
+    contentDescription: String,
+    selected: Boolean,
+    onSelect: (ReaderTheme) -> Unit,
+    schedule: ThemeSchedule,
+    autoMode: AutoReaderThemeMode,
+    appThemeReaderThemes: AppThemeReaderThemes,
+    swatchStyle: ThemeSwatchStyle,
+) {
+    FilterChip(
+        selected = selected,
+        onClick = { onSelect(theme) },
+        label = { Text(label) },
+        leadingIcon = {
+            ThemeSwatch(
+                theme = theme,
+                schedule = schedule,
+                autoMode = autoMode,
+                appThemeReaderThemes = appThemeReaderThemes,
+                style = swatchStyle,
+            )
+        },
+        modifier = Modifier.semantics { this.contentDescription = contentDescription },
+    )
 }
 
 @Composable

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -100,6 +100,7 @@ fun CbzReaderScreen(
     val effectivePanels by viewModel.effectivePanels.collectAsState()
     val currentPanelIndex by viewModel.currentPanelIndex.collectAsState()
     val effectiveComicFormatting by viewModel.effectiveComicFormatting.collectAsState()
+    val comicBackgroundTheme by viewModel.comicBackgroundTheme.collectAsState()
     val railSegments by viewModel.railSegments.collectAsState()
     val activeRailSegmentIndex by viewModel.activeRailSegmentIndex.collectAsState()
     val railCursorPosition by viewModel.railCursorPosition.collectAsState()
@@ -140,7 +141,7 @@ fun CbzReaderScreen(
         onDispose { window?.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON) }
     }
 
-    Box(modifier = Modifier.fillMaxSize().background(Color.Black)) {
+    Box(modifier = Modifier.fillMaxSize().background(comicBackgroundTheme.palette.background)) {
         when (val s = state) {
             CbzReaderState.Loading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
@@ -17,7 +17,9 @@ import com.riffle.core.domain.CbzRepository
 import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.ProgressSyncController
 import com.riffle.core.domain.ReadingSessionRepository
+import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.WakeLockPreferencesStore
+import com.riffle.core.domain.appearance.AppearanceCoordinator
 import com.riffle.core.models.LibraryItem
 import com.riffle.core.models.SessionPayload
 import com.riffle.core.domain.comic.BookComicFormattingOverrides
@@ -27,6 +29,7 @@ import com.riffle.core.domain.comic.ComicArchive
 import com.riffle.core.domain.comic.ComicFormattingPreferences
 import com.riffle.core.domain.comic.ComicFormattingPreferencesStore
 import com.riffle.core.domain.comic.PanelOverflowBehavior
+import com.riffle.core.domain.comic.resolveComicBackgroundTheme
 import com.riffle.core.data.comic.panel.PanelMaskEncoder
 import com.riffle.core.domain.comic.panel.PagePanels
 import com.riffle.core.domain.comic.panel.PanelBinaryMask
@@ -86,6 +89,7 @@ class CbzReaderViewModel @Inject constructor(
     private val comicFormattingPreferencesStore: ComicFormattingPreferencesStore,
     private val bookComicFormattingPreferencesStore: BookComicFormattingPreferencesStore,
     private val developerOptionsRepository: DeveloperOptionsRepository,
+    private val appearanceCoordinator: AppearanceCoordinator,
     val panelReportRepository: PanelReportRepository,
     private val panelDetector: PanelDetector,
 ) : AndroidViewModel(application) {
@@ -138,6 +142,11 @@ class CbzReaderViewModel @Inject constructor(
         combine(comicFormattingPreferencesStore.preferences, _bookComicOverrides) { global, overrides ->
             overrides.applyTo(global)
         }.stateIn(viewModelScope, SharingStarted.Eagerly, ComicFormattingPreferences())
+
+    val comicBackgroundTheme: StateFlow<ReaderTheme> =
+        combine(effectiveComicFormatting, appearanceCoordinator.resolved) { formatting, appearance ->
+            formatting.backgroundTheme.resolveComicBackgroundTheme(appearance.readerTheme.toReaderTheme())
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, ReaderTheme.Dark)
 
     val hasComicOverrides: StateFlow<Boolean> = _bookComicOverrides
         .map { !it.isEmpty() }
@@ -476,15 +485,7 @@ class CbzReaderViewModel @Inject constructor(
      * Only non-null fields in [patch] replace the corresponding field in the stored overrides.
      */
     fun updateComicFormatting(patch: BookComicFormattingOverrides) {
-        val merged = _bookComicOverrides.value.let { current ->
-            current.copy(
-                panelViewOn = patch.panelViewOn ?: current.panelViewOn,
-                panelOverflow = patch.panelOverflow ?: current.panelOverflow,
-                panelAnimationSpeedMs = patch.panelAnimationSpeedMs ?: current.panelAnimationSpeedMs,
-                showChapterMap = patch.showChapterMap ?: current.showChapterMap,
-                showPageProgress = patch.showPageProgress ?: current.showPageProgress,
-            )
-        }
+        val merged = mergeComicFormattingOverrides(_bookComicOverrides.value, patch)
         _bookComicOverrides.value = merged
         viewModelScope.launch { bookComicFormattingPreferencesStore.save(bookId, merged) }
     }
@@ -773,6 +774,18 @@ internal fun computeArchiveSwapState(
         thumbnailSource = null,
     )
 }
+
+internal fun mergeComicFormattingOverrides(
+    current: BookComicFormattingOverrides,
+    patch: BookComicFormattingOverrides,
+): BookComicFormattingOverrides = current.copy(
+    backgroundTheme = patch.backgroundTheme ?: current.backgroundTheme,
+    panelViewOn = patch.panelViewOn ?: current.panelViewOn,
+    panelOverflow = patch.panelOverflow ?: current.panelOverflow,
+    panelAnimationSpeedMs = patch.panelAnimationSpeedMs ?: current.panelAnimationSpeedMs,
+    showChapterMap = patch.showChapterMap ?: current.showChapterMap,
+    showPageProgress = patch.showPageProgress ?: current.showPageProgress,
+)
 
 /**
  * Returns the clamped page index when an archive swap reveals the real page count is smaller

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/ComicDisplaySection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/ComicDisplaySection.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.reader.cbz
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ListItem
@@ -8,23 +9,48 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.riffle.app.feature.reader.ThemeChipRows
+import com.riffle.app.feature.reader.ThemeSwatchStyle
+import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.comic.ComicBackgroundThemeChoices
 import com.riffle.core.domain.comic.ComicFormattingPreferences
 import com.riffle.core.domain.comic.PanelOverflowBehavior
+import com.riffle.core.domain.comic.asComicBackgroundTheme
 
 /**
- * Panel View, Panel Overflow, and on-screen-info controls. Reused by the in-reader formatting
- * sheet and the global Settings → Display screen.
+ * Background, Panel View, Panel Overflow, and on-screen-info controls. Reused by the in-reader
+ * formatting sheet and the global Settings → Display screen.
  */
 @Composable
 internal fun ComicDisplaySection(
     prefs: ComicFormattingPreferences,
+    backgroundHorizontalPadding: Dp = 0.dp,
+    onBackgroundThemeChange: (ReaderTheme) -> Unit,
     onPanelViewChange: (Boolean) -> Unit,
     onPanelOverflowChange: (PanelOverflowBehavior) -> Unit,
     onPanelAnimationSpeedChange: (Int) -> Unit,
     onShowReadingProgressChange: (Boolean) -> Unit,
     onShowPageNumbersChange: (Boolean) -> Unit,
 ) {
+    Column(modifier = Modifier.padding(horizontal = backgroundHorizontalPadding)) {
+        Text(
+            text = "Background",
+            style = MaterialTheme.typography.titleSmall,
+            modifier = Modifier.padding(top = 4.dp, bottom = 4.dp),
+        )
+        ThemeChipRows(
+            selected = prefs.backgroundTheme.asComicBackgroundTheme(),
+            onSelect = { onBackgroundThemeChange(it.asComicBackgroundTheme()) },
+            includeAuto = true,
+            swatchStyle = ThemeSwatchStyle.BackgroundOnly,
+            concreteThemes = ComicBackgroundThemeChoices,
+        )
+    }
+
+    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
     ListItem(
         headlineContent = { Text(androidx.compose.ui.res.stringResource(com.riffle.app.R.string.ui_panel_view)) },
         supportingContent = { Text(androidx.compose.ui.res.stringResource(com.riffle.app.R.string.ui_frame_one_panel_at_a_time_in_reading_order)) },

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/ComicFormattingSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/ComicFormattingSheet.kt
@@ -33,6 +33,8 @@ internal fun ComicFormattingSheet(
         ) {
             ComicDisplaySection(
                 prefs = formatting,
+                backgroundHorizontalPadding = 24.dp,
+                onBackgroundThemeChange = { onUpdate(BookComicFormattingOverrides(backgroundTheme = it)) },
                 onPanelViewChange = { onUpdate(BookComicFormattingOverrides(panelViewOn = it)) },
                 onPanelOverflowChange = { onUpdate(BookComicFormattingOverrides(panelOverflow = it)) },
                 onPanelAnimationSpeedChange = { onUpdate(BookComicFormattingOverrides(panelAnimationSpeedMs = it)) },

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/panels/ComicDisplaySettingsPanel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/panels/ComicDisplaySettingsPanel.kt
@@ -14,6 +14,7 @@ internal fun ComicDisplaySettingsPanel(
 ) = DetailScaffold(stringResource(R.string.ui_display), onDismiss) {
     ComicDisplaySection(
         prefs = prefs,
+        onBackgroundThemeChange = { onPrefsChange(prefs.copy(backgroundTheme = it)) },
         onPanelViewChange = { onPrefsChange(prefs.copy(panelViewOn = it)) },
         onPanelOverflowChange = { onPrefsChange(prefs.copy(panelOverflow = it)) },
         onPanelAnimationSpeedChange = { onPrefsChange(prefs.copy(panelAnimationSpeedMs = it)) },

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/sections/ComicsSection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/sections/ComicsSection.kt
@@ -6,10 +6,22 @@ import com.riffle.app.R
 import com.riffle.app.feature.settings.SettingsDrillInRow
 import com.riffle.app.feature.settings.SettingsPanel
 import com.riffle.app.feature.settings.SettingsSectionHeader
+import com.riffle.app.feature.reader.label
+import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.comic.ComicFormattingPreferences
 import com.riffle.core.domain.comic.PanelOverflowBehavior
+import com.riffle.core.domain.comic.asComicBackgroundTheme
 
 internal fun comicDisplaySummary(prefs: ComicFormattingPreferences): String = buildString {
+    val backgroundTheme = prefs.backgroundTheme.asComicBackgroundTheme()
+    append(
+        if (backgroundTheme == ReaderTheme.Auto) {
+            "Auto background"
+        } else {
+            "${backgroundTheme.label()} background"
+        }
+    )
+    append(" · ")
     append(
         if (prefs.panelViewOn) when (prefs.panelOverflow) {
             PanelOverflowBehavior.SPLIT -> "Panel View · Split"

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/ComicBackgroundThemeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/ComicBackgroundThemeTest.kt
@@ -1,0 +1,31 @@
+package com.riffle.app.feature.reader.cbz
+
+import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.comic.asComicBackgroundTheme
+import com.riffle.core.domain.comic.resolveComicBackgroundTheme
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ComicBackgroundThemeTest {
+
+    @Test
+    fun `concrete comic background ignores auto resolved reader theme`() {
+        assertEquals(
+            ReaderTheme.Sepia,
+            ReaderTheme.Sepia.resolveComicBackgroundTheme(ReaderTheme.Dark),
+        )
+    }
+
+    @Test
+    fun `legacy dim comic background is treated as dark`() {
+        assertEquals(ReaderTheme.Dark, ReaderTheme.DarkDim.asComicBackgroundTheme())
+    }
+
+    @Test
+    fun `auto comic background uses resolved reader theme after comic normalization`() {
+        assertEquals(
+            ReaderTheme.Dark,
+            ReaderTheme.Auto.resolveComicBackgroundTheme(ReaderTheme.DarkDim),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/ComicFormattingOverridesMergeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/ComicFormattingOverridesMergeTest.kt
@@ -1,0 +1,46 @@
+package com.riffle.app.feature.reader.cbz
+
+import com.riffle.core.domain.comic.BookComicFormattingOverrides
+import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.comic.PanelOverflowBehavior
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ComicFormattingOverridesMergeTest {
+
+    @Test
+    fun `merge applies backgroundTheme patch without dropping existing comic options`() {
+        val current = BookComicFormattingOverrides(
+            panelViewOn = true,
+            panelOverflow = PanelOverflowBehavior.SMART_SPLIT,
+            panelAnimationSpeedMs = 450,
+            showChapterMap = true,
+            showPageProgress = false,
+        )
+
+        val merged = mergeComicFormattingOverrides(
+            current = current,
+            patch = BookComicFormattingOverrides(backgroundTheme = ReaderTheme.Sepia),
+        )
+
+        assertEquals(ReaderTheme.Sepia, merged.backgroundTheme)
+        assertEquals(true, merged.panelViewOn)
+        assertEquals(PanelOverflowBehavior.SMART_SPLIT, merged.panelOverflow)
+        assertEquals(450, merged.panelAnimationSpeedMs)
+        assertEquals(true, merged.showChapterMap)
+        assertEquals(false, merged.showPageProgress)
+    }
+
+    @Test
+    fun `merge preserves existing backgroundTheme when patch leaves it unset`() {
+        val current = BookComicFormattingOverrides(backgroundTheme = ReaderTheme.Dark)
+
+        val merged = mergeComicFormattingOverrides(
+            current = current,
+            patch = BookComicFormattingOverrides(panelAnimationSpeedMs = 0),
+        )
+
+        assertEquals(ReaderTheme.Dark, merged.backgroundTheme)
+        assertEquals(0, merged.panelAnimationSpeedMs)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/settings/ComicDisplaySummaryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/settings/ComicDisplaySummaryTest.kt
@@ -1,6 +1,7 @@
 package com.riffle.app.feature.settings
 
 import com.riffle.app.feature.settings.sections.comicDisplaySummary
+import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.comic.ComicFormattingPreferences
 import com.riffle.core.domain.comic.PanelOverflowBehavior
 import org.junit.Assert.assertEquals
@@ -10,21 +11,21 @@ class ComicDisplaySummaryTest {
 
     @Test fun `panel view off shows Panel View off regardless of overflow`() {
         assertEquals(
-            "Panel View off",
+            "Dark background · Panel View off",
             comicDisplaySummary(ComicFormattingPreferences(panelViewOn = false, panelOverflow = PanelOverflowBehavior.SPLIT)),
         )
     }
 
     @Test fun `panel view on with SPLIT shows Split`() {
         assertEquals(
-            "Panel View · Split",
+            "Dark background · Panel View · Split",
             comicDisplaySummary(ComicFormattingPreferences(panelViewOn = true, panelOverflow = PanelOverflowBehavior.SPLIT)),
         )
     }
 
     @Test fun `panel view on with SMART_SPLIT shows Smart split`() {
         assertEquals(
-            "Panel View · Smart split",
+            "Dark background · Panel View · Smart split",
             comicDisplaySummary(ComicFormattingPreferences(panelViewOn = true, panelOverflow = PanelOverflowBehavior.SMART_SPLIT)),
         )
     }
@@ -33,36 +34,50 @@ class ComicDisplaySummaryTest {
         // PanelOverflowBehavior.OFF is now the user-selectable "No split" option in the
         // overflow radio group, so the summary must reflect that label.
         assertEquals(
-            "Panel View · No split",
+            "Dark background · Panel View · No split",
             comicDisplaySummary(ComicFormattingPreferences(panelViewOn = true, panelOverflow = PanelOverflowBehavior.OFF)),
         )
     }
 
     @Test fun `reading progress on appends to panel view summary`() {
         assertEquals(
-            "Panel View · Split · Reading progress",
+            "Dark background · Panel View · Split · Reading progress",
             comicDisplaySummary(ComicFormattingPreferences(panelViewOn = true, panelOverflow = PanelOverflowBehavior.SPLIT, showChapterMap = true)),
         )
     }
 
     @Test fun `reading progress on panel view also off`() {
         assertEquals(
-            "Panel View off · Reading progress",
+            "Dark background · Panel View off · Reading progress",
             comicDisplaySummary(ComicFormattingPreferences(panelViewOn = false, showChapterMap = true)),
         )
     }
 
     @Test fun `page numbers on appends after reading progress`() {
         assertEquals(
-            "Panel View off · Reading progress · Page numbers",
+            "Dark background · Panel View off · Reading progress · Page numbers",
             comicDisplaySummary(ComicFormattingPreferences(panelViewOn = false, showChapterMap = true, showPageProgress = true)),
         )
     }
 
     @Test fun `page progress on without chapter map does not append`() {
         assertEquals(
-            "Panel View off",
+            "Dark background · Panel View off",
             comicDisplaySummary(ComicFormattingPreferences(panelViewOn = false, showChapterMap = false, showPageProgress = true)),
+        )
+    }
+
+    @Test fun `background theme starts comic display summary`() {
+        assertEquals(
+            "Sepia background · Panel View off",
+            comicDisplaySummary(ComicFormattingPreferences(backgroundTheme = ReaderTheme.Sepia)),
+        )
+    }
+
+    @Test fun `auto background starts comic display summary`() {
+        assertEquals(
+            "Auto background · Panel View off",
+            comicDisplaySummary(ComicFormattingPreferences(backgroundTheme = ReaderTheme.Auto)),
         )
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/BookComicFormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/BookComicFormattingPreferencesStoreImpl.kt
@@ -2,9 +2,11 @@ package com.riffle.core.data
 
 import com.riffle.core.database.BookComicFormattingPreferencesDao
 import com.riffle.core.database.BookComicFormattingPreferencesEntity
+import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.comic.BookComicFormattingOverrides
 import com.riffle.core.domain.comic.BookComicFormattingPreferencesStore
 import com.riffle.core.domain.comic.PanelOverflowBehavior
+import com.riffle.core.domain.comic.asComicBackgroundTheme
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -27,6 +29,7 @@ class BookComicFormattingPreferencesStoreImpl @Inject constructor(
             BookComicFormattingPreferencesEntity(
                 sourceId = sourceId,
                 itemId = itemId,
+                backgroundTheme = overrides.backgroundTheme?.asComicBackgroundTheme()?.name,
                 panelViewOn = overrides.panelViewOn,
                 panelOverflow = overrides.panelOverflow?.name,
                 panelAnimationSpeedMs = overrides.panelAnimationSpeedMs,
@@ -40,6 +43,9 @@ class BookComicFormattingPreferencesStoreImpl @Inject constructor(
     }
 
     private fun BookComicFormattingPreferencesEntity.toDomain() = BookComicFormattingOverrides(
+        backgroundTheme = backgroundTheme?.let {
+            runCatching { ReaderTheme.valueOf(it) }.getOrNull()?.asComicBackgroundTheme()
+        },
         panelViewOn = panelViewOn,
         panelOverflow = panelOverflow?.let {
             runCatching { PanelOverflowBehavior.valueOf(it) }.getOrNull()

--- a/core/data/src/main/kotlin/com/riffle/core/data/ComicFormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/ComicFormattingPreferencesStoreImpl.kt
@@ -7,9 +7,11 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.riffle.core.data.di.ComicFormattingPreferencesDataStore
+import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.comic.ComicFormattingPreferences
 import com.riffle.core.domain.comic.ComicFormattingPreferencesStore
 import com.riffle.core.domain.comic.PanelOverflowBehavior
+import com.riffle.core.domain.comic.asComicBackgroundTheme
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -20,6 +22,9 @@ class ComicFormattingPreferencesStoreImpl @Inject constructor(
 
     override val preferences: Flow<ComicFormattingPreferences> = dataStore.data.map { prefs ->
         ComicFormattingPreferences(
+            backgroundTheme = prefs[BACKGROUND_THEME]
+                ?.let { runCatching { ReaderTheme.valueOf(it) }.getOrNull()?.asComicBackgroundTheme() }
+                ?: ReaderTheme.Dark,
             panelViewOn = prefs[PANEL_VIEW_ON] ?: false,
             panelOverflow = prefs[PANEL_OVERFLOW]
                 ?.let { runCatching { PanelOverflowBehavior.valueOf(it) }.getOrNull() }
@@ -32,6 +37,12 @@ class ComicFormattingPreferencesStoreImpl @Inject constructor(
 
     override suspend fun update(prefs: ComicFormattingPreferences) {
         dataStore.edit { data ->
+            val backgroundTheme = prefs.backgroundTheme.asComicBackgroundTheme()
+            if (backgroundTheme == ReaderTheme.Dark) {
+                data.remove(BACKGROUND_THEME)
+            } else {
+                data[BACKGROUND_THEME] = backgroundTheme.name
+            }
             if (prefs.panelViewOn) data[PANEL_VIEW_ON] = true else data.remove(PANEL_VIEW_ON)
             if (prefs.panelOverflow == PanelOverflowBehavior.SPLIT) {
                 data.remove(PANEL_OVERFLOW)
@@ -51,6 +62,7 @@ class ComicFormattingPreferencesStoreImpl @Inject constructor(
     }
 
     companion object {
+        private val BACKGROUND_THEME = stringPreferencesKey("background_theme")
         private val PANEL_VIEW_ON = booleanPreferencesKey("panel_view_on")
         private val PANEL_OVERFLOW = stringPreferencesKey("panel_overflow")
         private val PANEL_ANIMATION_SPEED_MS = intPreferencesKey("panel_animation_speed_ms")

--- a/core/data/src/test/kotlin/com/riffle/core/data/BookComicFormattingPreferencesStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/BookComicFormattingPreferencesStoreImplTest.kt
@@ -2,6 +2,8 @@ package com.riffle.core.data
 
 import com.riffle.core.database.BookComicFormattingPreferencesDao
 import com.riffle.core.database.BookComicFormattingPreferencesEntity
+import com.riffle.core.domain.comic.BookComicFormattingOverrides
+import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.comic.PanelOverflowBehavior
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
@@ -23,6 +25,7 @@ class BookComicFormattingPreferencesStoreImplTest {
     @Test fun `unknown panelOverflow name maps to null — forward-compat guard`() = runTest {
         val entity = BookComicFormattingPreferencesEntity(
             sourceId = "src", itemId = "item",
+            backgroundTheme = null,
             panelViewOn = true, panelOverflow = "UNKNOWN_FUTURE_VALUE",
             panelAnimationSpeedMs = null,
         )
@@ -34,6 +37,7 @@ class BookComicFormattingPreferencesStoreImplTest {
     @Test fun `known panelOverflow SPLIT is parsed correctly`() = runTest {
         val entity = BookComicFormattingPreferencesEntity(
             sourceId = "src", itemId = "item",
+            backgroundTheme = null,
             panelViewOn = null, panelOverflow = "SPLIT",
             panelAnimationSpeedMs = null,
         )
@@ -45,6 +49,7 @@ class BookComicFormattingPreferencesStoreImplTest {
     @Test fun `known panelOverflow SMART_SPLIT is parsed correctly`() = runTest {
         val entity = BookComicFormattingPreferencesEntity(
             sourceId = "src", itemId = "item",
+            backgroundTheme = null,
             panelViewOn = true, panelOverflow = "SMART_SPLIT",
             panelAnimationSpeedMs = null,
         )
@@ -62,6 +67,7 @@ class BookComicFormattingPreferencesStoreImplTest {
     @Test fun `panelAnimationSpeedMs is round-tripped through entity`() = runTest {
         val entity = BookComicFormattingPreferencesEntity(
             sourceId = "src", itemId = "item",
+            backgroundTheme = null,
             panelViewOn = true, panelOverflow = null,
             panelAnimationSpeedMs = 400,
         )
@@ -72,10 +78,87 @@ class BookComicFormattingPreferencesStoreImplTest {
     @Test fun `null panelAnimationSpeedMs in entity maps to null override — follows global`() = runTest {
         val entity = BookComicFormattingPreferencesEntity(
             sourceId = "src", itemId = "item",
+            backgroundTheme = null,
             panelViewOn = true, panelOverflow = null,
             panelAnimationSpeedMs = null,
         )
         val result = storeWith(entity).overrides("src::item").first()
         assertNull(result.panelAnimationSpeedMs)
+    }
+
+    @Test fun `known backgroundTheme is parsed correctly`() = runTest {
+        val entity = BookComicFormattingPreferencesEntity(
+            sourceId = "src", itemId = "item",
+            backgroundTheme = "Sepia",
+            panelViewOn = null, panelOverflow = null,
+            panelAnimationSpeedMs = null,
+        )
+        val result = storeWith(entity).overrides("src::item").first()
+        assertEquals(ReaderTheme.Sepia, result.backgroundTheme)
+    }
+
+    @Test fun `known backgroundTheme Auto is parsed correctly`() = runTest {
+        val entity = BookComicFormattingPreferencesEntity(
+            sourceId = "src", itemId = "item",
+            backgroundTheme = "Auto",
+            panelViewOn = null, panelOverflow = null,
+            panelAnimationSpeedMs = null,
+        )
+        val result = storeWith(entity).overrides("src::item").first()
+        assertEquals(ReaderTheme.Auto, result.backgroundTheme)
+    }
+
+    @Test fun `known backgroundTheme DarkDim is parsed as Dark for comics`() = runTest {
+        val entity = BookComicFormattingPreferencesEntity(
+            sourceId = "src", itemId = "item",
+            backgroundTheme = "DarkDim",
+            panelViewOn = null, panelOverflow = null,
+            panelAnimationSpeedMs = null,
+        )
+        val result = storeWith(entity).overrides("src::item").first()
+        assertEquals(ReaderTheme.Dark, result.backgroundTheme)
+    }
+
+    @Test fun `unknown backgroundTheme maps to null — forward-compat guard`() = runTest {
+        val entity = BookComicFormattingPreferencesEntity(
+            sourceId = "src", itemId = "item",
+            backgroundTheme = "UNKNOWN_FUTURE_VALUE",
+            panelViewOn = null, panelOverflow = null,
+            panelAnimationSpeedMs = null,
+        )
+        val result = storeWith(entity).overrides("src::item").first()
+        assertNull("Unknown enum name must not crash; maps to null", result.backgroundTheme)
+    }
+
+    @Test fun `save writes backgroundTheme override into entity`() = runTest {
+        var saved: BookComicFormattingPreferencesEntity? = null
+        val dao = object : BookComicFormattingPreferencesDao {
+            override suspend fun upsert(entity: BookComicFormattingPreferencesEntity) { saved = entity }
+            override suspend fun getByItemId(sourceId: String, itemId: String) = null
+            override suspend fun deleteByItemId(sourceId: String, itemId: String) {}
+        }
+
+        BookComicFormattingPreferencesStoreImpl(dao).save(
+            "src::item",
+            BookComicFormattingOverrides(backgroundTheme = ReaderTheme.Light),
+        )
+
+        assertEquals("Light", saved?.backgroundTheme)
+    }
+
+    @Test fun `save writes Dark when backgroundTheme override is DarkDim`() = runTest {
+        var saved: BookComicFormattingPreferencesEntity? = null
+        val dao = object : BookComicFormattingPreferencesDao {
+            override suspend fun upsert(entity: BookComicFormattingPreferencesEntity) { saved = entity }
+            override suspend fun getByItemId(sourceId: String, itemId: String) = null
+            override suspend fun deleteByItemId(sourceId: String, itemId: String) {}
+        }
+
+        BookComicFormattingPreferencesStoreImpl(dao).save(
+            "src::item",
+            BookComicFormattingOverrides(backgroundTheme = ReaderTheme.DarkDim),
+        )
+
+        assertEquals("Dark", saved?.backgroundTheme)
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/ComicFormattingPreferencesStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/ComicFormattingPreferencesStoreImplTest.kt
@@ -1,6 +1,7 @@
 package com.riffle.core.data
 
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.comic.ComicFormattingPreferences
 import com.riffle.core.domain.comic.PanelOverflowBehavior
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -31,6 +32,32 @@ class ComicFormattingPreferencesStoreImplTest {
         assertEquals(false, prefs.panelViewOn)
         assertEquals(PanelOverflowBehavior.SPLIT, prefs.panelOverflow)
         assertEquals(250, prefs.panelAnimationSpeedMs)
+        assertEquals(ReaderTheme.Dark, prefs.backgroundTheme)
+    }
+
+    @Test fun `backgroundTheme round-trips non-default value`() = testScope.runTest {
+        val store = newStore()
+        store.update(ComicFormattingPreferences(backgroundTheme = ReaderTheme.Sepia))
+        assertEquals(ReaderTheme.Sepia, store.preferences.first().backgroundTheme)
+    }
+
+    @Test fun `backgroundTheme Auto round-trips`() = testScope.runTest {
+        val store = newStore()
+        store.update(ComicFormattingPreferences(backgroundTheme = ReaderTheme.Auto))
+        assertEquals(ReaderTheme.Auto, store.preferences.first().backgroundTheme)
+    }
+
+    @Test fun `backgroundTheme default Dark is stored as absent and reads back as Dark`() = testScope.runTest {
+        val store = newStore()
+        store.update(ComicFormattingPreferences(backgroundTheme = ReaderTheme.Sepia))
+        store.update(ComicFormattingPreferences(backgroundTheme = ReaderTheme.Dark))
+        assertEquals(ReaderTheme.Dark, store.preferences.first().backgroundTheme)
+    }
+
+    @Test fun `backgroundTheme DarkDim is stored and read back as Dark for comics`() = testScope.runTest {
+        val store = newStore()
+        store.update(ComicFormattingPreferences(backgroundTheme = ReaderTheme.DarkDim))
+        assertEquals(ReaderTheme.Dark, store.preferences.first().backgroundTheme)
     }
 
     @Test fun `panelViewOn round-trips`() = testScope.runTest {

--- a/core/database-api/src/commonMain/kotlin/com/riffle/core/database/BookComicFormattingPreferencesEntity.kt
+++ b/core/database-api/src/commonMain/kotlin/com/riffle/core/database/BookComicFormattingPreferencesEntity.kt
@@ -27,6 +27,7 @@ import androidx.room.Query
 data class BookComicFormattingPreferencesEntity(
     @ColumnInfo(name = "source_id") val sourceId: String,
     @ColumnInfo(name = "item_id") val itemId: String,
+    @ColumnInfo(name = "background_theme") val backgroundTheme: String?,
     @ColumnInfo(name = "panel_view_on") val panelViewOn: Boolean?,
     @ColumnInfo(name = "panel_overflow") val panelOverflow: String?,
     @ColumnInfo(name = "panel_animation_speed_ms") val panelAnimationSpeedMs: Int?,

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/68.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/68.json
@@ -1,0 +1,2136 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 68,
+    "identityHash": "54fc11b49275720b692fd387234ee012",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER NOT NULL, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, `pageCount` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesSequence",
+            "columnName": "seriesSequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `coloredChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coloredChapterMap",
+            "columnName": "coloredChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "scope"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, `originFontFamily` TEXT, `emphasisStyles` TEXT, `textSnippetHtml` TEXT, `fragmentAnchor` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedFigures",
+            "columnName": "embeddedFigures",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageHref",
+            "columnName": "imageHref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageSvg",
+            "columnName": "imageSvg",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBytes",
+            "columnName": "imageBytes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originFontFamily",
+            "columnName": "originFontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "emphasisStyles",
+            "columnName": "emphasisStyles",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippetHtml",
+            "columnName": "textSnippetHtml",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fragmentAnchor",
+            "columnName": "fragmentAnchor",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "local_files_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `treeUri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `addedAtEpochMs` INTEGER NOT NULL, `libraryId` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `treeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtEpochMs",
+            "columnName": "addedAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "treeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `originalUri` TEXT NOT NULL, `copiedPath` TEXT NOT NULL, `coverPath` TEXT, `format` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `mtimeEpochMs` INTEGER NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, `displayName` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUri",
+            "columnName": "originalUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "copiedPath",
+            "columnName": "copiedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtimeEpochMs",
+            "columnName": "mtimeEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_files_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_file_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `folderTreeUri` TEXT NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`, `folderTreeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderTreeUri",
+            "columnName": "folderTreeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId",
+            "folderTreeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_file_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_local_files_file_folders_sourceId_folderTreeUri",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "folderTreeUri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId_folderTreeUri` ON `${TABLE_NAME}` (`sourceId`, `folderTreeUri`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_file_metadata_overrides",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `title` TEXT, `author` TEXT, `seriesName` TEXT, `seriesIndex` REAL, `coverUrl` TEXT, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "seriesIndex",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_file_metadata_overrides_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_file_metadata_overrides_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_item_freshness",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `lastFetchedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFetchedAt",
+            "columnName": "lastFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `rootId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootId",
+            "columnName": "rootId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_playlists_rootId",
+            "unique": false,
+            "columnNames": [
+              "rootId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_rootId` ON `${TABLE_NAME}` (`rootId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `orderIndex` INTEGER NOT NULL, PRIMARY KEY(`playlistId`, `sourceId`, `itemId`), FOREIGN KEY(`sourceId`, `playlistId`) REFERENCES `playlists`(`sourceId`, `id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "orderIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId",
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_items_sourceId_playlistId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_items_sourceId_playlistId` ON `${TABLE_NAME}` (`sourceId`, `playlistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId",
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "sourceId",
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "publication_metrics_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `totalPositions` INTEGER, `pageCount` INTEGER, `cachedAt` INTEGER NOT NULL, `epubVersion` TEXT, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPositions",
+            "columnName": "totalPositions",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epubVersion",
+            "columnName": "epubVersion",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_publication_metrics_cache_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_publication_metrics_cache_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_comic_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`source_id` TEXT NOT NULL, `item_id` TEXT NOT NULL, `background_theme` TEXT, `panel_view_on` INTEGER, `panel_overflow` TEXT, `panel_animation_speed_ms` INTEGER, PRIMARY KEY(`source_id`, `item_id`), FOREIGN KEY(`source_id`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "source_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundTheme",
+            "columnName": "background_theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "panelViewOn",
+            "columnName": "panel_view_on",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "panelOverflow",
+            "columnName": "panel_overflow",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "panelAnimationSpeedMs",
+            "columnName": "panel_animation_speed_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "source_id",
+            "item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_comic_formatting_preferences_source_id",
+            "unique": false,
+            "columnNames": [
+              "source_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_comic_formatting_preferences_source_id` ON `${TABLE_NAME}` (`source_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "source_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '54fc11b49275720b692fd387234ee012')"
+    ]
+  }
+}

--- a/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1921,7 +1921,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 66, true,
+            TEST_DB, 68, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -1988,6 +1988,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_64_65,
             RiffleDatabase.MIGRATION_65_66,
             RiffleDatabase.MIGRATION_66_67,
+            RiffleDatabase.MIGRATION_67_68,
         )
 
         db.query("SELECT url, username, serverType, absUserId, type FROM sources WHERE id = 's1'").use { cursor ->
@@ -2001,7 +2002,7 @@ class MigrationTest {
         }
         db.query("PRAGMA user_version").use { cursor ->
             assertTrue(cursor.moveToFirst())
-            assertEquals(66, cursor.getInt(0))
+            assertEquals(68, cursor.getInt(0))
         }
         db.query("SELECT coverUrl FROM local_file_metadata_overrides LIMIT 0").use { cursor ->
             assertEquals("coverUrl", cursor.getColumnName(0))
@@ -3083,6 +3084,40 @@ class MigrationTest {
             db.query("SELECT panel_animation_speed_ms FROM book_comic_formatting_preferences WHERE item_id = 'item2'").use { cursor ->
                 assertTrue(cursor.moveToFirst())
                 assertEquals(400, cursor.getInt(cursor.getColumnIndexOrThrow("panel_animation_speed_ms")))
+            }
+        }
+    }
+
+    @Test
+    fun migration67To68_addsBackgroundThemeToComicFormatting() {
+        helper.createDatabase(TEST_DB, 67).use { db ->
+            db.execSQL(
+                "INSERT INTO sources (id, url, isActive, insecureConnectionAllowed, username, serverType, absUserId, type) " +
+                    "VALUES ('src1', 'http://test', 1, 0, '', 'AUDIOBOOKSHELF', NULL, 'ABS')"
+            )
+            db.execSQL(
+                "INSERT INTO book_comic_formatting_preferences " +
+                    "(source_id, item_id, panel_view_on, panel_overflow, panel_animation_speed_ms) " +
+                    "VALUES ('src1', 'item1', 1, 'SPLIT', 400)"
+            )
+        }
+        helper.runMigrationsAndValidate(TEST_DB, 68, true, RiffleDatabase.MIGRATION_67_68).use { db ->
+            db.query("SELECT * FROM book_comic_formatting_preferences WHERE item_id = 'item1'").use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals(1, cursor.getInt(cursor.getColumnIndexOrThrow("panel_view_on")))
+                assertEquals("SPLIT", cursor.getString(cursor.getColumnIndexOrThrow("panel_overflow")))
+                assertEquals(400, cursor.getInt(cursor.getColumnIndexOrThrow("panel_animation_speed_ms")))
+                val col = cursor.getColumnIndexOrThrow("background_theme")
+                assertTrue(cursor.isNull(col))
+            }
+            db.execSQL(
+                "INSERT INTO book_comic_formatting_preferences " +
+                    "(source_id, item_id, panel_view_on, panel_overflow, panel_animation_speed_ms, background_theme) " +
+                    "VALUES ('src1', 'item2', 0, 'OFF', 0, 'Sepia')"
+            )
+            db.query("SELECT background_theme FROM book_comic_formatting_preferences WHERE item_id = 'item2'").use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals("Sepia", cursor.getString(cursor.getColumnIndexOrThrow("background_theme")))
             }
         }
     }

--- a/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -42,7 +42,7 @@ import androidx.sqlite.execSQL
         PublicationMetricsCacheEntity::class,
         BookComicFormattingPreferencesEntity::class,
     ],
-    version = 67,
+    version = 68,
     exportSchema = true,
 )
 @ConstructedBy(RiffleDatabaseConstructor::class)
@@ -1764,6 +1764,14 @@ abstract class RiffleDatabase : RoomDatabase() {
             override fun migrate(db: SQLiteConnection) {
                 db.execSQL(
                     "ALTER TABLE `book_comic_formatting_preferences` ADD COLUMN `panel_animation_speed_ms` INTEGER"
+                )
+            }
+        }
+
+        val MIGRATION_67_68 = object : Migration(67, 68) {
+            override fun migrate(db: SQLiteConnection) {
+                db.execSQL(
+                    "ALTER TABLE `book_comic_formatting_preferences` ADD COLUMN `background_theme` TEXT"
                 )
             }
         }

--- a/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabaseFactory.kt
+++ b/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabaseFactory.kt
@@ -114,4 +114,5 @@ internal val RIFFLE_DATABASE_MIGRATIONS: Array<Migration> = arrayOf(
     RiffleDatabase.MIGRATION_64_65,
     RiffleDatabase.MIGRATION_65_66,
     RiffleDatabase.MIGRATION_66_67,
+    RiffleDatabase.MIGRATION_67_68,
 )

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/ReaderTheme.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/ReaderTheme.kt
@@ -1,0 +1,3 @@
+package com.riffle.core.domain
+
+enum class ReaderTheme { Light, Dark, DarkDim, Sepia, Auto }

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/ComicFormattingPreferences.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/ComicFormattingPreferences.kt
@@ -1,8 +1,21 @@
 package com.riffle.core.domain.comic
 
+import com.riffle.core.domain.ReaderTheme
+
 enum class PanelOverflowBehavior { OFF, SPLIT, SMART_SPLIT }
 
+val ComicBackgroundThemeChoices: List<ReaderTheme> = listOf(ReaderTheme.Light, ReaderTheme.Dark, ReaderTheme.Sepia)
+
+fun ReaderTheme.asComicBackgroundTheme(): ReaderTheme = when (this) {
+    ReaderTheme.DarkDim -> ReaderTheme.Dark
+    else -> this
+}
+
+fun ReaderTheme.resolveComicBackgroundTheme(autoResolvedTheme: ReaderTheme): ReaderTheme =
+    if (this == ReaderTheme.Auto) autoResolvedTheme.asComicBackgroundTheme() else asComicBackgroundTheme()
+
 data class ComicFormattingPreferences(
+    val backgroundTheme: ReaderTheme = ReaderTheme.Dark,
     val panelViewOn: Boolean = false,
     val panelOverflow: PanelOverflowBehavior = PanelOverflowBehavior.SPLIT,
     val panelAnimationSpeedMs: Int = 250,
@@ -11,6 +24,7 @@ data class ComicFormattingPreferences(
 )
 
 data class BookComicFormattingOverrides(
+    val backgroundTheme: ReaderTheme? = null,
     val panelViewOn: Boolean? = null,
     val panelOverflow: PanelOverflowBehavior? = null,
     val panelAnimationSpeedMs: Int? = null,
@@ -18,6 +32,7 @@ data class BookComicFormattingOverrides(
     val showPageProgress: Boolean? = null,
 ) {
     fun applyTo(global: ComicFormattingPreferences) = global.copy(
+        backgroundTheme = (backgroundTheme ?: global.backgroundTheme).asComicBackgroundTheme(),
         panelViewOn = panelViewOn ?: global.panelViewOn,
         panelOverflow = panelOverflow ?: global.panelOverflow,
         panelAnimationSpeedMs = panelAnimationSpeedMs ?: global.panelAnimationSpeedMs,
@@ -25,6 +40,7 @@ data class BookComicFormattingOverrides(
         showPageProgress = showPageProgress ?: global.showPageProgress,
     )
 
-    fun isEmpty() = panelViewOn == null && panelOverflow == null && panelAnimationSpeedMs == null &&
+    fun isEmpty() = backgroundTheme == null &&
+        panelViewOn == null && panelOverflow == null && panelAnimationSpeedMs == null &&
         showChapterMap == null && showPageProgress == null
 }

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/FormattingPreferences.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/FormattingPreferences.kt
@@ -57,7 +57,6 @@ data class FormattingPreferences(
     }
 }
 
-enum class ReaderTheme { Light, Dark, DarkDim, Sepia, Auto }
 enum class AutoReaderThemeMode { Schedule, AppTheme }
 enum class ReaderFontFamily { Original, Serif, SansSerif, Monospace, Literata, Merriweather, OpenDyslexic }
 enum class ReaderOrientation { Horizontal, Vertical, Continuous }

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/comic/BookComicFormattingOverridesTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/comic/BookComicFormattingOverridesTest.kt
@@ -1,5 +1,6 @@
 package com.riffle.core.domain.comic
 
+import com.riffle.core.domain.ReaderTheme
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -15,6 +16,23 @@ class BookComicFormattingOverridesTest {
     @Test fun `applyTo returns global when overrides are all null`() {
         val result = BookComicFormattingOverrides().applyTo(global)
         assertEquals(global, result)
+    }
+
+    @Test fun `applyTo overrides backgroundTheme when set`() {
+        val result = BookComicFormattingOverrides(backgroundTheme = ReaderTheme.Sepia).applyTo(global)
+        assertEquals(ReaderTheme.Sepia, result.backgroundTheme)
+        assertEquals(global.panelViewOn, result.panelViewOn)
+        assertEquals(global.panelOverflow, result.panelOverflow)
+    }
+
+    @Test fun `applyTo preserves Auto backgroundTheme override`() {
+        val result = BookComicFormattingOverrides(backgroundTheme = ReaderTheme.Auto).applyTo(global)
+        assertEquals(ReaderTheme.Auto, result.backgroundTheme)
+    }
+
+    @Test fun `applyTo normalizes legacy DarkDim backgroundTheme to Dark`() {
+        val result = BookComicFormattingOverrides(backgroundTheme = ReaderTheme.DarkDim).applyTo(global)
+        assertEquals(ReaderTheme.Dark, result.backgroundTheme)
     }
 
     @Test fun `applyTo overrides panelViewOn when set`() {
@@ -46,6 +64,7 @@ class BookComicFormattingOverridesTest {
         assertFalse(BookComicFormattingOverrides(panelViewOn = true).isEmpty())
         assertFalse(BookComicFormattingOverrides(panelOverflow = PanelOverflowBehavior.OFF).isEmpty())
         assertFalse(BookComicFormattingOverrides(panelAnimationSpeedMs = 400).isEmpty())
+        assertFalse(BookComicFormattingOverrides(backgroundTheme = ReaderTheme.Light).isEmpty())
     }
 
     @Test fun `applyTo overrides panelAnimationSpeedMs when set`() {


### PR DESCRIPTION
## Summary

- Reuse the shared reader theme enum and theme chip UI for book and comic display settings.
- Add comic background theme preferences globally and per book, with Room migration 67→68 and schema 68.
- Expose comic background theme controls for Light, Dark, Sepia, and Auto only; normalize Dim/DarkDim to Dark for comics.
- Apply comic background themes to the CBZ reader backdrop and keep comic chips letterless/background-only.

## Tests

- `:core:domain:jvmTest --tests com.riffle.core.domain.comic.BookComicFormattingOverridesTest`
- `:core:data:testDebugUnitTest --tests com.riffle.core.data.ComicFormattingPreferencesStoreImplTest --tests com.riffle.core.data.BookComicFormattingPreferencesStoreImplTest`
- `:app:testDebugUnitTest --tests com.riffle.app.feature.reader.cbz.ComicBackgroundThemeTest --tests com.riffle.app.feature.reader.cbz.ComicFormattingOverridesMergeTest --tests com.riffle.app.feature.settings.ComicDisplaySummaryTest`
- `:app:compileDebugKotlin :app:compileDebugAndroidTestKotlin :core:database:compileAndroidDeviceTest`
- `make harness-test-class CLASS='com.riffle.app.feature.reader.ReaderSettingsSectionsTest#comicDisplaySection_backgroundThemeIncludesAutoThemeChip'`

Specific assertions that fail if reverted:

- Comic theme selector shows Auto, excludes Dim, and clicking Sepia/Auto emits the selected `ReaderTheme`.
- `ReaderTheme.DarkDim.asComicBackgroundTheme()` resolves to `ReaderTheme.Dark`.
- Per-book comic background override merge preserves existing panel fields while applying `backgroundTheme`.
- Comic formatting stores and per-book overrides round-trip background theme values and normalize DarkDim to Dark.
