### PR TITLE
fix(reader): eliminate multi-second blank comic pages on page turns

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/CollectionDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/CollectionDetailViewModel.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -36,6 +37,7 @@ class CollectionDetailViewModel @Inject constructor(
     private val tokenStorage: TokenStorage,
     private val offlineAvailability: LibraryItemOfflineAvailability,
     private val connectivityObserver: ConnectivityObserver,
+    private val dispatchers: com.riffle.core.domain.DispatcherProvider,
 ) : ViewModel() {
 
     val collectionId: String = savedStateHandle.get<String>("collectionId") ?: ""
@@ -55,7 +57,11 @@ class CollectionDetailViewModel @Inject constructor(
 
     val items: StateFlow<List<LibraryItem>> = combine(allItems, isOffline) { items, offline ->
         if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+    }
+        // isAvailableOffline stats the filesystem per item — keep the sweep off Main
+        // (see LibraryFilterEngine.projection).
+        .flowOn(dispatchers.default)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     var authToken: String by mutableStateOf("")
         private set

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryFilterEngine.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryFilterEngine.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 
 /**
@@ -117,6 +118,7 @@ class LibraryFilterEngine(
     searchQuery: Flow<String>,
     notStartedFilterActive: Flow<Boolean>,
     librarySortMode: Flow<LibrarySortMode>,
+    private val computeDispatcher: kotlinx.coroutines.CoroutineDispatcher = kotlinx.coroutines.Dispatchers.Default,
 ) {
 
     private val seriesProjection: Flow<List<Series>> =
@@ -237,7 +239,14 @@ class LibraryFilterEngine(
             annotations = values[9] as List<AnnotationSearchResult>,
             audiobookBookmarks = values[10] as List<AudiobookBookmarkSearchResult>,
         )
-    }
+    }.flowOn(computeDispatcher)
+    // flowOn moves EVERY upstream combine/filter in this graph off the collector's dispatcher.
+    // The ViewModel collects with stateIn(viewModelScope) — i.e. on Main — and the offline
+    // projections stat the filesystem for every library item (isAvailableOffline). Room re-emits
+    // the source flows on every reading-progress write, so without this hop each reader PAGE TURN
+    // ran a full-library filesystem sweep on the main thread: multi-second frozen frames and blank
+    // comic pages on large libraries whenever the library was in offline mode (device offline or
+    // last refresh failed).
 
     private fun filterCollectionsOffline(collections: List<Collection>, offline: Boolean): Flow<List<Collection>> {
         if (!offline || collections.isEmpty()) return flowOf(collections)

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryFilterEngine.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryFilterEngine.kt
@@ -118,7 +118,8 @@ class LibraryFilterEngine(
     searchQuery: Flow<String>,
     notStartedFilterActive: Flow<Boolean>,
     librarySortMode: Flow<LibrarySortMode>,
-    private val computeDispatcher: kotlinx.coroutines.CoroutineDispatcher = kotlinx.coroutines.Dispatchers.Default,
+    /** Off-Main dispatcher for the projection graph — production passes DispatcherProvider.default. */
+    private val computeDispatcher: kotlinx.coroutines.CoroutineDispatcher,
 ) {
 
     private val seriesProjection: Flow<List<Series>> =

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -73,6 +74,7 @@ class LibraryItemsViewModel @Inject constructor(
     private val annotationStore: AnnotationStore,
     private val audiobookBookmarkStore: AudiobookBookmarkStore,
     private val annotationsLibraryRepository: AnnotationsLibraryRepository,
+    private val dispatchers: com.riffle.core.domain.DispatcherProvider,
 ) : ViewModel() {
 
     val libraryId: String = savedStateHandle.get<String>("libraryId") ?: ""
@@ -233,6 +235,9 @@ class LibraryItemsViewModel @Inject constructor(
                 }
             }
         }
+        // representativeSeriesCoverUrl runs isAvailableOffline over series members when offline —
+        // filesystem stats that must not run on Main (see LibraryFilterEngine.projection).
+        .flowOn(dispatchers.default)
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyMap())
 
     private val _notStartedFilterActive = MutableStateFlow(false)
@@ -275,6 +280,7 @@ class LibraryItemsViewModel @Inject constructor(
         searchQuery = searchQuery,
         notStartedFilterActive = _notStartedFilterActive,
         librarySortMode = _librarySortMode,
+        computeDispatcher = dispatchers.default,
     )
 
     val projection: StateFlow<LibraryProjection> = filterEngine.projection

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -447,8 +447,10 @@ private fun CbzPage(
     val scope = rememberCoroutineScope()
     var zoomAnimJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
     val bitmap by produceState<Bitmap?>(initialValue = null, key1 = pageIndex, key2 = source) {
-        value = withContext(Dispatchers.IO) {
-            runCatching { decodeSampledBitmap(source, pageIndex, MAX_PAGE_DIMENSION) }.getOrNull()
+        value = decodeWithRetry {
+            withContext(Dispatchers.IO) {
+                runCatching { decodeSampledBitmap(source, pageIndex, MAX_PAGE_DIMENSION) }.getOrNull()
+            }
         }
     }
     val context = LocalContext.current
@@ -534,22 +536,28 @@ private fun CbzPage(
             },
         contentAlignment = Alignment.Center,
     ) {
-        SubcomposeAsyncImage(
-            model = ImageRequest.Builder(context)
-                .data(bitmap)
-                .crossfade(false)
-                .build(),
-            contentDescription = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.ui_comic_page_number, pageIndex + 1),
-            loading = { CircularProgressIndicator() },
-            modifier = Modifier
-                .fillMaxSize()
-                .graphicsLayer(
-                    scaleX = scale,
-                    scaleY = scale,
-                    translationX = offsetX,
-                    translationY = offsetY,
-                ),
-        )
+        // A null bitmap must render the Loading branch explicitly: feeding null data to Coil
+        // resolves to the (empty) error state immediately, so the streaming-phase fetch would
+        // otherwise show a fully blank page with no feedback until the download completes.
+        when (cbzPageContent(bitmap)) {
+            CbzPageContent.Loading -> CircularProgressIndicator()
+            CbzPageContent.Image -> SubcomposeAsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(bitmap)
+                    .crossfade(false)
+                    .build(),
+                contentDescription = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.ui_comic_page_number, pageIndex + 1),
+                loading = { CircularProgressIndicator() },
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer(
+                        scaleX = scale,
+                        scaleY = scale,
+                        translationX = offsetX,
+                        translationY = offsetY,
+                    ),
+            )
+        }
     }
 }
 
@@ -581,8 +589,10 @@ private fun CbzPanelViewer(
     }
 
     val bitmap by produceState<Bitmap?>(initialValue = null, key1 = currentPage, key2 = state.imageSource) {
-        value = withContext(Dispatchers.IO) {
-            runCatching { decodeSampledBitmap(state.imageSource, currentPage, MAX_PAGE_DIMENSION) }.getOrNull()
+        value = decodeWithRetry {
+            withContext(Dispatchers.IO) {
+                runCatching { decodeSampledBitmap(state.imageSource, currentPage, MAX_PAGE_DIMENSION) }.getOrNull()
+            }
         }
     }
 
@@ -663,26 +673,31 @@ private fun CbzPanelViewer(
             label = "cbz_panel_ty",
         )
 
-        SubcomposeAsyncImage(
-            model = ImageRequest.Builder(context)
-                .data(bitmap)
-                .crossfade(false)
-                .build(),
-            contentDescription = androidx.compose.ui.res.stringResource(
-                com.riffle.app.R.string.ui_comic_page_panel,
-                currentPage + 1,
-                panelIndex + 1,
-            ),
-            loading = { CircularProgressIndicator() },
-            modifier = Modifier
-                .fillMaxSize()
-                .graphicsLayer(
-                    scaleX = animatedScale,
-                    scaleY = animatedScale,
-                    translationX = animatedTx,
-                    translationY = animatedTy,
+        // Same null-bitmap contract as CbzPage: render the spinner ourselves — Coil treats a
+        // null model as an instant (empty) error, not a loading state.
+        when (cbzPageContent(bitmap)) {
+            CbzPageContent.Loading -> CircularProgressIndicator()
+            CbzPageContent.Image -> SubcomposeAsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(bitmap)
+                    .crossfade(false)
+                    .build(),
+                contentDescription = androidx.compose.ui.res.stringResource(
+                    com.riffle.app.R.string.ui_comic_page_panel,
+                    currentPage + 1,
+                    panelIndex + 1,
                 ),
-        )
+                loading = { CircularProgressIndicator() },
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer(
+                        scaleX = animatedScale,
+                        scaleY = animatedScale,
+                        translationX = animatedTx,
+                        translationY = animatedTy,
+                    ),
+            )
+        }
 
         if (peeking) {
             CbzPanelPeekOverlay(
@@ -742,6 +757,36 @@ private fun isReduceMotionEnabled(context: android.content.Context): Boolean {
 }
 
 internal enum class CbzPageGestureAction { Ignore, Zoom, PanZoomed }
+
+internal enum class CbzPageContent { Loading, Image }
+
+/**
+ * What a comic page slot should render for the given decoded bitmap. Null means the decode (or
+ * the streaming-phase network fetch feeding it) hasn't completed — the page must show a loading
+ * indicator, never a blank page.
+ */
+internal fun cbzPageContent(bitmap: Bitmap?): CbzPageContent =
+    if (bitmap == null) CbzPageContent.Loading else CbzPageContent.Image
+
+/**
+ * Runs [decode] until it yields a bitmap, retrying a failure (null) up to [attempts] total
+ * tries with [retryDelayMs] between them. A streaming-phase page decode is a network fetch
+ * under the hood; a single transient failure (timeout while the background full-file download
+ * hogs the link) previously left the page stuck on a permanently-null bitmap with no retry.
+ * Bounded rather than infinite so a genuinely undecodable page settles instead of spinning
+ * the network forever.
+ */
+internal suspend fun <T : Any> decodeWithRetry(
+    attempts: Int = 3,
+    retryDelayMs: Long = 2_000,
+    decode: suspend () -> T?,
+): T? {
+    repeat(attempts - 1) {
+        decode()?.let { return it }
+        delay(retryDelayMs)
+    }
+    return decode()
+}
 
 // Large BMPs can exceed 274MB decoded. Subsample to this max dimension to keep the Bitmap
 // allocation under the app heap limit.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -446,13 +446,15 @@ private fun CbzPage(
     var offsetY by remember(pageIndex) { mutableStateOf(0f) }
     val scope = rememberCoroutineScope()
     var zoomAnimJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
-    val bitmap by produceState<Bitmap?>(initialValue = null, key1 = pageIndex, key2 = source) {
-        value = decodeWithRetry {
+    val decode by produceState(initialValue = CbzPageDecodeState(), key1 = pageIndex, key2 = source) {
+        val result = decodeWithRetry(attempts = decodeAttemptsFor(source)) {
             withContext(Dispatchers.IO) {
                 runCatching { decodeSampledBitmap(source, pageIndex, MAX_PAGE_DIMENSION) }.getOrNull()
             }
         }
+        value = CbzPageDecodeState(bitmap = result, settled = true)
     }
+    val bitmap = decode.bitmap
     val context = LocalContext.current
 
     Box(
@@ -539,8 +541,14 @@ private fun CbzPage(
         // A null bitmap must render the Loading branch explicitly: feeding null data to Coil
         // resolves to the (empty) error state immediately, so the streaming-phase fetch would
         // otherwise show a fully blank page with no feedback until the download completes.
-        when (cbzPageContent(bitmap)) {
+        // Once the decode has settled without a bitmap (retry budget spent, or an undecodable
+        // page in a local archive), show an error instead of an infinite spinner.
+        when (cbzPageContent(bitmap, decode.settled)) {
             CbzPageContent.Loading -> CircularProgressIndicator()
+            CbzPageContent.Error -> Text(
+                text = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.error_comic_page_load_failed),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
             CbzPageContent.Image -> SubcomposeAsyncImage(
                 model = ImageRequest.Builder(context)
                     .data(bitmap)
@@ -588,13 +596,15 @@ private fun CbzPanelViewer(
         }
     }
 
-    val bitmap by produceState<Bitmap?>(initialValue = null, key1 = currentPage, key2 = state.imageSource) {
-        value = decodeWithRetry {
+    val decode by produceState(initialValue = CbzPageDecodeState(), key1 = currentPage, key2 = state.imageSource) {
+        val result = decodeWithRetry(attempts = decodeAttemptsFor(state.imageSource)) {
             withContext(Dispatchers.IO) {
                 runCatching { decodeSampledBitmap(state.imageSource, currentPage, MAX_PAGE_DIMENSION) }.getOrNull()
             }
         }
+        value = CbzPageDecodeState(bitmap = result, settled = true)
     }
+    val bitmap = decode.bitmap
 
     var viewportW by remember { mutableStateOf(0) }
     var viewportH by remember { mutableStateOf(0) }
@@ -675,8 +685,12 @@ private fun CbzPanelViewer(
 
         // Same null-bitmap contract as CbzPage: render the spinner ourselves — Coil treats a
         // null model as an instant (empty) error, not a loading state.
-        when (cbzPageContent(bitmap)) {
+        when (cbzPageContent(bitmap, decode.settled)) {
             CbzPageContent.Loading -> CircularProgressIndicator()
+            CbzPageContent.Error -> Text(
+                text = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.error_comic_page_load_failed),
+                color = MaterialTheme.colorScheme.onSurface,
+            )
             CbzPageContent.Image -> SubcomposeAsyncImage(
                 model = ImageRequest.Builder(context)
                     .data(bitmap)
@@ -758,15 +772,29 @@ private fun isReduceMotionEnabled(context: android.content.Context): Boolean {
 
 internal enum class CbzPageGestureAction { Ignore, Zoom, PanZoomed }
 
-internal enum class CbzPageContent { Loading, Image }
+internal enum class CbzPageContent { Loading, Image, Error }
+
+/** Result of a page decode attempt: [settled] flips true once the retry budget is spent. */
+internal data class CbzPageDecodeState(val bitmap: Bitmap? = null, val settled: Boolean = false)
 
 /**
- * What a comic page slot should render for the given decoded bitmap. Null means the decode (or
- * the streaming-phase network fetch feeding it) hasn't completed — the page must show a loading
- * indicator, never a blank page.
+ * What a comic page slot should render. A null bitmap with the decode still running must show a
+ * loading indicator, never a blank page; a null bitmap after the decode settled (retry budget
+ * spent, or an undecodable page) must show an error, never an infinite spinner.
  */
-internal fun cbzPageContent(bitmap: Bitmap?): CbzPageContent =
-    if (bitmap == null) CbzPageContent.Loading else CbzPageContent.Image
+internal fun cbzPageContent(bitmap: Bitmap?, decodeSettled: Boolean): CbzPageContent = when {
+    bitmap != null -> CbzPageContent.Image
+    decodeSettled -> CbzPageContent.Error
+    else -> CbzPageContent.Loading
+}
+
+/**
+ * Retries only make sense when a decode failure can be transient — i.e. the streaming phase,
+ * where the bytes come over the network. A local archive decode fails deterministically
+ * (corrupt page), so retrying just delays the error state.
+ */
+internal fun decodeAttemptsFor(source: CbzImageSource): Int =
+    if (source is NetworkImageSource) 3 else 1
 
 /**
  * Runs [decode] until it yields a bitmap, retrying a failure (null) up to [attempts] total

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
@@ -355,6 +355,7 @@ class CbzReaderViewModel @Inject constructor(
         val networkSource = NetworkImageSource(
             item.sourceId, item.id, result.pageCount, cbzRepository,
             readAheadScope = viewModelScope, readAheadCount = 2,
+            readAheadDispatcher = Dispatchers.IO,
         )
         val thumbnailSource = NetworkImageSource(item.sourceId, item.id, result.pageCount, cbzRepository, thumbnailWidth = 300)
         panelBook = panelEngine.forBook(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
@@ -350,7 +350,12 @@ class CbzReaderViewModel @Inject constructor(
         lastSavedPage = resumeIndex
         _currentPanelIndex.value = 0
 
-        val networkSource = NetworkImageSource(item.sourceId, item.id, result.pageCount, cbzRepository)
+        // Read-ahead so a streaming-phase page turn is served from the byte cache instead of a
+        // cold synchronous download racing the background full-file download for bandwidth.
+        val networkSource = NetworkImageSource(
+            item.sourceId, item.id, result.pageCount, cbzRepository,
+            readAheadScope = viewModelScope, readAheadCount = 2,
+        )
         val thumbnailSource = NetworkImageSource(item.sourceId, item.id, result.pageCount, cbzRepository, thumbnailWidth = 300)
         panelBook = panelEngine.forBook(
             bookId = bookId,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSource.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSource.kt
@@ -4,6 +4,11 @@ import com.riffle.core.domain.CbzRepository
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -17,8 +22,15 @@ import kotlinx.coroutines.runBlocking
  * blocking interface consumed from [kotlinx.coroutines.Dispatchers.IO] via produceState in the
  * reader. [runBlocking] on the IO dispatcher is safe — the IO pool is unbounded.
  *
- * A 3-entry byte cache eliminates the double-download that [decodeSampledBitmap] triggers
+ * The byte cache eliminates the double-download that [decodeSampledBitmap] triggers
  * (one bounds-only pass + one decode pass on the same page index).
+ *
+ * [readAheadCount] > 0 enables read-ahead: every page access asynchronously prefetches the next
+ * [readAheadCount] pages into the byte cache on [readAheadScope]. Without it, a page turn during
+ * the streaming phase is a cold synchronous full-resolution download — while the background
+ * full-file download is saturating the same link — which the user sees as a multi-second blank
+ * page. Read-ahead pipelines the next page's fetch into the dwell time on the current page.
+ * Keep it 0 for the thumbnail-strip source: the strip prewarms its own cache sequentially.
  *
  * Once the background download completes, the ViewModel replaces this source with an
  * [ArchiveImageSource] backed by the local [com.riffle.core.domain.comic.CbzArchive].
@@ -29,14 +41,25 @@ internal class NetworkImageSource(
     private val count: Int,
     private val repository: CbzRepository,
     private val thumbnailWidth: Int? = null,
+    private val readAheadScope: CoroutineScope? = null,
+    private val readAheadCount: Int = 0,
+    private val readAheadDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : CbzImageSource {
     override val pageCount: Int get() = count
 
+    // Holds the current page (fetched twice by decodeSampledBitmap's bounds+decode passes)
+    // plus the read-ahead neighbourhood. Access-order LRU so the current page isn't evicted
+    // by its own read-ahead.
+    private val maxCacheEntries = 3 + readAheadCount
     private val byteCache: MutableMap<Int, ByteArray> = Collections.synchronizedMap(
         object : LinkedHashMap<Int, ByteArray>(5, 0.75f, true) {
-            override fun removeEldestEntry(eldest: Map.Entry<Int, ByteArray>?) = size > 3
+            override fun removeEldestEntry(eldest: Map.Entry<Int, ByteArray>?) = size > maxCacheEntries
         }
     )
+
+    // Pages with a read-ahead fetch currently in flight, so rapid page turns don't stack
+    // duplicate downloads of the same index.
+    private val inFlight: MutableSet<Int> = ConcurrentHashMap.newKeySet()
 
     override fun imageBytes(pageIndex: Int): ByteArray = getBytes(pageIndex)
 
@@ -44,9 +67,29 @@ internal class NetworkImageSource(
         ByteArrayInputStream(getBytes(pageIndex))
 
     private fun getBytes(pageIndex: Int): ByteArray {
-        byteCache[pageIndex]?.let { return it }
-        return runBlocking {
+        val bytes = byteCache[pageIndex] ?: runBlocking {
             repository.fetchStreamingPageImage(sourceId, itemId, pageIndex, thumbnailWidth)
         }.also { byteCache[pageIndex] = it }
+        scheduleReadAhead(pageIndex)
+        return bytes
+    }
+
+    private fun scheduleReadAhead(fromIndex: Int) {
+        val scope = readAheadScope ?: return
+        for (offset in 1..readAheadCount) {
+            val target = fromIndex + offset
+            if (target >= count) break
+            if (byteCache.containsKey(target)) continue
+            if (!inFlight.add(target)) continue
+            scope.launch(readAheadDispatcher) {
+                try {
+                    byteCache[target] = repository.fetchStreamingPageImage(sourceId, itemId, target, thumbnailWidth)
+                } catch (_: Throwable) {
+                    // Best-effort: a failed prefetch just leaves the page to the on-demand path.
+                } finally {
+                    inFlight.remove(target)
+                }
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSource.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSource.kt
@@ -7,8 +7,9 @@ import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -57,9 +58,11 @@ internal class NetworkImageSource(
         }
     )
 
-    // Pages with a read-ahead fetch currently in flight, so rapid page turns don't stack
-    // duplicate downloads of the same index.
-    private val inFlight: MutableSet<Int> = ConcurrentHashMap.newKeySet()
+    // Read-ahead fetches currently in flight, keyed by page index. Deferred (not a Boolean set)
+    // so a page turn that arrives mid-prefetch JOINS the in-flight download instead of firing a
+    // duplicate cold fetch of the same image — on a link the background full-file download is
+    // already saturating, the duplicate is exactly the latency read-ahead exists to remove.
+    private val inFlight = ConcurrentHashMap<Int, Deferred<ByteArray>>()
 
     override fun imageBytes(pageIndex: Int): ByteArray = getBytes(pageIndex)
 
@@ -67,11 +70,28 @@ internal class NetworkImageSource(
         ByteArrayInputStream(getBytes(pageIndex))
 
     private fun getBytes(pageIndex: Int): ByteArray {
-        val bytes = byteCache[pageIndex] ?: runBlocking {
-            repository.fetchStreamingPageImage(sourceId, itemId, pageIndex, thumbnailWidth)
-        }.also { byteCache[pageIndex] = it }
+        val bytes = byteCache[pageIndex]
+            ?: joinInFlight(pageIndex)
+            ?: runBlocking {
+                repository.fetchStreamingPageImage(sourceId, itemId, pageIndex, thumbnailWidth)
+            }.also { byteCache[pageIndex] = it }
         scheduleReadAhead(pageIndex)
         return bytes
+    }
+
+    /**
+     * Awaits an in-flight read-ahead of [pageIndex] if one exists. Safe to block on: the deferred
+     * runs on [readAheadDispatcher] (a real thread pool), never on the caller's thread. Returns
+     * null when there is nothing in flight or the prefetch failed — the caller then falls back to
+     * its own fetch.
+     */
+    private fun joinInFlight(pageIndex: Int): ByteArray? {
+        val pending = inFlight[pageIndex] ?: return null
+        return try {
+            runBlocking { pending.await() }
+        } catch (_: Throwable) {
+            null
+        }
     }
 
     private fun scheduleReadAhead(fromIndex: Int) {
@@ -80,14 +100,14 @@ internal class NetworkImageSource(
             val target = fromIndex + offset
             if (target >= count) break
             if (byteCache.containsKey(target)) continue
-            if (!inFlight.add(target)) continue
-            scope.launch(readAheadDispatcher) {
-                try {
-                    byteCache[target] = repository.fetchStreamingPageImage(sourceId, itemId, target, thumbnailWidth)
-                } catch (_: Throwable) {
-                    // Best-effort: a failed prefetch just leaves the page to the on-demand path.
-                } finally {
-                    inFlight.remove(target)
+            inFlight.computeIfAbsent(target) {
+                scope.async(readAheadDispatcher) {
+                    try {
+                        repository.fetchStreamingPageImage(sourceId, itemId, target, thumbnailWidth)
+                            .also { byteCache[target] = it }
+                    } finally {
+                        inFlight.remove(target)
+                    }
                 }
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSource.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSource.kt
@@ -8,7 +8,6 @@ import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 
@@ -44,7 +43,8 @@ internal class NetworkImageSource(
     private val thumbnailWidth: Int? = null,
     private val readAheadScope: CoroutineScope? = null,
     private val readAheadCount: Int = 0,
-    private val readAheadDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    /** Required whenever [readAheadScope] is set — an IO-capable dispatcher for the prefetches. */
+    private val readAheadDispatcher: CoroutineDispatcher? = null,
 ) : CbzImageSource {
     override val pageCount: Int get() = count
 
@@ -96,12 +96,13 @@ internal class NetworkImageSource(
 
     private fun scheduleReadAhead(fromIndex: Int) {
         val scope = readAheadScope ?: return
+        val dispatcher = readAheadDispatcher ?: return
         for (offset in 1..readAheadCount) {
             val target = fromIndex + offset
             if (target >= count) break
             if (byteCache.containsKey(target)) continue
             inFlight.computeIfAbsent(target) {
-                scope.async(readAheadDispatcher) {
+                scope.async(dispatcher) {
                     try {
                         repository.fetchStreamingPageImage(sourceId, itemId, target, thumbnailWidth)
                             .also { byteCache[target] = it }

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -355,6 +355,7 @@
     <string name="error_couldnt_save_source">Източникът не можа да бъде запазен: %1$s</string>
     <string name="error_connection_failed">Връзката е неуспешна: %1$s</string>
     <string name="error_connected_library_load_failed">Свързано, но библиотеките не можаха да се заредят: %1$s</string>
+    <string name="error_comic_page_load_failed">Тази страница не можа да се зареди</string>
     <string name="error_select_failure_type">Изберете тип проблем преди изпращане</string>
     <string name="crash_report_title">Доклад за срив</string>
     <string name="crash_report_text">Riffle се срина. Отворете Настройки → Доклади за сривове, за да видите или споделите подробностите.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -355,6 +355,7 @@
     <string name="error_couldnt_save_source">No se pudo guardar la fuente: %1$s</string>
     <string name="error_connection_failed">Error de conexión: %1$s</string>
     <string name="error_connected_library_load_failed">Conectado, pero no se pudieron cargar las bibliotecas: %1$s</string>
+    <string name="error_comic_page_load_failed">No se pudo cargar esta página</string>
     <string name="error_select_failure_type">Selecciona un tipo de problema antes de enviar</string>
     <string name="crash_report_title">Informe de fallo</string>
     <string name="crash_report_text">Riffle falló. Abre Ajustes → Informes de fallos para ver o compartir los detalles.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -361,6 +361,7 @@
     <string name="error_couldnt_save_source">Couldn\'t save source: %1$s</string>
     <string name="error_connection_failed">Connection failed: %1$s</string>
     <string name="error_connected_library_load_failed">Connected, but couldn\'t load libraries: %1$s</string>
+    <string name="error_comic_page_load_failed">Couldn\'t load this page</string>
     <string name="error_select_failure_type">Select a failure type before submitting</string>
     <string name="crash_report_title">Crash report</string>
     <string name="crash_report_text">Riffle crashed. Open Settings → Crash reports to view or share the details.</string>

--- a/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/CollectionDetailViewModelTest.kt
@@ -150,6 +150,14 @@ class CollectionDetailViewModelTest {
             },
         ),
         connectivityObserver = connectivityObserver,
+        // Bind the VM's compute dispatcher to the test scheduler so the offline-filter flowOn hop
+        // stays under virtual time (advanceUntilIdle drains it deterministically).
+        dispatchers = object : com.riffle.core.domain.DispatcherProvider {
+            override val main = testDispatcher
+            override val mainImmediate = testDispatcher
+            override val io = testDispatcher
+            override val default = testDispatcher
+        },
     )
 
     private fun item(id: String) = LibraryItem(

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
@@ -201,6 +201,44 @@ class LibraryFilterEngineTest {
             title = title, createdAt = 0L,
         )
 
+    // --- threading (page-turn main-thread sweep regression) ---
+
+    @Test
+    fun `offline availability sweep runs on the compute dispatcher, never the collector thread`() = runTest {
+        val sweepThreads = java.util.Collections.synchronizedSet(mutableSetOf<String>())
+        val recordingEpubRepo = object : EpubRepository {
+            override suspend fun openEpub(item: LibraryItem) = EpubOpenResult.Offline
+            override suspend fun downloadEpub(item: LibraryItem, onProgress: (Long, Long) -> Unit) = EpubDownloadResult.Success
+            override suspend fun removeDownload(sourceId: String, itemId: String) {}
+            override fun isDownloaded(sourceId: String, itemId: String): Boolean {
+                sweepThreads.add(Thread.currentThread().name)
+                return itemId == "id-A"
+            }
+            override fun isCached(sourceId: String, itemId: String): Boolean = false
+            override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
+        }
+        val engine = makeEngine(epubRepository = recordingEpubRepo)
+        isOfflineFlow.value = true
+        allBooksFlow.value = listOf(item("A"), item("B"))
+
+        val collectorThread = Thread.currentThread().name
+        val p = engine.projection.first { it.allBooks.map { b -> b.id } == listOf("id-A") }
+        assertEquals(listOf("id-A"), p.allBooks.map { it.id })
+
+        // The whole point of the engine's flowOn: the per-item filesystem sweep must not run on
+        // the thread that collects the projection (in production that is Main — a page turn
+        // re-emits every source flow, and an on-Main sweep froze the reader for seconds).
+        org.junit.Assert.assertTrue("sweep never ran", sweepThreads.isNotEmpty())
+        org.junit.Assert.assertTrue(
+            "sweep ran on the collector thread: $sweepThreads",
+            sweepThreads.none { it == collectorThread },
+        )
+        org.junit.Assert.assertTrue(
+            "expected Dispatchers.Default workers, got $sweepThreads",
+            sweepThreads.all { it.contains("DefaultDispatcher") },
+        )
+    }
+
     // --- series ---
 
     @Test

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
@@ -172,6 +172,7 @@ class LibraryFilterEngineTest {
             searchQuery = searchQueryFlow,
             notStartedFilterActive = notStartedFilterFlow,
             librarySortMode = librarySortModeFlow,
+            computeDispatcher = kotlinx.coroutines.Dispatchers.Default,
         )
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemsViewModelTest.kt
@@ -337,6 +337,14 @@ class LibraryItemsViewModelTest {
         annotationStore = annotationStore,
         audiobookBookmarkStore = audiobookBookmarkStore,
         annotationsLibraryRepository = annotationsLibraryRepository,
+        // Bind the VM's compute dispatcher to the test scheduler so the offline-filter flowOn hop
+        // stays under virtual time (advanceUntilIdle drains it deterministically).
+        dispatchers = object : com.riffle.core.domain.DispatcherProvider {
+            override val main = testDispatcher
+            override val mainImmediate = testDispatcher
+            override val io = testDispatcher
+            override val default = testDispatcher
+        },
     )
 
     private fun series(name: String) = Series("id-$name", "lib-1", name, null, 1)

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/CbzPageContentTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/CbzPageContentTest.kt
@@ -1,17 +1,58 @@
 package com.riffle.app.feature.reader.cbz
 
+import com.riffle.core.domain.comic.ComicArchive
+import java.io.InputStream
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * A null bitmap (streaming-phase fetch or decode still in flight) must render a loading
- * indicator. The previous behaviour fed the null straight into Coil, which resolves a null
- * model as an instant empty error — the user saw a fully blank page for the whole multi-second
- * streaming fetch.
+ * A null bitmap while the decode is running must render a loading indicator — the previous
+ * behaviour fed the null straight into Coil, which resolves a null model as an instant empty
+ * error, so the user saw a fully blank page for the whole multi-second streaming fetch. Once the
+ * decode settles without a bitmap, the page must show an error, never an infinite spinner.
  */
 class CbzPageContentTest {
 
-    @Test fun `null bitmap renders the loading indicator, not a blank page`() {
-        assertEquals(CbzPageContent.Loading, cbzPageContent(null))
+    @Test fun `null bitmap while decoding renders the loading indicator, not a blank page`() {
+        assertEquals(CbzPageContent.Loading, cbzPageContent(null, decodeSettled = false))
     }
+
+    @Test fun `null bitmap after the decode settled renders an error, not an infinite spinner`() {
+        assertEquals(CbzPageContent.Error, cbzPageContent(null, decodeSettled = true))
+    }
+
+    // --- retry budget per source ---
+
+    private class FakeArchive : ComicArchive {
+        override val pageCount = 1
+        override fun imageBytes(pageIndex: Int): ByteArray = ByteArray(0)
+        override fun openStream(pageIndex: Int): InputStream = ByteArray(0).inputStream()
+        override fun mediaType(pageIndex: Int): String = "image/jpeg"
+        override fun close() {}
+    }
+
+    @Test fun `local archive decodes never retry - failure is deterministic`() {
+        assertEquals(1, decodeAttemptsFor(ArchiveImageSource(FakeArchive())))
+    }
+
+    @Test fun `streaming decodes retry - network failure is transient`() {
+        val source = NetworkImageSource("s", "i", 1, repository = FailingCbzRepository)
+        assertEquals(3, decodeAttemptsFor(source))
+    }
+}
+
+private object FailingCbzRepository : com.riffle.core.domain.CbzRepository {
+    override suspend fun openCbz(item: com.riffle.core.models.LibraryItem) = error("unused")
+    override suspend fun downloadCbz(
+        item: com.riffle.core.models.LibraryItem,
+        onProgress: (Long, Long) -> Unit,
+    ) = error("unused")
+    override suspend fun removeDownload(sourceId: String, itemId: String) = error("unused")
+    override fun isDownloaded(sourceId: String, itemId: String) = false
+    override fun isCached(sourceId: String, itemId: String) = false
+    override suspend fun saveReadingPosition(itemId: String, locatorJson: String) = error("unused")
+    override suspend fun supportsStreaming(sourceId: String) = true
+    override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int, maxWidth: Int?): ByteArray =
+        error("unused")
+    override suspend fun awaitCachedFile(item: com.riffle.core.models.LibraryItem): java.io.File? = null
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/CbzPageContentTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/CbzPageContentTest.kt
@@ -1,0 +1,17 @@
+package com.riffle.app.feature.reader.cbz
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * A null bitmap (streaming-phase fetch or decode still in flight) must render a loading
+ * indicator. The previous behaviour fed the null straight into Coil, which resolves a null
+ * model as an instant empty error — the user saw a fully blank page for the whole multi-second
+ * streaming fetch.
+ */
+class CbzPageContentTest {
+
+    @Test fun `null bitmap renders the loading indicator, not a blank page`() {
+        assertEquals(CbzPageContent.Loading, cbzPageContent(null))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/DecodeWithRetryTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/DecodeWithRetryTest.kt
@@ -1,0 +1,45 @@
+package com.riffle.app.feature.reader.cbz
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * A streaming-phase page decode is a network fetch under the hood. Before decodeWithRetry, a
+ * single transient fetch failure (e.g. timeout while the background full-file download hogs the
+ * link) permanently stuck the page: produceState ran the decode exactly once and a null bitmap
+ * rendered as a blank page forever.
+ */
+class DecodeWithRetryTest {
+
+    @Test fun `first success returns immediately without retrying`() = runTest {
+        var calls = 0
+        val result = decodeWithRetry(attempts = 3, retryDelayMs = 10) {
+            calls++
+            "page"
+        }
+        assertEquals("page", result)
+        assertEquals(1, calls)
+    }
+
+    @Test fun `transient failure is retried until success`() = runTest {
+        var calls = 0
+        val result = decodeWithRetry(attempts = 3, retryDelayMs = 10) {
+            calls++
+            if (calls < 3) null else "page"
+        }
+        assertEquals("page", result)
+        assertEquals(3, calls)
+    }
+
+    @Test fun `gives up after the attempt budget`() = runTest {
+        var calls = 0
+        val result = decodeWithRetry<String>(attempts = 3, retryDelayMs = 10) {
+            calls++
+            null
+        }
+        assertNull(result)
+        assertEquals(3, calls)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSourceTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSourceTest.kt
@@ -168,6 +168,7 @@ class NetworkImageSourceTest {
             "src", "item", 10, gatedRepo,
             readAheadScope = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO),
             readAheadCount = 2,
+            readAheadDispatcher = kotlinx.coroutines.Dispatchers.IO,
         )
         source.imageBytes(4) // schedules read-ahead of 5 and 6
         org.junit.Assert.assertTrue(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSourceTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSourceTest.kt
@@ -150,6 +150,39 @@ class NetworkImageSourceTest {
         assertEquals(listOf(4, 5, 6), repo.fetchedIndices.sorted())
     }
 
+    @Test fun `a page turn joins an in-flight read-ahead instead of duplicating the download`() {
+        val prefetchStarted = java.util.concurrent.CountDownLatch(1)
+        val releasePrefetch = java.util.concurrent.CountDownLatch(1)
+        val fetchCounts = java.util.concurrent.ConcurrentHashMap<Int, Int>()
+        val gatedRepo = object : CbzRepository by fakeRepo {
+            override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int, maxWidth: Int?): ByteArray {
+                fetchCounts.merge(pageIndex, 1, Int::plus)
+                if (pageIndex == 5) {
+                    prefetchStarted.countDown()
+                    releasePrefetch.await() // hold the prefetch in flight (real IO thread — blocking is fine)
+                }
+                return fakeBytes
+            }
+        }
+        val source = NetworkImageSource(
+            "src", "item", 10, gatedRepo,
+            readAheadScope = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO),
+            readAheadCount = 2,
+        )
+        source.imageBytes(4) // schedules read-ahead of 5 and 6
+        org.junit.Assert.assertTrue(
+            "read-ahead of page 5 never started",
+            prefetchStarted.await(5, java.util.concurrent.TimeUnit.SECONDS),
+        )
+        Thread.sleep(50) // let the in-flight registration settle
+        val turn = java.util.concurrent.Executors.newSingleThreadExecutor().submit<ByteArray> {
+            source.imageBytes(5) // the page turn — must join, not re-download
+        }
+        releasePrefetch.countDown()
+        assertArrayEquals(fakeBytes, turn.get(5, java.util.concurrent.TimeUnit.SECONDS))
+        assertEquals("page 5 downloaded more than once", 1, fetchCounts[5])
+    }
+
     @Test fun `cache retains current page alongside read-ahead entries`() = runTest {
         val repo = RecordingRepo(fakeRepo, fakeBytes)
         val source = readAheadSource(repo, pageCount = 20)

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSourceTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/NetworkImageSourceTest.kt
@@ -6,6 +6,11 @@ import com.riffle.core.domain.CbzRepository
 import com.riffle.core.models.EbookFormat
 import com.riffle.core.models.LibraryItem
 import java.io.File
+import java.util.Collections
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -83,5 +88,75 @@ class NetworkImageSourceTest {
         source.imageBytes(5)
         source.imageBytes(5) // same index — should hit cache
         assertEquals("expected only 1 network call due to byte cache", 1, callCount)
+    }
+
+    // --- Read-ahead (streaming-phase page-turn latency fix) ---
+
+    private class RecordingRepo(base: CbzRepository, private val bytes: ByteArray) : CbzRepository by base {
+        val fetchedIndices: MutableList<Int> = Collections.synchronizedList(mutableListOf())
+        override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int, maxWidth: Int?): ByteArray {
+            fetchedIndices.add(pageIndex)
+            return bytes
+        }
+    }
+
+    private fun TestScope.readAheadSource(repo: CbzRepository, pageCount: Int, readAheadCount: Int = 2) =
+        NetworkImageSource(
+            "src", "item", pageCount, repo,
+            readAheadScope = this,
+            readAheadCount = readAheadCount,
+            readAheadDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+    @Test fun `accessing a page prefetches the next readAheadCount pages`() = runTest {
+        val repo = RecordingRepo(fakeRepo, fakeBytes)
+        val source = readAheadSource(repo, pageCount = 10)
+        source.imageBytes(4)
+        advanceUntilIdle()
+        assertEquals(listOf(4, 5, 6), repo.fetchedIndices.sorted())
+    }
+
+    @Test fun `prefetched page is served from cache without a new network request`() = runTest {
+        val repo = RecordingRepo(fakeRepo, fakeBytes)
+        val source = readAheadSource(repo, pageCount = 10)
+        source.imageBytes(4)
+        advanceUntilIdle()
+        repo.fetchedIndices.clear()
+        source.imageBytes(5) // the page turn the user waits on — must be a cache hit
+        assertEquals("page 5 must not be re-fetched after read-ahead", emptyList<Int>(), repo.fetchedIndices.filter { it == 5 })
+    }
+
+    @Test fun `read-ahead stops at the last page`() = runTest {
+        val repo = RecordingRepo(fakeRepo, fakeBytes)
+        val source = readAheadSource(repo, pageCount = 10)
+        source.imageBytes(9)
+        advanceUntilIdle()
+        assertEquals(listOf(9), repo.fetchedIndices.toList())
+    }
+
+    @Test fun `read-ahead is off by default`() {
+        val repo = RecordingRepo(fakeRepo, fakeBytes)
+        val source = NetworkImageSource("src", "item", 10, repo)
+        source.imageBytes(4)
+        assertEquals(listOf(4), repo.fetchedIndices.toList())
+    }
+
+    @Test fun `read-ahead does not duplicate an in-flight prefetch`() = runTest {
+        val repo = RecordingRepo(fakeRepo, fakeBytes)
+        val source = readAheadSource(repo, pageCount = 10)
+        source.imageBytes(4)
+        source.imageBytes(4) // second access before the scheduler runs — must not re-enqueue 5/6
+        advanceUntilIdle()
+        assertEquals(listOf(4, 5, 6), repo.fetchedIndices.sorted())
+    }
+
+    @Test fun `cache retains current page alongside read-ahead entries`() = runTest {
+        val repo = RecordingRepo(fakeRepo, fakeBytes)
+        val source = readAheadSource(repo, pageCount = 20)
+        source.imageBytes(4) // decodeSampledBitmap bounds pass
+        advanceUntilIdle() // read-ahead of 5 and 6 completes
+        repo.fetchedIndices.clear()
+        source.imageBytes(4) // decode pass — must still be cached after read-ahead insertions
+        assertEquals(emptyList<Int>(), repo.fetchedIndices.toList())
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/RepositoriesModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/RepositoriesModule.kt
@@ -186,15 +186,14 @@ abstract class RepositoriesModule {
             audiobookDownloadRepository: AudiobookDownloadRepository,
             bundleAudiobookSource: BundleAudiobookSource,
             localAvailabilityEvents: LocalAvailabilityEvents,
+            applicationScope: com.riffle.core.domain.ApplicationScope,
         ): LibraryItemOfflineAvailability =
             LibraryItemOfflineAvailability(
                 epubRepository, pdfRepository, cbzRepository, audiobookDownloadRepository, bundleAudiobookSource,
                 availabilityChanges = localAvailabilityEvents.changes,
-                // Singleton-lifetime scope for the cache-invalidation collector; nothing to cancel
-                // before process death.
-                invalidationScope = kotlinx.coroutines.CoroutineScope(
-                    kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.Default,
-                ),
+                // Cache-invalidation collector lives for the process — the app's survivable scope
+                // is the named owner for that lifetime (see ApplicationScope).
+                invalidationScope = applicationScope.coroutineScope,
             )
     }
 }

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/modules/RepositoriesModule.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/modules/RepositoriesModule.kt
@@ -185,7 +185,16 @@ abstract class RepositoriesModule {
             cbzRepository: com.riffle.core.domain.CbzRepository,
             audiobookDownloadRepository: AudiobookDownloadRepository,
             bundleAudiobookSource: BundleAudiobookSource,
+            localAvailabilityEvents: LocalAvailabilityEvents,
         ): LibraryItemOfflineAvailability =
-            LibraryItemOfflineAvailability(epubRepository, pdfRepository, cbzRepository, audiobookDownloadRepository, bundleAudiobookSource)
+            LibraryItemOfflineAvailability(
+                epubRepository, pdfRepository, cbzRepository, audiobookDownloadRepository, bundleAudiobookSource,
+                availabilityChanges = localAvailabilityEvents.changes,
+                // Singleton-lifetime scope for the cache-invalidation collector; nothing to cancel
+                // before process death.
+                invalidationScope = kotlinx.coroutines.CoroutineScope(
+                    kotlinx.coroutines.SupervisorJob() + kotlinx.coroutines.Dispatchers.Default,
+                ),
+            )
     }
 }

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailability.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailability.kt
@@ -1,6 +1,10 @@
 package com.riffle.core.domain
 import com.riffle.core.models.EbookFormat
 import com.riffle.core.models.LibraryItem
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.launch
 
 /**
  * Decides whether a [LibraryItem] can be opened with no network — the single source of truth behind
@@ -8,6 +12,13 @@ import com.riffle.core.models.LibraryItem
  * cached (EPUB/PDF), OR when its audiobook is downloaded. Audiobooks have a download-only tier (no
  * auto-cache), so the audio side is a plain `isDownloaded` check (ADR 0035). An item is ALSO
  * offline-available when a downloaded readaloud bundle can supply its audio ([BundleAudiobookSource]).
+ *
+ * Results are memoized per item: each uncached check costs up to ~8 `File.exists()` syscalls (a
+ * miss internally constructs an ErrnoException with a full stack fill), and the library's offline
+ * projections re-run this over EVERY item whenever any Room flow re-emits — which happens on every
+ * reading-progress write, i.e. every reader page turn. Uncached, a large library turns each page
+ * turn into a multi-second filesystem sweep. The cache is invalidated per item by
+ * [LocalAvailabilityEvents.changes], which every download/cache/delete path already notifies.
  */
 class LibraryItemOfflineAvailability(
     private val epubRepository: EpubRepository,
@@ -15,8 +26,23 @@ class LibraryItemOfflineAvailability(
     private val cbzRepository: CbzRepository,
     private val audiobookDownloadRepository: AudiobookDownloadRepository,
     private val bundleAudiobookSource: BundleAudiobookSource,
+    availabilityChanges: SharedFlow<StoredItemRef>? = null,
+    invalidationScope: CoroutineScope? = null,
 ) {
-    fun isAvailableOffline(item: LibraryItem): Boolean {
+    private val cache = ConcurrentHashMap<String, Boolean>()
+
+    init {
+        if (availabilityChanges != null && invalidationScope != null) {
+            invalidationScope.launch {
+                availabilityChanges.collect { ref -> cache.remove(key(ref.sourceId, ref.itemId)) }
+            }
+        }
+    }
+
+    fun isAvailableOffline(item: LibraryItem): Boolean =
+        cache.getOrPut(key(item.sourceId, item.id)) { computeAvailability(item) }
+
+    private fun computeAvailability(item: LibraryItem): Boolean {
         val ebookAvailable = when (item.ebookFormat) {
             EbookFormat.Epub ->
                 epubRepository.isDownloaded(item.sourceId, item.id) || epubRepository.isCached(item.sourceId, item.id)
@@ -30,4 +56,6 @@ class LibraryItemOfflineAvailability(
             audiobookDownloadRepository.isDownloaded(item.sourceId, item.id) ||
             bundleAudiobookSource.isAvailableOffline(item.sourceId, item.id)
     }
+
+    private fun key(sourceId: String, itemId: String) = "$sourceId::$itemId"
 }

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailability.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailability.kt
@@ -17,8 +17,17 @@ import kotlinx.coroutines.launch
  * miss internally constructs an ErrnoException with a full stack fill), and the library's offline
  * projections re-run this over EVERY item whenever any Room flow re-emits — which happens on every
  * reading-progress write, i.e. every reader page turn. Uncached, a large library turns each page
- * turn into a multi-second filesystem sweep. The cache is invalidated per item by
- * [LocalAvailabilityEvents.changes], which every download/cache/delete path already notifies.
+ * turn into a multi-second filesystem sweep.
+ *
+ * Invalidation is two-layered:
+ *  - Event-driven: [LocalAvailabilityEvents.changes] evicts the exact item on every
+ *    download/cache/delete path that notifies.
+ *  - TTL backstop ([ttlMillis]): availability paths that do NOT notify (readaloud bundle
+ *    download/remove uses Storyteller-keyed storage and never emits an ABS-keyed event) and the
+ *    inherent check-then-act window between computing an entry and a concurrent change event
+ *    both self-heal within one TTL, restoring the pre-memo "next sweep recomputes" property with
+ *    bounded staleness. Sweeps fire many times per second during reading, so a 30 s TTL keeps
+ *    ~all of the syscall savings.
  */
 class LibraryItemOfflineAvailability(
     private val epubRepository: EpubRepository,
@@ -28,8 +37,12 @@ class LibraryItemOfflineAvailability(
     private val bundleAudiobookSource: BundleAudiobookSource,
     availabilityChanges: SharedFlow<StoredItemRef>? = null,
     invalidationScope: CoroutineScope? = null,
+    private val ttlMillis: Long = 30_000,
+    private val nowMillis: () -> Long = System::currentTimeMillis,
 ) {
-    private val cache = ConcurrentHashMap<String, Boolean>()
+    private class Entry(val available: Boolean, val computedAtMillis: Long)
+
+    private val cache = ConcurrentHashMap<String, Entry>()
 
     init {
         if (availabilityChanges != null && invalidationScope != null) {
@@ -39,8 +52,16 @@ class LibraryItemOfflineAvailability(
         }
     }
 
-    fun isAvailableOffline(item: LibraryItem): Boolean =
-        cache.getOrPut(key(item.sourceId, item.id)) { computeAvailability(item) }
+    fun isAvailableOffline(item: LibraryItem): Boolean {
+        val k = key(item.sourceId, item.id)
+        val now = nowMillis()
+        cache[k]?.let { entry ->
+            if (now - entry.computedAtMillis < ttlMillis) return entry.available
+        }
+        val computed = computeAvailability(item)
+        cache[k] = Entry(computed, now)
+        return computed
+    }
 
     private fun computeAvailability(item: LibraryItem): Boolean {
         val ebookAvailable = when (item.ebookFormat) {

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt
@@ -159,6 +159,7 @@ class LibraryItemOfflineAvailabilityTest {
     private fun cachingAvailability(
         counting: CountingCbzRepository,
         changes: MutableSharedFlow<StoredItemRef>? = null,
+        nowMillis: () -> Long = { 0L },
     ) = LibraryItemOfflineAvailability(
         epubRepository = FakeEpubRepository(),
         pdfRepository = FakePdfRepository(),
@@ -167,6 +168,7 @@ class LibraryItemOfflineAvailabilityTest {
         bundleAudiobookSource = FakeBundleAudiobookSource(),
         availabilityChanges = changes,
         invalidationScope = changes?.let { CoroutineScope(Dispatchers.Unconfined) },
+        nowMillis = nowMillis,
     )
 
     @Test
@@ -186,6 +188,21 @@ class LibraryItemOfflineAvailabilityTest {
         availability.isAvailableOffline(item(EbookFormat.Cbz))
         assertEquals(1, counting.isDownloadedCalls)
         changes.tryEmit(StoredItemRef("s1", "i1"))
+        availability.isAvailableOffline(item(EbookFormat.Cbz))
+        assertEquals(2, counting.isDownloadedCalls)
+    }
+
+    @Test
+    fun `memo entries expire after the TTL backstop`() {
+        // Availability paths that never notify (readaloud-bundle download/remove) must still be
+        // picked up eventually — the TTL restores the pre-memo self-healing with bounded staleness.
+        var now = 0L
+        val counting = CountingCbzRepository()
+        val availability = cachingAvailability(counting, nowMillis = { now })
+        availability.isAvailableOffline(item(EbookFormat.Cbz))
+        availability.isAvailableOffline(item(EbookFormat.Cbz))
+        assertEquals(1, counting.isDownloadedCalls)
+        now = 30_000
         availability.isAvailableOffline(item(EbookFormat.Cbz))
         assertEquals(2, counting.isDownloadedCalls)
     }

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt
@@ -1,5 +1,9 @@
 package com.riffle.core.domain
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -129,6 +133,72 @@ class LibraryItemOfflineAvailabilityTest {
         )
 
         assertFalse(availability.isAvailableOffline(item(EbookFormat.Unsupported, hasAudio = true)))
+    }
+
+    // --- Memoization (page-turn filesystem-sweep regression, see class KDoc) ---
+
+    private class CountingCbzRepository : CbzRepository {
+        var isDownloadedCalls = 0
+        override fun isDownloaded(sourceId: String, itemId: String): Boolean {
+            isDownloadedCalls++
+            return false
+        }
+        override fun isCached(sourceId: String, itemId: String) = false
+        override suspend fun openCbz(item: LibraryItem) = error("unused")
+        override suspend fun downloadCbz(
+            item: LibraryItem,
+            onProgress: (downloaded: Long, total: Long) -> Unit,
+        ) = error("unused")
+        override suspend fun removeDownload(sourceId: String, itemId: String) = error("unused")
+        override suspend fun saveReadingPosition(itemId: String, locatorJson: String) = error("unused")
+        override suspend fun supportsStreaming(sourceId: String) = false
+        override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int, maxWidth: Int?) = error("unused")
+        override suspend fun awaitCachedFile(item: LibraryItem): java.io.File? = null
+    }
+
+    private fun cachingAvailability(
+        counting: CountingCbzRepository,
+        changes: MutableSharedFlow<StoredItemRef>? = null,
+    ) = LibraryItemOfflineAvailability(
+        epubRepository = FakeEpubRepository(),
+        pdfRepository = FakePdfRepository(),
+        cbzRepository = counting,
+        audiobookDownloadRepository = FakeAudiobookDownloadRepository(),
+        bundleAudiobookSource = FakeBundleAudiobookSource(),
+        availabilityChanges = changes,
+        invalidationScope = changes?.let { CoroutineScope(Dispatchers.Unconfined) },
+    )
+
+    @Test
+    fun `repeated sweeps hit the memo instead of re-statting the filesystem`() {
+        val counting = CountingCbzRepository()
+        val availability = cachingAvailability(counting)
+        repeat(3) { availability.isAvailableOffline(item(EbookFormat.Cbz)) }
+        assertEquals(1, counting.isDownloadedCalls)
+    }
+
+    @Test
+    fun `a local availability change re-computes that item`() {
+        val changes = MutableSharedFlow<StoredItemRef>(extraBufferCapacity = 8)
+        val counting = CountingCbzRepository()
+        val availability = cachingAvailability(counting, changes)
+        availability.isAvailableOffline(item(EbookFormat.Cbz))
+        availability.isAvailableOffline(item(EbookFormat.Cbz))
+        assertEquals(1, counting.isDownloadedCalls)
+        changes.tryEmit(StoredItemRef("s1", "i1"))
+        availability.isAvailableOffline(item(EbookFormat.Cbz))
+        assertEquals(2, counting.isDownloadedCalls)
+    }
+
+    @Test
+    fun `a change for a different item does not invalidate the memo`() {
+        val changes = MutableSharedFlow<StoredItemRef>(extraBufferCapacity = 8)
+        val counting = CountingCbzRepository()
+        val availability = cachingAvailability(counting, changes)
+        availability.isAvailableOffline(item(EbookFormat.Cbz))
+        changes.tryEmit(StoredItemRef("s1", "OTHER"))
+        availability.isAvailableOffline(item(EbookFormat.Cbz))
+        assertEquals(1, counting.isDownloadedCalls)
     }
 
     private class FakeEpubRepository(


### PR DESCRIPTION
## Problem

Turning a comic page took 5–10 s with a fully blank page in between — reproduced on a real device with the book **fully downloaded**, with or without Panel View, but not on a LAN-connected AVD.

## Root causes (two independent ones)

**1. Library offline-availability sweep on the main thread (the reported repro).**
Every page turn writes reading progress → Room re-emits every library source flow → `LibraryFilterEngine`'s projections re-run on Main (`stateIn(viewModelScope)`, no `flowOn`). When the library is in offline mode — `isOffline = !online || lastRefreshFailed`, and one failed/slow refresh **latches for the session** — every projection filters every item through `isAvailableOffline`: up to ~8 `File.exists()` per item (each miss internally builds an `ErrnoException` with a full stack fill) plus one Room flow per series/collection. Several projections × several emissions per turn = seconds of blocked Main; the freshly composed page can't receive its decoded bitmap → blank page. Reproduced deterministically on an AVD by blackholing the source port (iptables DROP): `Choreographer: Skipped 141 frames` / `Davey! duration=2383ms` per turn, with `debuggerd` main-thread stacks caught inside `File.exists` under the filter engine. This affected all progress writers (EPUB/PDF/CBZ readers, audiobook player), not just comics — comics just made it maximally visible.

**2. Streaming-phase cold fetches (a second, also-real slow path).**
Before the background full-file download completes, every page turn synchronously downloaded the full-res page while competing with that download for bandwidth, with no read-ahead (the only incidental prefetch — panel detection — no-ops once panels are cached), no loading indicator (a null bitmap fed to Coil renders an instant empty error = blank), and no retry (one transient failure = permanently blank page).

## Fixes

- `LibraryFilterEngine.projection` (and `CollectionDetailViewModel.items`, `seriesCoverUrls`) now run the whole combine/filter graph on `Dispatchers.Default` via an injected `DispatcherProvider`.
- `LibraryItemOfflineAvailability` memoizes per-item results, invalidated per item by `LocalAvailabilityEvents.changes` + a 30 s TTL backstop (readaloud-bundle paths never notify; also closes the compute/invalidate race). Collector lives on the injectable `ApplicationScope`.
- `NetworkImageSource`: read-ahead of the next 2 pages during streaming; a page turn arriving mid-prefetch joins the in-flight download (Deferred-keyed) instead of duplicating it.
- CBZ page slots render an explicit spinner while decoding and an explicit error once the decode settles without a bitmap; bounded decode retry applies only to the streaming source (local-archive failures are deterministic).

## Verification

- On a 16 KB-page Android 16 foldable AVD with the book fully downloaded and the source port blackholed: pre-fix 141 skipped frames (~2.4 s frozen Main) per page turn; post-fix zero skipped-frame events, every page rendered <1 s.
- Streaming phase at EDGE throttle (~30 KB/s, cold fetch would take 15–20 s): sequential page turns and Panel View advances across page boundaries all render <1 s from the read-ahead cache; cold loads show a spinner instead of a blank page.
- Regression tests: engine sweep must run on Default workers and never the collector thread; memo hit/eviction/TTL; read-ahead prefetch/join/bounds; spinner/error state mapping; per-source retry budget. Full `:app`, `:core:domain`, `:core:data` suites green.

## Notes

- OS version was a red herring: the AVD never had a failed refresh (LAN server), so offline mode never latched there.
- The offline-mode latch itself (`refreshFailed` never resets while reading) is a possible follow-up; this PR removes its cost rather than its persistence.