### PR TITLE
fix(reader): elided view inherits global display prefs; full-book and elided book overrides share one DB row

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -69,7 +69,6 @@ import com.riffle.app.feature.reader.highlights.HighlightsPdfExporter
 import com.riffle.app.feature.reader.highlights.HighlightsPublicationFactory
 import com.riffle.app.feature.reader.highlights.ReaderSource
 import com.riffle.app.feature.reader.highlights.realCapturedFontOrNull
-import com.riffle.app.feature.reader.highlights.toFormattingScope
 import com.riffle.core.logging.LogChannel
 import com.riffle.core.logging.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -681,7 +680,7 @@ class EpubReaderViewModel @Inject constructor(
         val previous = _screenDimensionBucket.value
         _screenDimensionBucket.value = bucket
         if (previous != null && previous != bucket) {
-            formatting.bindToBook(itemId, source.toFormattingScope(), bucket)
+            formatting.bindToBook(itemId, bucket)
         }
     }
 
@@ -1156,7 +1155,7 @@ class EpubReaderViewModel @Inject constructor(
             // time first() returned and now. setScreenDimensionBucket only calls bindToBook when
             // previous!=null, so the init coroutine must pick up the latest value here rather
             // than the stale one captured by first().
-            formatting.bindToBook(itemId, source.toFormattingScope(), checkNotNull(_screenDimensionBucket.value))
+            formatting.bindToBook(itemId, checkNotNull(_screenDimensionBucket.value))
             openBook()
         }
         // Readaloud start ⇒ stop Auto-Scroll (mutual exclusion, ADR 0044). Stop (not Pause):

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/ReaderSource.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/highlights/ReaderSource.kt
@@ -1,7 +1,5 @@
 package com.riffle.app.feature.reader.highlights
 
-import com.riffle.core.models.FormattingScope
-
 /**
  * Which content the reader is currently displaying.
  *
@@ -11,10 +9,3 @@ import com.riffle.core.models.FormattingScope
  * highlight, each rendered down to its highlighted passages and notes.
  */
 enum class ReaderSource { FullBook, Highlights }
-
-// Formatting-preferences chain to use for this reading context. The annotations reading view has
-// its own independent chain so tweaks there never leak into the full-book reader (and vice versa).
-fun ReaderSource.toFormattingScope(): FormattingScope = when (this) {
-    ReaderSource.FullBook -> FormattingScope.FullBook
-    ReaderSource.Highlights -> FormattingScope.Highlights
-}

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
@@ -5,7 +5,6 @@ import com.riffle.core.domain.BookFormattingOverrides
 import com.riffle.core.domain.BookFormattingPreferencesStore
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.FormattingPreferencesStoreProvider
-import com.riffle.core.models.FormattingScope
 import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.WakeLockPreferencesStore
@@ -27,7 +26,6 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -52,16 +50,6 @@ class FormattingSession @AssistedInject constructor(
     private val autoScrollController: AutoScrollController,
     private val appearanceCoordinator: AppearanceCoordinator,
 ) {
-
-    // The reading context this session is bound to. Flips only at bindToBook() time — highlights
-    // mode uses the Highlights scope's independent global store + per-book override chain, while
-    // the full-book reader uses the default FullBook chain. Emitted as a StateFlow so the init
-    // combine below can flatMapLatest into the correct global preferences source when the scope
-    // changes (e.g., process reuse across sessions).
-    private val _scope = MutableStateFlow(FormattingScope.FullBook)
-    // Snapshot for suspend paths (bindToBook, resetToGlobalDefaults) so they read the same scope
-    // the flow-driven state is using.
-    private val activeScope: FormattingScope get() = _scope.value
 
     @AssistedFactory
     interface Factory {
@@ -148,18 +136,12 @@ class FormattingSession @AssistedInject constructor(
         // book open so a session that wasn't cleanly torn down (process kill mid-scroll, then
         // restart into a different book) does not auto-start the new book mid-air.
         autoScrollController.dispatch(AutoScrollEvent.Stop)
-        // Keep effective prefs in sync with both global changes and override updates. flatMapLatest
-        // over `_scope` so the global source switches when the scope flips (e.g. entering the
-        // annotations reading view mid-process). The scope defaults to FullBook so the very first
-        // emission — before bindToBook() runs — mirrors the previous single-store behaviour.
+        // Keep effective prefs in sync with both global changes and override updates.
         scope.launch {
-            _scope
-                .flatMapLatest { scope ->
-                    combine(
-                        formattingPreferencesStoreProvider.store(scope).preferences,
-                        _bookOverrides,
-                    ) { global, overrides -> overrides.applyTo(global) to !overrides.isEmpty }
-                }
+            combine(
+                formattingPreferencesStoreProvider.store().preferences,
+                _bookOverrides,
+            ) { global, overrides -> overrides.applyTo(global) to !overrides.isEmpty }
                 .collect { (effective, hasOverrides) ->
                     _formattingPreferences.value = effective
                     _hasBookOverrides.value = hasOverrides
@@ -211,25 +193,23 @@ class FormattingSession @AssistedInject constructor(
      * Load book-specific overrides for the given screen-dimension bucket and mark prefs as ready.
      * Must be called before [effectiveFormattingPreferences] is consumed by the navigator. May be
      * re-called when the device dimension changes (fold/rotate) to switch to the new bucket's row.
-     * If no row exists for this (itemId, scope, dimension), global defaults are seeded as a dense
+     * If no row exists for this (itemId, dimension), global defaults are seeded as a dense
      * override row so the dimension's settings are independent going forward.
      */
     fun bindToBook(
         itemId: String,
-        scope: FormattingScope = FormattingScope.FullBook,
         dimension: ScreenDimensionBucket = ScreenDimensionBucket.PhonePortrait,
     ) {
         val alreadyReady = _formattingPreferencesReady.value
         bookId = itemId
         activeDimension = dimension
-        _scope.value = scope
         // Only reset the ready flag on the first bind. Re-binding for a dimension change leaves the
         // prior prefs visible while the new dimension's row loads — avoids a spinner flash on fold/rotate.
         if (!alreadyReady) _formattingPreferencesReady.value = false
         bindJob?.cancel()
         bindJob = this.scope.launch {
-            val existing = bookFormattingPreferencesStore.load(itemId, scope, dimension)
-            val global = formattingPreferencesStoreProvider.store(scope).preferences.first()
+            val existing = bookFormattingPreferencesStore.load(itemId, dimension)
+            val global = formattingPreferencesStoreProvider.store().preferences.first()
             val overrides = if (existing != null) {
                 existing
             } else {
@@ -250,7 +230,7 @@ class FormattingSession @AssistedInject constructor(
                     doublePageSpread = global.doublePageSpread,
                     justifyText = global.justifyText,
                 ).also { seed ->
-                    bookFormattingPreferencesStore.save(itemId, scope, dimension, seed)
+                    bookFormattingPreferencesStore.save(itemId, dimension, seed)
                 }
             }
             _bookOverrides.value = overrides
@@ -278,9 +258,8 @@ class FormattingSession @AssistedInject constructor(
         _bookOverrides.value = updated
         _formattingPreferences.value = prefs
         _hasBookOverrides.value = !updated.isEmpty
-        val boundScope = activeScope
         val boundDimension = activeDimension
-        scope.launch { bookFormattingPreferencesStore.save(itemId, boundScope, boundDimension, updated) }
+        scope.launch { bookFormattingPreferencesStore.save(itemId, boundDimension, updated) }
     }
 
     /**
@@ -290,18 +269,17 @@ class FormattingSession @AssistedInject constructor(
      * The VM calls this once per open book when the JS probe reports its Intl.Segmenter answer.
      */
     fun persistCadencePlatformSupported(supported: Boolean) {
-        scope.launch { formattingPreferencesStoreProvider.store(activeScope).setCadencePlatformSupported(supported) }
+        scope.launch { formattingPreferencesStoreProvider.store().setCadencePlatformSupported(supported) }
     }
 
     /** Clear book-level overrides for the current dimension, reverting to global formatting preferences. */
     fun resetToGlobalDefaults(itemId: String) {
-        val boundScope = activeScope
         val boundDimension = activeDimension
         scope.launch {
-            bookFormattingPreferencesStore.clear(itemId, boundScope, boundDimension)
+            bookFormattingPreferencesStore.clear(itemId, boundDimension)
             _bookOverrides.value = BookFormattingOverrides()
             _formattingPreferences.value =
-                formattingPreferencesStoreProvider.store(boundScope).preferences.first()
+                formattingPreferencesStoreProvider.store().preferences.first()
             _hasBookOverrides.value = false
         }
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/PdfReaderViewModelFormattingTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/PdfReaderViewModelFormattingTest.kt
@@ -7,7 +7,6 @@ import com.riffle.core.domain.BookFormattingPreferencesStore
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.FormattingPreferencesStoreProvider
-import com.riffle.core.models.FormattingScope
 import com.riffle.core.models.ScreenDimensionBucket
 import com.riffle.core.domain.ListeningPreferencesStore
 import com.riffle.core.domain.WakeLockPreferencesStore
@@ -48,17 +47,17 @@ class PdfReaderViewModelFormattingTest {
     }
 
     private class FakeBookFormattingPreferencesStore : BookFormattingPreferencesStore {
-        private val saved = mutableMapOf<Triple<String, FormattingScope, ScreenDimensionBucket>, BookFormattingOverrides>()
-        override suspend fun load(itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket): BookFormattingOverrides? =
-            saved[Triple(itemId, scope, dimension)]
-        override suspend fun save(itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket, overrides: BookFormattingOverrides) {
-            saved[Triple(itemId, scope, dimension)] = overrides
+        private val saved = mutableMapOf<Pair<String, ScreenDimensionBucket>, BookFormattingOverrides>()
+        override suspend fun load(itemId: String, dimension: ScreenDimensionBucket): BookFormattingOverrides? =
+            saved[itemId to dimension]
+        override suspend fun save(itemId: String, dimension: ScreenDimensionBucket, overrides: BookFormattingOverrides) {
+            saved[itemId to dimension] = overrides
         }
-        override suspend fun clear(itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket) {
-            saved.remove(Triple(itemId, scope, dimension))
+        override suspend fun clear(itemId: String, dimension: ScreenDimensionBucket) {
+            saved.remove(itemId to dimension)
         }
-        fun captured(itemId: String, scope: FormattingScope = FormattingScope.FullBook, dimension: ScreenDimensionBucket = ScreenDimensionBucket.PhonePortrait): BookFormattingOverrides? =
-            saved[Triple(itemId, scope, dimension)]
+        fun captured(itemId: String, dimension: ScreenDimensionBucket = ScreenDimensionBucket.PhonePortrait): BookFormattingOverrides? =
+            saved[itemId to dimension]
     }
 
     private class FakeWakeLockPreferencesStore : WakeLockPreferencesStore {
@@ -106,7 +105,7 @@ class PdfReaderViewModelFormattingTest {
             scope = scope,
             formattingPreferencesStoreProvider = object : FormattingPreferencesStoreProvider {
                 private val store = FakeFormattingPreferencesStore()
-                override fun store(scope: FormattingScope) = store
+                override fun store() = store
             },
             bookFormattingPreferencesStore = bookStore,
             wakeLockPreferencesStore = FakeWakeLockPreferencesStore(),

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
@@ -6,8 +6,8 @@ import com.riffle.core.domain.BookFormattingPreferencesStore
 import com.riffle.core.domain.FormattingPreferences
 import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.FormattingPreferencesStoreProvider
-import com.riffle.core.models.FormattingScope
 import com.riffle.core.domain.ListeningPreferencesStore
+import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.WakeLockPreferencesStore
 import com.riffle.core.domain.appearance.AppearanceCoordinator
@@ -51,29 +51,26 @@ class FormattingSessionTest {
     }
 
     private class FakeBookFormattingPreferencesStore : BookFormattingPreferencesStore {
-        // Keyed by (itemId, scope, dimension) so scope and dimension combinations stay independent.
-        val saved = mutableMapOf<Triple<String, FormattingScope, ScreenDimensionBucket>, BookFormattingOverrides>()
+        // Keyed by (itemId, dimension) — mirrors the real store's (sourceId, itemId, bucket) PK,
+        // minus the fixed sourceId which is an active-source concern outside the session layer.
+        val saved = mutableMapOf<Pair<String, ScreenDimensionBucket>, BookFormattingOverrides>()
         private var toReturn: BookFormattingOverrides? = null
         fun willReturn(o: BookFormattingOverrides?) { toReturn = o }
         override suspend fun load(
-            itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket,
-        ): BookFormattingOverrides? = saved[Triple(itemId, scope, dimension)] ?: toReturn
+            itemId: String, dimension: ScreenDimensionBucket,
+        ): BookFormattingOverrides? = saved[itemId to dimension] ?: toReturn
         override suspend fun save(
-            itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket, overrides: BookFormattingOverrides,
-        ) { saved[Triple(itemId, scope, dimension)] = overrides }
+            itemId: String, dimension: ScreenDimensionBucket, overrides: BookFormattingOverrides,
+        ) { saved[itemId to dimension] = overrides }
         override suspend fun clear(
-            itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket,
-        ) { saved.remove(Triple(itemId, scope, dimension)) }
+            itemId: String, dimension: ScreenDimensionBucket,
+        ) { saved.remove(itemId to dimension) }
     }
 
     private class FakeFormattingPreferencesStoreProvider(
-        private val fullBook: FormattingPreferencesStore,
-        private val highlights: FormattingPreferencesStore = fullBook,
+        private val store: FormattingPreferencesStore,
     ) : FormattingPreferencesStoreProvider {
-        override fun store(scope: FormattingScope): FormattingPreferencesStore = when (scope) {
-            FormattingScope.FullBook -> fullBook
-            FormattingScope.Highlights -> highlights
-        }
+        override fun store(): FormattingPreferencesStore = store
     }
 
     private class FakeWakeLockPreferencesStore : WakeLockPreferencesStore {
@@ -185,7 +182,7 @@ class FormattingSessionTest {
             session.bindToBook("item1")
             val newPrefs = FormattingPreferences(fontSize = 1.8f)
             session.updateFormatting("item1", newPrefs)
-            assertTrue(bookStore.saved.containsKey(Triple("item1", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)))
+            assertTrue(bookStore.saved.containsKey("item1" to ScreenDimensionBucket.PhonePortrait))
         } finally {
             scope.cancel()
         }
@@ -201,7 +198,7 @@ class FormattingSessionTest {
             assertTrue(session.hasBookOverrides.value)
             session.resetToGlobalDefaults("item1")
             assertFalse(session.hasBookOverrides.value)
-            assertFalse(bookStore.saved.containsKey(Triple("item1", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)))
+            assertFalse(bookStore.saved.containsKey("item1" to ScreenDimensionBucket.PhonePortrait))
         } finally {
             scope.cancel()
         }
@@ -343,8 +340,8 @@ class FormattingSessionTest {
     fun `bindToBook applies overrides for each book`() = runTest {
         val fakeGlobal = FakeFormattingPreferencesStore(FormattingPreferences(fontSize = 1.0f))
         val fakeBook = FakeBookFormattingPreferencesStore()
-        fakeBook.saved[Triple("book-a", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)] = BookFormattingOverrides(fontSize = 1.5f)
-        fakeBook.saved[Triple("book-b", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)] = BookFormattingOverrides(fontSize = 2.0f)
+        fakeBook.saved["book-a" to ScreenDimensionBucket.PhonePortrait] = BookFormattingOverrides(fontSize = 1.5f)
+        fakeBook.saved["book-b" to ScreenDimensionBucket.PhonePortrait] = BookFormattingOverrides(fontSize = 2.0f)
         val (session, _, _, _, _, scope) = makeEager(fakeGlobal = fakeGlobal, fakeBook = fakeBook)
         try {
             session.bindToBook("book-a")
@@ -509,15 +506,16 @@ class FormattingSessionTest {
         }
     }
 
-    // Scope isolation: binding with FormattingScope.Highlights routes both reads and writes to the
-    // highlights global store and to the (itemId, Highlights) per-book slot. Revert either half of
-    // the split (the DAO scope column, the FormattingSession's flatMapLatest over _scope, or the
-    // provider selection in bindToBook) and this pins that regression.
+    // Global inheritance: binding in the elided (annotations) view exposes the same global
+    // preferences store as the full-book reader because FormattingPreferencesStoreProviderImpl
+    // returns the shared store. A global continuous-mode setting is therefore visible in the
+    // elided view. The store-routing pin lives in FormattingPreferencesStoreProviderImplTest.
     @Test
-    fun `bindToBook Highlights reads global from Highlights store not FullBook`() = runTest {
-        val fullBook = FakeFormattingPreferencesStore(FormattingPreferences(fontSize = 1.0f))
-        val highlights = FakeFormattingPreferencesStore(FormattingPreferences(fontSize = 2.0f))
-        val provider = FakeFormattingPreferencesStoreProvider(fullBook, highlights)
+    fun `bindToBook Highlights exposes global prefs from the shared store`() = runTest {
+        val global = FakeFormattingPreferencesStore(
+            FormattingPreferences(orientation = ReaderOrientation.Continuous),
+        )
+        val provider = FakeFormattingPreferencesStoreProvider(global)
         val dispatcher = UnconfinedTestDispatcher()
         val autoScrollController = AutoScrollController.forTest(dispatcher)
         val sessionScope = kotlinx.coroutines.CoroutineScope(dispatcher)
@@ -531,11 +529,11 @@ class FormattingSessionTest {
             appearanceCoordinator = FakeAppearanceCoordinator(),
         )
         try {
-            session.bindToBook("item1", FormattingScope.Highlights)
+            session.bindToBook("item1")
             assertEquals(
-                "Highlights bind must expose the highlights global's fontSize, not FullBook's",
-                2.0f,
-                session.effectiveFormattingPreferences.value.fontSize,
+                "Highlights bind must expose the global store's orientation",
+                ReaderOrientation.Continuous,
+                session.effectiveFormattingPreferences.value.orientation,
             )
         } finally {
             autoScrollController.release()
@@ -544,17 +542,14 @@ class FormattingSessionTest {
     }
 
     @Test
-    fun `updateFormatting under Highlights writes to Highlights per-book slot`() = runTest {
-        val fullBook = FakeFormattingPreferencesStore()
-        val highlights = FakeFormattingPreferencesStore()
-        val provider = FakeFormattingPreferencesStoreProvider(fullBook, highlights)
+    fun `updateFormatting writes to the shared per-book slot`() = runTest {
         val bookStore = FakeBookFormattingPreferencesStore()
         val dispatcher = UnconfinedTestDispatcher()
         val autoScrollController = AutoScrollController.forTest(dispatcher)
         val sessionScope = kotlinx.coroutines.CoroutineScope(dispatcher)
         val session = FormattingSession(
             scope = sessionScope,
-            formattingPreferencesStoreProvider = provider,
+            formattingPreferencesStoreProvider = FakeFormattingPreferencesStoreProvider(FakeFormattingPreferencesStore()),
             bookFormattingPreferencesStore = bookStore,
             wakeLockPreferencesStore = FakeWakeLockPreferencesStore(),
             listeningPreferencesStore = FakeListeningPreferencesStore(),
@@ -562,16 +557,12 @@ class FormattingSessionTest {
             appearanceCoordinator = FakeAppearanceCoordinator(),
         )
         try {
-            session.bindToBook("book-x", FormattingScope.Highlights)
+            session.bindToBook("book-x")
             session.updateFormatting("book-x", FormattingPreferences(fontSize = 1.75f))
 
             assertTrue(
-                "Highlights write must land in the Highlights per-book slot",
-                bookStore.saved.containsKey(Triple("book-x", FormattingScope.Highlights, ScreenDimensionBucket.PhonePortrait)),
-            )
-            assertFalse(
-                "Highlights write must NOT leak into the FullBook per-book slot",
-                bookStore.saved.containsKey(Triple("book-x", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)),
+                "updateFormatting must persist to the shared per-book slot",
+                bookStore.saved.containsKey("book-x" to ScreenDimensionBucket.PhonePortrait),
             )
         } finally {
             autoScrollController.release()
@@ -620,9 +611,9 @@ class FormattingSessionTest {
         val fakeGlobal = FakeFormattingPreferencesStore(globalPrefs)
         val b = makeEager(fakeGlobal = fakeGlobal, fakeBook = fakeBook)
         try {
-            b.session.bindToBook("book1", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)
+            b.session.bindToBook("book1", ScreenDimensionBucket.PhonePortrait)
 
-            val seeded = fakeBook.saved[Triple("book1", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)]
+            val seeded = fakeBook.saved["book1" to ScreenDimensionBucket.PhonePortrait]
             assertNotNull(seeded)
             assertEquals(1.5f, seeded!!.fontSize)
             assertEquals(0.8f, seeded.margins)
@@ -638,12 +629,12 @@ class FormattingSessionTest {
         val dimA = ScreenDimensionBucket.of(SizeClass.Compact, SizeClass.Compact)
         val dimB = ScreenDimensionBucket.PhonePortrait
         try {
-            b.session.bindToBook("book1", FormattingScope.FullBook, dimA)
+            b.session.bindToBook("book1", dimA)
             b.session.updateFormatting("book1", b.session.formattingPreferences.value.copy(fontSize = 2.0f))
-            b.session.bindToBook("book1", FormattingScope.FullBook, dimB)
+            b.session.bindToBook("book1", dimB)
 
-            val dimARow = fakeBook.saved[Triple("book1", FormattingScope.FullBook, dimA)]
-            val dimBRow = fakeBook.saved[Triple("book1", FormattingScope.FullBook, dimB)]
+            val dimARow = fakeBook.saved["book1" to dimA]
+            val dimBRow = fakeBook.saved["book1" to dimB]
             assertNotNull(dimARow)
             assertNotNull(dimBRow)
             assertEquals(2.0f, dimARow!!.fontSize)
@@ -658,16 +649,16 @@ class FormattingSessionTest {
         val dimA = ScreenDimensionBucket.of(SizeClass.Compact, SizeClass.Compact)
         val dimB = ScreenDimensionBucket.PhonePortrait
         val fakeBook = FakeBookFormattingPreferencesStore().also { it.willReturn(null) }
-        fakeBook.saved[Triple("book1", FormattingScope.FullBook, dimA)] = BookFormattingOverrides(fontSize = 1.2f)
-        fakeBook.saved[Triple("book1", FormattingScope.FullBook, dimB)] = BookFormattingOverrides(fontSize = 1.8f)
+        fakeBook.saved["book1" to dimA] = BookFormattingOverrides(fontSize = 1.2f)
+        fakeBook.saved["book1" to dimB] = BookFormattingOverrides(fontSize = 1.8f)
 
         val b = makeEager(fakeBook = fakeBook)
         try {
-            b.session.bindToBook("book1", FormattingScope.FullBook, dimA)
+            b.session.bindToBook("book1", dimA)
             b.session.resetToGlobalDefaults("book1")
 
-            assertNull(fakeBook.saved[Triple("book1", FormattingScope.FullBook, dimA)])
-            assertNotNull(fakeBook.saved[Triple("book1", FormattingScope.FullBook, dimB)])
+            assertNull(fakeBook.saved["book1" to dimA])
+            assertNotNull(fakeBook.saved["book1" to dimB])
         } finally {
             b.sessionScope.cancel()
         }
@@ -682,12 +673,12 @@ class FormattingSessionTest {
         val b = makeEager(fakeBook = fakeBook)
         try {
             // Call bindToBook twice in quick succession — dimB must win.
-            b.session.bindToBook("book1", FormattingScope.FullBook, dimA)
-            b.session.bindToBook("book1", FormattingScope.FullBook, dimB)
+            b.session.bindToBook("book1", dimA)
+            b.session.bindToBook("book1", dimB)
 
             // activeDimension must reflect the last call's dimension so any subsequent
             // updateFormatting / resetToGlobalDefaults targets dimB, not dimA.
-            val seededB = fakeBook.saved[Triple("book1", FormattingScope.FullBook, dimB)]
+            val seededB = fakeBook.saved["book1" to dimB]
             assertNotNull("dimB row must be seeded by the winning bindToBook call", seededB)
         } finally {
             b.sessionScope.cancel()

--- a/core/data/src/main/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
@@ -4,7 +4,6 @@ import com.riffle.core.database.BookFormattingPreferencesDao
 import com.riffle.core.database.BookFormattingPreferencesEntity
 import com.riffle.core.domain.BookFormattingOverrides
 import com.riffle.core.domain.BookFormattingPreferencesStore
-import com.riffle.core.models.FormattingScope
 import com.riffle.core.models.ScreenDimensionBucket
 import com.riffle.core.domain.ReaderFontFamily
 import com.riffle.core.domain.ReaderOrientation
@@ -12,10 +11,10 @@ import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.SourceRepository
 import javax.inject.Inject
 
-// Formatting is per-device but keyed by (sourceId, itemId, scope, screenDimensionBucket) so two
-// Sources' colliding item ids don't share one row (ADR 0031), the annotations reading view keeps
-// a chain independent from the full-book reader, and each screen-size class has independent
-// settings for the same book.
+// Formatting is per-device, keyed by (sourceId, itemId, screenDimensionBucket). sourceId
+// prevents colliding item ids across Sources from sharing one row (ADR 0031); screenDimensionBucket
+// gives each screen-size class independent settings for the same book. Both the full-book reader
+// and the elided (annotations) reader share the same row.
 class BookFormattingPreferencesStoreImpl @Inject constructor(
     private val dao: BookFormattingPreferencesDao,
     private val sourceRepository: SourceRepository,
@@ -23,11 +22,10 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
 
     override suspend fun load(
         itemId: String,
-        scope: FormattingScope,
         dimension: ScreenDimensionBucket,
     ): BookFormattingOverrides? {
         val sourceId = sourceRepository.getActive()?.id ?: return null
-        val entity = dao.getByItemId(sourceId, itemId, scope.name, dimension.encode()) ?: return null
+        val entity = dao.getByItemId(sourceId, itemId, dimension.encode()) ?: return null
         return BookFormattingOverrides(
             fontSize = entity.fontSize,
             theme = entity.theme?.let { runCatching { ReaderTheme.valueOf(it) }.getOrNull() },
@@ -47,20 +45,18 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
 
     override suspend fun save(
         itemId: String,
-        scope: FormattingScope,
         dimension: ScreenDimensionBucket,
         overrides: BookFormattingOverrides,
     ) {
         val sourceId = sourceRepository.getActive()?.id ?: return
         if (overrides.isEmpty) {
-            dao.deleteByItemId(sourceId, itemId, scope.name, dimension.encode())
+            dao.deleteByItemId(sourceId, itemId, dimension.encode())
             return
         }
         dao.upsert(
             BookFormattingPreferencesEntity(
                 sourceId = sourceId,
                 itemId = itemId,
-                scope = scope.name,
                 screenDimensionBucket = dimension.encode(),
                 fontSize = overrides.fontSize,
                 theme = overrides.theme?.name,
@@ -81,10 +77,9 @@ class BookFormattingPreferencesStoreImpl @Inject constructor(
 
     override suspend fun clear(
         itemId: String,
-        scope: FormattingScope,
         dimension: ScreenDimensionBucket,
     ) {
         val sourceId = sourceRepository.getActive()?.id ?: return
-        dao.deleteByItemId(sourceId, itemId, scope.name, dimension.encode())
+        dao.deleteByItemId(sourceId, itemId, dimension.encode())
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreProviderImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/FormattingPreferencesStoreProviderImpl.kt
@@ -2,16 +2,11 @@ package com.riffle.core.data
 
 import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.FormattingPreferencesStoreProvider
-import com.riffle.core.models.FormattingScope
 
-// Selects the right global store instance for a reading context. Both instances are `Singleton` in
-// Hilt so calling this repeatedly is free — no per-call DataStore construction.
+// Returns the single global formatting-preferences store shared by all reading contexts. The
+// singleton is free to call repeatedly — no per-call DataStore construction.
 class FormattingPreferencesStoreProviderImpl(
     private val fullBook: FormattingPreferencesStore,
-    private val highlights: FormattingPreferencesStore,
 ) : FormattingPreferencesStoreProvider {
-    override fun store(scope: FormattingScope): FormattingPreferencesStore = when (scope) {
-        FormattingScope.FullBook -> fullBook
-        FormattingScope.Highlights -> highlights
-    }
+    override fun store(): FormattingPreferencesStore = fullBook
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/PreferencesModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/PreferencesModule.kt
@@ -69,7 +69,6 @@ import com.riffle.core.domain.ContentCacheSettingsStore
 import com.riffle.core.domain.CoverGridDensityStore
 import com.riffle.core.domain.FormattingPreferencesStore
 import com.riffle.core.domain.FormattingPreferencesStoreProvider
-import com.riffle.core.models.FormattingScope
 import com.riffle.core.domain.HighlightColorPreferencesStore
 import com.riffle.core.domain.HighlightsResumeStore
 import com.riffle.core.domain.LastOpenedLibraryStore
@@ -156,18 +155,15 @@ abstract class PreferencesModule {
         @Provides @Singleton @HighlightsFormattingPreferencesDataStore
         fun provideHighlightsFormattingPreferencesDataStore(@ApplicationContext c: Context): DataStore<Preferences> = c.formattingPreferencesHighlightsDataStore
 
-        // FormattingPreferencesStoreProvider gives [FormattingSession] the right global store per
-        // reading context. The unqualified [FormattingPreferencesStore] binding continues to point
-        // at the FullBook instance so consumers that don't care about scope (e.g. Settings) work
-        // unchanged; the Highlights instance is constructed here around its own DataStore file.
+        // FormattingPreferencesStoreProvider gives [FormattingSession] access to the global
+        // formatting-preferences store. Both the full-book reader and the elided (annotations)
+        // reader share the same store so display settings propagate to both views automatically.
         @Provides
         @Singleton
         fun provideFormattingPreferencesStoreProvider(
             fullBook: FormattingPreferencesStoreImpl,
-            @HighlightsFormattingPreferencesDataStore highlightsDs: DataStore<Preferences>,
         ): FormattingPreferencesStoreProvider = FormattingPreferencesStoreProviderImpl(
             fullBook = fullBook,
-            highlights = FormattingPreferencesStoreImpl(highlightsDs),
         )
 
         @Provides @Singleton @LibraryVisibilityPreferencesDataStore

--- a/core/data/src/test/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImplTest.kt
@@ -7,7 +7,6 @@ import com.riffle.core.domain.CommitSourceResult
 import com.riffle.core.domain.PendingSource
 import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.domain.SourceRepository
-import com.riffle.core.models.FormattingScope
 import com.riffle.core.models.ScreenDimensionBucket
 import com.riffle.core.models.ScreenDimensionBucket.SizeClass
 import com.riffle.core.models.ServerType
@@ -41,26 +40,26 @@ class BookFormattingPreferencesStoreImplTest {
         override suspend fun getSourceVersion(sourceId: String): String? = null
     }
 
-    private val capturedGetArgs = mutableListOf<Pair<String, String>>() // (scope, bucket)
+    private val capturedGetBuckets = mutableListOf<String>()
 
     private inner class FakeDao : BookFormattingPreferencesDao {
         var entityToReturn: BookFormattingPreferencesEntity? = null
         val upserted = mutableListOf<BookFormattingPreferencesEntity>()
-        val deleted = mutableListOf<Pair<String, String>>() // (scope, bucket)
+        val deletedBuckets = mutableListOf<String>()
 
         override suspend fun upsert(entity: BookFormattingPreferencesEntity) {
             upserted += entity
         }
         override suspend fun getByItemId(
-            sourceId: String, itemId: String, scope: String, screenDimensionBucket: String,
+            sourceId: String, itemId: String, screenDimensionBucket: String,
         ): BookFormattingPreferencesEntity? {
-            capturedGetArgs += scope to screenDimensionBucket
+            capturedGetBuckets += screenDimensionBucket
             return entityToReturn
         }
         override suspend fun deleteByItemId(
-            sourceId: String, itemId: String, scope: String, screenDimensionBucket: String,
+            sourceId: String, itemId: String, screenDimensionBucket: String,
         ) {
-            deleted += scope to screenDimensionBucket
+            deletedBuckets += screenDimensionBucket
         }
     }
 
@@ -70,10 +69,9 @@ class BookFormattingPreferencesStoreImplTest {
         val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(testSource))
         val bucket = ScreenDimensionBucket.of(SizeClass.Compact, SizeClass.Compact)
 
-        store.load("book1", FormattingScope.FullBook, bucket)
+        store.load("book1", bucket)
 
-        assertEquals("FullBook", capturedGetArgs.first().first)
-        assertEquals(bucket.encode(), capturedGetArgs.first().second)
+        assertEquals(bucket.encode(), capturedGetBuckets.first())
     }
 
     @Test
@@ -81,7 +79,7 @@ class BookFormattingPreferencesStoreImplTest {
         val dao = FakeDao().also { it.entityToReturn = null }
         val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(testSource))
 
-        val result = store.load("book1", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)
+        val result = store.load("book1", ScreenDimensionBucket.PhonePortrait)
 
         assertNull(result)
     }
@@ -93,7 +91,7 @@ class BookFormattingPreferencesStoreImplTest {
         val bucket = ScreenDimensionBucket.of(SizeClass.Medium, SizeClass.Expanded)
         val overrides = BookFormattingOverrides(theme = ReaderTheme.Dark)
 
-        store.save("book1", FormattingScope.FullBook, bucket, overrides)
+        store.save("book1", bucket, overrides)
 
         assertEquals(1, dao.upserted.size)
         assertEquals(bucket.encode(), dao.upserted.first().screenDimensionBucket)
@@ -106,10 +104,10 @@ class BookFormattingPreferencesStoreImplTest {
         val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(testSource))
         val bucket = ScreenDimensionBucket.of(SizeClass.Expanded, SizeClass.Compact)
 
-        store.clear("book1", FormattingScope.FullBook, bucket)
+        store.clear("book1", bucket)
 
-        assertEquals(1, dao.deleted.size)
-        assertEquals(bucket.encode(), dao.deleted.first().second)
+        assertEquals(1, dao.deletedBuckets.size)
+        assertEquals(bucket.encode(), dao.deletedBuckets.first())
     }
 
     @Test
@@ -117,7 +115,7 @@ class BookFormattingPreferencesStoreImplTest {
         val dao = FakeDao()
         val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(null))
 
-        val result = store.load("book1", FormattingScope.FullBook, ScreenDimensionBucket.PhonePortrait)
+        val result = store.load("book1", ScreenDimensionBucket.PhonePortrait)
 
         assertNull(result)
     }

--- a/core/data/src/test/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreScopeIsolationTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreScopeIsolationTest.kt
@@ -5,12 +5,12 @@ import com.riffle.core.database.BookFormattingPreferencesEntity
 import com.riffle.core.domain.AuthenticateResult
 import com.riffle.core.domain.BookFormattingOverrides
 import com.riffle.core.domain.CommitSourceResult
-import com.riffle.core.models.FormattingScope
-import com.riffle.core.domain.PendingSource
 import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.models.ScreenDimensionBucket
+import com.riffle.core.models.ScreenDimensionBucket.SizeClass
 import com.riffle.core.models.ServerType
 import com.riffle.core.models.Source
+import com.riffle.core.domain.PendingSource
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceUrl
 import kotlinx.coroutines.flow.Flow
@@ -21,33 +21,40 @@ import org.junit.Assert.assertNull
 import org.junit.Test
 
 /**
- * Regression pins for the annotations-view separate-preferences change: a save under one
- * [FormattingScope] must not leak into a read under the other scope for the same book, and clear
- * must be scope-scoped. Revert the DAO's `scope` PK column or the [BookFormattingPreferencesStoreImpl]
- * threading of `scope.name` into DAO calls and these assertions flip red.
+ * Regression pins for the book-formatting-preferences key shape. Both the full-book reader and
+ * the elided (annotations) reader share one row per (sourceId, itemId, screenDimensionBucket),
+ * and each screenDimensionBucket gets an independent row.
+ *
+ * Removed-test: save under FullBook does not affect read under Highlights
+ * Removed-test: save under Highlights does not affect read under FullBook
+ * Removed-test: both scopes hold independent values for the same book
+ * Removed-test: clear only removes the targeted scope
+ *
+ * Behaviour retired: per-scope isolation in the book-preferences store no longer exists; the
+ * full-book reader and elided reader share one row so per-book customisations propagate to both.
+ * The separate FormattingScope-keyed store was added in migration 44→45 and removed in 70→71.
  */
 class BookFormattingPreferencesStoreScopeIsolationTest {
 
     private val dim = ScreenDimensionBucket.PhonePortrait
+    private val dimLandscape = ScreenDimensionBucket.of(SizeClass.Compact, SizeClass.Compact)
 
     private class InMemoryDao : BookFormattingPreferencesDao {
         val rows = mutableMapOf<Triple<String, String, String>, BookFormattingPreferencesEntity>()
         override suspend fun upsert(entity: BookFormattingPreferencesEntity) {
-            rows[Triple("${entity.sourceId}|${entity.scope}", entity.itemId, entity.screenDimensionBucket)] = entity
+            rows[Triple(entity.sourceId, entity.itemId, entity.screenDimensionBucket)] = entity
         }
         override suspend fun getByItemId(
             sourceId: String,
             itemId: String,
-            scope: String,
             screenDimensionBucket: String,
-        ): BookFormattingPreferencesEntity? = rows[Triple("$sourceId|$scope", itemId, screenDimensionBucket)]
+        ): BookFormattingPreferencesEntity? = rows[Triple(sourceId, itemId, screenDimensionBucket)]
         override suspend fun deleteByItemId(
             sourceId: String,
             itemId: String,
-            scope: String,
             screenDimensionBucket: String,
         ) {
-            rows.remove(Triple("$sourceId|$scope", itemId, screenDimensionBucket))
+            rows.remove(Triple(sourceId, itemId, screenDimensionBucket))
         }
     }
 
@@ -80,79 +87,53 @@ class BookFormattingPreferencesStoreScopeIsolationTest {
     )
 
     @Test
-    fun `save under FullBook does not affect read under Highlights`() = runTest {
+    fun `override round-trips for a book`() = runTest {
         val store = newStore()
-        store.save("item-1", FormattingScope.FullBook, dim, BookFormattingOverrides(fontSize = 2.0f))
-
-        assertEquals(
-            "FullBook read must return what FullBook wrote",
-            2.0f,
-            store.load("item-1", FormattingScope.FullBook, dim)?.fontSize,
-        )
-        assertNull(
-            "Highlights read must not see FullBook's write",
-            store.load("item-1", FormattingScope.Highlights, dim)?.fontSize,
-        )
-    }
-
-    @Test
-    fun `save under Highlights does not affect read under FullBook`() = runTest {
-        val store = newStore()
-        store.save("item-1", FormattingScope.Highlights, dim, BookFormattingOverrides(theme = ReaderTheme.Dark))
+        store.save("item-1", dim, BookFormattingOverrides(theme = ReaderTheme.Dark))
 
         assertEquals(
             ReaderTheme.Dark,
-            store.load("item-1", FormattingScope.Highlights, dim)?.theme,
+            store.load("item-1", dim)?.theme,
         )
+    }
+
+    @Test
+    fun `portrait and landscape dimensions hold independent values for the same book`() = runTest {
+        val store = newStore()
+        store.save("item-1", dim, BookFormattingOverrides(fontSize = 1.4f))
+        store.save("item-1", dimLandscape, BookFormattingOverrides(fontSize = 1.8f))
+
+        assertEquals(1.4f, store.load("item-1", dim)?.fontSize)
+        assertEquals(1.8f, store.load("item-1", dimLandscape)?.fontSize)
+    }
+
+    @Test
+    fun `clear removes the row for the targeted dimension only`() = runTest {
+        val store = newStore()
+        store.save("item-1", dim, BookFormattingOverrides(fontSize = 1.4f))
+        store.save("item-1", dimLandscape, BookFormattingOverrides(fontSize = 1.8f))
+
+        store.clear("item-1", dim)
+
         assertNull(
-            "FullBook read must not see Highlights' write",
-            store.load("item-1", FormattingScope.FullBook, dim)?.theme,
+            "Portrait value must be gone after a portrait-scoped clear",
+            store.load("item-1", dim)?.fontSize,
         )
-    }
-
-    @Test
-    fun `both scopes hold independent values for the same book`() = runTest {
-        val store = newStore()
-        store.save("item-1", FormattingScope.FullBook, dim, BookFormattingOverrides(fontSize = 1.4f))
-        store.save("item-1", FormattingScope.Highlights, dim, BookFormattingOverrides(fontSize = 1.8f))
-
-        assertEquals(1.4f, store.load("item-1", FormattingScope.FullBook, dim)?.fontSize)
-        assertEquals(1.8f, store.load("item-1", FormattingScope.Highlights, dim)?.fontSize)
-    }
-
-    @Test
-    fun `clear only removes the targeted scope`() = runTest {
-        val store = newStore()
-        store.save("item-1", FormattingScope.FullBook, dim, BookFormattingOverrides(fontSize = 1.4f))
-        store.save("item-1", FormattingScope.Highlights, dim, BookFormattingOverrides(fontSize = 1.8f))
-
-        store.clear("item-1", FormattingScope.Highlights, dim)
-
         assertEquals(
-            "FullBook value must survive a Highlights-scoped clear",
-            1.4f,
-            store.load("item-1", FormattingScope.FullBook, dim)?.fontSize,
-        )
-        assertNull(
-            "Highlights value must be gone after a Highlights-scoped clear",
-            store.load("item-1", FormattingScope.Highlights, dim)?.fontSize,
+            "Landscape value must survive a portrait-scoped clear",
+            1.8f,
+            store.load("item-1", dimLandscape)?.fontSize,
         )
     }
 
     @Test
     fun `colored chapter map override round-trips for a book`() = runTest {
         val store = newStore()
-
-        store.save(
-            "item-1",
-            FormattingScope.FullBook,
-            dim,
-            BookFormattingOverrides(coloredChapterMap = false),
-        )
+        store.save("item-1", dim, BookFormattingOverrides(coloredChapterMap = false))
 
         assertEquals(
             false,
-            store.load("item-1", FormattingScope.FullBook, dim)?.coloredChapterMap,
+            store.load("item-1", dim)?.coloredChapterMap,
         )
     }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/FormattingPreferencesStoreProviderImplTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/FormattingPreferencesStoreProviderImplTest.kt
@@ -1,0 +1,33 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.FormattingPreferences
+import com.riffle.core.domain.FormattingPreferencesStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+/**
+ * Pins that FormattingPreferencesStoreProviderImpl returns the same store instance every time
+ * so that the elided (annotations) view shares reading-mode and theme with the full-book reader.
+ * Revert to a multi-instance provider and this assertion flips red.
+ */
+class FormattingPreferencesStoreProviderImplTest {
+
+    private class StubStore : FormattingPreferencesStore {
+        override val preferences: Flow<FormattingPreferences> = MutableStateFlow(FormattingPreferences())
+        override suspend fun update(preferences: FormattingPreferences) = Unit
+        override suspend fun setCadencePlatformSupported(supported: Boolean) = Unit
+    }
+
+    @Test
+    fun `store returns the shared fullBook store instance`() {
+        val fullBook = StubStore()
+        val provider = FormattingPreferencesStoreProviderImpl(fullBook)
+        assertSame(
+            "store() must return the shared fullBook instance so global settings reach both reader modes",
+            fullBook,
+            provider.store(),
+        )
+    }
+}

--- a/core/database-api/src/commonMain/kotlin/com/riffle/core/database/BookFormattingPreferencesDao.kt
+++ b/core/database-api/src/commonMain/kotlin/com/riffle/core/database/BookFormattingPreferencesDao.kt
@@ -13,25 +13,23 @@ interface BookFormattingPreferencesDao {
 
     @Query(
         "SELECT * FROM book_formatting_preferences " +
-            "WHERE sourceId = :sourceId AND itemId = :itemId AND scope = :scope " +
+            "WHERE sourceId = :sourceId AND itemId = :itemId " +
             "AND screenDimensionBucket = :screenDimensionBucket LIMIT 1"
     )
     suspend fun getByItemId(
         sourceId: String,
         itemId: String,
-        scope: String,
         screenDimensionBucket: String,
     ): BookFormattingPreferencesEntity?
 
     @Query(
         "DELETE FROM book_formatting_preferences " +
-            "WHERE sourceId = :sourceId AND itemId = :itemId AND scope = :scope " +
+            "WHERE sourceId = :sourceId AND itemId = :itemId " +
             "AND screenDimensionBucket = :screenDimensionBucket"
     )
     suspend fun deleteByItemId(
         sourceId: String,
         itemId: String,
-        scope: String,
         screenDimensionBucket: String,
     )
 }

--- a/core/database-api/src/commonMain/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt
+++ b/core/database-api/src/commonMain/kotlin/com/riffle/core/database/BookFormattingPreferencesEntity.kt
@@ -4,17 +4,16 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 
-// Formatting stays per-device (never synced, never per-user). The row must point at the *right*
-// book and the *right* reading context: once item ids collide across Sources, itemId alone would
-// let two different books share one formatting row (ADR 0029), and once the annotations reading
-// view got its own preferences chain, sourceId+itemId alone would let the annotations view and
-// full-book view collide on the same book. `sourceId` FK-cascades so a removed Source's
-// formatting is cleared. `scope` is the `FormattingScope` enum name ("FullBook" / "Highlights").
-// `screenDimensionBucket` is `ScreenDimensionBucket.encode()` — e.g. "Compact_Medium" — so each
-// screen-size class gets independent settings for the same book.
+// Formatting stays per-device (never synced, never per-user). Once item ids collide across
+// Sources, itemId alone would let two different books share one formatting row (ADR 0029), so
+// `sourceId` is part of the PK. `sourceId` FK-cascades so a removed Source's formatting is
+// cleared. `screenDimensionBucket` is `ScreenDimensionBucket.encode()` — e.g. "Compact_Medium"
+// — so each screen-size class gets independent settings for the same book. The full-book reader
+// and the elided (annotations) reader share the same row so per-book customisations propagate
+// to both views without duplication.
 @Entity(
     tableName = "book_formatting_preferences",
-    primaryKeys = ["sourceId", "itemId", "scope", "screenDimensionBucket"],
+    primaryKeys = ["sourceId", "itemId", "screenDimensionBucket"],
     foreignKeys = [
         ForeignKey(
             entity = SourceEntity::class,
@@ -28,7 +27,6 @@ import androidx.room.Index
 data class BookFormattingPreferencesEntity(
     val sourceId: String,
     val itemId: String,
-    val scope: String,
     val screenDimensionBucket: String,
     val fontSize: Float? = null,
     val theme: String? = null,

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/71.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/71.json
@@ -1,0 +1,2226 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 71,
+    "identityHash": "f054047ee1f2acbe60b1863c0c4379dd",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER NOT NULL, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, `pageCount` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesSequence",
+            "columnName": "seriesSequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `screenDimensionBucket` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `coloredChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `screenDimensionBucket`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "screenDimensionBucket",
+            "columnName": "screenDimensionBucket",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coloredChapterMap",
+            "columnName": "coloredChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "screenDimensionBucket"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, `originFontFamily` TEXT, `emphasisStyles` TEXT, `textSnippetHtml` TEXT, `fragmentAnchor` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedFigures",
+            "columnName": "embeddedFigures",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageHref",
+            "columnName": "imageHref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageSvg",
+            "columnName": "imageSvg",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBytes",
+            "columnName": "imageBytes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originFontFamily",
+            "columnName": "originFontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "emphasisStyles",
+            "columnName": "emphasisStyles",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippetHtml",
+            "columnName": "textSnippetHtml",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fragmentAnchor",
+            "columnName": "fragmentAnchor",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "local_files_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `treeUri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `addedAtEpochMs` INTEGER NOT NULL, `libraryId` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `treeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtEpochMs",
+            "columnName": "addedAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "treeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `originalUri` TEXT NOT NULL, `copiedPath` TEXT NOT NULL, `coverPath` TEXT, `format` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `mtimeEpochMs` INTEGER NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, `displayName` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUri",
+            "columnName": "originalUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "copiedPath",
+            "columnName": "copiedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtimeEpochMs",
+            "columnName": "mtimeEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_files_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_file_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `folderTreeUri` TEXT NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`, `folderTreeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderTreeUri",
+            "columnName": "folderTreeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId",
+            "folderTreeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_file_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_local_files_file_folders_sourceId_folderTreeUri",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "folderTreeUri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId_folderTreeUri` ON `${TABLE_NAME}` (`sourceId`, `folderTreeUri`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_file_metadata_overrides",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `title` TEXT, `author` TEXT, `seriesName` TEXT, `seriesIndex` REAL, `coverUrl` TEXT, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "seriesIndex",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_file_metadata_overrides_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_file_metadata_overrides_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_item_freshness",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `lastFetchedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFetchedAt",
+            "columnName": "lastFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `rootId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootId",
+            "columnName": "rootId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_playlists_rootId",
+            "unique": false,
+            "columnNames": [
+              "rootId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_rootId` ON `${TABLE_NAME}` (`rootId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `orderIndex` INTEGER NOT NULL, PRIMARY KEY(`playlistId`, `sourceId`, `itemId`), FOREIGN KEY(`sourceId`, `playlistId`) REFERENCES `playlists`(`sourceId`, `id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "orderIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId",
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_items_sourceId_playlistId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_items_sourceId_playlistId` ON `${TABLE_NAME}` (`sourceId`, `playlistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId",
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "sourceId",
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "publication_metrics_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `totalPositions` INTEGER, `pageCount` INTEGER, `cachedAt` INTEGER NOT NULL, `epubVersion` TEXT, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPositions",
+            "columnName": "totalPositions",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epubVersion",
+            "columnName": "epubVersion",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_publication_metrics_cache_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_publication_metrics_cache_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_comic_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`source_id` TEXT NOT NULL, `item_id` TEXT NOT NULL, `background_theme` TEXT, `panel_view_on` INTEGER, `panel_overflow` TEXT, `panel_animation_speed_ms` INTEGER, PRIMARY KEY(`source_id`, `item_id`), FOREIGN KEY(`source_id`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "source_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundTheme",
+            "columnName": "background_theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "panelViewOn",
+            "columnName": "panel_view_on",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "panelOverflow",
+            "columnName": "panel_overflow",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "panelAnimationSpeedMs",
+            "columnName": "panel_animation_speed_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "source_id",
+            "item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_comic_formatting_preferences_source_id",
+            "unique": false,
+            "columnNames": [
+              "source_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_comic_formatting_preferences_source_id` ON `${TABLE_NAME}` (`source_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "source_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "dictionary_packs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`languageTag` TEXT NOT NULL, `packVersion` TEXT NOT NULL, `installedAt` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `attributionHtml` TEXT NOT NULL, `licenseUrl` TEXT NOT NULL, `state` TEXT NOT NULL, PRIMARY KEY(`languageTag`))",
+        "fields": [
+          {
+            "fieldPath": "languageTag",
+            "columnName": "languageTag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packVersion",
+            "columnName": "packVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedAt",
+            "columnName": "installedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attributionHtml",
+            "columnName": "attributionHtml",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "licenseUrl",
+            "columnName": "licenseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "languageTag"
+          ]
+        }
+      },
+      {
+        "tableName": "lookup_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `languageTag` TEXT NOT NULL, `form` TEXT NOT NULL, `lookedUpAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "languageTag",
+            "columnName": "languageTag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "form",
+            "columnName": "form",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lookedUpAt",
+            "columnName": "lookedUpAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f054047ee1f2acbe60b1863c0c4379dd')"
+    ]
+  }
+}

--- a/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1991,6 +1991,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_67_68,
             RiffleDatabase.MIGRATION_68_69,
             RiffleDatabase.MIGRATION_69_70,
+            RiffleDatabase.MIGRATION_70_71,
         )
 
         db.query("SELECT url, username, serverType, absUserId, type FROM sources WHERE id = 's1'").use { cursor ->
@@ -3186,6 +3187,59 @@ class MigrationTest {
             db.query("SELECT COUNT(*) FROM book_formatting_preferences WHERE itemId = 'book1'").use { cursor ->
                 assertTrue(cursor.moveToFirst())
                 assertEquals(2, cursor.getInt(0))
+            }
+        }
+    }
+
+    @Test
+    fun migration70To71_dropsScopeColumnAndPreservesFullBookRows() {
+        helper.createDatabase(TEST_DB, 70).use { db ->
+            db.execSQL(
+                "INSERT INTO sources (id, url, isActive, insecureConnectionAllowed, username, serverType, absUserId, type) " +
+                    "VALUES ('src', 'http://test', 1, 0, '', 'AUDIOBOOKSHELF', NULL, 'ABS')"
+            )
+            // One FullBook row and one Highlights row for the same (sourceId, itemId, bucket).
+            db.execSQL(
+                "INSERT INTO book_formatting_preferences (sourceId, itemId, scope, screenDimensionBucket, fontSize, theme) " +
+                    "VALUES ('src', 'book1', 'FullBook', 'Compact_Medium', 1.5, 'Dark')"
+            )
+            db.execSQL(
+                "INSERT INTO book_formatting_preferences (sourceId, itemId, scope, screenDimensionBucket, fontSize, theme) " +
+                    "VALUES ('src', 'book1', 'Highlights', 'Compact_Medium', 1.2, 'Light')"
+            )
+            // A second FullBook row under a different dimension.
+            db.execSQL(
+                "INSERT INTO book_formatting_preferences (sourceId, itemId, scope, screenDimensionBucket, fontSize, theme) " +
+                    "VALUES ('src', 'book1', 'FullBook', 'Compact_Compact', 1.0, NULL)"
+            )
+        }
+
+        helper.runMigrationsAndValidate(
+            TEST_DB, 71, true, RiffleDatabase.MIGRATION_70_71
+        ).use { db ->
+            // Only the FullBook rows survive (via INSERT OR IGNORE); Highlights rows are dropped.
+            db.query("SELECT COUNT(*) FROM book_formatting_preferences").use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals(2, cursor.getInt(0))
+            }
+
+            // The FullBook row for Compact_Medium must carry its data through.
+            db.query(
+                "SELECT fontSize, theme FROM book_formatting_preferences WHERE itemId = 'book1' AND screenDimensionBucket = 'Compact_Medium'"
+            ).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals(1.5f, cursor.getFloat(0))
+                assertEquals("Dark", cursor.getString(1))
+            }
+
+            // The scope column must no longer exist: new inserts work without it.
+            db.execSQL(
+                "INSERT INTO book_formatting_preferences (sourceId, itemId, screenDimensionBucket, fontSize) " +
+                    "VALUES ('src', 'book2', 'Compact_Medium', 2.0)"
+            )
+            db.query("SELECT COUNT(*) FROM book_formatting_preferences WHERE itemId = 'book2'").use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals(1, cursor.getInt(0))
             }
         }
     }

--- a/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/SourceDaoDeleteGraphTest.kt
+++ b/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/SourceDaoDeleteGraphTest.kt
@@ -55,7 +55,7 @@ class SourceDaoDeleteGraphTest {
         sql("INSERT INTO libraries (id, name, mediaType, sourceId, isUnsupported) VALUES ('lib-1', 'Books', 'book', '$ABS_SOURCE_ID', 0)")
         sql("INSERT INTO library_items (sourceId, id, libraryId, title, author, coverUrl, readingProgress, ebookFormat, hasAudio, audioDurationSec, genres, addedAt) VALUES ('$ABS_SOURCE_ID', 'item-1', 'lib-1', 'Title', 'Author', NULL, 0.25, 'epub', 1, 123.0, '', 10)")
         sql("INSERT INTO reading_positions (sourceId, itemId, cfi, localUpdatedAt, lastSyncedAt) VALUES ('$ABS_SOURCE_ID', 'item-1', 'epubcfi(/6/4!/4/1:0)', 20, 10)")
-        sql("INSERT INTO book_formatting_preferences (sourceId, itemId, scope, screenDimensionBucket, fontSize) VALUES ('$ABS_SOURCE_ID', 'item-1', 'FullBook', 'Compact_Medium', 1.0)")
+        sql("INSERT INTO book_formatting_preferences (sourceId, itemId, screenDimensionBucket, fontSize) VALUES ('$ABS_SOURCE_ID', 'item-1', 'Compact_Medium', 1.0)")
         db.annotationDao().upsertAll(
             listOf(
                 AnnotationEntity(

--- a/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -44,7 +44,7 @@ import androidx.sqlite.execSQL
         DictionaryPackEntity::class,
         LookupHistoryEntity::class,
     ],
-    version = 70,
+    version = 71,
     exportSchema = true,
 )
 @ConstructedBy(RiffleDatabaseConstructor::class)
@@ -1821,6 +1821,50 @@ abstract class RiffleDatabase : RoomDatabase() {
                         "`justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, " +
                         "PRIMARY KEY(`sourceId`, `itemId`, `scope`, `screenDimensionBucket`), " +
                         "FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` " +
+                        "ON `book_formatting_preferences` (`sourceId`)"
+                )
+            }
+        }
+
+        // Remove `scope` from the per-book formatting-preferences PK. The full-book reader and the
+        // elided (annotations) reader now share one row per (sourceId, itemId, screenDimensionBucket)
+        // so per-book customisations (font size, margins, etc.) propagate to both views. Existing
+        // FullBook rows are kept as the authoritative per-book settings; any Highlights rows (which
+        // were written by a separate, now-removed preferences chain that had no settings UI) are
+        // discarded. WHERE scope = 'FullBook' ensures only one row per natural key is inserted; the
+        // INSERT OR IGNORE guard is belt-and-suspenders in case a device somehow has both scopes.
+        val MIGRATION_70_71 = object : Migration(70, 71) {
+            override fun migrate(db: SQLiteConnection) {
+                db.execSQL(
+                    "CREATE TABLE `book_formatting_preferences_new` " +
+                        "(`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, " +
+                        "`screenDimensionBucket` TEXT NOT NULL, " +
+                        "`fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, " +
+                        "`margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, " +
+                        "`coloredChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, " +
+                        "`showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, " +
+                        "`justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, " +
+                        "PRIMARY KEY(`sourceId`, `itemId`, `screenDimensionBucket`), " +
+                        "FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )"
+                )
+                db.execSQL(
+                    "INSERT OR IGNORE INTO `book_formatting_preferences_new` " +
+                        "(sourceId, itemId, screenDimensionBucket, fontSize, theme, fontFamily, " +
+                        "lineSpacing, margins, orientation, showChapterMap, coloredChapterMap, " +
+                        "showReadingProgressLabels, showCurrentChapterLabel, doublePageSpread, " +
+                        "justifyText, showReadingTimeEstimate) " +
+                        "SELECT sourceId, itemId, screenDimensionBucket, fontSize, theme, fontFamily, " +
+                        "lineSpacing, margins, orientation, showChapterMap, coloredChapterMap, " +
+                        "showReadingProgressLabels, showCurrentChapterLabel, doublePageSpread, " +
+                        "justifyText, showReadingTimeEstimate " +
+                        "FROM `book_formatting_preferences` WHERE scope = 'FullBook'"
+                )
+                db.execSQL("DROP TABLE `book_formatting_preferences`")
+                db.execSQL(
+                    "ALTER TABLE `book_formatting_preferences_new` RENAME TO `book_formatting_preferences`"
                 )
                 db.execSQL(
                     "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` " +

--- a/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabaseFactory.kt
+++ b/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabaseFactory.kt
@@ -119,4 +119,5 @@ internal val RIFFLE_DATABASE_MIGRATIONS: Array<Migration> = arrayOf(
     RiffleDatabase.MIGRATION_67_68,
     RiffleDatabase.MIGRATION_68_69,
     RiffleDatabase.MIGRATION_69_70,
+    RiffleDatabase.MIGRATION_70_71,
 )

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/BookFormattingPreferencesStore.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/BookFormattingPreferencesStore.kt
@@ -1,11 +1,10 @@
 package com.riffle.core.domain
 
-import com.riffle.core.models.FormattingScope
 import com.riffle.core.models.ScreenDimensionBucket
 
 interface BookFormattingPreferencesStore {
-    // Returns null if no row exists for this (itemId, scope, dimension) — caller is responsible for seeding.
-    suspend fun load(itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket): BookFormattingOverrides?
-    suspend fun save(itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket, overrides: BookFormattingOverrides)
-    suspend fun clear(itemId: String, scope: FormattingScope, dimension: ScreenDimensionBucket)
+    // Returns null if no row exists for this (itemId, dimension) — caller is responsible for seeding.
+    suspend fun load(itemId: String, dimension: ScreenDimensionBucket): BookFormattingOverrides?
+    suspend fun save(itemId: String, dimension: ScreenDimensionBucket, overrides: BookFormattingOverrides)
+    suspend fun clear(itemId: String, dimension: ScreenDimensionBucket)
 }

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/FormattingPreferencesStoreProvider.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/FormattingPreferencesStoreProvider.kt
@@ -1,10 +1,9 @@
 package com.riffle.core.domain
-import com.riffle.core.models.FormattingScope
 
-// Selects the global formatting-preferences store for a given reading context. Full-book and
-// highlights each get their own DataStore instance so their global defaults are independent.
-// Consumers that only ever want the full-book prefs (e.g. Settings screen) inject
+// Returns the single global formatting-preferences store. Both the full-book reader and the
+// elided (annotations) reader share the same global store so display settings propagate to both
+// views automatically. Consumers that only ever want global prefs (e.g. Settings screen) inject
 // [FormattingPreferencesStore] directly and don't need this provider.
 interface FormattingPreferencesStoreProvider {
-    fun store(scope: FormattingScope): FormattingPreferencesStore
+    fun store(): FormattingPreferencesStore
 }

--- a/core/models/src/commonMain/kotlin/com/riffle/core/models/FormattingScope.kt
+++ b/core/models/src/commonMain/kotlin/com/riffle/core/models/FormattingScope.kt
@@ -1,8 +1,0 @@
-package com.riffle.core.models
-
-// Identifies which reading context the formatting preferences belong to. The full-book reader and
-// the annotations-view reader each have their own independent prefs chain (global defaults +
-// per-book overrides), so a tweak in one context never leaks into the other. Enum name values are
-// used verbatim as the `source` PK column in `book_formatting_preferences`, so renaming is a DB
-// migration.
-enum class FormattingScope { FullBook, Highlights }


### PR DESCRIPTION
## Summary

- **Global preferences not inherited by elided view.** `FormattingPreferencesStoreProviderImpl` wired a separate DataStore for the `Highlights` scope that was never exposed in Settings. Both reading contexts now share a single no-arg `store()` returning the same `FormattingPreferencesStoreImpl`.

- **Per-book overrides siloed by scope (DB migration 70→71).** `BookFormattingPreferencesEntity` had `scope` as part of its composite PK, meaning per-book font/theme overrides set in the full-book reader were invisible in the elided reader (different rows). Migration 70→71 rebuilds the table without `scope`, preserving FullBook rows via `INSERT OR IGNORE`. Both reader modes now share one row per `(sourceId, itemId, screenDimensionBucket)`.

- **`FormattingScope` enum deleted end-to-end.** Removed from `core:models`, the domain interfaces (`FormattingPreferencesStoreProvider`, `BookFormattingPreferencesStore`), `FormattingSession.bindToBook()`, `EpubReaderViewModel`, and the `ReaderSource.toFormattingScope()` extension.

## Removed tests (behaviour retired)

| Test | Reason |
|---|---|
| `save under FullBook does not affect read under Highlights` | Scope isolation no longer exists |
| `save under Highlights does not affect read under FullBook` | Scope isolation no longer exists |
| `both scopes hold independent values for the same book` | Scope isolation no longer exists |
| `clear only removes the targeted scope` | Scope isolation no longer exists |
| `FullBook scope returns the fullBook store` | Single `store()` replaces scoped routing |
| `Highlights scope returns the same store as FullBook` | Single `store()` replaces scoped routing |

## Test plan

- [ ] `FormattingSessionTest` — global prefs shared, per-book slot writes confirmed
- [ ] `BookFormattingPreferencesStoreScopeIsolationTest` — dimension isolation still works; scope isolation tests retired with trailers
- [ ] `FormattingPreferencesStoreProviderImplTest` — `store()` returns the shared instance
- [ ] `BookFormattingPreferencesStoreImplTest` — DAO calls without scope param
- [ ] `MigrationTest.migration70To71_dropsScopeColumnAndPreservesFullBookRows` — migration preserves FullBook rows, discards Highlights rows, accepts scopeless inserts
- [ ] `MigrationTest.migrateFullChain` — full chain includes 70→71