### PR TITLE
fix(reader-settings): add horizontal scroll to theme and reading-mode chip rows

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderSettingsSectionsTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ReaderSettingsSectionsTest.kt
@@ -21,6 +21,7 @@ import com.riffle.app.feature.reader.cbz.ComicDisplaySection
 import com.riffle.app.feature.reader.formatting.RenderCapabilities
 import com.riffle.core.domain.AutoReaderThemeMode
 import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.comic.ComicFormattingPreferences
 import org.junit.Assert.assertFalse
@@ -137,6 +138,57 @@ class ReaderSettingsSectionsTest {
         composeTestRule.runOnIdle {
             assertFalse(updated!!.coloredChapterMap)
         }
+    }
+
+    @Test
+    fun displaySection_allReadingOrientationChipsAreClickable() {
+        var updated: FormattingPreferences? = null
+        composeTestRule.setContent {
+            DisplaySection(
+                prefs = FormattingPreferences().copy(orientation = ReaderOrientation.Horizontal),
+                onPrefsChange = { updated = it },
+                scheduleEditable = false,
+            )
+        }
+
+        // All three orientation chips must be reachable and produce the expected preference update.
+        // Regression: in locales with longer translations (e.g. Spanish "Continuo") the last chip
+        // was clipped/word-wrapped because the Row had no horizontal scroll.
+        composeTestRule.onNodeWithContentDescription("Paginated reading orientation").performClick()
+        composeTestRule.runOnIdle { assertEquals(ReaderOrientation.Horizontal, updated!!.orientation) }
+
+        composeTestRule.onNodeWithContentDescription("Scroll reading orientation").performClick()
+        composeTestRule.runOnIdle { assertEquals(ReaderOrientation.Vertical, updated!!.orientation) }
+
+        composeTestRule.onNodeWithContentDescription("Continuous reading orientation").performClick()
+        composeTestRule.runOnIdle { assertEquals(ReaderOrientation.Continuous, updated!!.orientation) }
+    }
+
+    @Test
+    fun displaySection_allConcreteThemeChipsAreClickable() {
+        var updated: FormattingPreferences? = null
+        composeTestRule.setContent {
+            DisplaySection(
+                prefs = FormattingPreferences().copy(theme = ReaderTheme.Light),
+                onPrefsChange = { updated = it },
+                scheduleEditable = false,
+            )
+        }
+
+        // All four concrete theme chips must be reachable and produce the expected preference update.
+        // Regression: in locales with longer translations (e.g. Spanish "Atenuado") the Sepia chip
+        // was squeezed to zero width because the Row had no horizontal scroll.
+        composeTestRule.onNodeWithContentDescription("Light theme").performClick()
+        composeTestRule.runOnIdle { assertEquals(ReaderTheme.Light, updated!!.theme) }
+
+        composeTestRule.onNodeWithContentDescription("Dark theme").performClick()
+        composeTestRule.runOnIdle { assertEquals(ReaderTheme.Dark, updated!!.theme) }
+
+        composeTestRule.onNodeWithContentDescription("Dim theme").performClick()
+        composeTestRule.runOnIdle { assertEquals(ReaderTheme.DarkDim, updated!!.theme) }
+
+        composeTestRule.onNodeWithContentDescription("Sepia theme").performClick()
+        composeTestRule.runOnIdle { assertEquals(ReaderTheme.Sepia, updated!!.theme) }
     }
 
     @Test

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/DisplaySection.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/DisplaySection.kt
@@ -1,8 +1,10 @@
 package com.riffle.app.feature.reader
 
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -89,7 +91,10 @@ fun DisplaySection(
         }
         if (capabilities.supportsReadingModeSwitch) {
             Text(stringResource(R.string.ui_reading_mode), style = MaterialTheme.typography.labelMedium)
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.horizontalScroll(rememberScrollState()),
+            ) {
                 ReaderOrientation.entries.forEach { orientation ->
                     val label = orientation.localizedLabel()
                     val orientationContentDescription = stringResource(R.string.ui_reading_orientation_named, label)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsControls.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ReaderSettingsControls.kt
@@ -6,7 +6,9 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -215,7 +217,10 @@ internal fun ThemeChipRows(
     labelForTheme: @Composable (ReaderTheme) -> String = { it.label() },
     contentDescriptionForTheme: @Composable (ReaderTheme, String) -> String = { _, label -> "$label theme" },
 ) {
-    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.horizontalScroll(rememberScrollState()),
+    ) {
         concreteThemes.forEach { theme ->
             val label = labelForTheme(theme)
             ThemeChip(


### PR DESCRIPTION
## Problem

In Spanish (and other locales with longer translations), the Display tab in reader settings showed two visual bugs:

- **"Sepia" theme chip** rendered with its label letters stacked vertically (S/e/p/i/a), because the 4-chip theme row overflowed and the chip was squeezed to near-zero width. Spanish "Atenuado" (DarkDim) is much longer than the English equivalent, pushing Sepia off the edge.
- **"Continuo" chip** (Continuous reading mode) wrapped mid-word as "Conti\nnuo" for the same reason.

## Root cause

Both chip groups are laid in a plain `Row` with no overflow handling. `FlowRow` cannot be used — there is an existing comment in `ReaderSettingsControls.kt` explaining that the compile-time and runtime Compose Foundation versions disagree on `FlowRow`'s signature and it throws `NoSuchMethodError` at runtime.

## Fix

Add `Modifier.horizontalScroll(rememberScrollState())` to:
- The concrete theme chips `Row` in `ThemeChipRows` (`ReaderSettingsControls.kt`)
- The reading orientation chips `Row` in `DisplaySection.kt`

This lets all chips render at their natural size and remain accessible via a horizontal swipe in any locale.

## Tests

Two new instrumentation tests in `ReaderSettingsSectionsTest`:
- `displaySection_allReadingOrientationChipsAreClickable` — verifies all three orientation chips produce the correct `FormattingPreferences` update when clicked.
- `displaySection_allConcreteThemeChipsAreClickable` — verifies all four concrete theme chips (including Sepia) produce the correct update.

Note: the overflow rendering itself can only be verified visually (no screenshot-test infrastructure). The tests pin the behavioral surface: if any chip becomes completely unreachable (clipped to zero bounds), its `performClick()` assertion will fail.