### PR TITLE
fix(comics): store panel report mask fixtures in gists instead of panel-reports branch

### DIFF
--- a/core/data/src/main/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepository.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepository.kt
@@ -3,9 +3,7 @@ package com.riffle.core.data.comic.panel
 import com.riffle.core.domain.comic.panel.PanelDetectionReport
 import com.riffle.core.domain.comic.panel.PanelReportRepository
 import io.ktor.client.HttpClient
-import io.ktor.client.request.get
 import io.ktor.client.request.header
-import io.ktor.client.request.patch
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
@@ -20,9 +18,6 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import java.io.IOException
-import java.util.UUID
-
-private const val MAX_REF_RETRIES = 3
 
 class GitHubPanelReportRepository(
     private val pat: String,
@@ -30,7 +25,6 @@ class GitHubPanelReportRepository(
     private val repoName: String = "riffle",
     private val client: HttpClient,
     private val apiBase: String = "https://api.github.com",
-    private val rawBase: String = "https://raw.githubusercontent.com",
 ) : PanelReportRepository {
 
     private val json = Json { ignoreUnknownKeys = true }
@@ -38,107 +32,54 @@ class GitHubPanelReportRepository(
     override suspend fun submit(report: PanelDetectionReport, maskPng: ByteArray): Result<String> =
         runCatching {
             val pngBase64 = java.util.Base64.getEncoder().encodeToString(maskPng)
-            val filename = "panel-report-${UUID.randomUUID()}.png"
 
-            // 1. Create blob
-            val blobSha = post(
-                "$apiBase/repos/$owner/$repoName/git/blobs",
-                jsonObject("content" to pngBase64, "encoding" to "base64"),
-            ).field("sha")
+            // 1. Create gist with mask (base64) and metadata
+            val gistResponse = post("$apiBase/gists", buildGistBody(report, pngBase64))
+            val gistHtmlUrl = gistResponse.field("html_url")
+            val maskRawUrl = gistResponse["files"]!!.jsonObject["mask.b64"]!!
+                .jsonObject["raw_url"]!!.jsonPrimitive.content
 
-            val rawUrl = "$rawBase/$owner/$repoName/panel-reports/fixtures/$filename"
+            // 2. Create issue linking the gist
+            post(
+                "$apiBase/repos/$owner/$repoName/issues",
+                JsonObject(mapOf(
+                    "title" to JsonPrimitive("[Panel Detection] ${report.failureType.label} — page ${report.pageIndex}"),
+                    "body" to JsonPrimitive(buildIssueBody(report, gistHtmlUrl, maskRawUrl)),
+                    "labels" to JsonArray(listOf(JsonPrimitive("panel-view-issue"))),
+                )).toString(),
+            ).field("html_url")
+        }
 
-            // Steps 2–6 may race with concurrent submissions; retry on 422 (not a fast-forward).
-            repeat(MAX_REF_RETRIES) { attempt ->
-                // 2. Get current commit sha from panel-reports branch (create from main if absent)
-                val currentCommitSha = try {
-                    get("$apiBase/repos/$owner/$repoName/git/ref/heads/panel-reports")
-                        .let { it["object"]!!.jsonObject["sha"]!!.jsonPrimitive.content }
-                } catch (e: IOException) {
-                    if ("404" !in (e.message ?: "")) throw e
-                    val mainSha = get("$apiBase/repos/$owner/$repoName/git/ref/heads/main")
-                        .let { it["object"]!!.jsonObject["sha"]!!.jsonPrimitive.content }
-                    post(
-                        "$apiBase/repos/$owner/$repoName/git/refs",
-                        jsonObject("ref" to "refs/heads/panel-reports", "sha" to mainSha),
-                    )
-                    mainSha
-                }
+    private fun buildGistBody(report: PanelDetectionReport, pngBase64: String): String =
+        JsonObject(mapOf(
+            "description" to JsonPrimitive(
+                "Panel detection report: ${report.failureType.label} — page ${report.pageIndex}"
+            ),
+            "public" to JsonPrimitive(false),
+            "files" to JsonObject(mapOf(
+                "mask.b64" to JsonObject(mapOf("content" to JsonPrimitive(pngBase64))),
+                "metadata.json" to JsonObject(mapOf("content" to JsonPrimitive(buildMetadata(report)))),
+            )),
+        )).toString()
 
-                // 3. Get current tree sha
-                val commitJson = get("$apiBase/repos/$owner/$repoName/git/commits/$currentCommitSha")
-                val currentTreeSha = commitJson["tree"]!!.jsonObject["sha"]!!.jsonPrimitive.content
-
-                // 4. Create tree
-                val newTreeSha = post(
-                    "$apiBase/repos/$owner/$repoName/git/trees",
+    private fun buildMetadata(report: PanelDetectionReport): String =
+        JsonObject(
+            buildMap {
+                put("pageIndex", JsonPrimitive(report.pageIndex))
+                put("failureType", JsonPrimitive(report.failureType.label))
+                put("detectedPanels", JsonArray(report.detectedPanels.map { p ->
                     JsonObject(mapOf(
-                        "base_tree" to JsonPrimitive(currentTreeSha),
-                        "tree" to JsonArray(listOf(JsonObject(mapOf(
-                            "path" to JsonPrimitive("fixtures/$filename"),
-                            "mode" to JsonPrimitive("100644"),
-                            "type" to JsonPrimitive("blob"),
-                            "sha" to JsonPrimitive(blobSha),
-                        )))),
-                    )).toString(),
-                ).field("sha")
-
-                // 5. Create commit
-                val newCommitSha = post(
-                    "$apiBase/repos/$owner/$repoName/git/commits",
-                    JsonObject(mapOf(
-                        "message" to JsonPrimitive("panel report: ${report.failureType.label} p${report.pageIndex}"),
-                        "tree" to JsonPrimitive(newTreeSha),
-                        "parents" to JsonArray(listOf(JsonPrimitive(currentCommitSha))),
-                    )).toString(),
-                ).field("sha")
-
-                // 6. Advance ref — may 422 if another report landed since step 2; retry if so
-                try {
-                    patch(
-                        "$apiBase/repos/$owner/$repoName/git/refs/heads/panel-reports",
-                        jsonObject("sha" to newCommitSha),
-                    )
-                    // Ref advanced — break out of retry loop
-                    return@runCatching submitIssue(report, rawUrl)
-                } catch (e: IOException) {
-                    if ("422" !in (e.message ?: "") || attempt == MAX_REF_RETRIES - 1) throw e
-                    // else loop and retry with fresh branch HEAD
+                        "x" to JsonPrimitive(p.x),
+                        "y" to JsonPrimitive(p.y),
+                        "w" to JsonPrimitive(p.width),
+                        "h" to JsonPrimitive(p.height),
+                    ))
+                }))
+                report.expectedPanelOrder?.let { order ->
+                    put("expectedPanelOrder", JsonArray(order.map { JsonPrimitive(it) }))
                 }
             }
-
-            // Unreachable (loop always returns or throws), but required for exhaustive return
-            throw IOException("Failed to advance panel-reports ref after $MAX_REF_RETRIES attempts")
-        }
-
-    private suspend fun submitIssue(report: PanelDetectionReport, rawUrl: String): String =
-        // 7. Create issue
-        post(
-            "$apiBase/repos/$owner/$repoName/issues",
-            JsonObject(mapOf(
-                "title" to JsonPrimitive("[Panel Detection] ${report.failureType.label} — page ${report.pageIndex}"),
-                "body" to JsonPrimitive(buildIssueBody(report, rawUrl)),
-                "labels" to JsonArray(listOf(JsonPrimitive("panel-view-issue"))),
-            )).toString(),
-        ).field("html_url")
-
-    private fun jsonObject(vararg pairs: Pair<String, String>): String =
-        JsonObject(pairs.associate { (k, v) -> k to JsonPrimitive(v) }).toString()
-
-    private suspend fun get(url: String): JsonObject {
-        val response = client.get(url) {
-            header(HttpHeaders.Authorization, "token $pat")
-            header(HttpHeaders.Accept, "application/vnd.github+json")
-            header("X-GitHub-Api-Version", "2022-11-28")
-        }
-        val bodyStr = response.bodyAsText()
-        val obj = json.parseToJsonElement(bodyStr).jsonObject
-        if (!response.status.isSuccess()) {
-            val msg = obj["message"]?.jsonPrimitive?.content ?: response.status.description
-            throw IOException("GitHub ${response.status.value}: $msg")
-        }
-        return obj
-    }
+        ).toString()
 
     private suspend fun post(url: String, body: String): JsonObject {
         val response = client.post(url) {
@@ -157,26 +98,9 @@ class GitHubPanelReportRepository(
         return obj
     }
 
-    private suspend fun patch(url: String, body: String) {
-        val response = client.patch(url) {
-            header(HttpHeaders.Authorization, "token $pat")
-            header(HttpHeaders.Accept, "application/vnd.github+json")
-            header("X-GitHub-Api-Version", "2022-11-28")
-            contentType(ContentType.Application.Json)
-            setBody(body)
-        }
-        if (!response.status.isSuccess()) {
-            val bodyStr = response.bodyAsText()
-            val msg = runCatching {
-                json.parseToJsonElement(bodyStr).jsonObject["message"]?.jsonPrimitive?.content
-            }.getOrNull() ?: response.status.description
-            throw IOException("GitHub ${response.status.value}: $msg")
-        }
-    }
-
     private fun JsonObject.field(key: String): String = this[key]!!.jsonPrimitive.content
 
-    private fun buildIssueBody(report: PanelDetectionReport, imageUrl: String): String = buildString {
+    private fun buildIssueBody(report: PanelDetectionReport, gistHtmlUrl: String, maskRawUrl: String): String = buildString {
         appendLine("## Panel Detection Report")
         appendLine()
         appendLine("**Failure type:** ${report.failureType.label}")
@@ -220,8 +144,8 @@ class GitHubPanelReportRepository(
             }
             appendLine()
         }
-        appendLine("**Page image:**")
-        appendLine("![page]($imageUrl)")
+        appendLine("**Mask fixture (gist):** $gistHtmlUrl")
+        appendLine("**Mask raw URL:** `$maskRawUrl`")
         appendLine()
         appendLine("---")
         appendLine("*panel-detection-issue · Filed automatically by Riffle panel detection reporter (ADR 0062)*")

--- a/core/data/src/test/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepositoryTest.kt
@@ -43,7 +43,6 @@ class GitHubPanelReportRepositoryTest {
             repoName = "riffle",
             client = httpClient,
             apiBase = baseUrl,
-            rawBase = baseUrl,
         )
     }
 
@@ -61,46 +60,75 @@ class GitHubPanelReportRepositoryTest {
         tappedPanelIndex = 0,
     )
 
+    private fun gistResponse(gistUrl: String, maskRawUrl: String): String =
+        """{"html_url":"$gistUrl","files":{"mask.b64":{"raw_url":"$maskRawUrl"}}}"""
+
     @Test
-    fun `submit makes 7 API calls and returns issue URL`() = runTest {
-        // 1. create blob
-        server.enqueue(MockResponse().setBody("""{"sha":"blob-sha-123"}""").setResponseCode(201))
-        // 2. get ref (current commit sha)
-        server.enqueue(MockResponse().setBody("""{"object":{"sha":"commit-abc"}}""").setResponseCode(200))
-        // 3. get commit (tree sha)
-        server.enqueue(MockResponse().setBody("""{"tree":{"sha":"tree-xyz"}}""").setResponseCode(200))
-        // 4. create tree
-        server.enqueue(MockResponse().setBody("""{"sha":"new-tree-sha"}""").setResponseCode(201))
-        // 5. create commit
-        server.enqueue(MockResponse().setBody("""{"sha":"new-commit-sha"}""").setResponseCode(201))
-        // 6. patch ref
-        server.enqueue(MockResponse().setBody("""{"ref":"refs/heads/panel-reports"}""").setResponseCode(200))
-        // 7. create issue
+    fun `submit makes 2 API calls and returns issue URL`() = runTest {
+        // 1. create gist
+        server.enqueue(MockResponse().setBody(
+            gistResponse("https://gist.github.com/pkmetski/abc123", "https://gist.githubusercontent.com/raw/mask.b64")
+        ).setResponseCode(201))
+        // 2. create issue
         server.enqueue(MockResponse().setBody("""{"html_url":"https://github.com/pkmetski/riffle/issues/99"}""").setResponseCode(201))
 
         val result = repo().submit(fakeReport, ByteArray(5) { it.toByte() })
 
         assertTrue(result.isSuccess)
         assertEquals("https://github.com/pkmetski/riffle/issues/99", result.getOrNull())
-        assertEquals(7, server.requestCount)
+        assertEquals(2, server.requestCount)
+    }
 
-        // Verify issue body contains failure type and notes (7th request = create issue)
-        val requests = (1..7).map { server.takeRequest() }
-        val issueBody = requests[6].body.readUtf8()
+    @Test
+    fun `gist body contains base64-encoded mask and metadata`() = runTest {
+        server.enqueue(MockResponse().setBody(
+            gistResponse("https://gist.github.com/pkmetski/abc123", "https://gist.githubusercontent.com/raw/mask.b64")
+        ).setResponseCode(201))
+        server.enqueue(MockResponse().setBody("""{"html_url":"https://github.com/pkmetski/riffle/issues/99"}""").setResponseCode(201))
+
+        val maskBytes = ByteArray(5) { it.toByte() }
+        repo().submit(fakeReport, maskBytes)
+
+        val gistRequest = server.takeRequest()
+        val gistBody = Json { ignoreUnknownKeys = true }
+            .parseToJsonElement(gistRequest.body.readUtf8()).jsonObject
+        val expectedBase64 = java.util.Base64.getEncoder().encodeToString(maskBytes)
+        val maskContent = gistBody["files"]!!.jsonObject["mask.b64"]!!
+            .jsonObject["content"]!!.jsonPrimitive.content
+        assertEquals(expectedBase64, maskContent)
+        // metadata file present
+        val metadata = gistBody["files"]!!.jsonObject["metadata.json"]!!
+            .jsonObject["content"]!!.jsonPrimitive.content
+        assertTrue("metadata contains pageIndex", metadata.contains("3"))
+        assertTrue("metadata contains failureType", metadata.contains("Merged panels"))
+    }
+
+    @Test
+    fun `issue body contains gist URL and mask raw URL`() = runTest {
+        val gistHtmlUrl = "https://gist.github.com/pkmetski/abc123"
+        val maskRawUrl = "https://gist.githubusercontent.com/raw/mask.b64"
+        server.enqueue(MockResponse().setBody(
+            gistResponse(gistHtmlUrl, maskRawUrl)
+        ).setResponseCode(201))
+        server.enqueue(MockResponse().setBody("""{"html_url":"https://github.com/pkmetski/riffle/issues/99"}""").setResponseCode(201))
+
+        repo().submit(fakeReport, ByteArray(0))
+
+        server.takeRequest() // consume gist
+        val issueRequest = server.takeRequest()
         val parsedBody = Json { ignoreUnknownKeys = true }
-            .parseToJsonElement(issueBody).jsonObject["body"]?.jsonPrimitive?.content ?: ""
+            .parseToJsonElement(issueRequest.body.readUtf8()).jsonObject["body"]?.jsonPrimitive?.content ?: ""
+        assertTrue("body contains gist URL", parsedBody.contains(gistHtmlUrl))
+        assertTrue("body contains mask raw URL", parsedBody.contains(maskRawUrl))
         assertTrue("body contains failure type", parsedBody.contains("Merged panels"))
         assertTrue("body contains notes", parsedBody.contains("Top two panels merged"))
     }
 
     @Test
     fun `issue body contains expected panel order when WrongPanelOrder report submitted`() = runTest {
-        server.enqueue(MockResponse().setBody("""{"sha":"blob-sha-123"}""").setResponseCode(201))
-        server.enqueue(MockResponse().setBody("""{"object":{"sha":"commit-abc"}}""").setResponseCode(200))
-        server.enqueue(MockResponse().setBody("""{"tree":{"sha":"tree-xyz"}}""").setResponseCode(200))
-        server.enqueue(MockResponse().setBody("""{"sha":"new-tree-sha"}""").setResponseCode(201))
-        server.enqueue(MockResponse().setBody("""{"sha":"new-commit-sha"}""").setResponseCode(201))
-        server.enqueue(MockResponse().setBody("""{"ref":"refs/heads/panel-reports"}""").setResponseCode(200))
+        server.enqueue(MockResponse().setBody(
+            gistResponse("https://gist.github.com/pkmetski/abc123", "https://gist.githubusercontent.com/raw/mask.b64")
+        ).setResponseCode(201))
         server.enqueue(MockResponse().setBody("""{"html_url":"https://github.com/pkmetski/riffle/issues/99"}""").setResponseCode(201))
 
         val reportWithOrder = fakeReport.copy(
@@ -109,10 +137,10 @@ class GitHubPanelReportRepositoryTest {
         )
         repo().submit(reportWithOrder, ByteArray(0))
 
-        val requests = (1..7).map { server.takeRequest() }
-        val issueBody = requests[6].body.readUtf8()
+        server.takeRequest() // consume gist
+        val issueRequest = server.takeRequest()
         val parsedBody = Json { ignoreUnknownKeys = true }
-            .parseToJsonElement(issueBody).jsonObject["body"]?.jsonPrimitive?.content ?: ""
+            .parseToJsonElement(issueRequest.body.readUtf8()).jsonObject["body"]?.jsonPrimitive?.content ?: ""
         assertTrue("body contains expected order", parsedBody.contains("[1, 0]"))
     }
 
@@ -123,40 +151,5 @@ class GitHubPanelReportRepositoryTest {
         val result = repo().submit(fakeReport, ByteArray(0))
 
         assertTrue(result.isFailure)
-    }
-
-    @Test
-    fun `submit retries on 422 not-a-fast-forward and succeeds on second attempt`() = runTest {
-        // 1. create blob
-        server.enqueue(MockResponse().setBody("""{"sha":"blob-sha-123"}""").setResponseCode(201))
-        // --- attempt 1 ---
-        // 2. get ref
-        server.enqueue(MockResponse().setBody("""{"object":{"sha":"stale-commit"}}""").setResponseCode(200))
-        // 3. get commit
-        server.enqueue(MockResponse().setBody("""{"tree":{"sha":"stale-tree"}}""").setResponseCode(200))
-        // 4. create tree
-        server.enqueue(MockResponse().setBody("""{"sha":"new-tree-1"}""").setResponseCode(201))
-        // 5. create commit
-        server.enqueue(MockResponse().setBody("""{"sha":"new-commit-1"}""").setResponseCode(201))
-        // 6. patch ref → 422
-        server.enqueue(MockResponse().setBody("""{"message":"Update is not a fast forward"}""").setResponseCode(422))
-        // --- attempt 2 ---
-        // 2. get ref (now returns fresh sha)
-        server.enqueue(MockResponse().setBody("""{"object":{"sha":"fresh-commit"}}""").setResponseCode(200))
-        // 3. get commit
-        server.enqueue(MockResponse().setBody("""{"tree":{"sha":"fresh-tree"}}""").setResponseCode(200))
-        // 4. create tree
-        server.enqueue(MockResponse().setBody("""{"sha":"new-tree-2"}""").setResponseCode(201))
-        // 5. create commit
-        server.enqueue(MockResponse().setBody("""{"sha":"new-commit-2"}""").setResponseCode(201))
-        // 6. patch ref → success
-        server.enqueue(MockResponse().setBody("""{"ref":"refs/heads/panel-reports"}""").setResponseCode(200))
-        // 7. create issue
-        server.enqueue(MockResponse().setBody("""{"html_url":"https://github.com/pkmetski/riffle/issues/42"}""").setResponseCode(201))
-
-        val result = repo().submit(fakeReport, ByteArray(0))
-
-        assertTrue(result.isSuccess)
-        assertEquals("https://github.com/pkmetski/riffle/issues/42", result.getOrNull())
     }
 }

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/panel/PanelReportRepository.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/panel/PanelReportRepository.kt
@@ -2,7 +2,7 @@ package com.riffle.core.domain.comic.panel
 
 interface PanelReportRepository {
     /**
-     * Commits [maskPng] to the `panel-reports` GitHub branch and creates an issue.
+     * Uploads [maskPng] to a GitHub gist and creates an issue linking it.
      * Returns the URL of the created issue on success.
      */
     suspend fun submit(report: PanelDetectionReport, maskPng: ByteArray): Result<String>

--- a/docs/adr/0062-panel-detection-reporting-system.md
+++ b/docs/adr/0062-panel-detection-reporting-system.md
@@ -48,11 +48,13 @@ The failure type becomes a GitHub issue label. The tapped coordinates appear in 
 
 Reports are filed programmatically without opening a browser:
 
-1. The Sanitized Page Mask PNG is committed to the `panel-reports` branch via the GitHub git data API (blob → tree → commit → ref update). The branch is a dedicated dumping ground and is never merged into `main`.
-2. A `raw.githubusercontent.com` URL for the committed PNG is embedded as a Markdown inline image in the issue body.
+1. The Sanitized Page Mask PNG (base64-encoded) and a metadata JSON file are uploaded as a secret gist via `POST /gists`. The gist description names the failure type and page index for self-containment.
+2. The issue body links the gist HTML URL and embeds the `raw_url` of the `mask.b64` file so the `address-panel-detection-issues` skill can download and decode the fixture in one `curl` call.
 3. `POST /repos/pkmetski/riffle/issues` creates the issue with title, body, and the failure-type label.
 
-The PAT is stored in `EncryptedSharedPreferences` and entered once via the Developer Options section in Settings. It requires `public_repo` scope only.
+The PAT is stored in `EncryptedSharedPreferences` and entered once via the Developer Options section in Settings. It requires `public_repo` and `gist` scopes.
+
+Masks are ~100–220 KB base64, well under the 1 MB gist file truncation threshold; the `raw_url` fallback covers any larger masks.
 
 ### Developer Options
 
@@ -62,7 +64,9 @@ Tapping the app version number in Settings 7 times sets `developerModeEnabled = 
 
 **Luma-only greyscale PNG as the fixture format:** preserves more signal for texture-based detection paths but still renders the original artwork (desaturated). Rejected — copyright risk remains, and the binarized mask captures exactly the signal `PanelDetector` acts on after its first step.
 
-**Imgur for image hosting:** anonymous upload API requires only a client ID; simpler than the git data API. Rejected — third-party permanence is uncertain and the git data API keeps everything within GitHub at the cost of five API calls.
+**Imgur for image hosting:** anonymous upload API requires only a client ID; simpler. Rejected — third-party permanence is uncertain; gists keep everything within GitHub with one API call.
+
+**`panel-reports` branch in this repo (original implementation):** git blob → tree → commit → ref update, with a 422-retry loop for concurrent submissions. Replaced — the branch polluted the product repo, required five API calls, and could not be deleted permanently (auto-recreated from main). Gists are individually deletable, require one call, and carry the `gist` PAT scope rather than `public_repo`.
 
 **Browser-based issue filing (`issues/new?body=...`):** requires no PAT configuration. Rejected — cannot attach the image automatically; the user would need to drag the PNG into the browser manually, breaking the single-tap submit flow.
 


### PR DESCRIPTION
Closes #789

## Summary

- Replaces the 6-step git blob/tree/commit/ref dance in `GitHubPanelReportRepository` with a single `POST /gists` call. Total API calls drop from 7 (+ retry loop on 422) to 2.
- The mask PNG is base64-encoded and stored as a secret gist alongside a `metadata.json` file (page index, failure type, detected panels, expected order).
- The issue body now links the gist HTML URL and embeds the `mask.b64` raw URL so the `address-panel-detection-issues` skill can download and decode the fixture with one `curl | base64 -d` call.
- The `panel-reports` branch in this repo is no longer written to and can be deleted.
- PAT now requires the `gist` scope in addition to `public_repo`.

## Files changed

- `GitHubPanelReportRepository.kt` — gist-based submission; removed `rawBase`, `patch`, and retry loop
- `GitHubPanelReportRepositoryTest.kt` — updated for 2-call flow; replaced retry test with gist payload and issue body assertions
- `PanelReportRepository.kt` — updated docstring
- `docs/adr/0062-panel-detection-reporting-system.md` — amended GitHub Issue Creation section and Alternatives
- `~/.claude/skills/address-panel-detection-issues/SKILL.md` — updated step 2a (user-side, not in this repo)

## Test plan

- [ ] `./gradlew :core:data:test` — all 5 `GitHubPanelReportRepository` tests pass
- [ ] Verify the `panel-reports` branch can be deleted after this merges