### PR TITLE
fix(comics): improve CutPanelCutOff panel reporting

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportSheet.kt
@@ -2,6 +2,8 @@ package com.riffle.app.feature.reader.cbz
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -60,9 +62,11 @@ internal fun PanelReportSheet(
     val state by viewModel.state.collectAsState()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
+    val cutOffMode = state.failureType == PanelDetectionFailureType.CutPanelCutOff
     val drawMode = state.failureType == PanelDetectionFailureType.MissedPanel ||
         state.failureType == PanelDetectionFailureType.MergedPanels ||
-        state.failureType == PanelDetectionFailureType.SplitPanel
+        state.failureType == PanelDetectionFailureType.SplitPanel ||
+        cutOffMode
     val drawsRectangle = state.failureType == PanelDetectionFailureType.MissedPanel ||
         state.failureType == PanelDetectionFailureType.SplitPanel
     val orderMode = state.failureType == PanelDetectionFailureType.WrongPanelOrder
@@ -135,6 +139,8 @@ internal fun PanelReportSheet(
                 val hint = when (state.failureType) {
                     PanelDetectionFailureType.MissedPanel,
                     PanelDetectionFailureType.SplitPanel -> "Draw the correct panel boundary"
+                    PanelDetectionFailureType.CutPanelCutOff ->
+                        "Tap the cut-off panel to identify it; drag to draw its correct boundary"
                     else -> "Draw panel boundary lines"
                 }
                 Text(hint, style = androidx.compose.material3.MaterialTheme.typography.bodySmall)
@@ -151,9 +157,48 @@ internal fun PanelReportSheet(
                     .aspectRatio(mask.width.toFloat() / mask.height.toFloat())
                     .border(1.dp, Color.Gray)
                     .onSizeChanged { canvasSize = it }
-                    .pointerInput(drawMode, orderMode, state.failureType, canvasSize) {
-                        if (drawMode) {
-                            detectDragGestures(
+                    .pointerInput(cutOffMode, drawMode, orderMode, state.failureType, canvasSize) {
+                        when {
+                            cutOffMode -> awaitEachGesture {
+                                val down = awaitFirstDown(requireUnconsumed = false)
+                                down.consume()
+                                val startPos = down.position
+                                var currentPos = startPos
+                                var crossedSlop = false
+                                while (true) {
+                                    val event = awaitPointerEvent()
+                                    val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                                    change.consume()
+                                    if (!change.pressed) break
+                                    currentPos = change.position
+                                    if (!crossedSlop) {
+                                        val dist = kotlin.math.hypot(
+                                            (currentPos.x - startPos.x).toDouble(),
+                                            (currentPos.y - startPos.y).toDouble(),
+                                        )
+                                        if (dist > viewConfiguration.touchSlop) {
+                                            crossedSlop = true
+                                            dragStart = startPos
+                                        }
+                                    }
+                                    if (crossedSlop) dragCurrent = currentPos
+                                }
+                                if (scaleX > 0f && scaleY > 0f) {
+                                    if (!crossedSlop) {
+                                        val ix = (startPos.x / scaleX).toInt().coerceIn(0, mask.width - 1)
+                                        val iy = (startPos.y / scaleY).toInt().coerceIn(0, mask.height - 1)
+                                        viewModel.onTap(tappedImageX = ix, tappedImageY = iy)
+                                    } else {
+                                        val ix1 = (startPos.x / scaleX).toInt().coerceIn(0, mask.width - 1)
+                                        val iy1 = (startPos.y / scaleY).toInt().coerceIn(0, mask.height - 1)
+                                        val ix2 = (currentPos.x / scaleX).toInt().coerceIn(0, mask.width - 1)
+                                        val iy2 = (currentPos.y / scaleY).toInt().coerceIn(0, mask.height - 1)
+                                        viewModel.addDrawnPanel(ix1, iy1, ix2, iy2)
+                                    }
+                                }
+                                dragStart = null; dragCurrent = null
+                            }
+                            drawMode -> detectDragGestures(
                                 onDragStart = { offset -> dragStart = offset; dragCurrent = offset },
                                 onDrag = { _, drag -> dragCurrent = dragCurrent?.plus(drag) },
                                 onDragEnd = {
@@ -173,8 +218,7 @@ internal fun PanelReportSheet(
                                 },
                                 onDragCancel = { dragStart = null; dragCurrent = null },
                             )
-                        } else {
-                            detectTapGestures { offset ->
+                            else -> detectTapGestures { offset ->
                                 if (scaleX > 0f && scaleY > 0f) {
                                     val ix = (offset.x / scaleX).toInt().coerceIn(0, mask.width - 1)
                                     val iy = (offset.y / scaleY).toInt().coerceIn(0, mask.height - 1)
@@ -250,7 +294,7 @@ internal fun PanelReportSheet(
                     // In-progress draw preview (yellow)
                     val s = dragStart; val e = dragCurrent
                     if (s != null && e != null) {
-                        if (drawsRectangle) {
+                        if (drawsRectangle || cutOffMode) {
                             drawRect(
                                 color = Color.Yellow,
                                 topLeft = Offset(minOf(s.x, e.x), minOf(s.y, e.y)),
@@ -270,7 +314,7 @@ internal fun PanelReportSheet(
                 if (hasDrawn) {
                     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                         OutlinedButton(onClick = {
-                            if (drawsRectangle)
+                            if (drawsRectangle || cutOffMode)
                                 viewModel.clearLastDrawnPanel()
                             else
                                 viewModel.clearLastDrawnBoundary()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModel.kt
@@ -43,7 +43,16 @@ class PanelReportViewModel(
     val state: StateFlow<PanelReportUiState> = _state.asStateFlow()
 
     fun setFailureType(type: PanelDetectionFailureType) {
-        _state.update { it.copy(failureType = type, error = null, drawnPanels = emptyList(), drawnBoundaries = emptyList(), orderedPanelIndices = emptyList()) }
+        _state.update { it.copy(
+            failureType = type,
+            error = null,
+            tappedX = null,
+            tappedY = null,
+            tappedPanelIndex = null,
+            drawnPanels = emptyList(),
+            drawnBoundaries = emptyList(),
+            orderedPanelIndices = emptyList(),
+        ) }
     }
 
     fun addOrRemoveOrderedPanel(panelIndex: Int) {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModelTest.kt
@@ -209,6 +209,33 @@ class PanelReportViewModelTest {
     }
 
     @Test
+    fun `CutPanelCutOff supports both tap-selection and drawn boundary rectangle`() = runTest {
+        val region = PanelRegion(x = 0, y = 0, width = 200, height = 200)
+        val vm = makeVm(panels = listOf(region))
+        vm.setFailureType(PanelDetectionFailureType.CutPanelCutOff)
+        // Tap within an existing panel — should select it.
+        vm.onTap(tappedImageX = 50, tappedImageY = 50)
+        assertEquals(0, vm.state.value.tappedPanelIndex)
+        // Draw the correct boundary rectangle alongside the selection.
+        vm.addDrawnPanel(0, 0, 250, 200)
+        assertEquals(1, vm.state.value.drawnPanels.size)
+        assertTrue(vm.state.value.drawnBoundaries.isEmpty())
+    }
+
+    @Test
+    fun `setFailureType clears tap state`() = runTest {
+        val region = PanelRegion(x = 0, y = 0, width = 200, height = 200)
+        val vm = makeVm(panels = listOf(region))
+        vm.onTap(tappedImageX = 50, tappedImageY = 50)
+        assertNull(vm.state.value.failureType)
+        assertEquals(0, vm.state.value.tappedPanelIndex)
+        vm.setFailureType(PanelDetectionFailureType.FalsePanel)
+        assertNull(vm.state.value.tappedX)
+        assertNull(vm.state.value.tappedY)
+        assertNull(vm.state.value.tappedPanelIndex)
+    }
+
+    @Test
     fun `submit requires failure type`() = runTest {
         val vm = makeVm()
         vm.submit(maskPng = ByteArray(0))

--- a/core/data/src/main/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepository.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepository.kt
@@ -22,6 +22,8 @@ import kotlinx.serialization.json.jsonPrimitive
 import java.io.IOException
 import java.util.UUID
 
+private const val MAX_REF_RETRIES = 3
+
 class GitHubPanelReportRepository(
     private val pat: String,
     private val owner: String = "pkmetski",
@@ -44,67 +46,81 @@ class GitHubPanelReportRepository(
                 jsonObject("content" to pngBase64, "encoding" to "base64"),
             ).field("sha")
 
-            // 2. Get current commit sha from panel-reports branch (create from main if absent)
-            val currentCommitSha = try {
-                get("$apiBase/repos/$owner/$repoName/git/ref/heads/panel-reports")
-                    .let { it["object"]!!.jsonObject["sha"]!!.jsonPrimitive.content }
-            } catch (e: IOException) {
-                if ("404" !in (e.message ?: "")) throw e
-                val mainSha = get("$apiBase/repos/$owner/$repoName/git/ref/heads/main")
-                    .let { it["object"]!!.jsonObject["sha"]!!.jsonPrimitive.content }
-                post(
-                    "$apiBase/repos/$owner/$repoName/git/refs",
-                    jsonObject("ref" to "refs/heads/panel-reports", "sha" to mainSha),
-                )
-                mainSha
-            }
-
-            // 3. Get current tree sha
-            val commitJson = get("$apiBase/repos/$owner/$repoName/git/commits/$currentCommitSha")
-            val currentTreeSha = commitJson["tree"]!!.jsonObject["sha"]!!.jsonPrimitive.content
-
-            // 4. Create tree
-            val newTreeSha = post(
-                "$apiBase/repos/$owner/$repoName/git/trees",
-                JsonObject(mapOf(
-                    "base_tree" to JsonPrimitive(currentTreeSha),
-                    "tree" to JsonArray(listOf(JsonObject(mapOf(
-                        "path" to JsonPrimitive("fixtures/$filename"),
-                        "mode" to JsonPrimitive("100644"),
-                        "type" to JsonPrimitive("blob"),
-                        "sha" to JsonPrimitive(blobSha),
-                    )))),
-                )).toString(),
-            ).field("sha")
-
-            // 5. Create commit
-            val newCommitSha = post(
-                "$apiBase/repos/$owner/$repoName/git/commits",
-                JsonObject(mapOf(
-                    "message" to JsonPrimitive("panel report: ${report.failureType.label} p${report.pageIndex}"),
-                    "tree" to JsonPrimitive(newTreeSha),
-                    "parents" to JsonArray(listOf(JsonPrimitive(currentCommitSha))),
-                )).toString(),
-            ).field("sha")
-
-            // 6. Advance ref
-            patch(
-                "$apiBase/repos/$owner/$repoName/git/refs/heads/panel-reports",
-                jsonObject("sha" to newCommitSha),
-            )
-
             val rawUrl = "$rawBase/$owner/$repoName/panel-reports/fixtures/$filename"
 
-            // 7. Create issue
-            post(
-                "$apiBase/repos/$owner/$repoName/issues",
-                JsonObject(mapOf(
-                    "title" to JsonPrimitive("[Panel Detection] ${report.failureType.label} — page ${report.pageIndex}"),
-                    "body" to JsonPrimitive(buildIssueBody(report, rawUrl)),
-                    "labels" to JsonArray(listOf(JsonPrimitive("panel-view-issue"))),
-                )).toString(),
-            ).field("html_url")
+            // Steps 2–6 may race with concurrent submissions; retry on 422 (not a fast-forward).
+            repeat(MAX_REF_RETRIES) { attempt ->
+                // 2. Get current commit sha from panel-reports branch (create from main if absent)
+                val currentCommitSha = try {
+                    get("$apiBase/repos/$owner/$repoName/git/ref/heads/panel-reports")
+                        .let { it["object"]!!.jsonObject["sha"]!!.jsonPrimitive.content }
+                } catch (e: IOException) {
+                    if ("404" !in (e.message ?: "")) throw e
+                    val mainSha = get("$apiBase/repos/$owner/$repoName/git/ref/heads/main")
+                        .let { it["object"]!!.jsonObject["sha"]!!.jsonPrimitive.content }
+                    post(
+                        "$apiBase/repos/$owner/$repoName/git/refs",
+                        jsonObject("ref" to "refs/heads/panel-reports", "sha" to mainSha),
+                    )
+                    mainSha
+                }
+
+                // 3. Get current tree sha
+                val commitJson = get("$apiBase/repos/$owner/$repoName/git/commits/$currentCommitSha")
+                val currentTreeSha = commitJson["tree"]!!.jsonObject["sha"]!!.jsonPrimitive.content
+
+                // 4. Create tree
+                val newTreeSha = post(
+                    "$apiBase/repos/$owner/$repoName/git/trees",
+                    JsonObject(mapOf(
+                        "base_tree" to JsonPrimitive(currentTreeSha),
+                        "tree" to JsonArray(listOf(JsonObject(mapOf(
+                            "path" to JsonPrimitive("fixtures/$filename"),
+                            "mode" to JsonPrimitive("100644"),
+                            "type" to JsonPrimitive("blob"),
+                            "sha" to JsonPrimitive(blobSha),
+                        )))),
+                    )).toString(),
+                ).field("sha")
+
+                // 5. Create commit
+                val newCommitSha = post(
+                    "$apiBase/repos/$owner/$repoName/git/commits",
+                    JsonObject(mapOf(
+                        "message" to JsonPrimitive("panel report: ${report.failureType.label} p${report.pageIndex}"),
+                        "tree" to JsonPrimitive(newTreeSha),
+                        "parents" to JsonArray(listOf(JsonPrimitive(currentCommitSha))),
+                    )).toString(),
+                ).field("sha")
+
+                // 6. Advance ref — may 422 if another report landed since step 2; retry if so
+                try {
+                    patch(
+                        "$apiBase/repos/$owner/$repoName/git/refs/heads/panel-reports",
+                        jsonObject("sha" to newCommitSha),
+                    )
+                    // Ref advanced — break out of retry loop
+                    return@runCatching submitIssue(report, rawUrl)
+                } catch (e: IOException) {
+                    if ("422" !in (e.message ?: "") || attempt == MAX_REF_RETRIES - 1) throw e
+                    // else loop and retry with fresh branch HEAD
+                }
+            }
+
+            // Unreachable (loop always returns or throws), but required for exhaustive return
+            throw IOException("Failed to advance panel-reports ref after $MAX_REF_RETRIES attempts")
         }
+
+    private suspend fun submitIssue(report: PanelDetectionReport, rawUrl: String): String =
+        // 7. Create issue
+        post(
+            "$apiBase/repos/$owner/$repoName/issues",
+            JsonObject(mapOf(
+                "title" to JsonPrimitive("[Panel Detection] ${report.failureType.label} — page ${report.pageIndex}"),
+                "body" to JsonPrimitive(buildIssueBody(report, rawUrl)),
+                "labels" to JsonArray(listOf(JsonPrimitive("panel-view-issue"))),
+            )).toString(),
+        ).field("html_url")
 
     private fun jsonObject(vararg pairs: Pair<String, String>): String =
         JsonObject(pairs.associate { (k, v) -> k to JsonPrimitive(v) }).toString()

--- a/core/data/src/test/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepositoryTest.kt
@@ -124,4 +124,39 @@ class GitHubPanelReportRepositoryTest {
 
         assertTrue(result.isFailure)
     }
+
+    @Test
+    fun `submit retries on 422 not-a-fast-forward and succeeds on second attempt`() = runTest {
+        // 1. create blob
+        server.enqueue(MockResponse().setBody("""{"sha":"blob-sha-123"}""").setResponseCode(201))
+        // --- attempt 1 ---
+        // 2. get ref
+        server.enqueue(MockResponse().setBody("""{"object":{"sha":"stale-commit"}}""").setResponseCode(200))
+        // 3. get commit
+        server.enqueue(MockResponse().setBody("""{"tree":{"sha":"stale-tree"}}""").setResponseCode(200))
+        // 4. create tree
+        server.enqueue(MockResponse().setBody("""{"sha":"new-tree-1"}""").setResponseCode(201))
+        // 5. create commit
+        server.enqueue(MockResponse().setBody("""{"sha":"new-commit-1"}""").setResponseCode(201))
+        // 6. patch ref → 422
+        server.enqueue(MockResponse().setBody("""{"message":"Update is not a fast forward"}""").setResponseCode(422))
+        // --- attempt 2 ---
+        // 2. get ref (now returns fresh sha)
+        server.enqueue(MockResponse().setBody("""{"object":{"sha":"fresh-commit"}}""").setResponseCode(200))
+        // 3. get commit
+        server.enqueue(MockResponse().setBody("""{"tree":{"sha":"fresh-tree"}}""").setResponseCode(200))
+        // 4. create tree
+        server.enqueue(MockResponse().setBody("""{"sha":"new-tree-2"}""").setResponseCode(201))
+        // 5. create commit
+        server.enqueue(MockResponse().setBody("""{"sha":"new-commit-2"}""").setResponseCode(201))
+        // 6. patch ref → success
+        server.enqueue(MockResponse().setBody("""{"ref":"refs/heads/panel-reports"}""").setResponseCode(200))
+        // 7. create issue
+        server.enqueue(MockResponse().setBody("""{"html_url":"https://github.com/pkmetski/riffle/issues/42"}""").setResponseCode(201))
+
+        val result = repo().submit(fakeReport, ByteArray(0))
+
+        assertTrue(result.isSuccess)
+        assertEquals("https://github.com/pkmetski/riffle/issues/42", result.getOrNull())
+    }
 }


### PR DESCRIPTION
## Summary

- **`CutPanelCutOff` reporting now supports tap + draw**: a short tap identifies the cut-off panel (highlights it red); a drag draws the correct boundary rectangle. Previously only a plain dot was placed, which didn't identify which panel was affected and couldn't represent a case where another panel was covering the correct area.
- **Scroll conflict fixed**: the custom `awaitEachGesture` handler now consumes pointer events so the sheet's `verticalScroll` no longer steals drag gestures.
- **Rectangle preview in draw mode**: the yellow in-progress preview correctly shows a rectangle shape (was incorrectly showing a line).
- **Clear last fixed**: the erase button now calls `clearLastDrawnPanel` in `cutOffMode` (was calling `clearLastDrawnBoundary`).
- **`setFailureType` clears tap state**: switching issue type no longer leaves a stale panel selection.
- **GitHub ref retry on 422**: `GitHubPanelReportRepository` retries the branch-head fetch + commit + PATCH cycle up to 3 times on a non-fast-forward rejection, preventing concurrent reports from failing silently.

## Test plan

- [ ] Select "Panel cut off" — tap an existing panel → it turns red
- [ ] Drag to draw a rectangle — yellow rectangle preview appears, no sheet scrolling
- [ ] Release — green rectangle committed, "Borrar último" removes it
- [ ] Tap blank space → magenta dot appears
- [ ] Switch to another issue type → tap selection clears
- [ ] `PanelReportViewModelTest` passes (two new cases: `CutPanelCutOff` and `setFailureType clears tap state`)
- [ ] `GitHubPanelReportRepositoryTest` passes (new retry-on-422 case)