### PR TITLE
fix(downloads): consistent spacing between cache settings options

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
@@ -212,8 +212,7 @@ private fun CacheSettingsDialog(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { onSelected(option) }
-                            .padding(vertical = 4.dp),
+                            .clickable { onSelected(option) },
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         RadioButton(

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,6 @@ org.gradle.parallel=true
 android.useAndroidX=true
 kotlin.code.style=official
 ksp.useKSP2=true
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
## Summary

- `CacheSettingsDialog` used both `Arrangement.spacedBy(4.dp)` on the `Column` and `.padding(vertical = 4.dp)` on each option `Row`, causing the gaps between options (12dp: 4dp spacedBy + 4dp bottom + 4dp top) to differ from the gap between the description text and the first option (8dp). On small screens where the dialog is narrow this inconsistency is especially visible.
- Fix: remove the redundant `.padding(vertical = 4.dp)` from the option `Row` so `Arrangement.spacedBy(4.dp)` is the sole spacing source — consistent 4dp between all items. `RadioButton` manages its own 48dp min touch target size internally, so tap area is unchanged.

Also includes a `gradle.properties` addition enabling `org.gradle.tooling.parallel` for Gradle 9.4+ parallel sync.

## Test plan

- [ ] Open Downloads screen → tap "Cache settings" → verify spacing between options is even on a small-screen device or compact-window emulator
- [ ] Verify radio button tap targets still work correctly