### PR TITLE
fix(comics): improve panel report outline readability

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportSheet.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
@@ -243,15 +244,10 @@ internal fun PanelReportSheet(
                         val orderPos = orderedIndexMap[i]
                         val isOrdered = orderPos != null
                         val selected = state.tappedPanelIndex == i
-                        drawRect(
-                            color = when {
-                                isOrdered -> Color(0xFFFF9800)
-                                selected -> Color.Red
-                                else -> Color.Blue
-                            },
+                        drawPanelReportOutline(
                             topLeft = Offset(p.x * scaleX, p.y * scaleY),
                             size = Size(p.width * scaleX, p.height * scaleY),
-                            style = Stroke(width = if (selected || isOrdered) 3f else 1.5f),
+                            style = panelReportOutlineStyle(selected = selected, ordered = isOrdered),
                         )
                         if (orderPos != null) {
                             drawIntoCanvas { canvas ->
@@ -357,4 +353,58 @@ internal fun PanelReportSheet(
             Spacer(Modifier.height(16.dp))
         }
     }
+}
+
+internal data class PanelReportOutlineStyle(
+    val haloColor: Color,
+    val haloWidth: Float,
+    val contrastColor: Color,
+    val contrastWidth: Float,
+    val foregroundColor: Color,
+    val foregroundWidth: Float,
+)
+
+internal fun panelReportOutlineStyle(
+    selected: Boolean,
+    ordered: Boolean,
+): PanelReportOutlineStyle {
+    val foreground = when {
+        ordered -> Color(0xFFFF9800)
+        selected -> Color.Red
+        else -> Color(0xFF00B8FF)
+    }
+    val foregroundWidth = if (selected || ordered) 3.5f else 2.75f
+    return PanelReportOutlineStyle(
+        haloColor = Color(0xE6000000),
+        haloWidth = foregroundWidth + 4f,
+        contrastColor = Color.White,
+        contrastWidth = foregroundWidth + 2f,
+        foregroundColor = foreground,
+        foregroundWidth = foregroundWidth,
+    )
+}
+
+private fun DrawScope.drawPanelReportOutline(
+    topLeft: Offset,
+    size: Size,
+    style: PanelReportOutlineStyle,
+) {
+    drawRect(
+        color = style.haloColor,
+        topLeft = topLeft,
+        size = size,
+        style = Stroke(width = style.haloWidth),
+    )
+    drawRect(
+        color = style.contrastColor,
+        topLeft = topLeft,
+        size = size,
+        style = Stroke(width = style.contrastWidth),
+    )
+    drawRect(
+        color = style.foregroundColor,
+        topLeft = topLeft,
+        size = size,
+        style = Stroke(width = style.foregroundWidth),
+    )
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportOutlineStyleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportOutlineStyleTest.kt
@@ -1,0 +1,29 @@
+package com.riffle.app.feature.reader.cbz
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PanelReportOutlineStyleTest {
+
+    @Test
+    fun `default detected panel outline uses readable layered strokes`() {
+        val style = panelReportOutlineStyle(selected = false, ordered = false)
+
+        assertNotEquals(Color.Blue, style.foregroundColor)
+        assertEquals(Color(0xFF00B8FF), style.foregroundColor)
+        assertEquals(Color(0xE6000000), style.haloColor)
+        assertEquals(Color.White, style.contrastColor)
+        assertTrue(style.foregroundWidth > 1.5f)
+        assertTrue(style.contrastWidth > style.foregroundWidth)
+        assertTrue(style.haloWidth > style.contrastWidth)
+    }
+
+    @Test
+    fun `selected and ordered outlines keep their semantic colors`() {
+        assertEquals(Color.Red, panelReportOutlineStyle(selected = true, ordered = false).foregroundColor)
+        assertEquals(Color(0xFFFF9800), panelReportOutlineStyle(selected = false, ordered = true).foregroundColor)
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the thin default detected-panel blue outline in the panel report preview with layered high-contrast strokes.
- Preserve selected and ordered panel semantic colors while giving every detected outline a dark halo and white contrast stroke.
- Add a JVM regression test for the outline style values.

## Tests
- `JAVA_HOME='/Applications/Android Studio.app/Contents/jbr/Contents/Home' ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :app:testDebugUnitTest --tests 'com.riffle.app.feature.reader.cbz.PanelReportOutlineStyleTest' --tests 'com.riffle.app.feature.reader.cbz.PanelReportViewModelTest'`\n- `git diff --check`\n\n## Regression assertions\n- `default detected panel outline uses readable layered strokes` would fail if the default foreground were reverted to `Color.Blue`, if the foreground stroke returned to the old 1.5px hairline, or if the dark/white contrast strokes were removed.\n- `selected and ordered outlines keep their semantic colors` would fail if selected red or ordered orange markers lost their existing meaning.\n