### PR TITLE
feat(ios): add Koin infrastructure alongside Hilt — entry points and build wiring

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -163,6 +163,12 @@ dependencies {
     implementation(libs.hilt.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
 
+    val koinBom = platform(libs.koin.bom)
+    implementation(koinBom)
+    implementation(libs.koin.android)
+    implementation(libs.koin.compose)
+    implementation(libs.koin.androidx.compose)
+
     implementation(libs.coil.compose)
     implementation(libs.okhttp)
 

--- a/app/src/androidTest/kotlin/com/riffle/app/HiltTestRunner.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/HiltTestRunner.kt
@@ -4,6 +4,9 @@ import android.app.Application
 import android.content.Context
 import androidx.test.runner.AndroidJUnitRunner
 import dagger.hilt.android.testing.HiltTestApplication
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.GlobalContext
+import org.koin.core.context.startKoin
 
 class HiltTestRunner : AndroidJUnitRunner() {
     override fun newApplication(
@@ -11,4 +14,18 @@ class HiltTestRunner : AndroidJUnitRunner() {
         className: String?,
         context: Context?,
     ): Application = super.newApplication(cl, HiltTestApplication::class.java.name, context)
+
+    override fun callApplicationOnCreate(app: Application) {
+        // HiltTestApplication skips RiffleApplication.onCreate, so the Koin graph that
+        // MainActivity's KoinAndroidContext resolves against is never started. Start it here
+        // with the production module list, mirroring RiffleApplication. getOrNull() guards
+        // against multi-run process reuse where Koin is already up.
+        if (GlobalContext.getOrNull() == null) {
+            startKoin {
+                androidContext(app)
+                modules(riffleKoinModules())
+            }
+        }
+        super.callApplicationOnCreate(app)
+    }
 }

--- a/app/src/main/kotlin/com/riffle/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/riffle/app/MainActivity.kt
@@ -45,6 +45,7 @@ import com.riffle.core.domain.appearance.AppearanceCoordinator
 import com.riffle.core.domain.appearance.ResolvedAppearance
 import androidx.compose.runtime.LaunchedEffect
 import dagger.hilt.android.AndroidEntryPoint
+import org.koin.androidx.compose.KoinAndroidContext
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -106,31 +107,36 @@ class MainActivity : FragmentActivity() {
         )
         handleIntent(intent)
         setContent {
-            // Feed reactive OS dark-mode toggles into the coordinator so its `resolved`
-            // StateFlow stays in step with the system theme without polling.
-            val systemDark = isSystemInDarkTheme()
-            LaunchedEffect(systemDark) { appearanceCoordinator.setSystemDark(systemDark) }
-            val appearance: ResolvedAppearance by appearanceCoordinator.resolved.collectAsState()
-            val isDark = appearance.appChrome.isDark
-            // Keep the transparent status-bar icon contrast in step with the chosen chrome theme,
-            // overriding the system-driven default from enableEdgeToEdge above (otherwise a forced
-            // Dark theme under a Light OS would render dark icons on the dark top app bar).
-            // The navigation bar always sits over our dark BottomNavBarScrim, so its icons must
-            // stay light regardless of theme — otherwise light-mode renders dark-on-dark and the
-            // gesture pill / 3-button nav vanishes.
-            val view = LocalView.current
-            SideEffect {
-                WindowCompat.getInsetsController(window, view).run {
-                    isAppearanceLightStatusBars = !isDark
-                    isAppearanceLightNavigationBars = false
+            // Koin and Hilt run side by side during the migration: composables converted to
+            // koinViewModel()/koinInject() resolve through this context while the rest still
+            // resolve through Hilt.
+            KoinAndroidContext {
+                // Feed reactive OS dark-mode toggles into the coordinator so its `resolved`
+                // StateFlow stays in step with the system theme without polling.
+                val systemDark = isSystemInDarkTheme()
+                LaunchedEffect(systemDark) { appearanceCoordinator.setSystemDark(systemDark) }
+                val appearance: ResolvedAppearance by appearanceCoordinator.resolved.collectAsState()
+                val isDark = appearance.appChrome.isDark
+                // Keep the transparent status-bar icon contrast in step with the chosen chrome theme,
+                // overriding the system-driven default from enableEdgeToEdge above (otherwise a forced
+                // Dark theme under a Light OS would render dark icons on the dark top app bar).
+                // The navigation bar always sits over our dark BottomNavBarScrim, so its icons must
+                // stay light regardless of theme — otherwise light-mode renders dark-on-dark and the
+                // gesture pill / 3-button nav vanishes.
+                val view = LocalView.current
+                SideEffect {
+                    WindowCompat.getInsetsController(window, view).run {
+                        isAppearanceLightStatusBars = !isDark
+                        isAppearanceLightNavigationBars = false
+                    }
                 }
-            }
-            RiffleTheme(darkTheme = isDark) {
-                @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
-                val windowSizeClass = calculateWindowSizeClass(this)
-                Box(Modifier.fillMaxSize()) {
-                    MainScreen(windowSizeClass = windowSizeClass)
-                    BottomNavBarScrim(modifier = Modifier.align(Alignment.BottomCenter))
+                RiffleTheme(darkTheme = isDark) {
+                    @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+                    val windowSizeClass = calculateWindowSizeClass(this)
+                    Box(Modifier.fillMaxSize()) {
+                        MainScreen(windowSizeClass = windowSizeClass)
+                        BottomNavBarScrim(modifier = Modifier.align(Alignment.BottomCenter))
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
+++ b/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
@@ -83,7 +83,7 @@ class RiffleApplication : Application(), ImageLoaderFactory {
         if (shouldSkipMainProcessStartup(ACRA.isACRASenderServiceProcess())) return
         startKoin {
             androidContext(this@RiffleApplication)
-            modules()
+            modules(riffleKoinModules())
         }
         val entryPoint = EntryPointAccessors.fromApplication(this, MigratorEntryPoint::class.java)
         val applicationScope = entryPoint.applicationScope()
@@ -183,6 +183,12 @@ class RiffleApplication : Application(), ImageLoaderFactory {
  * when we're the ACRA process.
  */
 internal fun shouldSkipMainProcessStartup(isAcraProcess: Boolean): Boolean = isAcraProcess
+
+/**
+ * The Koin module graph for the app. Empty while Hilt still owns every binding; the Hilt → Koin
+ * migration PRs move bindings here module by module until Hilt can be dropped entirely.
+ */
+internal fun riffleKoinModules(): List<org.koin.core.module.Module> = emptyList()
 
 /** 100 MB cap for the on-disk cover cache. */
 internal const val IMAGE_DISK_CACHE_MAX_BYTES = 100L * 1024 * 1024

--- a/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
+++ b/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
@@ -17,6 +17,8 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.HiltAndroidApp
 import dagger.hilt.components.SingletonComponent
+import org.koin.android.ext.koin.androidContext
+import org.koin.core.context.startKoin
 import org.acra.ACRA
 import org.acra.ReportField
 import org.acra.config.dialog
@@ -79,6 +81,10 @@ class RiffleApplication : Application(), ImageLoaderFactory {
     override fun onCreate() {
         super.onCreate()
         if (shouldSkipMainProcessStartup(ACRA.isACRASenderServiceProcess())) return
+        startKoin {
+            androidContext(this@RiffleApplication)
+            modules()
+        }
         val entryPoint = EntryPointAccessors.fromApplication(this, MigratorEntryPoint::class.java)
         val applicationScope = entryPoint.applicationScope()
         logger = entryPoint.logger()

--- a/app/src/test/kotlin/com/riffle/app/RiffleApplicationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/RiffleApplicationTest.kt
@@ -3,8 +3,23 @@ package com.riffle.app
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.koin.dsl.koinApplication
 
 class RiffleApplicationTest {
+
+    @Test
+    fun `riffleKoinModules produce a loadable Koin graph`() {
+        // Boots a Koin application with the exact module list RiffleApplication passes to
+        // startKoin. Fails on any definition-level error (duplicate binding, invalid module),
+        // which is the only validation Koin offers at startup after Hilt's compile-time
+        // graph checking is gone.
+        val koinApp = koinApplication { modules(riffleKoinModules()) }
+        try {
+            koinApp.createEagerInstances()
+        } finally {
+            koinApp.close()
+        }
+    }
 
     @Test
     fun `shouldSkipMainProcessStartup returns true for ACRA process`() {

--- a/app/src/test/kotlin/com/riffle/app/RiffleApplicationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/RiffleApplicationTest.kt
@@ -1,0 +1,18 @@
+package com.riffle.app
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RiffleApplicationTest {
+
+    @Test
+    fun `shouldSkipMainProcessStartup returns true for ACRA process`() {
+        assertTrue(shouldSkipMainProcessStartup(isAcraProcess = true))
+    }
+
+    @Test
+    fun `shouldSkipMainProcessStartup returns false for main process`() {
+        assertFalse(shouldSkipMainProcessStartup(isAcraProcess = false))
+    }
+}

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 kotlin {
     jvm()
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -54,6 +54,8 @@ dependencies {
     implementation(libs.androidx.security.crypto)
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
+    implementation(platform(libs.koin.bom))
+    implementation(libs.koin.android)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.okhttp)

--- a/core/database-api/build.gradle.kts
+++ b/core/database-api/build.gradle.kts
@@ -14,7 +14,6 @@ kotlin {
         }
     }
     jvm()
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -24,7 +24,6 @@ kotlin {
         }
     }
     jvm()
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 
@@ -55,7 +54,6 @@ kotlin {
 dependencies {
     add("kspAndroid", libs.androidx.room.compiler)
     add("kspJvm", libs.androidx.room.compiler)
-    add("kspIosX64", libs.androidx.room.compiler)
     add("kspIosArm64", libs.androidx.room.compiler)
     add("kspIosSimulatorArm64", libs.androidx.room.compiler)
 }

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 kotlin {
     jvm()
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/core/logging/build.gradle.kts
+++ b/core/logging/build.gradle.kts
@@ -23,6 +23,8 @@ dependencies {
     coreLibraryDesugaring(libs.desugar.jdk.libs)
 
     implementation(libs.hilt.android)
+    implementation(platform(libs.koin.bom))
+    implementation(libs.koin.android)
     implementation(libs.kotlinx.coroutines.core)
     ksp(libs.hilt.compiler)
 

--- a/core/models/build.gradle.kts
+++ b/core/models/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 kotlin {
     jvm()
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/core/net/build.gradle.kts
+++ b/core/net/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 kotlin {
     jvm()
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/core/sources/build.gradle.kts
+++ b/core/sources/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 kotlin {
     jvm()
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/core/sync/build.gradle.kts
+++ b/core/sync/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 kotlin {
     jvm()
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ navigation = "2.9.8"
 hiltNavigation = "1.4.0"
 security = "1.1.0"
 hilt = "2.60.1"
+koin = "4.0.2"
 acra = "5.13.1"
 # Pinned to latest (3.3.0). The readaloud highlight is now text-anchored so it's engine-independent
 # (Readium strips media-overlay spans regardless of version). Reflowable column defaults and decoration
@@ -78,6 +79,10 @@ androidx-security-crypto = { group = "androidx.security", name = "security-crypt
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
+koin-bom = { group = "io.insert-koin", name = "koin-bom", version.ref = "koin" }
+koin-android = { group = "io.insert-koin", name = "koin-android" }
+koin-compose = { group = "io.insert-koin", name = "koin-compose" }
+koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compose" }
 acra-core = { group = "ch.acra", name = "acra-core", version.ref = "acra" }
 acra-toast = { group = "ch.acra", name = "acra-toast", version.ref = "acra" }
 acra-dialog = { group = "ch.acra", name = "acra-dialog", version.ref = "acra" }


### PR DESCRIPTION
Closes #735

## What changed

First of the Hilt → Koin PRs (#735). Adds Koin 4.0.2 to the build and wires both Android entry points, so subsequent PRs (#736 ViewModels, #737 DI modules) can convert bindings incrementally.

- **Version catalogue**: `koin-bom`, `koin-android`, `koin-compose`, `koin-androidx-compose` (4.0.2).
- **`RiffleApplication`**: `startKoin { androidContext(...); modules(riffleKoinModules()) }` in `onCreate`. The module list is extracted to `riffleKoinModules()` (currently empty — bindings move there in #736/#737).
- **`MainActivity`**: Compose tree wrapped in `KoinAndroidContext`, so composables converted to `koinViewModel()`/`koinInject()` later resolve through the Koin graph.
- **`core:data` / `core:logging`**: Koin BOM + `koin-android` added alongside Hilt, per the issue's task list, ahead of their module conversion in #737.
- **`HiltTestRunner`**: starts Koin with the production module list — `HiltTestApplication` skips `RiffleApplication.onCreate`, so without this every harness test launching `MainActivity` would crash with "KoinApplication has not been started" at first composition.

## Deviation from the issue text

The issue says to *remove* the Hilt plugin/deps in this PR, but that is impossible in isolation: every `@Inject`/`@HiltViewModel` in the codebase still resolves through Hilt until #736/#737 land. This PR runs Koin **alongside** Hilt (nothing resolves differently yet); Hilt removal happens in #737 once no binding remains.

## Piggy-backed build fix

`build(kmp): drop iosX64 target` — the Dependabot bump of `androidx.sqlite:sqlite-bundled` to 2.7.0 (#811) broke KMP dependency resolution repo-wide because Google stopped publishing the iosX64 (Intel-Mac simulator) artifact from 2.7.0 onward (2.7.1/2.8.0 verified missing too). Removed `iosX64()` from the eight KMP modules; `iosArm64` and `iosSimulatorArm64` remain.

## Tests

- New: `RiffleApplicationTest.riffleKoinModules produce a loadable Koin graph` — boots a Koin application from the exact production module list; fails on any definition-level error, the only startup validation left once Hilt's compile-time graph checking is gone.
- Full JVM suite (`./gradlew test jvmTest`) green locally.