### PR TITLE
feat(library): save cover grid scale per-library and per-screen-size

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/di/TestDatabaseModule.kt
@@ -3,6 +3,7 @@ package com.riffle.app.di
 import android.content.Context
 import com.riffle.core.data.di.DatabaseModule
 import com.riffle.core.database.AnnotationDao
+import com.riffle.core.database.CoverGridScaleDao
 import com.riffle.core.database.AudioPlaybackPreferencesDao
 import com.riffle.core.database.AudiobookBookmarkDao
 import com.riffle.core.database.AudiobookChapterCacheDao
@@ -170,4 +171,8 @@ object TestDatabaseModule {
     @Singleton
     fun provideLookupHistoryDao(db: RiffleDatabaseAccess): com.riffle.core.database.LookupHistoryDao =
         db.lookupHistoryDao()
+
+    @Provides
+    @Singleton
+    fun provideCoverGridScaleDao(db: RiffleDatabaseAccess): CoverGridScaleDao = db.coverGridScaleDao()
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -131,6 +131,8 @@ import kotlin.math.floor
 import kotlin.math.max
 import com.riffle.app.ui.DefaultCoverPlaceholder
 import com.riffle.app.ui.source.asAuthHeader
+import androidx.compose.material3.windowsizeclass.WindowSizeClass
+import com.riffle.app.ui.toScreenDimensionBucket
 
 
 /**
@@ -145,6 +147,7 @@ private fun coverAspectRatio(square: Boolean): Float = if (square) 1f else 2f / 
 @Composable
 fun LibraryItemsScreen(
     libraryName: String,
+    windowSizeClass: WindowSizeClass,
     onOpenDrawer: () -> Unit,
     onSeriesSelected: (Series) -> Unit,
     onCollectionSelected: (Collection) -> Unit,
@@ -206,6 +209,10 @@ fun LibraryItemsScreen(
     // tab, and the clamp would survive clearing the query.
     LaunchedEffect(tabVisibility, searchQuery) {
         if (shouldClampSelectedTab(searchQuery, tabVisibility, selectedTab)) selectedTab = 0
+    }
+
+    LaunchedEffect(windowSizeClass) {
+        viewModel.setScreenDimensionBucket(windowSizeClass.toScreenDimensionBucket())
     }
 
     // Drive the grids off a local live scale so a pinch reflows instantly; the

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.flowOf
@@ -80,14 +81,14 @@ class LibraryItemsViewModel @Inject constructor(
     private val _screenDimensionBucket = MutableStateFlow<ScreenDimensionBucket?>(null)
 
     /** User's persisted pinch-to-zoom multiplier for the cover grids (1.0 = defaults). */
-    val coverGridScale: StateFlow<Float> = combine(_activeSourceId, _screenDimensionBucket) { sid, bucket -> sid to bucket }
-        .flatMapLatest { (sourceId, bucket) ->
+    val coverGridScale: StateFlow<Float> = combine(_activeSourceId, _screenDimensionBucket) { sourceId, bucket ->
             if (sourceId != null && bucket != null) {
                 coverGridDensityStore.scale(sourceId, libraryId, bucket)
             } else {
                 coverGridDensityStore.scale
             }
         }
+        .flatMapLatest { it }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 1f)
 
     private var coverScalePersistJob: Job? = null
@@ -100,9 +101,9 @@ class LibraryItemsViewModel @Inject constructor(
         coverScalePersistJob?.cancel()
         coverScalePersistJob = viewModelScope.launch {
             delay(200)
-            val sourceId = _activeSourceId.value
+            val sourceId = _activeSourceId.filterNotNull().first()
             val bucket = _screenDimensionBucket.value
-            if (sourceId != null && bucket != null) {
+            if (bucket != null) {
                 coverGridDensityStore.setScale(sourceId, libraryId, bucket, value)
             } else {
                 coverGridDensityStore.setScale(value)

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import com.riffle.core.domain.AnnotationStore
 import com.riffle.core.domain.AudiobookBookmarkStore
 import com.riffle.core.models.Collection
+import com.riffle.core.models.ScreenDimensionBucket
 import com.riffle.core.domain.ConnectivityObserver
 import com.riffle.core.domain.collectReconnects
 import com.riffle.core.models.LibraryItem
@@ -75,8 +76,18 @@ class LibraryItemsViewModel @Inject constructor(
 
     val libraryId: String = savedStateHandle.get<String>("libraryId") ?: ""
 
+    private val _activeSourceId = MutableStateFlow<String?>(null)
+    private val _screenDimensionBucket = MutableStateFlow<ScreenDimensionBucket?>(null)
+
     /** User's persisted pinch-to-zoom multiplier for the cover grids (1.0 = defaults). */
-    val coverGridScale: StateFlow<Float> = coverGridDensityStore.scale
+    val coverGridScale: StateFlow<Float> = combine(_activeSourceId, _screenDimensionBucket) { sid, bucket -> sid to bucket }
+        .flatMapLatest { (sourceId, bucket) ->
+            if (sourceId != null && bucket != null) {
+                coverGridDensityStore.scale(sourceId, libraryId, bucket)
+            } else {
+                coverGridDensityStore.scale
+            }
+        }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 1f)
 
     private var coverScalePersistJob: Job? = null
@@ -89,8 +100,18 @@ class LibraryItemsViewModel @Inject constructor(
         coverScalePersistJob?.cancel()
         coverScalePersistJob = viewModelScope.launch {
             delay(200)
-            coverGridDensityStore.setScale(value)
+            val sourceId = _activeSourceId.value
+            val bucket = _screenDimensionBucket.value
+            if (sourceId != null && bucket != null) {
+                coverGridDensityStore.setScale(sourceId, libraryId, bucket, value)
+            } else {
+                coverGridDensityStore.setScale(value)
+            }
         }
+    }
+
+    fun setScreenDimensionBucket(bucket: ScreenDimensionBucket) {
+        _screenDimensionBucket.value = bucket
     }
 
     val series: StateFlow<List<Series>> = libraryObserver.observeSeries(libraryId)
@@ -347,6 +368,7 @@ class LibraryItemsViewModel @Inject constructor(
                 val prefsDeferred = async { libraryFilterPreferencesStore.preferences(source.id, libraryId).first() }
                 authToken = tokenDeferred.await()
                 libraryFilterSourceId = source.id
+                _activeSourceId.value = source.id
                 val prefs = prefsDeferred.await()
                 _notStartedFilterActive.value = prefs.notStartedFilterActive
                 _librarySortMode.value = prefs.sortModeName

--- a/app/src/main/kotlin/com/riffle/app/navigation/LibraryNavGraph.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/LibraryNavGraph.kt
@@ -83,6 +83,7 @@ internal fun NavGraphBuilder.libraryNavGraph(
         }
         LibraryItemsScreen(
             libraryName = libraryName,
+            windowSizeClass = windowSizeClass,
             onOpenDrawer = { scope.launch { drawerState.open() } },
             backEnabled = libBackEnabled,
             // Read the committed back stack synchronously at handler-fire time (not via

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -1650,4 +1650,76 @@ class LibraryItemsViewModelTest {
 
         assertTrue(refreshItems.calls > refreshBefore)
     }
+
+    // --- per-library cover grid scale ---
+
+    @Test
+    fun `coverGridScale uses per-library store once sourceId and bucket are available`() = runTest {
+        val bucket = com.riffle.core.models.ScreenDimensionBucket.PhonePortrait
+        val perLibraryFlow = MutableStateFlow(1.5f)
+        val store = object : com.riffle.core.domain.CoverGridDensityStore {
+            override val scale = kotlinx.coroutines.flow.flowOf(1f)
+            override suspend fun setScale(value: Float) {}
+            override fun scale(
+                sourceId: String, libraryId: String,
+                bucket: com.riffle.core.models.ScreenDimensionBucket,
+            ) = perLibraryFlow
+            override suspend fun setScale(
+                sourceId: String, libraryId: String,
+                bucket: com.riffle.core.models.ScreenDimensionBucket,
+                value: Float,
+            ) {}
+        }
+        val vm = makeViewModel(
+            coverGridDensityStore = store,
+            sourceRepository = fakeActiveSourceRepo("src-1"),
+        )
+        backgroundScope.launch { vm.coverGridScale.collect {} }
+        vm.setScreenDimensionBucket(bucket)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(1.5f, vm.coverGridScale.value)
+    }
+
+    @Test
+    fun `setCoverGridScale writes to per-library store when sourceId and bucket are set`() = runTest {
+        val bucket = com.riffle.core.models.ScreenDimensionBucket.PhonePortrait
+        var writtenSourceId: String? = null
+        var writtenLibraryId: String? = null
+        var writtenBucket: com.riffle.core.models.ScreenDimensionBucket? = null
+        var writtenValue: Float? = null
+        val store = object : com.riffle.core.domain.CoverGridDensityStore {
+            override val scale = kotlinx.coroutines.flow.flowOf(1f)
+            override suspend fun setScale(value: Float) {}
+            override fun scale(
+                sourceId: String, libraryId: String,
+                bucket: com.riffle.core.models.ScreenDimensionBucket,
+            ) = kotlinx.coroutines.flow.flowOf(1f)
+            override suspend fun setScale(
+                sourceId: String, libraryId: String,
+                bucket: com.riffle.core.models.ScreenDimensionBucket,
+                value: Float,
+            ) {
+                writtenSourceId = sourceId
+                writtenLibraryId = libraryId
+                writtenBucket = bucket
+                writtenValue = value
+            }
+        }
+        val vm = makeViewModel(
+            savedStateHandle = SavedStateHandle(mapOf("libraryId" to "lib-99")),
+            coverGridDensityStore = store,
+            sourceRepository = fakeActiveSourceRepo("src-1"),
+        )
+        vm.setScreenDimensionBucket(bucket)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.setCoverGridScale(1.2f)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("src-1", writtenSourceId)
+        assertEquals("lib-99", writtenLibraryId)
+        assertEquals(bucket, writtenBucket)
+        assertEquals(1.2f, writtenValue)
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -296,6 +296,15 @@ class LibraryItemsViewModelTest {
         coverGridDensityStore: com.riffle.core.domain.CoverGridDensityStore = object : com.riffle.core.domain.CoverGridDensityStore {
             override val scale = kotlinx.coroutines.flow.flowOf(1f)
             override suspend fun setScale(value: Float) {}
+            override fun scale(
+                sourceId: String, libraryId: String,
+                bucket: com.riffle.core.models.ScreenDimensionBucket,
+            ) = kotlinx.coroutines.flow.flowOf(1f)
+            override suspend fun setScale(
+                sourceId: String, libraryId: String,
+                bucket: com.riffle.core.models.ScreenDimensionBucket,
+                value: Float,
+            ) {}
         },
         libraryFilterPreferencesStore: LibraryFilterPreferencesStore = FakeLibraryFilterPreferencesStore(),
         annotationStore: com.riffle.core.domain.AnnotationStore = fakeAnnotationStore(),

--- a/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
@@ -411,6 +411,15 @@ class ChitankaBrowseViewModelTest {
         object : CoverGridDensityStore {
             override val scale = flowOf(1f)
             override suspend fun setScale(value: Float) = Unit
+            override fun scale(
+                sourceId: String, libraryId: String,
+                bucket: com.riffle.core.models.ScreenDimensionBucket,
+            ) = flowOf(1f)
+            override suspend fun setScale(
+                sourceId: String, libraryId: String,
+                bucket: com.riffle.core.models.ScreenDimensionBucket,
+                value: Float,
+            ) = Unit
         }
 
     private class RecordingCoverGridDensityStore : CoverGridDensityStore {
@@ -420,6 +429,17 @@ class ChitankaBrowseViewModelTest {
         override suspend fun setScale(value: Float) {
             persistedScale = value
         }
+
+        override fun scale(
+            sourceId: String, libraryId: String,
+            bucket: com.riffle.core.models.ScreenDimensionBucket,
+        ) = flowOf(1f)
+
+        override suspend fun setScale(
+            sourceId: String, libraryId: String,
+            bucket: com.riffle.core.models.ScreenDimensionBucket,
+            value: Float,
+        ) = Unit
     }
 
     // ─── Not-Started filter ───────────────────────────────────────────────────────────────────────

--- a/app/src/test/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModelTest.kt
@@ -202,6 +202,8 @@ class GutenbergBrowseViewModelTest {
         object : CoverGridDensityStore {
             override val scale = flowOf(1f)
             override suspend fun setScale(value: Float) = Unit
+            override fun scale(sourceId: String, libraryId: String, bucket: com.riffle.core.models.ScreenDimensionBucket) = flowOf(1f)
+            override suspend fun setScale(sourceId: String, libraryId: String, bucket: com.riffle.core.models.ScreenDimensionBucket, value: Float) = Unit
         }
 
     private fun emptyLibraryObserver() = FakeLibraryObserver()

--- a/core/data/src/main/kotlin/com/riffle/core/data/CoverGridDensityStoreImpl.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/CoverGridDensityStoreImpl.kt
@@ -1,0 +1,30 @@
+package com.riffle.core.data
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import com.riffle.core.database.CoverGridScaleDao
+import com.riffle.core.database.CoverGridScaleEntity
+import com.riffle.core.domain.CoverGridDensityStore
+import com.riffle.core.models.ScreenDimensionBucket
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class CoverGridDensityStoreImpl @Inject constructor(
+    dataStore: DataStore<Preferences>,
+    private val dao: CoverGridScaleDao,
+) : CoverGridDensityStore {
+
+    private val globalStore = preferenceStore(dataStore, PrefCodecs.float("cover_grid_scale", default = 1f))
+
+    override val scale: Flow<Float> = globalStore.flow
+
+    override suspend fun setScale(value: Float) = globalStore.update(value)
+
+    override fun scale(sourceId: String, libraryId: String, bucket: ScreenDimensionBucket): Flow<Float> =
+        dao.observeScale(sourceId, libraryId, bucket.encode()).map { it ?: 1f }
+
+    override suspend fun setScale(sourceId: String, libraryId: String, bucket: ScreenDimensionBucket, value: Float) {
+        dao.upsert(CoverGridScaleEntity(sourceId, libraryId, bucket.encode(), value))
+    }
+}

--- a/core/data/src/main/kotlin/com/riffle/core/data/PreferenceStoreFactories.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/PreferenceStoreFactories.kt
@@ -49,6 +49,15 @@ fun CoverGridDensityStore(dataStore: DataStore<Preferences>): CoverGridDensitySt
     return object : CoverGridDensityStore {
         override val scale: Flow<Float> = store.flow
         override suspend fun setScale(value: Float) = store.update(value)
+        override fun scale(
+            sourceId: String, libraryId: String,
+            bucket: com.riffle.core.models.ScreenDimensionBucket,
+        ): Flow<Float> = store.flow
+        override suspend fun setScale(
+            sourceId: String, libraryId: String,
+            bucket: com.riffle.core.models.ScreenDimensionBucket,
+            value: Float,
+        ) = store.update(value)
     }
 }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/PreferenceStoreFactories.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/PreferenceStoreFactories.kt
@@ -9,7 +9,6 @@ import com.riffle.core.domain.AppThemeStore
 import com.riffle.core.domain.AppUpdatePreferencesStore
 import com.riffle.core.domain.ContentCacheAutoClear
 import com.riffle.core.domain.ContentCacheSettingsStore
-import com.riffle.core.domain.CoverGridDensityStore
 import com.riffle.core.domain.EmphasisPreferencesStore
 import com.riffle.core.models.EmphasisStyle
 import com.riffle.core.models.HighlightColor
@@ -41,23 +40,6 @@ fun AppThemeStore(dataStore: DataStore<Preferences>): AppThemeStore {
     return object : AppThemeStore {
         override val appTheme: Flow<AppTheme> = store.flow
         override suspend fun setAppTheme(value: AppTheme) = store.update(value)
-    }
-}
-
-fun CoverGridDensityStore(dataStore: DataStore<Preferences>): CoverGridDensityStore {
-    val store = preferenceStore(dataStore, PrefCodecs.float("cover_grid_scale", default = 1f))
-    return object : CoverGridDensityStore {
-        override val scale: Flow<Float> = store.flow
-        override suspend fun setScale(value: Float) = store.update(value)
-        override fun scale(
-            sourceId: String, libraryId: String,
-            bucket: com.riffle.core.models.ScreenDimensionBucket,
-        ): Flow<Float> = store.flow
-        override suspend fun setScale(
-            sourceId: String, libraryId: String,
-            bucket: com.riffle.core.models.ScreenDimensionBucket,
-            value: Float,
-        ) = store.update(value)
     }
 }
 

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/DatabaseModule.kt
@@ -164,4 +164,9 @@ object DatabaseModule {
     @Singleton
     fun provideLookupHistoryDao(db: RiffleDatabaseAccess): com.riffle.core.database.LookupHistoryDao =
         db.lookupHistoryDao()
+
+    @Provides
+    @Singleton
+    fun provideCoverGridScaleDao(db: RiffleDatabaseAccess): com.riffle.core.database.CoverGridScaleDao =
+        db.coverGridScaleDao()
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/PreferencesModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/PreferencesModule.kt
@@ -83,7 +83,7 @@ import com.riffle.core.domain.WakeLockPreferencesStore
 import com.riffle.core.data.AppThemeStore as createAppThemeStore
 import com.riffle.core.data.AppUpdatePreferencesStore as createAppUpdatePreferencesStore
 import com.riffle.core.data.ContentCacheSettingsStore as createContentCacheSettingsStore
-import com.riffle.core.data.CoverGridDensityStore as createCoverGridDensityStore
+import com.riffle.core.data.CoverGridDensityStoreImpl
 import com.riffle.core.data.EmphasisPreferencesStore as createEmphasisPreferencesStore
 import com.riffle.core.data.HighlightColorPreferencesStore as createHighlightColorPreferencesStore
 import com.riffle.core.data.HighlightsResumeStore as createHighlightsResumeStore
@@ -233,7 +233,8 @@ abstract class PreferencesModule {
         @Singleton
         fun provideCoverGridDensityStore(
             @CoverGridDensityDataStore dataStore: DataStore<Preferences>,
-        ): CoverGridDensityStore = createCoverGridDensityStore(dataStore)
+            dao: com.riffle.core.database.CoverGridScaleDao,
+        ): CoverGridDensityStore = CoverGridDensityStoreImpl(dataStore, dao)
 
         @Provides
         @Singleton

--- a/core/data/src/test/kotlin/com/riffle/core/data/CoverGridDensityStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/CoverGridDensityStoreTest.kt
@@ -1,12 +1,14 @@
 package com.riffle.core.data
 
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
-import kotlinx.coroutines.CoroutineScope
+import com.riffle.core.database.CoverGridScaleDao
+import com.riffle.core.database.CoverGridScaleEntity
+import com.riffle.core.models.ScreenDimensionBucket
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -24,50 +26,68 @@ class CoverGridDensityStoreTest {
     private val dispatcher = UnconfinedTestDispatcher()
     private val testScope = TestScope(dispatcher)
 
-    private fun buildStore() = CoverGridDensityStore(
+    private val fakeDao = FakeCoverGridScaleDao()
+
+    private fun buildStore() = CoverGridDensityStoreImpl(
         PreferenceDataStoreFactory.create(
             scope = testScope.backgroundScope,
             produceFile = { tmp.newFile("cover_grid_density.preferences_pb") },
-        )
+        ),
+        fakeDao,
     )
 
     @Test
-    fun `default scale is 1 when DataStore is empty`() = testScope.runTest {
+    fun `global scale default is 1 when DataStore is empty`() = testScope.runTest {
         assertEquals(1f, buildStore().scale.first())
     }
 
     @Test
-    fun `setScale round-trips on read`() = testScope.runTest {
+    fun `global setScale round-trips on read`() = testScope.runTest {
         val store = buildStore()
         store.setScale(1.4f)
         assertEquals(1.4f, store.scale.first())
     }
 
     @Test
-    fun `scale persists across store instances`() {
-        val file = tmp.newFile("cover_grid_density_round_trip.preferences_pb")
-
-        // DataStore disallows concurrent instances on the same file, so the write scope
-        // must be fully cancelled before a second instance reads.
-        val writeScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
-        runBlocking {
-            CoverGridDensityStore(
-                PreferenceDataStoreFactory.create(
-                    scope = writeScope,
-                    produceFile = { file },
-                )
-            ).setScale(0.8f)
-        }
-        writeScope.cancel()
-
-        val readScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
-        val store2 = CoverGridDensityStore(
-            PreferenceDataStoreFactory.create(
-                scope = readScope,
-                produceFile = { file },
-            )
-        )
-        assertEquals(0.8f, runBlocking { store2.scale.first() })
-        readScope.cancel()
+    fun `per-library scale defaults to 1 when no row exists`() = testScope.runTest {
+        val bucket = ScreenDimensionBucket.PhonePortrait
+        assertEquals(1f, buildStore().scale("src1", "lib1", bucket).first())
     }
+
+    @Test
+    fun `per-library setScale round-trips on read`() = testScope.runTest {
+        val store = buildStore()
+        val bucket = ScreenDimensionBucket.PhonePortrait
+        store.setScale("src1", "lib1", bucket, 1.3f)
+        assertEquals(1.3f, store.scale("src1", "lib1", bucket).first())
+    }
+
+    @Test
+    fun `per-library scales are keyed independently`() = testScope.runTest {
+        val store = buildStore()
+        val bucket = ScreenDimensionBucket.PhonePortrait
+        store.setScale("src1", "lib1", bucket, 1.2f)
+        store.setScale("src1", "lib2", bucket, 0.9f)
+        assertEquals(1.2f, store.scale("src1", "lib1", bucket).first())
+        assertEquals(0.9f, store.scale("src1", "lib2", bucket).first())
+    }
+
+    @Test
+    fun `per-library scale does not affect global scale`() = testScope.runTest {
+        val store = buildStore()
+        val bucket = ScreenDimensionBucket.PhonePortrait
+        store.setScale("src1", "lib1", bucket, 1.5f)
+        assertEquals(1f, store.scale.first())
+    }
+}
+
+private class FakeCoverGridScaleDao : CoverGridScaleDao {
+    private val rows = MutableStateFlow<Map<Triple<String, String, String>, Float>>(emptyMap())
+
+    override suspend fun upsert(entity: CoverGridScaleEntity) {
+        rows.value = rows.value + (Triple(entity.sourceId, entity.libraryId, entity.screenDimensionBucket) to entity.scale)
+    }
+
+    override fun observeScale(sourceId: String, libraryId: String, bucket: String): Flow<Float?> =
+        rows.map { it[Triple(sourceId, libraryId, bucket)] }
 }

--- a/core/data/src/test/kotlin/com/riffle/core/data/CoverGridDensityStoreTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/CoverGridDensityStoreTest.kt
@@ -4,11 +4,15 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import com.riffle.core.database.CoverGridScaleDao
 import com.riffle.core.database.CoverGridScaleEntity
 import com.riffle.core.models.ScreenDimensionBucket
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -37,15 +41,38 @@ class CoverGridDensityStoreTest {
     )
 
     @Test
-    fun `global scale default is 1 when DataStore is empty`() = testScope.runTest {
+    fun `default scale is 1 when DataStore is empty`() = testScope.runTest {
         assertEquals(1f, buildStore().scale.first())
     }
 
     @Test
-    fun `global setScale round-trips on read`() = testScope.runTest {
+    fun `setScale round-trips on read`() = testScope.runTest {
         val store = buildStore()
         store.setScale(1.4f)
         assertEquals(1.4f, store.scale.first())
+    }
+
+    @Test
+    fun `scale persists across store instances`() {
+        val file = tmp.newFile("cover_grid_density_round_trip.preferences_pb")
+        val fakeDao = FakeCoverGridScaleDao()
+
+        val writeScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        runBlocking {
+            CoverGridDensityStoreImpl(
+                PreferenceDataStoreFactory.create(scope = writeScope, produceFile = { file }),
+                fakeDao,
+            ).setScale(0.8f)
+        }
+        writeScope.cancel()
+
+        val readScope = CoroutineScope(UnconfinedTestDispatcher() + Job())
+        val store2 = CoverGridDensityStoreImpl(
+            PreferenceDataStoreFactory.create(scope = readScope, produceFile = { file }),
+            fakeDao,
+        )
+        assertEquals(0.8f, runBlocking { store2.scale.first() })
+        readScope.cancel()
     }
 
     @Test

--- a/core/database-api/src/commonMain/kotlin/com/riffle/core/database/CoverGridScaleDao.kt
+++ b/core/database-api/src/commonMain/kotlin/com/riffle/core/database/CoverGridScaleDao.kt
@@ -1,0 +1,20 @@
+package com.riffle.core.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface CoverGridScaleDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: CoverGridScaleEntity)
+
+    @Query(
+        "SELECT scale FROM cover_grid_scale " +
+            "WHERE sourceId = :sourceId AND libraryId = :libraryId AND screenDimensionBucket = :bucket"
+    )
+    fun observeScale(sourceId: String, libraryId: String, bucket: String): Flow<Float?>
+}

--- a/core/database-api/src/commonMain/kotlin/com/riffle/core/database/CoverGridScaleEntity.kt
+++ b/core/database-api/src/commonMain/kotlin/com/riffle/core/database/CoverGridScaleEntity.kt
@@ -1,0 +1,29 @@
+package com.riffle.core.database
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+// Per-library cover-grid zoom. Each row holds the pinch-to-zoom scale factor a user set for
+// one library on one screen-size class. `sourceId` FK-cascades so a removed Source's rows are
+// cleared. `screenDimensionBucket` is `ScreenDimensionBucket.encode()` — e.g. "Compact_Medium"
+// — so a phone in portrait and in landscape share one row (rotation-invariant, per ADR 0029).
+@Entity(
+    tableName = "cover_grid_scale",
+    primaryKeys = ["sourceId", "libraryId", "screenDimensionBucket"],
+    foreignKeys = [
+        ForeignKey(
+            entity = SourceEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["sourceId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index("sourceId")],
+)
+data class CoverGridScaleEntity(
+    val sourceId: String,
+    val libraryId: String,
+    val screenDimensionBucket: String,
+    val scale: Float,
+)

--- a/core/database-api/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabaseAccess.kt
+++ b/core/database-api/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabaseAccess.kt
@@ -37,4 +37,5 @@ interface RiffleDatabaseAccess {
     fun bookComicFormattingPreferencesDao(): BookComicFormattingPreferencesDao
     fun dictionaryPackDao(): DictionaryPackDao
     fun lookupHistoryDao(): LookupHistoryDao
+    fun coverGridScaleDao(): CoverGridScaleDao
 }

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/71.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/71.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 71,
-    "identityHash": "b0363107cc81f2ee9303de642f5aec2c",
+    "identityHash": "f054047ee1f2acbe60b1863c0c4379dd",
     "entities": [
       {
         "tableName": "sources",
@@ -514,7 +514,7 @@
       },
       {
         "tableName": "book_formatting_preferences",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `screenDimensionBucket` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `coloredChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`, `screenDimensionBucket`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `screenDimensionBucket` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `coloredChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `screenDimensionBucket`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "sourceId",
@@ -525,12 +525,6 @@
           {
             "fieldPath": "itemId",
             "columnName": "itemId",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "scope",
-            "columnName": "scope",
             "affinity": "TEXT",
             "notNull": true
           },
@@ -611,7 +605,6 @@
           "columnNames": [
             "sourceId",
             "itemId",
-            "scope",
             "screenDimensionBucket"
           ]
         },
@@ -2223,73 +2216,11 @@
             "id"
           ]
         }
-      },
-      {
-        "tableName": "cover_grid_scale",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `screenDimensionBucket` TEXT NOT NULL, `scale` REAL NOT NULL, PRIMARY KEY(`sourceId`, `libraryId`, `screenDimensionBucket`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
-        "fields": [
-          {
-            "fieldPath": "sourceId",
-            "columnName": "sourceId",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "libraryId",
-            "columnName": "libraryId",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "screenDimensionBucket",
-            "columnName": "screenDimensionBucket",
-            "affinity": "TEXT",
-            "notNull": true
-          },
-          {
-            "fieldPath": "scale",
-            "columnName": "scale",
-            "affinity": "REAL",
-            "notNull": true
-          }
-        ],
-        "primaryKey": {
-          "autoGenerate": false,
-          "columnNames": [
-            "sourceId",
-            "libraryId",
-            "screenDimensionBucket"
-          ]
-        },
-        "indices": [
-          {
-            "name": "index_cover_grid_scale_sourceId",
-            "unique": false,
-            "columnNames": [
-              "sourceId"
-            ],
-            "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `index_cover_grid_scale_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
-          }
-        ],
-        "foreignKeys": [
-          {
-            "table": "sources",
-            "onDelete": "CASCADE",
-            "onUpdate": "NO ACTION",
-            "columns": [
-              "sourceId"
-            ],
-            "referencedColumns": [
-              "id"
-            ]
-          }
-        ]
       }
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b0363107cc81f2ee9303de642f5aec2c')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f054047ee1f2acbe60b1863c0c4379dd')"
     ]
   }
 }

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/71.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/71.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 71,
-    "identityHash": "f054047ee1f2acbe60b1863c0c4379dd",
+    "identityHash": "b0363107cc81f2ee9303de642f5aec2c",
     "entities": [
       {
         "tableName": "sources",
@@ -514,7 +514,7 @@
       },
       {
         "tableName": "book_formatting_preferences",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `screenDimensionBucket` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `coloredChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `screenDimensionBucket`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `scope` TEXT NOT NULL, `screenDimensionBucket` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `coloredChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `scope`, `screenDimensionBucket`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "sourceId",
@@ -525,6 +525,12 @@
           {
             "fieldPath": "itemId",
             "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
             "affinity": "TEXT",
             "notNull": true
           },
@@ -605,6 +611,7 @@
           "columnNames": [
             "sourceId",
             "itemId",
+            "scope",
             "screenDimensionBucket"
           ]
         },
@@ -2216,11 +2223,73 @@
             "id"
           ]
         }
+      },
+      {
+        "tableName": "cover_grid_scale",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `screenDimensionBucket` TEXT NOT NULL, `scale` REAL NOT NULL, PRIMARY KEY(`sourceId`, `libraryId`, `screenDimensionBucket`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "screenDimensionBucket",
+            "columnName": "screenDimensionBucket",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scale",
+            "columnName": "scale",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "libraryId",
+            "screenDimensionBucket"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cover_grid_scale_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cover_grid_scale_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
       }
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f054047ee1f2acbe60b1863c0c4379dd')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b0363107cc81f2ee9303de642f5aec2c')"
     ]
   }
 }

--- a/core/database/schemas/com.riffle.core.database.RiffleDatabase/72.json
+++ b/core/database/schemas/com.riffle.core.database.RiffleDatabase/72.json
@@ -1,0 +1,2288 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 72,
+    "identityHash": "178a09f19aeb3a448de221f52d8aabbe",
+    "entities": [
+      {
+        "tableName": "sources",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `url` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `insecureConnectionAllowed` INTEGER NOT NULL, `username` TEXT NOT NULL, `serverType` TEXT NOT NULL, `absUserId` TEXT, `type` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "insecureConnectionAllowed",
+            "columnName": "insecureConnectionAllowed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverType",
+            "columnName": "serverType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absUserId",
+            "columnName": "absUserId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "libraries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `mediaType` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `isUnsupported` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaType",
+            "columnName": "mediaType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnsupported",
+            "columnName": "isUnsupported",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_libraries_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_libraries_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "library_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `coverUrl` TEXT, `readingProgress` REAL NOT NULL, `ebookFileIno` TEXT, `ebookFormat` TEXT NOT NULL, `hasAudio` INTEGER NOT NULL, `audioDurationSec` REAL NOT NULL, `description` TEXT, `seriesName` TEXT, `seriesSequence` TEXT, `publishedYear` TEXT, `genres` TEXT NOT NULL, `publisher` TEXT, `language` TEXT, `lastOpenedAt` INTEGER, `addedAt` INTEGER NOT NULL, `isbn` TEXT, `asin` TEXT, `finishedAt` INTEGER, `pageCount` INTEGER, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "readingProgress",
+            "columnName": "readingProgress",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "ebookFormat",
+            "columnName": "ebookFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hasAudio",
+            "columnName": "hasAudio",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioDurationSec",
+            "columnName": "audioDurationSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesSequence",
+            "columnName": "seriesSequence",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "publishedYear",
+            "columnName": "publishedYear",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genres",
+            "columnName": "genres",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publisher",
+            "columnName": "publisher",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastOpenedAt",
+            "columnName": "lastOpenedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isbn",
+            "columnName": "isbn",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "asin",
+            "columnName": "asin",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "finishedAt",
+            "columnName": "finishedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_library_items_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_library_items_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "series",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `coverUrl` TEXT, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collections",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "series_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`seriesId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `sequenceOrder` REAL NOT NULL, PRIMARY KEY(`seriesId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "seriesId",
+            "columnName": "seriesId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceOrder",
+            "columnName": "sequenceOrder",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "seriesId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "collection_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`collectionId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, PRIMARY KEY(`collectionId`, `sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "collectionId",
+            "columnName": "collectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "collectionId",
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "reading_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `cfi` TEXT NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_reading_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_reading_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `screenDimensionBucket` TEXT NOT NULL, `fontSize` REAL, `theme` TEXT, `fontFamily` TEXT, `lineSpacing` REAL, `margins` REAL, `orientation` TEXT, `showChapterMap` INTEGER, `coloredChapterMap` INTEGER, `showReadingProgressLabels` INTEGER, `showCurrentChapterLabel` INTEGER, `doublePageSpread` INTEGER, `justifyText` INTEGER, `showReadingTimeEstimate` INTEGER, PRIMARY KEY(`sourceId`, `itemId`, `screenDimensionBucket`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "screenDimensionBucket",
+            "columnName": "screenDimensionBucket",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fontSize",
+            "columnName": "fontSize",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "theme",
+            "columnName": "theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fontFamily",
+            "columnName": "fontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lineSpacing",
+            "columnName": "lineSpacing",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "margins",
+            "columnName": "margins",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "orientation",
+            "columnName": "orientation",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showChapterMap",
+            "columnName": "showChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "coloredChapterMap",
+            "columnName": "coloredChapterMap",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingProgressLabels",
+            "columnName": "showReadingProgressLabels",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showCurrentChapterLabel",
+            "columnName": "showCurrentChapterLabel",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "doublePageSpread",
+            "columnName": "doublePageSpread",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "justifyText",
+            "columnName": "justifyText",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "showReadingTimeEstimate",
+            "columnName": "showReadingTimeEstimate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId",
+            "screenDimensionBucket"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_formatting_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_links",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `state` TEXT NOT NULL, `userConfirmed` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `identityResult` TEXT NOT NULL, PRIMARY KEY(`absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userConfirmed",
+            "columnName": "userConfirmed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "identityResult",
+            "columnName": "identityResult",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_links_storytellerSourceId_storytellerBookId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId",
+              "storytellerBookId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId_storytellerBookId` ON `${TABLE_NAME}` (`storytellerSourceId`, `storytellerBookId`)"
+          },
+          {
+            "name": "index_readaloud_links_storytellerSourceId",
+            "unique": false,
+            "columnNames": [
+              "storytellerSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_links_storytellerSourceId` ON `${TABLE_NAME}` (`storytellerSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_candidates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, `score` REAL NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`absSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_candidates_absSourceId",
+            "unique": false,
+            "columnNames": [
+              "absSourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_candidates_absSourceId` ON `${TABLE_NAME}` (`absSourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "absSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_dismissals",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`storytellerSourceId` TEXT NOT NULL, `storytellerBookId` TEXT NOT NULL, `scope` TEXT NOT NULL, `absSourceId` TEXT NOT NULL, `absLibraryItemId` TEXT NOT NULL, PRIMARY KEY(`storytellerSourceId`, `storytellerBookId`, `absSourceId`, `absLibraryItemId`), FOREIGN KEY(`storytellerSourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "storytellerSourceId",
+            "columnName": "storytellerSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerBookId",
+            "columnName": "storytellerBookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scope",
+            "columnName": "scope",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absSourceId",
+            "columnName": "absSourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "absLibraryItemId",
+            "columnName": "absLibraryItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "storytellerSourceId",
+            "storytellerBookId",
+            "absSourceId",
+            "absLibraryItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "storytellerSourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "cross_epub_index",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`absEpubChecksum` TEXT NOT NULL, `storytellerEpubChecksum` TEXT NOT NULL, `perChapterMapsBlob` TEXT NOT NULL, `builtAt` INTEGER NOT NULL, PRIMARY KEY(`absEpubChecksum`, `storytellerEpubChecksum`))",
+        "fields": [
+          {
+            "fieldPath": "absEpubChecksum",
+            "columnName": "absEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storytellerEpubChecksum",
+            "columnName": "storytellerEpubChecksum",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "perChapterMapsBlob",
+            "columnName": "perChapterMapsBlob",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "builtAt",
+            "columnName": "builtAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "absEpubChecksum",
+            "storytellerEpubChecksum"
+          ]
+        }
+      },
+      {
+        "tableName": "annotations",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `type` TEXT NOT NULL, `cfi` TEXT NOT NULL, `color` TEXT NOT NULL, `note` TEXT, `textSnippet` TEXT NOT NULL, `textBefore` TEXT NOT NULL, `textAfter` TEXT NOT NULL, `chapterHref` TEXT NOT NULL, `spineIndex` INTEGER NOT NULL, `progression` REAL NOT NULL, `bookmarkTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `originDeviceId` TEXT NOT NULL, `lastModifiedByDeviceId` TEXT NOT NULL, `deleted` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `embeddedFigures` TEXT, `imageHref` TEXT, `imageSvg` TEXT, `imageBytes` TEXT, `originFontFamily` TEXT, `emphasisStyles` TEXT, `textSnippetHtml` TEXT, `fragmentAnchor` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cfi",
+            "columnName": "cfi",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippet",
+            "columnName": "textSnippet",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textBefore",
+            "columnName": "textBefore",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textAfter",
+            "columnName": "textAfter",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapterHref",
+            "columnName": "chapterHref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spineIndex",
+            "columnName": "spineIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkTitle",
+            "columnName": "bookmarkTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originDeviceId",
+            "columnName": "originDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastModifiedByDeviceId",
+            "columnName": "lastModifiedByDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedFigures",
+            "columnName": "embeddedFigures",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageHref",
+            "columnName": "imageHref",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageSvg",
+            "columnName": "imageSvg",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageBytes",
+            "columnName": "imageBytes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originFontFamily",
+            "columnName": "originFontFamily",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "emphasisStyles",
+            "columnName": "emphasisStyles",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSnippetHtml",
+            "columnName": "textSnippetHtml",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fragmentAnchor",
+            "columnName": "fragmentAnchor",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_annotations_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_annotations_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "readaloud_resume_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `href` TEXT NOT NULL, `progression` REAL, `fragmentRef` TEXT, `localUpdatedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "href",
+            "columnName": "href",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progression",
+            "columnName": "progression",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "fragmentRef",
+            "columnName": "fragmentRef",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_readaloud_resume_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_readaloud_resume_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_playback_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `bookId` TEXT NOT NULL, `speed` REAL, PRIMARY KEY(`sourceId`, `bookId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookId",
+            "columnName": "bookId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speed",
+            "columnName": "speed",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "bookId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audio_playback_preferences_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audio_playback_preferences_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_positions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_positions_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_positions_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audiobook_bookmarks",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `positionSec` REAL NOT NULL, `title` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `localUpdatedAt` INTEGER NOT NULL, `lastSyncedAt` INTEGER NOT NULL, `deleted` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "positionSec",
+            "columnName": "positionSec",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localUpdatedAt",
+            "columnName": "localUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleted",
+            "columnName": "deleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_audiobook_bookmarks_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_audiobook_bookmarks_sourceId_itemId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "itemId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_audiobook_bookmarks_sourceId_itemId` ON `${TABLE_NAME}` (`sourceId`, `itemId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "toc_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `entriesJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entriesJson",
+            "columnName": "entriesJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "audiobook_chapter_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `chaptersJson` TEXT NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `itemId`))",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chaptersJson",
+            "columnName": "chaptersJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        }
+      },
+      {
+        "tableName": "local_files_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `treeUri` TEXT NOT NULL, `displayName` TEXT NOT NULL, `addedAtEpochMs` INTEGER NOT NULL, `libraryId` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `treeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "treeUri",
+            "columnName": "treeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAtEpochMs",
+            "columnName": "addedAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "treeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_files",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `originalUri` TEXT NOT NULL, `copiedPath` TEXT NOT NULL, `coverPath` TEXT, `format` TEXT NOT NULL, `sizeBytes` INTEGER NOT NULL, `mtimeEpochMs` INTEGER NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, `displayName` TEXT NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalUri",
+            "columnName": "originalUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "copiedPath",
+            "columnName": "copiedPath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "coverPath",
+            "columnName": "coverPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mtimeEpochMs",
+            "columnName": "mtimeEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "displayName",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_files_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_files_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_files_file_folders",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `folderTreeUri` TEXT NOT NULL, `lastSeenAtEpochMs` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`, `folderTreeUri`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "folderTreeUri",
+            "columnName": "folderTreeUri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSeenAtEpochMs",
+            "columnName": "lastSeenAtEpochMs",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId",
+            "folderTreeUri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_files_file_folders_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_local_files_file_folders_sourceId_folderTreeUri",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "folderTreeUri"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_files_file_folders_sourceId_folderTreeUri` ON `${TABLE_NAME}` (`sourceId`, `folderTreeUri`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "local_file_metadata_overrides",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `title` TEXT, `author` TEXT, `seriesName` TEXT, `seriesIndex` REAL, `coverUrl` TEXT, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesName",
+            "columnName": "seriesName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "seriesIndex",
+            "columnName": "seriesIndex",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "coverUrl",
+            "columnName": "coverUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_local_file_metadata_overrides_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_local_file_metadata_overrides_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "remote_item_freshness",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `sourceItemId` TEXT NOT NULL, `lastFetchedAt` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `sourceItemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceItemId",
+            "columnName": "sourceItemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastFetchedAt",
+            "columnName": "lastFetchedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "sourceItemId"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `rootId` TEXT NOT NULL, `name` TEXT NOT NULL, `bookCount` INTEGER NOT NULL, PRIMARY KEY(`sourceId`, `id`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rootId",
+            "columnName": "rootId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookCount",
+            "columnName": "bookCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          },
+          {
+            "name": "index_playlists_rootId",
+            "unique": false,
+            "columnNames": [
+              "rootId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_rootId` ON `${TABLE_NAME}` (`rootId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `orderIndex` INTEGER NOT NULL, PRIMARY KEY(`playlistId`, `sourceId`, `itemId`), FOREIGN KEY(`sourceId`, `playlistId`) REFERENCES `playlists`(`sourceId`, `id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "orderIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId",
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_items_sourceId_playlistId",
+            "unique": false,
+            "columnNames": [
+              "sourceId",
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_items_sourceId_playlistId` ON `${TABLE_NAME}` (`sourceId`, `playlistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId",
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "sourceId",
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "publication_metrics_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `itemId` TEXT NOT NULL, `ebookFileIno` TEXT NOT NULL, `totalPositions` INTEGER, `pageCount` INTEGER, `cachedAt` INTEGER NOT NULL, `epubVersion` TEXT, PRIMARY KEY(`sourceId`, `itemId`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "itemId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ebookFileIno",
+            "columnName": "ebookFileIno",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalPositions",
+            "columnName": "totalPositions",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pageCount",
+            "columnName": "pageCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "epubVersion",
+            "columnName": "epubVersion",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "itemId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_publication_metrics_cache_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_publication_metrics_cache_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "book_comic_formatting_preferences",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`source_id` TEXT NOT NULL, `item_id` TEXT NOT NULL, `background_theme` TEXT, `panel_view_on` INTEGER, `panel_overflow` TEXT, `panel_animation_speed_ms` INTEGER, PRIMARY KEY(`source_id`, `item_id`), FOREIGN KEY(`source_id`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "source_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundTheme",
+            "columnName": "background_theme",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "panelViewOn",
+            "columnName": "panel_view_on",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "panelOverflow",
+            "columnName": "panel_overflow",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "panelAnimationSpeedMs",
+            "columnName": "panel_animation_speed_ms",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "source_id",
+            "item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_book_comic_formatting_preferences_source_id",
+            "unique": false,
+            "columnNames": [
+              "source_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_book_comic_formatting_preferences_source_id` ON `${TABLE_NAME}` (`source_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "source_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "dictionary_packs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`languageTag` TEXT NOT NULL, `packVersion` TEXT NOT NULL, `installedAt` INTEGER NOT NULL, `sizeBytes` INTEGER NOT NULL, `attributionHtml` TEXT NOT NULL, `licenseUrl` TEXT NOT NULL, `state` TEXT NOT NULL, PRIMARY KEY(`languageTag`))",
+        "fields": [
+          {
+            "fieldPath": "languageTag",
+            "columnName": "languageTag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "packVersion",
+            "columnName": "packVersion",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "installedAt",
+            "columnName": "installedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeBytes",
+            "columnName": "sizeBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attributionHtml",
+            "columnName": "attributionHtml",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "licenseUrl",
+            "columnName": "licenseUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "languageTag"
+          ]
+        }
+      },
+      {
+        "tableName": "lookup_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `languageTag` TEXT NOT NULL, `form` TEXT NOT NULL, `lookedUpAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "languageTag",
+            "columnName": "languageTag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "form",
+            "columnName": "form",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lookedUpAt",
+            "columnName": "lookedUpAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "cover_grid_scale",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sourceId` TEXT NOT NULL, `libraryId` TEXT NOT NULL, `screenDimensionBucket` TEXT NOT NULL, `scale` REAL NOT NULL, PRIMARY KEY(`sourceId`, `libraryId`, `screenDimensionBucket`), FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sourceId",
+            "columnName": "sourceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "libraryId",
+            "columnName": "libraryId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "screenDimensionBucket",
+            "columnName": "screenDimensionBucket",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scale",
+            "columnName": "scale",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sourceId",
+            "libraryId",
+            "screenDimensionBucket"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_cover_grid_scale_sourceId",
+            "unique": false,
+            "columnNames": [
+              "sourceId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_cover_grid_scale_sourceId` ON `${TABLE_NAME}` (`sourceId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sources",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sourceId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '178a09f19aeb3a448de221f52d8aabbe')"
+    ]
+  }
+}

--- a/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -3154,6 +3154,32 @@ class MigrationTest {
     }
 
     @Test
+    fun migration70To71_createsCoverGridScaleTable() {
+        helper.createDatabase(TEST_DB, 70).use { db ->
+            db.execSQL(
+                "INSERT INTO sources (id, url, isActive, insecureConnectionAllowed, username, serverType, absUserId, type) " +
+                    "VALUES ('src1', 'http://test', 1, 0, '', 'AUDIOBOOKSHELF', NULL, 'ABS')"
+            )
+        }
+
+        helper.runMigrationsAndValidate(
+            TEST_DB, 71, true, RiffleDatabase.MIGRATION_70_71
+        ).use { db ->
+            // Table must exist and accept a row.
+            db.execSQL(
+                "INSERT INTO cover_grid_scale (sourceId, libraryId, screenDimensionBucket, scale) " +
+                    "VALUES ('src1', 'lib1', 'Compact_Medium', 1.3)"
+            )
+            db.query(
+                "SELECT scale FROM cover_grid_scale WHERE sourceId = 'src1' AND libraryId = 'lib1' AND screenDimensionBucket = 'Compact_Medium'"
+            ).use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals(1.3f, cursor.getFloat(0), 0.001f)
+            }
+        }
+    }
+
+    @Test
     fun migration69To70_addsScreenDimensionBucketColumn() {
         helper.createDatabase(TEST_DB, 69).use { db ->
             db.execSQL(

--- a/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -2006,7 +2006,7 @@ class MigrationTest {
         }
         db.query("PRAGMA user_version").use { cursor ->
             assertTrue(cursor.moveToFirst())
-            assertEquals(70, cursor.getInt(0))
+            assertEquals(72, cursor.getInt(0))
         }
         db.query("SELECT coverUrl FROM local_file_metadata_overrides LIMIT 0").use { cursor ->
             assertEquals("coverUrl", cursor.getColumnName(0))

--- a/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
+++ b/core/database/src/androidDeviceTest/kotlin/com/riffle/core/database/MigrationTest.kt
@@ -1921,7 +1921,7 @@ class MigrationTest {
         }
 
         val db = helper.runMigrationsAndValidate(
-            TEST_DB, 70, true,
+            TEST_DB, 72, true,
             RiffleDatabase.MIGRATION_1_2,
             RiffleDatabase.MIGRATION_2_3,
             RiffleDatabase.MIGRATION_3_4,
@@ -1992,6 +1992,7 @@ class MigrationTest {
             RiffleDatabase.MIGRATION_68_69,
             RiffleDatabase.MIGRATION_69_70,
             RiffleDatabase.MIGRATION_70_71,
+            RiffleDatabase.MIGRATION_71_72,
         )
 
         db.query("SELECT url, username, serverType, absUserId, type FROM sources WHERE id = 's1'").use { cursor ->
@@ -3154,8 +3155,8 @@ class MigrationTest {
     }
 
     @Test
-    fun migration70To71_createsCoverGridScaleTable() {
-        helper.createDatabase(TEST_DB, 70).use { db ->
+    fun migration71To72_createsCoverGridScaleTable() {
+        helper.createDatabase(TEST_DB, 71).use { db ->
             db.execSQL(
                 "INSERT INTO sources (id, url, isActive, insecureConnectionAllowed, username, serverType, absUserId, type) " +
                     "VALUES ('src1', 'http://test', 1, 0, '', 'AUDIOBOOKSHELF', NULL, 'ABS')"
@@ -3163,7 +3164,7 @@ class MigrationTest {
         }
 
         helper.runMigrationsAndValidate(
-            TEST_DB, 71, true, RiffleDatabase.MIGRATION_70_71
+            TEST_DB, 72, true, RiffleDatabase.MIGRATION_71_72
         ).use { db ->
             // Table must exist and accept a row.
             db.execSQL(

--- a/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabase.kt
+++ b/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabase.kt
@@ -43,8 +43,9 @@ import androidx.sqlite.execSQL
         BookComicFormattingPreferencesEntity::class,
         DictionaryPackEntity::class,
         LookupHistoryEntity::class,
+        CoverGridScaleEntity::class,
     ],
-    version = 71,
+    version = 72,
     exportSchema = true,
 )
 @ConstructedBy(RiffleDatabaseConstructor::class)
@@ -77,6 +78,7 @@ abstract class RiffleDatabase : RoomDatabase() {
     abstract fun bookComicFormattingPreferencesDao(): BookComicFormattingPreferencesDao
     abstract fun dictionaryPackDao(): DictionaryPackDao
     abstract fun lookupHistoryDao(): LookupHistoryDao
+    abstract fun coverGridScaleDao(): CoverGridScaleDao
 
     companion object {
         val MIGRATION_1_2 = object : Migration(1, 2) {
@@ -1869,6 +1871,22 @@ abstract class RiffleDatabase : RoomDatabase() {
                 db.execSQL(
                     "CREATE INDEX IF NOT EXISTS `index_book_formatting_preferences_sourceId` " +
                         "ON `book_formatting_preferences` (`sourceId`)"
+                )
+            }
+        }
+
+        val MIGRATION_71_72 = object : Migration(71, 72) {
+            override fun migrate(db: SQLiteConnection) {
+                db.execSQL(
+                    "CREATE TABLE `cover_grid_scale` " +
+                        "(`sourceId` TEXT NOT NULL, `libraryId` TEXT NOT NULL, " +
+                        "`screenDimensionBucket` TEXT NOT NULL, `scale` REAL NOT NULL, " +
+                        "PRIMARY KEY(`sourceId`, `libraryId`, `screenDimensionBucket`), " +
+                        "FOREIGN KEY(`sourceId`) REFERENCES `sources`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_cover_grid_scale_sourceId` " +
+                        "ON `cover_grid_scale` (`sourceId`)"
                 )
             }
         }

--- a/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabaseFactory.kt
+++ b/core/database/src/commonMain/kotlin/com/riffle/core/database/RiffleDatabaseFactory.kt
@@ -47,6 +47,7 @@ internal class DefaultRiffleDatabaseAccess(
     override fun bookComicFormattingPreferencesDao() = database.bookComicFormattingPreferencesDao()
     override fun dictionaryPackDao() = database.dictionaryPackDao()
     override fun lookupHistoryDao() = database.lookupHistoryDao()
+    override fun coverGridScaleDao() = database.coverGridScaleDao()
 }
 
 internal val RIFFLE_DATABASE_MIGRATIONS: Array<Migration> = arrayOf(
@@ -120,4 +121,5 @@ internal val RIFFLE_DATABASE_MIGRATIONS: Array<Migration> = arrayOf(
     RiffleDatabase.MIGRATION_68_69,
     RiffleDatabase.MIGRATION_69_70,
     RiffleDatabase.MIGRATION_70_71,
+    RiffleDatabase.MIGRATION_71_72,
 )

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/CoverGridDensityStore.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/CoverGridDensityStore.kt
@@ -1,18 +1,16 @@
 package com.riffle.core.domain
 
+import com.riffle.core.models.ScreenDimensionBucket
 import kotlinx.coroutines.flow.Flow
 
-/**
- * Persisted, per-device cover-grid zoom. [scale] is a multiplier applied to the
- * default cover-grid cell sizes: 1.0 keeps the shipped defaults, > 1.0 zooms in
- * (bigger covers, fewer per row), < 1.0 zooms out (smaller covers, more per row).
- *
- * Intentionally global — not scoped by server or library — like the reader
- * formatting / volume-key / wake-lock preferences (ADR 0029): it's an ergonomic
- * UI preference about how dense the browse grids feel, not a property of any
- * library's content.
- */
 interface CoverGridDensityStore {
+    // Global scale — used by non-library browse screens (Chitanka, Gutenberg, web-source).
     val scale: Flow<Float>
     suspend fun setScale(value: Float)
+
+    // Per-library scale keyed by source + library + screen size class.
+    // `bucket` is ScreenDimensionBucket.encode() — e.g. "Compact_Medium" — so a phone in
+    // portrait and in landscape share one row (rotation-invariant, per ADR 0029).
+    fun scale(sourceId: String, libraryId: String, bucket: ScreenDimensionBucket): Flow<Float>
+    suspend fun setScale(sourceId: String, libraryId: String, bucket: ScreenDimensionBucket, value: Float)
 }


### PR DESCRIPTION
## Summary

- Adds `cover_grid_scale` table (Room, v71→v72) with composite PK `(sourceId, libraryId, screenDimensionBucket)` and FK cascade from `sources`
- Extends `CoverGridDensityStore` with per-library `scale(sourceId, libraryId, bucket)` and `setScale(...)` overloads; global DataStore API preserved for non-library browse screens (Chitanka, Gutenberg)
- `LibraryItemsViewModel` reads and writes the per-library scale, using the active source and the `ScreenDimensionBucket` pushed from `LibraryItemsScreen` via `WindowSizeClass`
- `setCoverGridScale` waits for `_activeSourceId` via `filterNotNull().first()` instead of snapshotting `.value`, eliminating a cold-start race where the scale write could fall through to the global store before the source repo returned
- Restores `71.json` to match main exactly (was incorrectly merged during rebase conflict resolution)

## Changes by commit

| Commit | Scope |
|--------|-------|
| `feat(domain)` | `CoverGridDensityStore` interface extended |
| `feat(database)` | `CoverGridScaleEntity` + `CoverGridScaleDao` in `core:database-api` |
| `feat(database)` | `MIGRATION_71_72`, `RiffleDatabase` v72, factory + DI wiring |
| `feat(library)` | `CoverGridDensityStoreImpl` backed by both DataStore + DAO; `LibraryItemsViewModel` per-library scale path |
| `feat(ui)` | `LibraryItemsScreen` passes `windowSizeClass` → ViewModel |
| `test(database)` | `migration71To72_createsCoverGridScaleTable` + `migrateFullChain` wired to v72 + `72.json` schema |
| `fix(library)` | Correct `71.json`, fix `_activeSourceId` race, eliminate intermediate `Pair` |