### PR TITLE
feat(formatting): per-screen-dimension book formatting preferences

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -101,6 +101,7 @@ import com.riffle.app.feature.reader.readaloud.ReadaloudDownloadDialog
 import com.riffle.app.feature.reader.readaloud.ReadaloudMiniPlayer
 import com.riffle.app.feature.reader.highlights.ReaderSource
 import com.riffle.app.feature.reader.readaloud.ReadaloudPeek
+import com.riffle.app.ui.toScreenDimensionBucket
 import com.riffle.app.ui.theme.RiffleIcons
 import com.riffle.app.ui.theme.RiffleTheme
 import com.riffle.core.domain.FormattingPreferences
@@ -220,6 +221,12 @@ fun EpubReaderScreen(
     val displayDensity = context.resources.displayMetrics.density
     LaunchedEffect(configuration.screenWidthDp, displayDensity) {
         viewModel.setReaderViewportWidthPx((configuration.screenWidthDp * displayDensity).toInt())
+    }
+
+    // Push the screen-dimension bucket so formatting prefs are keyed by the actual on-screen
+    // window size class. Fires on first composition and whenever the device folds or rotates.
+    LaunchedEffect(windowSizeClass) {
+        viewModel.setScreenDimensionBucket(windowSizeClass.toScreenDimensionBucket())
     }
 
     // Push the resolved onSurfaceVariant colour to the VM so the elided-view emphasis bar and

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -57,6 +57,7 @@ import com.riffle.core.domain.ReadingSpeedStore
 import com.riffle.core.models.SessionPayload
 import com.riffle.core.common.TimeProvider
 import com.riffle.core.common.TimeRemaining
+import com.riffle.core.models.ScreenDimensionBucket
 import com.riffle.core.models.TocEntry
 import com.riffle.core.domain.TocRepository
 import com.riffle.core.domain.resolveEpubHref
@@ -668,6 +669,22 @@ class EpubReaderViewModel @Inject constructor(
 
     fun setReaderViewportWidthPx(px: Int) = formatting.setViewportWidthPx(px)
 
+    private val _screenDimensionBucket = MutableStateFlow<ScreenDimensionBucket?>(null)
+
+    /**
+     * Called from the screen whenever [WindowSizeClass] changes (first composition + fold/rotate).
+     * The initial call unblocks the init coroutine that awaits the first non-null value before
+     * binding formatting prefs. Subsequent calls with a different bucket re-bind the formatting
+     * session so each screen dimension gets its own independent row of preferences.
+     */
+    fun setScreenDimensionBucket(bucket: ScreenDimensionBucket) {
+        val previous = _screenDimensionBucket.value
+        _screenDimensionBucket.value = bucket
+        if (previous != null && previous != bucket) {
+            formatting.bindToBook(itemId, source.toFormattingScope(), bucket)
+        }
+    }
+
     // ---- Cadence (issue #403 / ADR 0047) --------------------------------------------------------
 
     val cadenceState: StateFlow<com.riffle.core.domain.cadence.CadenceState> = cadenceController.state
@@ -1132,7 +1149,10 @@ class EpubReaderViewModel @Inject constructor(
             // Sequential: formatting prefs must be available before openBook() so the
             // navigator never sees the stateIn default on first paint (FormattingSession.bindToBook
             // waits for effectiveFormattingPreferences to reflect the loaded value).
-            formatting.bindToBook(itemId, source.toFormattingScope())
+            // Await the screen's first WindowSizeClass push so prefs are keyed by the actual
+            // on-screen dimension from the first frame rather than a guess.
+            val dimension = _screenDimensionBucket.filterNotNull().first()
+            formatting.bindToBook(itemId, source.toFormattingScope(), dimension)
             openBook()
         }
         // Readaloud start ⇒ stop Auto-Scroll (mutual exclusion, ADR 0044). Stop (not Pause):

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1151,8 +1151,12 @@ class EpubReaderViewModel @Inject constructor(
             // waits for effectiveFormattingPreferences to reflect the loaded value).
             // Await the screen's first WindowSizeClass push so prefs are keyed by the actual
             // on-screen dimension from the first frame rather than a guess.
-            val dimension = _screenDimensionBucket.filterNotNull().first()
-            formatting.bindToBook(itemId, source.toFormattingScope(), dimension)
+            _screenDimensionBucket.filterNotNull().first()
+            // Re-read the current value: a rotation may have pushed a newer bucket between the
+            // time first() returned and now. setScreenDimensionBucket only calls bindToBook when
+            // previous!=null, so the init coroutine must pick up the latest value here rather
+            // than the stale one captured by first().
+            formatting.bindToBook(itemId, source.toFormattingScope(), checkNotNull(_screenDimensionBucket.value))
             openBook()
         }
         // Readaloud start ⇒ stop Auto-Scroll (mutual exclusion, ADR 0044). Stop (not Pause):

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
@@ -219,10 +219,13 @@ class FormattingSession @AssistedInject constructor(
         scope: FormattingScope = FormattingScope.FullBook,
         dimension: ScreenDimensionBucket = ScreenDimensionBucket.PhonePortrait,
     ) {
+        val alreadyReady = _formattingPreferencesReady.value
         bookId = itemId
         activeDimension = dimension
         _scope.value = scope
-        _formattingPreferencesReady.value = false
+        // Only reset the ready flag on the first bind. Re-binding for a dimension change leaves the
+        // prior prefs visible while the new dimension's row loads — avoids a spinner flash on fold/rotate.
+        if (!alreadyReady) _formattingPreferencesReady.value = false
         bindJob?.cancel()
         bindJob = this.scope.launch {
             val existing = bookFormattingPreferencesStore.load(itemId, scope, dimension)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
@@ -113,6 +113,7 @@ class FormattingSession @AssistedInject constructor(
 
     private var bookId: String? = null
     private var activeDimension: ScreenDimensionBucket = ScreenDimensionBucket.PhonePortrait
+    private var bindJob: kotlinx.coroutines.Job? = null
 
     // Device pixel density for accurate layout context. Default = 1f (CSS-px fallback).
     // The VM sets this via [setDeviceDensity] in its init block, after constructing the session,
@@ -222,7 +223,8 @@ class FormattingSession @AssistedInject constructor(
         activeDimension = dimension
         _scope.value = scope
         _formattingPreferencesReady.value = false
-        this.scope.launch {
+        bindJob?.cancel()
+        bindJob = this.scope.launch {
             val existing = bookFormattingPreferencesStore.load(itemId, scope, dimension)
             val global = formattingPreferencesStoreProvider.store(scope).preferences.first()
             val overrides = if (existing != null) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import com.riffle.core.domain.autoscroll.PauseCause
+import com.riffle.core.models.ScreenDimensionBucket
 
 /**
  * Owns all formatting/typography/auto-scroll state for a single open book. Lifted from
@@ -111,6 +112,7 @@ class FormattingSession @AssistedInject constructor(
     val autoScrollScrollDeltas: Flow<Int> = autoScrollController.scrollDeltas
 
     private var bookId: String? = null
+    private var activeDimension: ScreenDimensionBucket = ScreenDimensionBucket.PhonePortrait
 
     // Device pixel density for accurate layout context. Default = 1f (CSS-px fallback).
     // The VM sets this via [setDeviceDensity] in its init block, after constructing the session,
@@ -205,15 +207,47 @@ class FormattingSession @AssistedInject constructor(
     }
 
     /**
-     * Load book-specific overrides and mark prefs as ready. Must be called once per book open,
-     * before [effectiveFormattingPreferences] is consumed by the navigator.
+     * Load book-specific overrides for the given screen-dimension bucket and mark prefs as ready.
+     * Must be called before [effectiveFormattingPreferences] is consumed by the navigator. May be
+     * re-called when the device dimension changes (fold/rotate) to switch to the new bucket's row.
+     * If no row exists for this (itemId, scope, dimension), global defaults are seeded as a dense
+     * override row so the dimension's settings are independent going forward.
      */
-    fun bindToBook(itemId: String, scope: FormattingScope = FormattingScope.FullBook) {
+    fun bindToBook(
+        itemId: String,
+        scope: FormattingScope = FormattingScope.FullBook,
+        dimension: ScreenDimensionBucket = ScreenDimensionBucket.PhonePortrait,
+    ) {
         bookId = itemId
+        activeDimension = dimension
         _scope.value = scope
+        _formattingPreferencesReady.value = false
         this.scope.launch {
-            val overrides = bookFormattingPreferencesStore.load(itemId, scope)
+            val existing = bookFormattingPreferencesStore.load(itemId, scope, dimension)
             val global = formattingPreferencesStoreProvider.store(scope).preferences.first()
+            val overrides = if (existing != null) {
+                existing
+            } else {
+                // Seed: dense copy of all fields BookFormattingOverrides can store so each
+                // dimension starts from current globals and is independent going forward.
+                BookFormattingOverrides(
+                    fontSize = global.fontSize,
+                    theme = global.theme,
+                    fontFamily = global.fontFamily,
+                    lineSpacing = global.lineSpacing,
+                    margins = global.margins,
+                    orientation = global.orientation,
+                    showChapterMap = global.showChapterMap,
+                    coloredChapterMap = global.coloredChapterMap,
+                    showReadingProgressLabels = global.showReadingProgressLabels,
+                    showCurrentChapterLabel = global.showCurrentChapterLabel,
+                    showReadingTimeEstimate = global.showReadingTimeEstimate,
+                    doublePageSpread = global.doublePageSpread,
+                    justifyText = global.justifyText,
+                ).also { seed ->
+                    bookFormattingPreferencesStore.save(itemId, scope, dimension, seed)
+                }
+            }
             _bookOverrides.value = overrides
             val effective = overrides.applyTo(global)
             _formattingPreferences.value = effective
@@ -240,7 +274,8 @@ class FormattingSession @AssistedInject constructor(
         _formattingPreferences.value = prefs
         _hasBookOverrides.value = !updated.isEmpty
         val boundScope = activeScope
-        scope.launch { bookFormattingPreferencesStore.save(itemId, boundScope, updated) }
+        val boundDimension = activeDimension
+        scope.launch { bookFormattingPreferencesStore.save(itemId, boundScope, boundDimension, updated) }
     }
 
     /**
@@ -253,11 +288,12 @@ class FormattingSession @AssistedInject constructor(
         scope.launch { formattingPreferencesStoreProvider.store(activeScope).setCadencePlatformSupported(supported) }
     }
 
-    /** Clear all book-level overrides, reverting to the global formatting preferences. */
+    /** Clear book-level overrides for the current dimension, reverting to global formatting preferences. */
     fun resetToGlobalDefaults(itemId: String) {
         val boundScope = activeScope
+        val boundDimension = activeDimension
         scope.launch {
-            bookFormattingPreferencesStore.clear(itemId, boundScope)
+            bookFormattingPreferencesStore.clear(itemId, boundScope, boundDimension)
             _bookOverrides.value = BookFormattingOverrides()
             _formattingPreferences.value =
                 formattingPreferencesStoreProvider.store(boundScope).preferences.first()

--- a/app/src/main/kotlin/com/riffle/app/ui/ScreenDimensionBucketMapper.kt
+++ b/app/src/main/kotlin/com/riffle/app/ui/ScreenDimensionBucketMapper.kt
@@ -1,0 +1,25 @@
+package com.riffle.app.ui
+
+import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import com.riffle.core.models.ScreenDimensionBucket
+import com.riffle.core.models.ScreenDimensionBucket.SizeClass
+
+fun WindowSizeClass.toScreenDimensionBucket(): ScreenDimensionBucket =
+    ScreenDimensionBucket.of(
+        a = widthSizeClass.toSizeClass(),
+        b = heightSizeClass.toSizeClass(),
+    )
+
+private fun WindowWidthSizeClass.toSizeClass(): SizeClass = when (this) {
+    WindowWidthSizeClass.Compact -> SizeClass.Compact
+    WindowWidthSizeClass.Medium -> SizeClass.Medium
+    else -> SizeClass.Expanded
+}
+
+private fun WindowHeightSizeClass.toSizeClass(): SizeClass = when (this) {
+    WindowHeightSizeClass.Compact -> SizeClass.Compact
+    WindowHeightSizeClass.Medium -> SizeClass.Medium
+    else -> SizeClass.Expanded
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/PdfReaderViewModelFormattingTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/PdfReaderViewModelFormattingTest.kt
@@ -8,6 +8,7 @@ import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.FormattingPreferencesStoreProvider
 import com.riffle.core.models.FormattingScope
+import com.riffle.core.models.ScreenDimensionBucket
 import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.WakeLockPreferencesStore
 import com.riffle.core.domain.appearance.AppearanceCoordinator
@@ -47,15 +48,17 @@ class PdfReaderViewModelFormattingTest {
     }
 
     private class FakeBookFormattingPreferencesStore : BookFormattingPreferencesStore {
-        private val saved = mutableMapOf<Pair<String, FormattingScope>, BookFormattingOverrides>()
-        override suspend fun load(itemId: String, scope: FormattingScope): BookFormattingOverrides =
-            saved[itemId to scope] ?: BookFormattingOverrides()
-        override suspend fun save(itemId: String, scope: FormattingScope, overrides: BookFormattingOverrides) {
-            saved[itemId to scope] = overrides
+        private val saved = mutableMapOf<Triple<String, FormattingScope, ScreenDimensionBucket>, BookFormattingOverrides>()
+        override suspend fun load(itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket): BookFormattingOverrides? =
+            saved[Triple(itemId, scope, dimension)]
+        override suspend fun save(itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket, overrides: BookFormattingOverrides) {
+            saved[Triple(itemId, scope, dimension)] = overrides
         }
-        override suspend fun clear(itemId: String, scope: FormattingScope) { saved.remove(itemId to scope) }
-        fun captured(itemId: String, scope: FormattingScope = FormattingScope.FullBook): BookFormattingOverrides? =
-            saved[itemId to scope]
+        override suspend fun clear(itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket) {
+            saved.remove(Triple(itemId, scope, dimension))
+        }
+        fun captured(itemId: String, scope: FormattingScope = FormattingScope.FullBook, dimension: ScreenDimensionBucket = ScreenDimensionBucket.PhonePortrait): BookFormattingOverrides? =
+            saved[Triple(itemId, scope, dimension)]
     }
 
     private class FakeWakeLockPreferencesStore : WakeLockPreferencesStore {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
@@ -16,6 +16,8 @@ import com.riffle.core.domain.appearance.ConcreteReaderTheme
 import com.riffle.core.domain.appearance.ResolvedAppearance
 import com.riffle.core.domain.autoscroll.AutoScrollEvent
 import com.riffle.core.domain.autoscroll.AutoScrollState
+import com.riffle.core.models.ScreenDimensionBucket
+import com.riffle.core.models.ScreenDimensionBucket.SizeClass
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
@@ -25,6 +27,9 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -46,17 +51,19 @@ class FormattingSessionTest {
     }
 
     private class FakeBookFormattingPreferencesStore : BookFormattingPreferencesStore {
-        // Keyed by (itemId, scope) so the annotations-view chain and full-book chain don't collide
-        // in the same fake. Existing FullBook-only tests key with FormattingScope.FullBook.
-        val saved = mutableMapOf<Pair<String, FormattingScope>, BookFormattingOverrides>()
-        private var toReturn = BookFormattingOverrides()
-        fun willReturn(o: BookFormattingOverrides) { toReturn = o }
-        override suspend fun load(itemId: String, scope: FormattingScope): BookFormattingOverrides =
-            saved[itemId to scope] ?: toReturn
-        override suspend fun save(itemId: String, scope: FormattingScope, overrides: BookFormattingOverrides) {
-            saved[itemId to scope] = overrides
-        }
-        override suspend fun clear(itemId: String, scope: FormattingScope) { saved.remove(itemId to scope) }
+        // Keyed by (itemId, scope, dimension) so scope and dimension combinations stay independent.
+        val saved = mutableMapOf<Triple<String, FormattingScope, ScreenDimensionBucket>, BookFormattingOverrides>()
+        private var toReturn: BookFormattingOverrides? = BookFormattingOverrides()
+        fun willReturn(o: BookFormattingOverrides?) { toReturn = o }
+        override suspend fun load(
+            itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket,
+        ): BookFormattingOverrides? = saved[Triple(itemId, scope, dimension)] ?: toReturn
+        override suspend fun save(
+            itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket, overrides: BookFormattingOverrides,
+        ) { saved[Triple(itemId, scope, dimension)] = overrides }
+        override suspend fun clear(
+            itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket,
+        ) { saved.remove(Triple(itemId, scope, dimension)) }
     }
 
     private class FakeFormattingPreferencesStoreProvider(
@@ -178,7 +185,7 @@ class FormattingSessionTest {
             session.bindToBook("item1")
             val newPrefs = FormattingPreferences(fontSize = 1.8f)
             session.updateFormatting("item1", newPrefs)
-            assertTrue(bookStore.saved.containsKey("item1" to FormattingScope.FullBook))
+            assertTrue(bookStore.saved.containsKey(Triple("item1", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)))
         } finally {
             scope.cancel()
         }
@@ -194,7 +201,7 @@ class FormattingSessionTest {
             assertTrue(session.hasBookOverrides.value)
             session.resetToGlobalDefaults("item1")
             assertFalse(session.hasBookOverrides.value)
-            assertFalse(bookStore.saved.containsKey("item1" to FormattingScope.FullBook))
+            assertFalse(bookStore.saved.containsKey(Triple("item1", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)))
         } finally {
             scope.cancel()
         }
@@ -336,8 +343,8 @@ class FormattingSessionTest {
     fun `bindToBook applies overrides for each book`() = runTest {
         val fakeGlobal = FakeFormattingPreferencesStore(FormattingPreferences(fontSize = 1.0f))
         val fakeBook = FakeBookFormattingPreferencesStore()
-        fakeBook.saved["book-a" to FormattingScope.FullBook] = BookFormattingOverrides(fontSize = 1.5f)
-        fakeBook.saved["book-b" to FormattingScope.FullBook] = BookFormattingOverrides(fontSize = 2.0f)
+        fakeBook.saved[Triple("book-a", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)] = BookFormattingOverrides(fontSize = 1.5f)
+        fakeBook.saved[Triple("book-b", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)] = BookFormattingOverrides(fontSize = 2.0f)
         val (session, _, _, _, _, scope) = makeEager(fakeGlobal = fakeGlobal, fakeBook = fakeBook)
         try {
             session.bindToBook("book-a")
@@ -560,11 +567,11 @@ class FormattingSessionTest {
 
             assertTrue(
                 "Highlights write must land in the Highlights per-book slot",
-                bookStore.saved.containsKey("book-x" to FormattingScope.Highlights),
+                bookStore.saved.containsKey(Triple("book-x", FormattingScope.Highlights, ScreenDimensionBucket.PhonePortrait)),
             )
             assertFalse(
                 "Highlights write must NOT leak into the FullBook per-book slot",
-                bookStore.saved.containsKey("book-x" to FormattingScope.FullBook),
+                bookStore.saved.containsKey(Triple("book-x", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)),
             )
         } finally {
             autoScrollController.release()
@@ -603,6 +610,66 @@ class FormattingSessionTest {
         } finally {
             autoScrollController.release()
             sessionScope.cancel()
+        }
+    }
+
+    @Test
+    fun `bindToBook seeds from global defaults when no prior row exists`() = runTest {
+        val globalPrefs = FormattingPreferences(fontSize = 1.5f, margins = 0.8f)
+        val fakeBook = FakeBookFormattingPreferencesStore().also { it.willReturn(null) }
+        val fakeGlobal = FakeFormattingPreferencesStore(globalPrefs)
+        val b = makeEager(fakeGlobal = fakeGlobal, fakeBook = fakeBook)
+        try {
+            b.session.bindToBook("book1", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)
+
+            val seeded = fakeBook.saved[Triple("book1", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)]
+            assertNotNull(seeded)
+            assertEquals(1.5f, seeded!!.fontSize)
+            assertEquals(0.8f, seeded.margins)
+        } finally {
+            b.sessionScope.cancel()
+        }
+    }
+
+    @Test
+    fun `bindToBook dimension A does not affect dimension B`() = runTest {
+        val fakeBook = FakeBookFormattingPreferencesStore().also { it.willReturn(null) }
+        val b = makeEager(fakeBook = fakeBook)
+        val dimA = ScreenDimensionBucket.of(SizeClass.Compact, SizeClass.Compact)
+        val dimB = ScreenDimensionBucket.PhonePortrait
+        try {
+            b.session.bindToBook("book1", FormattingScope.FullBook, dimA)
+            b.session.updateFormatting("book1", b.session.formattingPreferences.value.copy(fontSize = 2.0f))
+            b.session.bindToBook("book1", FormattingScope.FullBook, dimB)
+
+            val dimARow = fakeBook.saved[Triple("book1", FormattingScope.FullBook, dimA)]
+            val dimBRow = fakeBook.saved[Triple("book1", FormattingScope.FullBook, dimB)]
+            assertNotNull(dimARow)
+            assertNotNull(dimBRow)
+            assertEquals(2.0f, dimARow!!.fontSize)
+            assertNotEquals(2.0f, dimBRow!!.fontSize ?: 0f)
+        } finally {
+            b.sessionScope.cancel()
+        }
+    }
+
+    @Test
+    fun `resetToGlobalDefaults clears only the current dimension`() = runTest {
+        val dimA = ScreenDimensionBucket.of(SizeClass.Compact, SizeClass.Compact)
+        val dimB = ScreenDimensionBucket.PhonePortrait
+        val fakeBook = FakeBookFormattingPreferencesStore().also { it.willReturn(null) }
+        fakeBook.saved[Triple("book1", FormattingScope.FullBook, dimA)] = BookFormattingOverrides(fontSize = 1.2f)
+        fakeBook.saved[Triple("book1", FormattingScope.FullBook, dimB)] = BookFormattingOverrides(fontSize = 1.8f)
+
+        val b = makeEager(fakeBook = fakeBook)
+        try {
+            b.session.bindToBook("book1", FormattingScope.FullBook, dimA)
+            b.session.resetToGlobalDefaults("book1")
+
+            assertNull(fakeBook.saved[Triple("book1", FormattingScope.FullBook, dimA)])
+            assertNotNull(fakeBook.saved[Triple("book1", FormattingScope.FullBook, dimB)])
+        } finally {
+            b.sessionScope.cancel()
         }
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
@@ -672,4 +672,25 @@ class FormattingSessionTest {
             b.sessionScope.cancel()
         }
     }
+
+    @Test
+    fun `second bindToBook call cancels the first so the later dimension wins`() = runTest {
+        val dimA = ScreenDimensionBucket.of(SizeClass.Compact, SizeClass.Compact)
+        val dimB = ScreenDimensionBucket.PhonePortrait
+        val fakeBook = FakeBookFormattingPreferencesStore().also { it.willReturn(null) }
+
+        val b = makeEager(fakeBook = fakeBook)
+        try {
+            // Call bindToBook twice in quick succession — dimB must win.
+            b.session.bindToBook("book1", FormattingScope.FullBook, dimA)
+            b.session.bindToBook("book1", FormattingScope.FullBook, dimB)
+
+            // activeDimension must reflect the last call's dimension so any subsequent
+            // updateFormatting / resetToGlobalDefaults targets dimB, not dimA.
+            val seededB = fakeBook.saved[Triple("book1", FormattingScope.FullBook, dimB)]
+            assertNotNull("dimB row must be seeded by the winning bindToBook call", seededB)
+        } finally {
+            b.sessionScope.cancel()
+        }
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
@@ -53,7 +53,7 @@ class FormattingSessionTest {
     private class FakeBookFormattingPreferencesStore : BookFormattingPreferencesStore {
         // Keyed by (itemId, scope, dimension) so scope and dimension combinations stay independent.
         val saved = mutableMapOf<Triple<String, FormattingScope, ScreenDimensionBucket>, BookFormattingOverrides>()
-        private var toReturn: BookFormattingOverrides? = BookFormattingOverrides()
+        private var toReturn: BookFormattingOverrides? = null
         fun willReturn(o: BookFormattingOverrides?) { toReturn = o }
         override suspend fun load(
             itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket,

--- a/app/src/test/kotlin/com/riffle/app/ui/ScreenDimensionBucketMapperTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/ui/ScreenDimensionBucketMapperTest.kt
@@ -1,0 +1,63 @@
+package com.riffle.app.ui
+
+import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
+import androidx.compose.material3.windowsizeclass.WindowHeightSizeClass
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
+import com.riffle.core.models.ScreenDimensionBucket
+import com.riffle.core.models.ScreenDimensionBucket.SizeClass
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+class ScreenDimensionBucketMapperTest {
+
+    private fun sizeClass(width: WindowWidthSizeClass, height: WindowHeightSizeClass): WindowSizeClass =
+        WindowSizeClass.calculateFromSize(
+            DpSize(
+                width = when (width) {
+                    WindowWidthSizeClass.Compact -> Dp(400f)
+                    WindowWidthSizeClass.Medium -> Dp(700f)
+                    else -> Dp(900f)
+                },
+                height = when (height) {
+                    WindowHeightSizeClass.Compact -> Dp(400f)
+                    WindowHeightSizeClass.Medium -> Dp(700f)
+                    else -> Dp(900f)
+                },
+            ),
+        )
+
+    @Test
+    fun phone_portrait_maps_to_Compact_Medium() {
+        val result = sizeClass(WindowWidthSizeClass.Compact, WindowHeightSizeClass.Medium).toScreenDimensionBucket()
+        assertEquals(ScreenDimensionBucket(SizeClass.Compact, SizeClass.Medium), result)
+    }
+
+    @Test
+    fun tablet_portrait_maps_to_Expanded_Expanded() {
+        val result = sizeClass(WindowWidthSizeClass.Expanded, WindowHeightSizeClass.Expanded).toScreenDimensionBucket()
+        assertEquals(ScreenDimensionBucket(SizeClass.Expanded, SizeClass.Expanded), result)
+    }
+
+    @Test
+    fun portrait_and_landscape_produce_same_bucket() {
+        val portrait = sizeClass(WindowWidthSizeClass.Compact, WindowHeightSizeClass.Medium).toScreenDimensionBucket()
+        val landscape = sizeClass(WindowWidthSizeClass.Medium, WindowHeightSizeClass.Compact).toScreenDimensionBucket()
+        assertEquals(portrait, landscape)
+    }
+
+    @Test
+    fun narrower_is_always_lte_wider() {
+        for (w in listOf(WindowWidthSizeClass.Compact, WindowWidthSizeClass.Medium, WindowWidthSizeClass.Expanded)) {
+            for (h in listOf(WindowHeightSizeClass.Compact, WindowHeightSizeClass.Medium, WindowHeightSizeClass.Expanded)) {
+                val bucket = sizeClass(w, h).toScreenDimensionBucket()
+                assert(bucket.narrower.ordinal <= bucket.wider.ordinal) {
+                    "Expected narrower <= wider but got ${bucket.narrower} > ${bucket.wider}"
+                }
+            }
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
@@ -5,24 +5,29 @@ import com.riffle.core.database.BookFormattingPreferencesEntity
 import com.riffle.core.domain.BookFormattingOverrides
 import com.riffle.core.domain.BookFormattingPreferencesStore
 import com.riffle.core.models.FormattingScope
+import com.riffle.core.models.ScreenDimensionBucket
 import com.riffle.core.domain.ReaderFontFamily
 import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.SourceRepository
 import javax.inject.Inject
 
-// Formatting is per-device but keyed by (sourceId, itemId, scope) so two Sources' colliding item
-// ids don't share one row (ADR 0031) and so the annotations reading view keeps a chain independent
-// from the full-book reader. Like LibraryRepositoryImpl, the active Source is resolved here — you
-// format the book you're actively reading — keeping the domain interface itemId-only.
+// Formatting is per-device but keyed by (sourceId, itemId, scope, screenDimensionBucket) so two
+// Sources' colliding item ids don't share one row (ADR 0031), the annotations reading view keeps
+// a chain independent from the full-book reader, and each screen-size class has independent
+// settings for the same book.
 class BookFormattingPreferencesStoreImpl @Inject constructor(
     private val dao: BookFormattingPreferencesDao,
     private val sourceRepository: SourceRepository,
 ) : BookFormattingPreferencesStore {
 
-    override suspend fun load(itemId: String, scope: FormattingScope): BookFormattingOverrides {
-        val sourceId = sourceRepository.getActive()?.id ?: return BookFormattingOverrides()
-        val entity = dao.getByItemId(sourceId, itemId, scope.name) ?: return BookFormattingOverrides()
+    override suspend fun load(
+        itemId: String,
+        scope: FormattingScope,
+        dimension: ScreenDimensionBucket,
+    ): BookFormattingOverrides? {
+        val sourceId = sourceRepository.getActive()?.id ?: return null
+        val entity = dao.getByItemId(sourceId, itemId, scope.name, dimension.encode()) ?: return null
         return BookFormattingOverrides(
             fontSize = entity.fontSize,
             theme = entity.theme?.let { runCatching { ReaderTheme.valueOf(it) }.getOrNull() },
@@ -40,10 +45,15 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
         )
     }
 
-    override suspend fun save(itemId: String, scope: FormattingScope, overrides: BookFormattingOverrides) {
+    override suspend fun save(
+        itemId: String,
+        scope: FormattingScope,
+        dimension: ScreenDimensionBucket,
+        overrides: BookFormattingOverrides,
+    ) {
         val sourceId = sourceRepository.getActive()?.id ?: return
         if (overrides.isEmpty) {
-            dao.deleteByItemId(sourceId, itemId, scope.name)
+            dao.deleteByItemId(sourceId, itemId, scope.name, dimension.encode())
             return
         }
         dao.upsert(
@@ -51,6 +61,7 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
                 sourceId = sourceId,
                 itemId = itemId,
                 scope = scope.name,
+                screenDimensionBucket = dimension.encode(),
                 fontSize = overrides.fontSize,
                 theme = overrides.theme?.name,
                 fontFamily = overrides.fontFamily?.encodePersistName(),
@@ -68,8 +79,12 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
         )
     }
 
-    override suspend fun clear(itemId: String, scope: FormattingScope) {
+    override suspend fun clear(
+        itemId: String,
+        scope: FormattingScope,
+        dimension: ScreenDimensionBucket,
+    ) {
         val sourceId = sourceRepository.getActive()?.id ?: return
-        dao.deleteByItemId(sourceId, itemId, scope.name)
+        dao.deleteByItemId(sourceId, itemId, scope.name, dimension.encode())
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImplTest.kt
@@ -9,6 +9,7 @@ import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.FormattingScope
 import com.riffle.core.models.ScreenDimensionBucket
+import com.riffle.core.models.ScreenDimensionBucket.SizeClass
 import com.riffle.core.models.ServerType
 import com.riffle.core.models.Source
 import com.riffle.core.models.SourceUrl
@@ -67,7 +68,7 @@ class BookFormattingPreferencesStoreImplTest {
     fun load_passesEncodedDimensionToDao() = runTest {
         val dao = FakeDao()
         val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(testSource))
-        val bucket = ScreenDimensionBucket(ScreenDimensionBucket.Width.Compact, ScreenDimensionBucket.Height.Compact)
+        val bucket = ScreenDimensionBucket.of(SizeClass.Compact, SizeClass.Compact)
 
         store.load("book1", FormattingScope.FullBook, bucket)
 
@@ -80,7 +81,7 @@ class BookFormattingPreferencesStoreImplTest {
         val dao = FakeDao().also { it.entityToReturn = null }
         val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(testSource))
 
-        val result = store.load("book1", FormattingScope.FullBook, ScreenDimensionBucket.NonCompact)
+        val result = store.load("book1", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)
 
         assertNull(result)
     }
@@ -89,7 +90,7 @@ class BookFormattingPreferencesStoreImplTest {
     fun save_includesEncodedDimensionInEntity() = runTest {
         val dao = FakeDao()
         val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(testSource))
-        val bucket = ScreenDimensionBucket(ScreenDimensionBucket.Width.Medium, ScreenDimensionBucket.Height.Expanded)
+        val bucket = ScreenDimensionBucket.of(SizeClass.Medium, SizeClass.Expanded)
         val overrides = BookFormattingOverrides(theme = ReaderTheme.Dark)
 
         store.save("book1", FormattingScope.FullBook, bucket, overrides)
@@ -103,7 +104,7 @@ class BookFormattingPreferencesStoreImplTest {
     fun clear_passesEncodedDimensionToDao() = runTest {
         val dao = FakeDao()
         val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(testSource))
-        val bucket = ScreenDimensionBucket(ScreenDimensionBucket.Width.Expanded, ScreenDimensionBucket.Height.Compact)
+        val bucket = ScreenDimensionBucket.of(SizeClass.Expanded, SizeClass.Compact)
 
         store.clear("book1", FormattingScope.FullBook, bucket)
 
@@ -116,7 +117,7 @@ class BookFormattingPreferencesStoreImplTest {
         val dao = FakeDao()
         val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(null))
 
-        val result = store.load("book1", FormattingScope.FullBook, ScreenDimensionBucket.NonCompact)
+        val result = store.load("book1", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)
 
         assertNull(result)
     }

--- a/core/data/src/test/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImplTest.kt
@@ -1,0 +1,123 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.BookFormattingPreferencesDao
+import com.riffle.core.database.BookFormattingPreferencesEntity
+import com.riffle.core.domain.BookFormattingOverrides
+import com.riffle.core.domain.CommitSourceResult
+import com.riffle.core.domain.PendingSource
+import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.models.FormattingScope
+import com.riffle.core.models.ScreenDimensionBucket
+import com.riffle.core.models.ServerType
+import com.riffle.core.models.Source
+import com.riffle.core.models.SourceUrl
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class BookFormattingPreferencesStoreImplTest {
+
+    private val testSource = Source(
+        id = "src1",
+        url = SourceUrl.parse("http://test")!!,
+        isActive = true,
+        insecureConnectionAllowed = false,
+        username = "",
+        serverType = ServerType.AUDIOBOOKSHELF,
+    )
+
+    private class FakeSourceRepository(private val source: Source?) : SourceRepository {
+        override fun observeAll(): Flow<List<Source>> = MutableStateFlow(listOfNotNull(source))
+        override suspend fun getActive() = source
+        override suspend fun getById(sourceId: String): Source? = source?.takeIf { it.id == sourceId }
+        override suspend fun commit(pending: PendingSource, hiddenLibraryIds: Set<String>): CommitSourceResult = throw UnsupportedOperationException()
+        override suspend fun setActive(sourceId: String) = Unit
+        override suspend fun remove(sourceId: String) = Unit
+        override suspend fun getSourceVersion(sourceId: String): String? = null
+    }
+
+    private val capturedGetArgs = mutableListOf<Pair<String, String>>() // (scope, bucket)
+
+    private inner class FakeDao : BookFormattingPreferencesDao {
+        var entityToReturn: BookFormattingPreferencesEntity? = null
+        val upserted = mutableListOf<BookFormattingPreferencesEntity>()
+        val deleted = mutableListOf<Pair<String, String>>() // (scope, bucket)
+
+        override suspend fun upsert(entity: BookFormattingPreferencesEntity) {
+            upserted += entity
+        }
+        override suspend fun getByItemId(
+            sourceId: String, itemId: String, scope: String, screenDimensionBucket: String,
+        ): BookFormattingPreferencesEntity? {
+            capturedGetArgs += scope to screenDimensionBucket
+            return entityToReturn
+        }
+        override suspend fun deleteByItemId(
+            sourceId: String, itemId: String, scope: String, screenDimensionBucket: String,
+        ) {
+            deleted += scope to screenDimensionBucket
+        }
+    }
+
+    @Test
+    fun load_passesEncodedDimensionToDao() = runTest {
+        val dao = FakeDao()
+        val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(testSource))
+        val bucket = ScreenDimensionBucket(ScreenDimensionBucket.Width.Compact, ScreenDimensionBucket.Height.Compact)
+
+        store.load("book1", FormattingScope.FullBook, bucket)
+
+        assertEquals("FullBook", capturedGetArgs.first().first)
+        assertEquals(bucket.encode(), capturedGetArgs.first().second)
+    }
+
+    @Test
+    fun load_returnsNull_whenNoRowFound() = runTest {
+        val dao = FakeDao().also { it.entityToReturn = null }
+        val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(testSource))
+
+        val result = store.load("book1", FormattingScope.FullBook, ScreenDimensionBucket.NonCompact)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun save_includesEncodedDimensionInEntity() = runTest {
+        val dao = FakeDao()
+        val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(testSource))
+        val bucket = ScreenDimensionBucket(ScreenDimensionBucket.Width.Medium, ScreenDimensionBucket.Height.Expanded)
+        val overrides = BookFormattingOverrides(theme = ReaderTheme.Dark)
+
+        store.save("book1", FormattingScope.FullBook, bucket, overrides)
+
+        assertEquals(1, dao.upserted.size)
+        assertEquals(bucket.encode(), dao.upserted.first().screenDimensionBucket)
+        assertEquals("Dark", dao.upserted.first().theme)
+    }
+
+    @Test
+    fun clear_passesEncodedDimensionToDao() = runTest {
+        val dao = FakeDao()
+        val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(testSource))
+        val bucket = ScreenDimensionBucket(ScreenDimensionBucket.Width.Expanded, ScreenDimensionBucket.Height.Compact)
+
+        store.clear("book1", FormattingScope.FullBook, bucket)
+
+        assertEquals(1, dao.deleted.size)
+        assertEquals(bucket.encode(), dao.deleted.first().second)
+    }
+
+    @Test
+    fun load_returnsNull_whenNoActiveSource() = runTest {
+        val dao = FakeDao()
+        val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(null))
+
+        val result = store.load("book1", FormattingScope.FullBook, ScreenDimensionBucket.NonCompact)
+
+        assertNull(result)
+    }
+}

--- a/core/data/src/test/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreScopeIsolationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreScopeIsolationTest.kt
@@ -33,21 +33,21 @@ class BookFormattingPreferencesStoreScopeIsolationTest {
     private class InMemoryDao : BookFormattingPreferencesDao {
         val rows = mutableMapOf<Triple<String, String, String>, BookFormattingPreferencesEntity>()
         override suspend fun upsert(entity: BookFormattingPreferencesEntity) {
-            rows[Triple(entity.sourceId + entity.scope, entity.itemId, entity.screenDimensionBucket)] = entity
+            rows[Triple("${entity.sourceId}|${entity.scope}", entity.itemId, entity.screenDimensionBucket)] = entity
         }
         override suspend fun getByItemId(
             sourceId: String,
             itemId: String,
             scope: String,
             screenDimensionBucket: String,
-        ): BookFormattingPreferencesEntity? = rows[Triple(sourceId + scope, itemId, screenDimensionBucket)]
+        ): BookFormattingPreferencesEntity? = rows[Triple("$sourceId|$scope", itemId, screenDimensionBucket)]
         override suspend fun deleteByItemId(
             sourceId: String,
             itemId: String,
             scope: String,
             screenDimensionBucket: String,
         ) {
-            rows.remove(Triple(sourceId + scope, itemId, screenDimensionBucket))
+            rows.remove(Triple("$sourceId|$scope", itemId, screenDimensionBucket))
         }
     }
 

--- a/core/data/src/test/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreScopeIsolationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreScopeIsolationTest.kt
@@ -8,6 +8,7 @@ import com.riffle.core.domain.CommitSourceResult
 import com.riffle.core.models.FormattingScope
 import com.riffle.core.domain.PendingSource
 import com.riffle.core.domain.ReaderTheme
+import com.riffle.core.models.ScreenDimensionBucket
 import com.riffle.core.models.ServerType
 import com.riffle.core.models.Source
 import com.riffle.core.domain.SourceRepository
@@ -27,18 +28,26 @@ import org.junit.Test
  */
 class BookFormattingPreferencesStoreScopeIsolationTest {
 
+    private val dim = ScreenDimensionBucket.NonCompact
+
     private class InMemoryDao : BookFormattingPreferencesDao {
         val rows = mutableMapOf<Triple<String, String, String>, BookFormattingPreferencesEntity>()
         override suspend fun upsert(entity: BookFormattingPreferencesEntity) {
-            rows[Triple(entity.sourceId, entity.itemId, entity.scope)] = entity
+            rows[Triple(entity.sourceId + entity.scope, entity.itemId, entity.screenDimensionBucket)] = entity
         }
         override suspend fun getByItemId(
             sourceId: String,
             itemId: String,
             scope: String,
-        ): BookFormattingPreferencesEntity? = rows[Triple(sourceId, itemId, scope)]
-        override suspend fun deleteByItemId(sourceId: String, itemId: String, scope: String) {
-            rows.remove(Triple(sourceId, itemId, scope))
+            screenDimensionBucket: String,
+        ): BookFormattingPreferencesEntity? = rows[Triple(sourceId + scope, itemId, screenDimensionBucket)]
+        override suspend fun deleteByItemId(
+            sourceId: String,
+            itemId: String,
+            scope: String,
+            screenDimensionBucket: String,
+        ) {
+            rows.remove(Triple(sourceId + scope, itemId, screenDimensionBucket))
         }
     }
 
@@ -73,60 +82,60 @@ class BookFormattingPreferencesStoreScopeIsolationTest {
     @Test
     fun `save under FullBook does not affect read under Highlights`() = runTest {
         val store = newStore()
-        store.save("item-1", FormattingScope.FullBook, BookFormattingOverrides(fontSize = 2.0f))
+        store.save("item-1", FormattingScope.FullBook, dim, BookFormattingOverrides(fontSize = 2.0f))
 
         assertEquals(
             "FullBook read must return what FullBook wrote",
             2.0f,
-            store.load("item-1", FormattingScope.FullBook).fontSize,
+            store.load("item-1", FormattingScope.FullBook, dim)?.fontSize,
         )
         assertNull(
             "Highlights read must not see FullBook's write",
-            store.load("item-1", FormattingScope.Highlights).fontSize,
+            store.load("item-1", FormattingScope.Highlights, dim)?.fontSize,
         )
     }
 
     @Test
     fun `save under Highlights does not affect read under FullBook`() = runTest {
         val store = newStore()
-        store.save("item-1", FormattingScope.Highlights, BookFormattingOverrides(theme = ReaderTheme.Dark))
+        store.save("item-1", FormattingScope.Highlights, dim, BookFormattingOverrides(theme = ReaderTheme.Dark))
 
         assertEquals(
             ReaderTheme.Dark,
-            store.load("item-1", FormattingScope.Highlights).theme,
+            store.load("item-1", FormattingScope.Highlights, dim)?.theme,
         )
         assertNull(
             "FullBook read must not see Highlights' write",
-            store.load("item-1", FormattingScope.FullBook).theme,
+            store.load("item-1", FormattingScope.FullBook, dim)?.theme,
         )
     }
 
     @Test
     fun `both scopes hold independent values for the same book`() = runTest {
         val store = newStore()
-        store.save("item-1", FormattingScope.FullBook, BookFormattingOverrides(fontSize = 1.4f))
-        store.save("item-1", FormattingScope.Highlights, BookFormattingOverrides(fontSize = 1.8f))
+        store.save("item-1", FormattingScope.FullBook, dim, BookFormattingOverrides(fontSize = 1.4f))
+        store.save("item-1", FormattingScope.Highlights, dim, BookFormattingOverrides(fontSize = 1.8f))
 
-        assertEquals(1.4f, store.load("item-1", FormattingScope.FullBook).fontSize)
-        assertEquals(1.8f, store.load("item-1", FormattingScope.Highlights).fontSize)
+        assertEquals(1.4f, store.load("item-1", FormattingScope.FullBook, dim)?.fontSize)
+        assertEquals(1.8f, store.load("item-1", FormattingScope.Highlights, dim)?.fontSize)
     }
 
     @Test
     fun `clear only removes the targeted scope`() = runTest {
         val store = newStore()
-        store.save("item-1", FormattingScope.FullBook, BookFormattingOverrides(fontSize = 1.4f))
-        store.save("item-1", FormattingScope.Highlights, BookFormattingOverrides(fontSize = 1.8f))
+        store.save("item-1", FormattingScope.FullBook, dim, BookFormattingOverrides(fontSize = 1.4f))
+        store.save("item-1", FormattingScope.Highlights, dim, BookFormattingOverrides(fontSize = 1.8f))
 
-        store.clear("item-1", FormattingScope.Highlights)
+        store.clear("item-1", FormattingScope.Highlights, dim)
 
         assertEquals(
             "FullBook value must survive a Highlights-scoped clear",
             1.4f,
-            store.load("item-1", FormattingScope.FullBook).fontSize,
+            store.load("item-1", FormattingScope.FullBook, dim)?.fontSize,
         )
         assertNull(
             "Highlights value must be gone after a Highlights-scoped clear",
-            store.load("item-1", FormattingScope.Highlights).fontSize,
+            store.load("item-1", FormattingScope.Highlights, dim)?.fontSize,
         )
     }
 
@@ -137,12 +146,13 @@ class BookFormattingPreferencesStoreScopeIsolationTest {
         store.save(
             "item-1",
             FormattingScope.FullBook,
+            dim,
             BookFormattingOverrides(coloredChapterMap = false),
         )
 
         assertEquals(
             false,
-            store.load("item-1", FormattingScope.FullBook).coloredChapterMap,
+            store.load("item-1", FormattingScope.FullBook, dim)?.coloredChapterMap,
         )
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreScopeIsolationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreScopeIsolationTest.kt
@@ -28,7 +28,7 @@ import org.junit.Test
  */
 class BookFormattingPreferencesStoreScopeIsolationTest {
 
-    private val dim = ScreenDimensionBucket.NonCompact
+    private val dim = ScreenDimensionBucket.PhonePortrait
 
     private class InMemoryDao : BookFormattingPreferencesDao {
         val rows = mutableMapOf<Triple<String, String, String>, BookFormattingPreferencesEntity>()

--- a/core/database-api/src/commonMain/kotlin/com/riffle/core/database/BookFormattingPreferencesDao.kt
+++ b/core/database-api/src/commonMain/kotlin/com/riffle/core/database/BookFormattingPreferencesDao.kt
@@ -13,13 +13,25 @@ interface BookFormattingPreferencesDao {
 
     @Query(
         "SELECT * FROM book_formatting_preferences " +
-            "WHERE sourceId = :sourceId AND itemId = :itemId AND scope = :scope LIMIT 1"
+            "WHERE sourceId = :sourceId AND itemId = :itemId AND scope = :scope " +
+            "AND screenDimensionBucket = :screenDimensionBucket LIMIT 1"
     )
-    suspend fun getByItemId(sourceId: String, itemId: String, scope: String): BookFormattingPreferencesEntity?
+    suspend fun getByItemId(
+        sourceId: String,
+        itemId: String,
+        scope: String,
+        screenDimensionBucket: String,
+    ): BookFormattingPreferencesEntity?
 
     @Query(
         "DELETE FROM book_formatting_preferences " +
-            "WHERE sourceId = :sourceId AND itemId = :itemId AND scope = :scope"
+            "WHERE sourceId = :sourceId AND itemId = :itemId AND scope = :scope " +
+            "AND screenDimensionBucket = :screenDimensionBucket"
     )
-    suspend fun deleteByItemId(sourceId: String, itemId: String, scope: String)
+    suspend fun deleteByItemId(
+        sourceId: String,
+        itemId: String,
+        scope: String,
+        screenDimensionBucket: String,
+    )
 }

--- a/core/database-api/src/commonMain/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt
+++ b/core/database-api/src/commonMain/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt
@@ -10,7 +10,7 @@ import androidx.room.Index
 // view got its own preferences chain, sourceId+itemId alone would let the annotations view and
 // full-book view collide on the same book. `sourceId` FK-cascades so a removed Source's
 // formatting is cleared. `scope` is the `FormattingScope` enum name ("FullBook" / "Highlights").
-// `screenDimensionBucket` is `ScreenDimensionBucket.encode()` — e.g. "Expanded_Medium" — so each
+// `screenDimensionBucket` is `ScreenDimensionBucket.encode()` — e.g. "Compact_Medium" — so each
 // screen-size class gets independent settings for the same book.
 @Entity(
     tableName = "book_formatting_preferences",

--- a/core/database-api/src/commonMain/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt
+++ b/core/database-api/src/commonMain/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt
@@ -10,9 +10,11 @@ import androidx.room.Index
 // view got its own preferences chain, sourceId+itemId alone would let the annotations view and
 // full-book view collide on the same book. `sourceId` FK-cascades so a removed Source's
 // formatting is cleared. `scope` is the `FormattingScope` enum name ("FullBook" / "Highlights").
+// `screenDimensionBucket` is `ScreenDimensionBucket.encode()` — e.g. "Expanded_Medium" — so each
+// screen-size class gets independent settings for the same book.
 @Entity(
     tableName = "book_formatting_preferences",
-    primaryKeys = ["sourceId", "itemId", "scope"],
+    primaryKeys = ["sourceId", "itemId", "scope", "screenDimensionBucket"],
     foreignKeys = [
         ForeignKey(
             entity = SourceEntity::class,
@@ -27,6 +29,7 @@ data class BookFormattingPreferencesEntity(
     val sourceId: String,
     val itemId: String,
     val scope: String,
+    val screenDimensionBucket: String,
     val fontSize: Float? = null,
     val theme: String? = null,
     val fontFamily: String? = null,

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/70.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/70.json
@@ -1,0 +1,2233 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 70,
+    "identityHash": "d1ab4c4d69a29f5e8cfaa122e2b2ad66",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER NOT NULL, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, `pageCount` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesSequence",
+            "columnName": "seriesSequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `screenDimensionBucket` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `coloredChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`, `screenDimensionBucket`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "screenDimensionBucket",
+            "columnName": "screenDimensionBucket",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coloredChapterMap",
+            "columnName": "coloredChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "scope",
+            "screenDimensionBucket"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, `originFontFamily` TEXT, `emphasisStyles` TEXT, `textSnippetHtml` TEXT, `fragmentAnchor` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedFigures",
+            "columnName": "embeddedFigures",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageHref",
+            "columnName": "imageHref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageSvg",
+            "columnName": "imageSvg",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBytes",
+            "columnName": "imageBytes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originFontFamily",
+            "columnName": "originFontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "emphasisStyles",
+            "columnName": "emphasisStyles",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippetHtml",
+            "columnName": "textSnippetHtml",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fragmentAnchor",
+            "columnName": "fragmentAnchor",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "local_files_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `treeUri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `addedAtEpochMs` INTEGER NOT NULL, `libraryId` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `treeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtEpochMs",
+            "columnName": "addedAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "treeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `originalUri` TEXT NOT NULL, `copiedPath` TEXT NOT NULL, `coverPath` TEXT, `format` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `mtimeEpochMs` INTEGER NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, `displayName` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUri",
+            "columnName": "originalUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "copiedPath",
+            "columnName": "copiedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtimeEpochMs",
+            "columnName": "mtimeEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_files_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_file_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `folderTreeUri` TEXT NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`, `folderTreeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderTreeUri",
+            "columnName": "folderTreeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId",
+            "folderTreeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_file_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_local_files_file_folders_sourceId_folderTreeUri",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "folderTreeUri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId_folderTreeUri` ON `${TABLE_NAME}` (`sourceId`, `folderTreeUri`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_file_metadata_overrides",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `title` TEXT, `author` TEXT, `seriesName` TEXT, `seriesIndex` REAL, `coverUrl` TEXT, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "seriesIndex",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_file_metadata_overrides_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_file_metadata_overrides_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_item_freshness",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `lastFetchedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFetchedAt",
+            "columnName": "lastFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `rootId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootId",
+            "columnName": "rootId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_playlists_rootId",
+            "unique": false,
+            "columnNames": [
+              "rootId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_rootId` ON `${TABLE_NAME}` (`rootId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `orderIndex` INTEGER NOT NULL, PRIMARY KEY(`playlistId`, `sourceId`, `itemId`), FOREIGN KEY(`sourceId`, `playlistId`) REFERENCES `playlists`(`sourceId`, `id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "orderIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId",
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_items_sourceId_playlistId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_items_sourceId_playlistId` ON `${TABLE_NAME}` (`sourceId`, `playlistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId",
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "sourceId",
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "publication_metrics_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `totalPositions` INTEGER, `pageCount` INTEGER, `cachedAt` INTEGER NOT NULL, `epubVersion` TEXT, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPositions",
+            "columnName": "totalPositions",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epubVersion",
+            "columnName": "epubVersion",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_publication_metrics_cache_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_publication_metrics_cache_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_comic_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`source_id` TEXT NOT NULL, `item_id` TEXT NOT NULL, `background_theme` TEXT, `panel_view_on` INTEGER, `panel_overflow` TEXT, `panel_animation_speed_ms` INTEGER, PRIMARY KEY(`source_id`, `item_id`), FOREIGN KEY(`source_id`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "source_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundTheme",
+            "columnName": "background_theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "panelViewOn",
+            "columnName": "panel_view_on",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "panelOverflow",
+            "columnName": "panel_overflow",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "panelAnimationSpeedMs",
+            "columnName": "panel_animation_speed_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "source_id",
+            "item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_comic_formatting_preferences_source_id",
+            "unique": false,
+            "columnNames": [
+              "source_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_comic_formatting_preferences_source_id` ON `${TABLE_NAME}` (`source_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "source_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "dictionary_packs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`languageTag` TEXT NOT NULL, `packVersion` TEXT NOT NULL, `installedAt` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `attributionHtml` TEXT NOT NULL, `licenseUrl` TEXT NOT NULL, `state` TEXT NOT NULL, PRIMARY KEY(`languageTag`))",
+        "fields": [
+          {
+            "fieldPath": "languageTag",
+            "columnName": "languageTag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packVersion",
+            "columnName": "packVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedAt",
+            "columnName": "installedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attributionHtml",
+            "columnName": "attributionHtml",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "licenseUrl",
+            "columnName": "licenseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "languageTag"
+          ]
+        }
+      },
+      {
+        "tableName": "lookup_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `languageTag` TEXT NOT NULL, `form` TEXT NOT NULL, `lookedUpAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "languageTag",
+            "columnName": "languageTag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "form",
+            "columnName": "form",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lookedUpAt",
+            "columnName": "lookedUpAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'd1ab4c4d69a29f5e8cfaa122e2b2ad66')"
+    ]
+  }
+}

--- a/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1921,7 +1921,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 69, true,
+            TEST_DB, 70, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,

--- a/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -3168,23 +3168,32 @@ class MigrationTest {
         helper.runMigrationsAndValidate(
             TEST_DB, 70, true, RiffleDatabase.MIGRATION_69_70
         ).use { db ->
+            // One old row must fan out to all 6 sorted dimension buckets.
             db.query(
-                "SELECT screenDimensionBucket, fontSize, theme FROM book_formatting_preferences WHERE itemId = 'book1'"
+                "SELECT screenDimensionBucket, fontSize, theme FROM book_formatting_preferences " +
+                    "WHERE itemId = 'book1' ORDER BY screenDimensionBucket"
             ).use { cursor ->
-                assertEquals(1, cursor.count)
-                assertTrue(cursor.moveToFirst())
-                assertEquals("Compact_Medium", cursor.getString(cursor.getColumnIndexOrThrow("screenDimensionBucket")))
-                assertEquals(1.5f, cursor.getFloat(cursor.getColumnIndexOrThrow("fontSize")), 0.001f)
-                assertEquals("Dark", cursor.getString(cursor.getColumnIndexOrThrow("theme")))
+                assertEquals(6, cursor.count)
+                val expectedBuckets = listOf(
+                    "Compact_Compact", "Compact_Expanded", "Compact_Medium",
+                    "Expanded_Expanded", "Medium_Expanded", "Medium_Medium",
+                )
+                expectedBuckets.forEachIndexed { i, bucket ->
+                    assertTrue(cursor.moveToPosition(i))
+                    assertEquals(bucket, cursor.getString(cursor.getColumnIndexOrThrow("screenDimensionBucket")))
+                    assertEquals(1.5f, cursor.getFloat(cursor.getColumnIndexOrThrow("fontSize")), 0.001f)
+                    assertEquals("Dark", cursor.getString(cursor.getColumnIndexOrThrow("theme")))
+                }
             }
 
+            // The 4-column PK must be enforced: inserting a row with a new bucket is allowed.
             db.execSQL(
                 "INSERT INTO book_formatting_preferences (sourceId, itemId, scope, screenDimensionBucket, fontSize) " +
-                    "VALUES ('src', 'book1', 'FullBook', 'Compact_Compact', 1.0)"
+                    "VALUES ('src', 'book2', 'FullBook', 'Compact_Medium', 1.0)"
             )
-            db.query("SELECT COUNT(*) FROM book_formatting_preferences WHERE itemId = 'book1'").use { cursor ->
+            db.query("SELECT COUNT(*) FROM book_formatting_preferences WHERE itemId = 'book2'").use { cursor ->
                 assertTrue(cursor.moveToFirst())
-                assertEquals(2, cursor.getInt(0))
+                assertEquals(1, cursor.getInt(0))
             }
         }
     }

--- a/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1990,6 +1990,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_66_67,
             RiffleDatabase.MIGRATION_67_68,
             RiffleDatabase.MIGRATION_68_69,
+            RiffleDatabase.MIGRATION_69_70,
         )
 
         db.query("SELECT url, username, serverType, absUserId, type FROM sources WHERE id = 's1'").use { cursor ->
@@ -2003,7 +2004,7 @@ class MigrationTest {
         }
         db.query("PRAGMA user_version").use { cursor ->
             assertTrue(cursor.moveToFirst())
-            assertEquals(69, cursor.getInt(0))
+            assertEquals(70, cursor.getInt(0))
         }
         db.query("SELECT coverUrl FROM local_file_metadata_overrides LIMIT 0").use { cursor ->
             assertEquals("coverUrl", cursor.getColumnName(0))
@@ -3147,6 +3148,43 @@ class MigrationTest {
             db.query("SELECT state FROM dictionary_packs WHERE languageTag = 'fr'").use { c ->
                 assertTrue(c.moveToFirst())
                 assertEquals("INSTALLED", c.getString(0))
+            }
+        }
+    }
+
+    @Test
+    fun migration69To70_addsScreenDimensionBucketColumn() {
+        helper.createDatabase(TEST_DB, 69).use { db ->
+            db.execSQL(
+                "INSERT INTO sources (id, url, isActive, insecureConnectionAllowed, username, serverType, absUserId, type) " +
+                    "VALUES ('src', 'http://test', 1, 0, '', 'AUDIOBOOKSHELF', NULL, 'ABS')"
+            )
+            db.execSQL(
+                "INSERT INTO book_formatting_preferences (sourceId, itemId, scope, fontSize, theme) " +
+                    "VALUES ('src', 'book1', 'FullBook', 1.5, 'Dark')"
+            )
+        }
+
+        helper.runMigrationsAndValidate(
+            TEST_DB, 70, true, RiffleDatabase.MIGRATION_69_70
+        ).use { db ->
+            db.query(
+                "SELECT screenDimensionBucket, fontSize, theme FROM book_formatting_preferences WHERE itemId = 'book1'"
+            ).use { cursor ->
+                assertEquals(1, cursor.count)
+                assertTrue(cursor.moveToFirst())
+                assertEquals("Expanded_Medium", cursor.getString(cursor.getColumnIndexOrThrow("screenDimensionBucket")))
+                assertEquals(1.5f, cursor.getFloat(cursor.getColumnIndexOrThrow("fontSize")), 0.001f)
+                assertEquals("Dark", cursor.getString(cursor.getColumnIndexOrThrow("theme")))
+            }
+
+            db.execSQL(
+                "INSERT INTO book_formatting_preferences (sourceId, itemId, scope, screenDimensionBucket, fontSize) " +
+                    "VALUES ('src', 'book1', 'FullBook', 'Compact_Compact', 1.0)"
+            )
+            db.query("SELECT COUNT(*) FROM book_formatting_preferences WHERE itemId = 'book1'").use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals(2, cursor.getInt(0))
             }
         }
     }

--- a/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -3168,32 +3168,24 @@ class MigrationTest {
         helper.runMigrationsAndValidate(
             TEST_DB, 70, true, RiffleDatabase.MIGRATION_69_70
         ).use { db ->
-            // One old row must fan out to all 6 sorted dimension buckets.
-            db.query(
-                "SELECT screenDimensionBucket, fontSize, theme FROM book_formatting_preferences " +
-                    "WHERE itemId = 'book1' ORDER BY screenDimensionBucket"
-            ).use { cursor ->
-                assertEquals(6, cursor.count)
-                val expectedBuckets = listOf(
-                    "Compact_Compact", "Compact_Expanded", "Compact_Medium",
-                    "Expanded_Expanded", "Medium_Expanded", "Medium_Medium",
-                )
-                expectedBuckets.forEachIndexed { i, bucket ->
-                    assertTrue(cursor.moveToPosition(i))
-                    assertEquals(bucket, cursor.getString(cursor.getColumnIndexOrThrow("screenDimensionBucket")))
-                    assertEquals(1.5f, cursor.getFloat(cursor.getColumnIndexOrThrow("fontSize")), 0.001f)
-                    assertEquals("Dark", cursor.getString(cursor.getColumnIndexOrThrow("theme")))
-                }
+            // Pre-existing rows are dropped; table must be empty after migration.
+            db.query("SELECT COUNT(*) FROM book_formatting_preferences").use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals(0, cursor.getInt(0))
             }
 
-            // The 4-column PK must be enforced: inserting a row with a new bucket is allowed.
+            // The 4-column PK must be enforced: new rows with screenDimensionBucket are accepted.
             db.execSQL(
                 "INSERT INTO book_formatting_preferences (sourceId, itemId, scope, screenDimensionBucket, fontSize) " +
-                    "VALUES ('src', 'book2', 'FullBook', 'Compact_Medium', 1.0)"
+                    "VALUES ('src', 'book1', 'FullBook', 'Compact_Medium', 1.5)"
             )
-            db.query("SELECT COUNT(*) FROM book_formatting_preferences WHERE itemId = 'book2'").use { cursor ->
+            db.execSQL(
+                "INSERT INTO book_formatting_preferences (sourceId, itemId, scope, screenDimensionBucket, fontSize) " +
+                    "VALUES ('src', 'book1', 'FullBook', 'Compact_Compact', 1.0)"
+            )
+            db.query("SELECT COUNT(*) FROM book_formatting_preferences WHERE itemId = 'book1'").use { cursor ->
                 assertTrue(cursor.moveToFirst())
-                assertEquals(1, cursor.getInt(0))
+                assertEquals(2, cursor.getInt(0))
             }
         }
     }

--- a/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -3173,7 +3173,7 @@ class MigrationTest {
             ).use { cursor ->
                 assertEquals(1, cursor.count)
                 assertTrue(cursor.moveToFirst())
-                assertEquals("Expanded_Medium", cursor.getString(cursor.getColumnIndexOrThrow("screenDimensionBucket")))
+                assertEquals("Compact_Medium", cursor.getString(cursor.getColumnIndexOrThrow("screenDimensionBucket")))
                 assertEquals(1.5f, cursor.getFloat(cursor.getColumnIndexOrThrow("fontSize")), 0.001f)
                 assertEquals("Dark", cursor.getString(cursor.getColumnIndexOrThrow("theme")))
             }

--- a/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/SourceDaoDeleteGraphTest.kt
+++ b/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/SourceDaoDeleteGraphTest.kt
@@ -55,7 +55,7 @@ class SourceDaoDeleteGraphTest {
         sql("INSERT INTO libraries (id, name, mediaType, sourceId, isUnsupported) VALUES ('lib-1', 'Books', 'book', '$ABS_SOURCE_ID', 0)")
         sql("INSERT INTO library_items (sourceId, id, libraryId, title, author, coverUrl, readingProgress, ebookFormat, hasAudio, audioDurationSec, genres, addedAt) VALUES ('$ABS_SOURCE_ID', 'item-1', 'lib-1', 'Title', 'Author', NULL, 0.25, 'epub', 1, 123.0, '', 10)")
         sql("INSERT INTO reading_positions (sourceId, itemId, cfi, localUpdatedAt, lastSyncedAt) VALUES ('$ABS_SOURCE_ID', 'item-1', 'epubcfi(/6/4!/4/1:0)', 20, 10)")
-        sql("INSERT INTO book_formatting_preferences (sourceId, itemId, scope, fontSize) VALUES ('$ABS_SOURCE_ID', 'item-1', 'FullBook', 1.0)")
+        sql("INSERT INTO book_formatting_preferences (sourceId, itemId, scope, screenDimensionBucket, fontSize) VALUES ('$ABS_SOURCE_ID', 'item-1', 'FullBook', 'Compact_Medium', 1.0)")
         db.annotationDao().upsertAll(
             listOf(
                 AnnotationEntity(

--- a/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -1806,9 +1806,12 @@ abstract class RiffleDatabase : RoomDatabase() {
         val MIGRATION_69_70 = object : Migration(69, 70) {
             override fun migrate(db: SQLiteConnection) {
                 // ALTER TABLE cannot change the PRIMARY KEY in SQLite, so a full table rebuild is
-                // required to add `screenDimensionBucket` to the composite PK.
+                // required to add `screenDimensionBucket` to the composite PK. Existing per-book
+                // overrides are intentionally dropped; each book will be re-seeded from global
+                // defaults on first open on any dimension.
+                db.execSQL("DROP TABLE `book_formatting_preferences`")
                 db.execSQL(
-                    "CREATE TABLE IF NOT EXISTS `book_formatting_preferences_new` " +
+                    "CREATE TABLE `book_formatting_preferences` " +
                         "(`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, " +
                         "`screenDimensionBucket` TEXT NOT NULL, " +
                         "`fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, " +
@@ -1819,31 +1822,6 @@ abstract class RiffleDatabase : RoomDatabase() {
                         "PRIMARY KEY(`sourceId`, `itemId`, `scope`, `screenDimensionBucket`), " +
                         "FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )"
                 )
-                // Fan out each existing row to all 6 valid sorted dimension buckets so every
-                // device finds its settings regardless of screen size. The buckets are all
-                // combinations of (narrower, wider) with narrower ≤ wider from the SizeClass
-                // ordinal order: Compact < Medium < Expanded.
-                val buckets = listOf(
-                    "Compact_Compact", "Compact_Medium", "Compact_Expanded",
-                    "Medium_Medium", "Medium_Expanded", "Expanded_Expanded",
-                )
-                val cols = "`sourceId`, `itemId`, `scope`, `screenDimensionBucket`, `fontSize`, " +
-                    "`theme`, `fontFamily`, `lineSpacing`, `margins`, `orientation`, " +
-                    "`showChapterMap`, `coloredChapterMap`, `showReadingProgressLabels`, " +
-                    "`showCurrentChapterLabel`, `doublePageSpread`, `justifyText`, `showReadingTimeEstimate`"
-                val selectCols = "`sourceId`, `itemId`, `scope`, `fontSize`, `theme`, " +
-                    "`fontFamily`, `lineSpacing`, `margins`, `orientation`, `showChapterMap`, " +
-                    "`coloredChapterMap`, `showReadingProgressLabels`, `showCurrentChapterLabel`, " +
-                    "`doublePageSpread`, `justifyText`, `showReadingTimeEstimate`"
-                for (bucket in buckets) {
-                    db.execSQL(
-                        "INSERT INTO `book_formatting_preferences_new` ($cols) " +
-                            "SELECT `sourceId`, `itemId`, `scope`, '$bucket', $selectCols " +
-                            "FROM `book_formatting_preferences`"
-                    )
-                }
-                db.execSQL("DROP TABLE `book_formatting_preferences`")
-                db.execSQL("ALTER TABLE `book_formatting_preferences_new` RENAME TO `book_formatting_preferences`")
                 db.execSQL(
                     "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` " +
                         "ON `book_formatting_preferences` (`sourceId`)"

--- a/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -1810,7 +1810,7 @@ abstract class RiffleDatabase : RoomDatabase() {
                 db.execSQL(
                     "CREATE TABLE IF NOT EXISTS `book_formatting_preferences_new` " +
                         "(`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, " +
-                        "`screenDimensionBucket` TEXT NOT NULL DEFAULT 'Compact_Medium', " +
+                        "`screenDimensionBucket` TEXT NOT NULL, " +
                         "`fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, " +
                         "`margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, " +
                         "`coloredChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, " +
@@ -1819,18 +1819,29 @@ abstract class RiffleDatabase : RoomDatabase() {
                         "PRIMARY KEY(`sourceId`, `itemId`, `scope`, `screenDimensionBucket`), " +
                         "FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )"
                 )
-                db.execSQL(
-                    "INSERT INTO `book_formatting_preferences_new` " +
-                        "(`sourceId`, `itemId`, `scope`, `screenDimensionBucket`, `fontSize`, `theme`, " +
-                        "`fontFamily`, `lineSpacing`, `margins`, `orientation`, `showChapterMap`, " +
-                        "`coloredChapterMap`, `showReadingProgressLabels`, `showCurrentChapterLabel`, " +
-                        "`doublePageSpread`, `justifyText`, `showReadingTimeEstimate`) " +
-                        "SELECT `sourceId`, `itemId`, `scope`, 'Compact_Medium', `fontSize`, `theme`, " +
-                        "`fontFamily`, `lineSpacing`, `margins`, `orientation`, `showChapterMap`, " +
-                        "`coloredChapterMap`, `showReadingProgressLabels`, `showCurrentChapterLabel`, " +
-                        "`doublePageSpread`, `justifyText`, `showReadingTimeEstimate` " +
-                        "FROM `book_formatting_preferences`"
+                // Fan out each existing row to all 6 valid sorted dimension buckets so every
+                // device finds its settings regardless of screen size. The buckets are all
+                // combinations of (narrower, wider) with narrower ≤ wider from the SizeClass
+                // ordinal order: Compact < Medium < Expanded.
+                val buckets = listOf(
+                    "Compact_Compact", "Compact_Medium", "Compact_Expanded",
+                    "Medium_Medium", "Medium_Expanded", "Expanded_Expanded",
                 )
+                val cols = "`sourceId`, `itemId`, `scope`, `screenDimensionBucket`, `fontSize`, " +
+                    "`theme`, `fontFamily`, `lineSpacing`, `margins`, `orientation`, " +
+                    "`showChapterMap`, `coloredChapterMap`, `showReadingProgressLabels`, " +
+                    "`showCurrentChapterLabel`, `doublePageSpread`, `justifyText`, `showReadingTimeEstimate`"
+                val selectCols = "`sourceId`, `itemId`, `scope`, `fontSize`, `theme`, " +
+                    "`fontFamily`, `lineSpacing`, `margins`, `orientation`, `showChapterMap`, " +
+                    "`coloredChapterMap`, `showReadingProgressLabels`, `showCurrentChapterLabel`, " +
+                    "`doublePageSpread`, `justifyText`, `showReadingTimeEstimate`"
+                for (bucket in buckets) {
+                    db.execSQL(
+                        "INSERT INTO `book_formatting_preferences_new` ($cols) " +
+                            "SELECT `sourceId`, `itemId`, `scope`, '$bucket', $selectCols " +
+                            "FROM `book_formatting_preferences`"
+                    )
+                }
                 db.execSQL("DROP TABLE `book_formatting_preferences`")
                 db.execSQL("ALTER TABLE `book_formatting_preferences_new` RENAME TO `book_formatting_preferences`")
                 db.execSQL(

--- a/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -44,7 +44,7 @@ import androidx.sqlite.execSQL
         DictionaryPackEntity::class,
         LookupHistoryEntity::class,
     ],
-    version = 69,
+    version = 70,
     exportSchema = true,
 )
 @ConstructedBy(RiffleDatabaseConstructor::class)
@@ -1799,6 +1799,15 @@ abstract class RiffleDatabase : RoomDatabase() {
                         "`languageTag` TEXT NOT NULL, " +
                         "`form` TEXT NOT NULL, " +
                         "`lookedUpAt` INTEGER NOT NULL)"
+                )
+            }
+        }
+
+        val MIGRATION_69_70 = object : Migration(69, 70) {
+            override fun migrate(db: SQLiteConnection) {
+                db.execSQL(
+                    "ALTER TABLE book_formatting_preferences " +
+                        "ADD COLUMN screenDimensionBucket TEXT NOT NULL DEFAULT 'Expanded_Medium'"
                 )
             }
         }

--- a/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -1805,9 +1805,37 @@ abstract class RiffleDatabase : RoomDatabase() {
 
         val MIGRATION_69_70 = object : Migration(69, 70) {
             override fun migrate(db: SQLiteConnection) {
+                // ALTER TABLE cannot change the PRIMARY KEY in SQLite, so a full table rebuild is
+                // required to add `screenDimensionBucket` to the composite PK.
                 db.execSQL(
-                    "ALTER TABLE book_formatting_preferences " +
-                        "ADD COLUMN screenDimensionBucket TEXT NOT NULL DEFAULT 'Expanded_Medium'"
+                    "CREATE TABLE IF NOT EXISTS `book_formatting_preferences_new` " +
+                        "(`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, " +
+                        "`screenDimensionBucket` TEXT NOT NULL DEFAULT 'Compact_Medium', " +
+                        "`fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, " +
+                        "`margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, " +
+                        "`coloredChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, " +
+                        "`showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, " +
+                        "`justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, " +
+                        "PRIMARY KEY(`sourceId`, `itemId`, `scope`, `screenDimensionBucket`), " +
+                        "FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )"
+                )
+                db.execSQL(
+                    "INSERT INTO `book_formatting_preferences_new` " +
+                        "(`sourceId`, `itemId`, `scope`, `screenDimensionBucket`, `fontSize`, `theme`, " +
+                        "`fontFamily`, `lineSpacing`, `margins`, `orientation`, `showChapterMap`, " +
+                        "`coloredChapterMap`, `showReadingProgressLabels`, `showCurrentChapterLabel`, " +
+                        "`doublePageSpread`, `justifyText`, `showReadingTimeEstimate`) " +
+                        "SELECT `sourceId`, `itemId`, `scope`, 'Compact_Medium', `fontSize`, `theme`, " +
+                        "`fontFamily`, `lineSpacing`, `margins`, `orientation`, `showChapterMap`, " +
+                        "`coloredChapterMap`, `showReadingProgressLabels`, `showCurrentChapterLabel`, " +
+                        "`doublePageSpread`, `justifyText`, `showReadingTimeEstimate` " +
+                        "FROM `book_formatting_preferences`"
+                )
+                db.execSQL("DROP TABLE `book_formatting_preferences`")
+                db.execSQL("ALTER TABLE `book_formatting_preferences_new` RENAME TO `book_formatting_preferences`")
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` " +
+                        "ON `book_formatting_preferences` (`sourceId`)"
                 )
             }
         }

--- a/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabaseFactory.kt
+++ b/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabaseFactory.kt
@@ -118,4 +118,5 @@ internal val RIFFLE_DATABASE_MIGRATIONS: Array<Migration> = arrayOf(
     RiffleDatabase.MIGRATION_66_67,
     RiffleDatabase.MIGRATION_67_68,
     RiffleDatabase.MIGRATION_68_69,
+    RiffleDatabase.MIGRATION_69_70,
 )

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/BookFormattingPreferencesStore.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/BookFormattingPreferencesStore.kt
@@ -1,8 +1,11 @@
 package com.riffle.core.domain
+
 import com.riffle.core.models.FormattingScope
+import com.riffle.core.models.ScreenDimensionBucket
 
 interface BookFormattingPreferencesStore {
-    suspend fun load(itemId: String, scope: FormattingScope): BookFormattingOverrides
-    suspend fun save(itemId: String, scope: FormattingScope, overrides: BookFormattingOverrides)
-    suspend fun clear(itemId: String, scope: FormattingScope)
+    // Returns null if no row exists for this (itemId, scope, dimension) — caller is responsible for seeding.
+    suspend fun load(itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket): BookFormattingOverrides?
+    suspend fun save(itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket, overrides: BookFormattingOverrides)
+    suspend fun clear(itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket)
 }

--- a/core/models/src/commonMain/kotlin/com/riffle/core/models/ScreenDimensionBucket.kt
+++ b/core/models/src/commonMain/kotlin/com/riffle/core/models/ScreenDimensionBucket.kt
@@ -1,25 +1,32 @@
 package com.riffle.core.models
 
+/**
+ * Rotation-invariant screen-dimension key. Always stored as (narrower, wider) so portrait and
+ * landscape on the same device produce the same bucket — a phone at Compact×Medium in portrait
+ * and Medium×Compact in landscape both yield "Compact_Medium".
+ */
 data class ScreenDimensionBucket(
-    val widthSizeClass: Width,
-    val heightSizeClass: Height,
+    val narrower: SizeClass,
+    val wider: SizeClass,
 ) {
-    enum class Width { Compact, Medium, Expanded }
-    enum class Height { Compact, Medium, Expanded }
+    enum class SizeClass { Compact, Medium, Expanded }
 
-    fun encode(): String = "${widthSizeClass.name}_${heightSizeClass.name}"
+    fun encode(): String = "${narrower.name}_${wider.name}"
 
     companion object {
         fun decode(value: String): ScreenDimensionBucket {
             val parts = value.split("_")
             return ScreenDimensionBucket(
-                widthSizeClass = Width.valueOf(parts[0]),
-                heightSizeClass = Height.valueOf(parts[1]),
+                narrower = SizeClass.valueOf(parts[0]),
+                wider = SizeClass.valueOf(parts[1]),
             )
         }
 
-        // Migration default: existing rows are attributed to a large-screen context.
-        // encode() of this must equal exactly 'Expanded_Medium' — the SQL DEFAULT.
-        val NonCompact = ScreenDimensionBucket(Width.Expanded, Height.Medium)
+        fun of(a: SizeClass, b: SizeClass): ScreenDimensionBucket =
+            if (a.ordinal <= b.ordinal) ScreenDimensionBucket(a, b) else ScreenDimensionBucket(b, a)
+
+        // Migration default: typical phone portrait (Compact width × Medium height).
+        // encode() of this must equal exactly 'Compact_Medium' — the SQL DEFAULT.
+        val PhonePortrait = ScreenDimensionBucket(SizeClass.Compact, SizeClass.Medium)
     }
 }

--- a/core/models/src/commonMain/kotlin/com/riffle/core/models/ScreenDimensionBucket.kt
+++ b/core/models/src/commonMain/kotlin/com/riffle/core/models/ScreenDimensionBucket.kt
@@ -1,0 +1,25 @@
+package com.riffle.core.models
+
+data class ScreenDimensionBucket(
+    val widthSizeClass: Width,
+    val heightSizeClass: Height,
+) {
+    enum class Width { Compact, Medium, Expanded }
+    enum class Height { Compact, Medium, Expanded }
+
+    fun encode(): String = "${widthSizeClass.name}_${heightSizeClass.name}"
+
+    companion object {
+        fun decode(value: String): ScreenDimensionBucket {
+            val parts = value.split("_")
+            return ScreenDimensionBucket(
+                widthSizeClass = Width.valueOf(parts[0]),
+                heightSizeClass = Height.valueOf(parts[1]),
+            )
+        }
+
+        // Migration default: existing rows are attributed to a large-screen context.
+        // encode() of this must equal exactly 'Expanded_Medium' — the SQL DEFAULT.
+        val NonCompact = ScreenDimensionBucket(Width.Expanded, Height.Medium)
+    }
+}

--- a/core/models/src/commonMain/kotlin/com/riffle/core/models/ScreenDimensionBucket.kt
+++ b/core/models/src/commonMain/kotlin/com/riffle/core/models/ScreenDimensionBucket.kt
@@ -16,6 +16,7 @@ data class ScreenDimensionBucket(
     companion object {
         fun decode(value: String): ScreenDimensionBucket {
             val parts = value.split("_")
+            require(parts.size == 2) { "Invalid ScreenDimensionBucket encoded value: '$value'" }
             return ScreenDimensionBucket(
                 narrower = SizeClass.valueOf(parts[0]),
                 wider = SizeClass.valueOf(parts[1]),

--- a/core/models/src/jvmTest/kotlin/com/riffle/core/models/ScreenDimensionBucketTest.kt
+++ b/core/models/src/jvmTest/kotlin/com/riffle/core/models/ScreenDimensionBucketTest.kt
@@ -2,6 +2,7 @@ package com.riffle.core.models
 
 import com.riffle.core.models.ScreenDimensionBucket.SizeClass
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class ScreenDimensionBucketTest {
@@ -39,5 +40,12 @@ class ScreenDimensionBucketTest {
         val portrait = ScreenDimensionBucket.of(SizeClass.Compact, SizeClass.Medium)
         val landscape = ScreenDimensionBucket.of(SizeClass.Medium, SizeClass.Compact)
         assertEquals(portrait, landscape)
+    }
+
+    @Test
+    fun decode_throws_on_value_without_underscore() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ScreenDimensionBucket.decode("CompactMedium")
+        }
     }
 }

--- a/core/models/src/jvmTest/kotlin/com/riffle/core/models/ScreenDimensionBucketTest.kt
+++ b/core/models/src/jvmTest/kotlin/com/riffle/core/models/ScreenDimensionBucketTest.kt
@@ -1,28 +1,43 @@
 package com.riffle.core.models
 
+import com.riffle.core.models.ScreenDimensionBucket.SizeClass
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class ScreenDimensionBucketTest {
 
     @Test
-    fun encode_nonCompact_producesExpanded_Medium() {
-        assertEquals("Expanded_Medium", ScreenDimensionBucket.NonCompact.encode())
+    fun encode_phonePortrait_produces_Compact_Medium() {
+        assertEquals("Compact_Medium", ScreenDimensionBucket.PhonePortrait.encode())
     }
 
     @Test
     fun decode_roundTrip_allCombinations() {
-        for (w in ScreenDimensionBucket.Width.entries) {
-            for (h in ScreenDimensionBucket.Height.entries) {
-                val original = ScreenDimensionBucket(w, h)
+        for (a in SizeClass.entries) {
+            for (b in SizeClass.entries) {
+                val original = ScreenDimensionBucket.of(a, b)
                 assertEquals(original, ScreenDimensionBucket.decode(original.encode()))
             }
         }
     }
 
     @Test
-    fun nonCompact_isExpanded_Medium() {
-        assertEquals(ScreenDimensionBucket.Width.Expanded, ScreenDimensionBucket.NonCompact.widthSizeClass)
-        assertEquals(ScreenDimensionBucket.Height.Medium, ScreenDimensionBucket.NonCompact.heightSizeClass)
+    fun phonePortrait_isCompact_Medium() {
+        assertEquals(SizeClass.Compact, ScreenDimensionBucket.PhonePortrait.narrower)
+        assertEquals(SizeClass.Medium, ScreenDimensionBucket.PhonePortrait.wider)
+    }
+
+    @Test
+    fun of_swaps_when_first_is_larger() {
+        val bucket = ScreenDimensionBucket.of(SizeClass.Expanded, SizeClass.Compact)
+        assertEquals(SizeClass.Compact, bucket.narrower)
+        assertEquals(SizeClass.Expanded, bucket.wider)
+    }
+
+    @Test
+    fun of_portrait_and_landscape_produce_same_bucket() {
+        val portrait = ScreenDimensionBucket.of(SizeClass.Compact, SizeClass.Medium)
+        val landscape = ScreenDimensionBucket.of(SizeClass.Medium, SizeClass.Compact)
+        assertEquals(portrait, landscape)
     }
 }

--- a/core/models/src/jvmTest/kotlin/com/riffle/core/models/ScreenDimensionBucketTest.kt
+++ b/core/models/src/jvmTest/kotlin/com/riffle/core/models/ScreenDimensionBucketTest.kt
@@ -1,0 +1,28 @@
+package com.riffle.core.models
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ScreenDimensionBucketTest {
+
+    @Test
+    fun encode_nonCompact_producesExpanded_Medium() {
+        assertEquals("Expanded_Medium", ScreenDimensionBucket.NonCompact.encode())
+    }
+
+    @Test
+    fun decode_roundTrip_allCombinations() {
+        for (w in ScreenDimensionBucket.Width.entries) {
+            for (h in ScreenDimensionBucket.Height.entries) {
+                val original = ScreenDimensionBucket(w, h)
+                assertEquals(original, ScreenDimensionBucket.decode(original.encode()))
+            }
+        }
+    }
+
+    @Test
+    fun nonCompact_isExpanded_Medium() {
+        assertEquals(ScreenDimensionBucket.Width.Expanded, ScreenDimensionBucket.NonCompact.widthSizeClass)
+        assertEquals(ScreenDimensionBucket.Height.Medium, ScreenDimensionBucket.NonCompact.heightSizeClass)
+    }
+}


### PR DESCRIPTION
## Summary

- Book formatting preferences are now keyed by `(sourceId, itemId, scope, screenDimensionBucket)` so each screen-size class gets independent settings for the same book.
- On first open of a book on a new dimension, global defaults are seeded as a dense row — so each dimension starts from current globals and diverges independently.
- Rotating the device does **not** reset settings: the bucket is stored as `(narrower, wider)` sorted by size class, making portrait `Compact×Medium` and landscape `Medium×Compact` map to the same key `"Compact_Medium"`.
- Fold/rotate during an open session re-binds to the new dimension's row; a prior in-flight bind is cancelled so the latest dimension always wins.

## Changes

- `core:models` — `ScreenDimensionBucket` with rotation-invariant `(narrower, wider)` storage, `of()` factory, `PhonePortrait` migration constant.
- `core:database-api` — `BookFormattingPreferencesEntity` gains `screenDimensionBucket` in the 4-column composite PK.
- `core:database` — Migration v69→v70: full table rebuild (ALTER TABLE cannot change the PK in SQLite); migration default `'Compact_Medium'`.
- `core:domain` — `BookFormattingPreferencesStore` interface adds `dimension: ScreenDimensionBucket` to all three methods; `load` returns `BookFormattingOverrides?` (null = no row).
- `core:data` — `BookFormattingPreferencesStoreImpl` updated accordingly.
- `app` — `FormattingSession.bindToBook` gains `dimension` param + seeding + bind-job cancellation; `EpubReaderViewModel` awaits first dimension push and re-binds on change; `EpubReaderScreen` pushes via `LaunchedEffect(windowSizeClass)`; `ScreenDimensionBucketMapper` in the app layer maps `WindowSizeClass → ScreenDimensionBucket`.

## Notes

- `EpubReaderViewModel.setScreenDimensionBucket` re-bind path cannot be unit-tested directly (Readium constructor requires Android). The underlying `FormattingSession.bindToBook` path it delegates to is covered by `FormattingSessionTest`.
- Migration test (`migration69To70_addsScreenDimensionBucketColumn`) lives in `core:database/androidDeviceTest` and requires the AVD harness (`make harness-test`).