### PR TITLE
fix(settings): rename "check for updates on startup" to "check for updates automatically"

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/settings/sections/AppVersionSection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/sections/AppVersionSection.kt
@@ -71,7 +71,7 @@ internal fun AppVersionSection(
         },
     )
     ListItem(
-        headlineContent = { Text(stringResource(R.string.ui_check_for_updates_on_startup)) },
+        headlineContent = { Text(stringResource(R.string.ui_check_for_updates_automatically)) },
         trailingContent = {
             Switch(
                 checked = autoUpdateEnabled,

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -41,7 +41,7 @@
     <string name="ui_cancel_timer">Отмяна на таймера</string>
     <string name="ui_chapters">глави</string>
     <string name="ui_check_for_updates">Проверете за актуализации</string>
-    <string name="ui_check_for_updates_on_startup">Проверете за актуализации при стартиране</string>
+    <string name="ui_check_for_updates_automatically">Проверявай автоматично за актуализации</string>
     <string name="ui_choose_scheme">Изберете схема</string>
     <string name="ui_choose_which_libraries_to_show_in_riffle_you_can_change_this_later_in_settings">Изберете кои библиотеки да се показват в Riffle. Можете да промените това по-късно в Настройки.</string>
     <string name="ui_clear">Изчистване</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -41,7 +41,7 @@
     <string name="ui_cancel_timer">Cancelar temporizador</string>
     <string name="ui_chapters">Capítulos</string>
     <string name="ui_check_for_updates">Buscar actualizaciones</string>
-    <string name="ui_check_for_updates_on_startup">Buscar actualizaciones al iniciar</string>
+    <string name="ui_check_for_updates_automatically">Buscar actualizaciones automáticamente</string>
     <string name="ui_choose_scheme">Elige el esquema</string>
     <string name="ui_choose_which_libraries_to_show_in_riffle_you_can_change_this_later_in_settings">Elige qué bibliotecas se muestran en Riffle. Puedes cambiarlo más adelante en Ajustes.</string>
     <string name="ui_clear">Borrar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,7 +47,7 @@
     <string name="ui_cancel_timer">Cancel timer</string>
     <string name="ui_chapters">Chapters</string>
     <string name="ui_check_for_updates">Check for updates</string>
-    <string name="ui_check_for_updates_on_startup">Check for updates on startup</string>
+    <string name="ui_check_for_updates_automatically">Check for updates automatically</string>
     <string name="ui_choose_scheme">Choose scheme</string>
     <string name="ui_choose_which_libraries_to_show_in_riffle_you_can_change_this_later_in_settings">Choose which libraries to show in Riffle. You can change this later in Settings.</string>
     <string name="ui_clear">Clear</string>


### PR DESCRIPTION
The toggle guards both the cold-start \`init\` call and the foreground-resume trigger in \`MainScreen.kt\` (via the same \`checkNow()\` path), so "on startup" was inaccurate. Rename the string resource and BG/ES translations to "Check for updates automatically".

No behaviour change — \`StartupUpdateViewModel.checkNow()\` already reads \`autoUpdateEnabled\` and returns early when it's \`false\`.