### PR TITLE
feat(cbz): pinch-to-zoom and double-tap zoom toggle in page reader

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -6,6 +6,7 @@ import android.util.LruCache
 import android.view.WindowManager
 import android.provider.Settings
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
@@ -50,6 +51,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -442,6 +444,8 @@ private fun CbzPage(
     var scale by remember(pageIndex) { mutableStateOf(1f) }
     var offsetX by remember(pageIndex) { mutableStateOf(0f) }
     var offsetY by remember(pageIndex) { mutableStateOf(0f) }
+    val scope = rememberCoroutineScope()
+    var zoomAnimJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
     val bitmap by produceState<Bitmap?>(initialValue = null, key1 = pageIndex, key2 = source) {
         value = withContext(Dispatchers.IO) {
             runCatching { decodeSampledBitmap(source, pageIndex, MAX_PAGE_DIMENSION) }.getOrNull()
@@ -454,10 +458,35 @@ private fun CbzPage(
             .fillMaxSize()
             .pointerInput(pageIndex) {
                 detectTapGestures(
-                    onDoubleTap = {
-                        scale = 1f
-                        offsetX = 0f
-                        offsetY = 0f
+                    onDoubleTap = { tapOffset ->
+                        zoomAnimJob?.cancel()
+                        if (scale > 1f) {
+                            val fromScale = scale
+                            val fromX = offsetX
+                            val fromY = offsetY
+                            zoomAnimJob = scope.launch {
+                                launch { animate(fromScale, 1f) { v, _ -> scale = v } }
+                                launch { animate(fromX, 0f) { v, _ -> offsetX = v } }
+                                animate(fromY, 0f) { v, _ -> offsetY = v }
+                            }
+                        } else {
+                            val targetScale = 2.5f
+                            val (tx, ty) = doubleTapZoomTranslation(
+                                tapX = tapOffset.x,
+                                tapY = tapOffset.y,
+                                containerWidth = size.width.toFloat(),
+                                containerHeight = size.height.toFloat(),
+                                targetScale = targetScale,
+                            )
+                            val fromScale = scale
+                            val fromX = offsetX
+                            val fromY = offsetY
+                            zoomAnimJob = scope.launch {
+                                launch { animate(fromScale, targetScale) { v, _ -> scale = v } }
+                                launch { animate(fromX, tx) { v, _ -> offsetX = v } }
+                                animate(fromY, ty) { v, _ -> offsetY = v }
+                            }
+                        }
                     },
                     onTap = { pos ->
                         val third = size.width / 3f
@@ -478,6 +507,7 @@ private fun CbzPage(
                         val pointerCount = event.changes.count { it.pressed }
                         when (cbzPageGestureAction(pointerCount, scale)) {
                             CbzPageGestureAction.Zoom -> {
+                                zoomAnimJob?.cancel()
                                 val zoom = event.calculateZoom()
                                 val pan = event.calculatePan()
                                 scale = (scale * zoom).coerceIn(1f, 5f)
@@ -491,6 +521,7 @@ private fun CbzPage(
                                 event.changes.forEach { it.consume() }
                             }
                             CbzPageGestureAction.PanZoomed -> {
+                                zoomAnimJob?.cancel()
                                 val pan = event.calculatePan()
                                 offsetX += pan.x
                                 offsetY += pan.y
@@ -749,6 +780,24 @@ internal fun decodeSampledBitmap(source: CbzImageSource, pageIndex: Int, maxDime
     }
     return null
 }
+
+/**
+ * Returns the graphicsLayer (translationX, translationY) that keeps the tapped pixel
+ * stationary after scaling by [targetScale] around the composable center.
+ *
+ * graphicsLayer scales around center, so a point (tapX, tapY) moves to
+ *   center + (tapX - center) * targetScale + translation
+ * Setting that equal to tapX gives: translation = (tapX - center) * (1 - targetScale).
+ */
+internal fun doubleTapZoomTranslation(
+    tapX: Float,
+    tapY: Float,
+    containerWidth: Float,
+    containerHeight: Float,
+    targetScale: Float,
+): Pair<Float, Float> =
+    (tapX - containerWidth / 2f) * (1f - targetScale) to
+    (tapY - containerHeight / 2f) * (1f - targetScale)
 
 /**
  * Decides how the per-page pointer handler should react to an event.

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/DoubleTapZoomTranslationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/DoubleTapZoomTranslationTest.kt
@@ -1,0 +1,50 @@
+package com.riffle.app.feature.reader.cbz
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the double-tap zoom translation math.
+ *
+ * When the user double-taps at position (tapX, tapY), the graphicsLayer translation
+ * must shift the image so that the tapped pixel stays under the finger after scaling.
+ * The scale pivot is the center of the composable, so the required offsets are:
+ *
+ *   tx = (tapX - containerWidth/2)  * (1 - targetScale)
+ *   ty = (tapY - containerHeight/2) * (1 - targetScale)
+ *
+ * If doubleTapZoomTranslation is ever reverted or the formula changed, these assertions
+ * flip red.
+ */
+class DoubleTapZoomTranslationTest {
+
+    @Test
+    fun tap_at_center_produces_no_translation() {
+        val (tx, ty) = doubleTapZoomTranslation(500f, 1000f, 1000f, 2000f, 2.5f)
+        assertEquals(0f, tx, 0.001f)
+        assertEquals(0f, ty, 0.001f)
+    }
+
+    @Test
+    fun tap_at_top_left_shifts_image_down_and_right() {
+        // (0 - 500) * (1 - 2) = 500,  (0 - 1000) * (1 - 2) = 1000
+        val (tx, ty) = doubleTapZoomTranslation(0f, 0f, 1000f, 2000f, 2f)
+        assertEquals(500f, tx, 0.001f)
+        assertEquals(1000f, ty, 0.001f)
+    }
+
+    @Test
+    fun tap_at_bottom_right_shifts_image_up_and_left() {
+        // (1000 - 500) * (1 - 2) = -500,  (2000 - 1000) * (1 - 2) = -1000
+        val (tx, ty) = doubleTapZoomTranslation(1000f, 2000f, 1000f, 2000f, 2f)
+        assertEquals(-500f, tx, 0.001f)
+        assertEquals(-1000f, ty, 0.001f)
+    }
+
+    @Test
+    fun scale_1x_produces_no_translation_regardless_of_tap() {
+        val (tx, ty) = doubleTapZoomTranslation(100f, 300f, 1000f, 2000f, 1f)
+        assertEquals(0f, tx, 0.001f)
+        assertEquals(0f, ty, 0.001f)
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,6 @@ org.gradle.parallel=true
 android.useAndroidX=true
 kotlin.code.style=official
 ksp.useKSP2=true
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
## Summary

- Double-tap on a comic page zooms to 2.5× centred on the tap point (animated). A second double-tap restores to 1× (also animated).
- Any pinch gesture immediately cancels an in-flight double-tap animation and takes over, so pinch-to-zoom and pan continue to work exactly as before.
- `CbzPanelViewer` (guided panel mode) is unaffected — it manages its own zoom model via `PanelFitTransform`.

## Changes

- `CbzReaderScreen.kt` — `onDoubleTap` now toggles zoom-in/zoom-out using `animate()` coroutines that write back to the existing `mutableStateOf` state vars. A `zoomAnimJob` ref lets pinch/pan cancel any running animation. New internal function `doubleTapZoomTranslation()` holds the graphicsLayer offset math.
- `DoubleTapZoomTranslationTest.kt` — 4 unit tests covering centre tap (no shift), top-left tap (shifts right+down), bottom-right tap (shifts left+up), and 1× target scale (no shift regardless of tap position).

Also includes an unrelated `gradle.properties` tweak (`org.gradle.tooling.parallel=true`) that was auto-added by the Gradle tooling during the build.

## Test plan

- [ ] Double-tap zooms in to ~2.5× centred on tap point (animated)
- [ ] Double-tap again restores to 1× (animated)
- [ ] Pinch-to-zoom still works; cancels any in-flight double-tap animation
- [ ] Single-finger swipe at scale=1× still turns pages
- [ ] Single-finger pan while zoomed in still works
- [ ] `DoubleTapZoomTranslationTest` — all 4 assertions green