### PR TITLE
feat(ios): replace Hilt ViewModels with Koin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -210,6 +210,8 @@ dependencies {
     androidTestImplementation(libs.okhttp.mockwebserver)
     androidTestImplementation(libs.hilt.android.testing)
     kspAndroidTest(libs.hilt.compiler)
+    androidTestImplementation(platform(libs.koin.bom))
+    androidTestImplementation(libs.koin.test.android)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -210,8 +210,6 @@ dependencies {
     androidTestImplementation(libs.okhttp.mockwebserver)
     androidTestImplementation(libs.hilt.android.testing)
     kspAndroidTest(libs.hilt.compiler)
-    androidTestImplementation(platform(libs.koin.bom))
-    androidTestImplementation(libs.koin.test.android)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 }

--- a/app/src/androidTest/kotlin/com/riffle/app/di/KoinModulesTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/di/KoinModulesTest.kt
@@ -1,0 +1,41 @@
+package com.riffle.app.di
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.riffle.core.domain.LibraryObserver
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.koin.core.context.GlobalContext
+
+/**
+ * Smoke test that verifies the Koin ViewModel module graph initializes correctly and the
+ * Hilt bridge exposes at least one known dep. Full graph verification (checkModules) will be
+ * added in #737 when the data layer is fully Koin-native and no bridge is needed.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class KoinModulesTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @Test
+    fun koinBridgeResolvesLibraryObserver() {
+        // Application.onCreate() already started Koin with riffleViewModelKoinModules().
+        // Resolving a bridged singleton confirms the Hilt entry point and Koin module wiring are
+        // both healthy. If the bridge entry point is missing a binding this throws at runtime.
+        val koin = GlobalContext.get()
+        val observer = koin.get<LibraryObserver>()
+        assertNotNull(observer)
+    }
+
+    @Test
+    fun koinViewModelModulesAreNonEmpty() {
+        val modules = riffleViewModelKoinModules()
+        assert(modules.isNotEmpty()) { "riffleViewModelKoinModules() must not be empty" }
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
+++ b/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import coil.ImageLoader
 import coil.ImageLoaderFactory
 import coil.disk.DiskCache
+import com.riffle.app.di.riffleViewModelKoinModules
 import com.riffle.app.sync.kickSweepsOnReconnect
 import com.riffle.core.data.AnnotationSweep
 import com.riffle.core.data.LocalStoreMigrator
@@ -188,7 +189,7 @@ internal fun shouldSkipMainProcessStartup(isAcraProcess: Boolean): Boolean = isA
  * The Koin module graph for the app. Empty while Hilt still owns every binding; the Hilt → Koin
  * migration PRs move bindings here module by module until Hilt can be dropped entirely.
  */
-internal fun riffleKoinModules(): List<org.koin.core.module.Module> = emptyList()
+internal fun riffleKoinModules(): List<org.koin.core.module.Module> = riffleViewModelKoinModules()
 
 /** 100 MB cap for the on-disk cover cache. */
 internal const val IMAGE_DISK_CACHE_MAX_BYTES = 100L * 1024 * 1024

--- a/app/src/main/kotlin/com/riffle/app/di/KoinBridgeEntryPoint.kt
+++ b/app/src/main/kotlin/com/riffle/app/di/KoinBridgeEntryPoint.kt
@@ -1,0 +1,194 @@
+package com.riffle.app.di
+
+import com.riffle.app.feature.library.BookImportManager
+import com.riffle.app.feature.library.DownloadManager
+import com.riffle.app.feature.library.ExtractPdfPageCountUseCase
+import com.riffle.app.feature.library.FetchAudiobookChaptersUseCase
+import com.riffle.app.feature.library.LibraryTabVisibilityObserver
+import com.riffle.app.feature.reader.ExtractEpubTocUseCase
+import com.riffle.app.feature.reader.readaloud.ReadaloudOfflineDownloader
+import com.riffle.app.feature.server.AddSourceViewModel
+import com.riffle.app.playback.NowPlayingNavigator
+import com.riffle.app.playback.NowPlayingStore
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.common.Clock
+import com.riffle.core.data.AnnotationSyncMaintenance
+import com.riffle.core.data.AnnotationsLibraryRepository
+import com.riffle.core.data.CrossEpubIndexBuildTrigger
+import com.riffle.core.data.PlaylistsRepository
+import com.riffle.core.data.ReadaloudMatchingService
+import com.riffle.core.data.ReadaloudSidecarPrefetcher
+import com.riffle.core.data.ReadaloudSidecarStore
+import com.riffle.core.data.StorytellerReadaloudSyncer
+import com.riffle.core.data.ToReadRepository
+import com.riffle.core.data.credentialed.CredentialedAuthenticator
+import com.riffle.core.data.localfiles.CopyCoverImageUseCase
+import com.riffle.core.data.localfiles.LocalFilesFolderHealthChecker
+import com.riffle.core.data.localfiles.LocalFilesFolderRepository
+import com.riffle.core.data.localfiles.LocalFilesScanner
+import com.riffle.core.data.localfiles.LocalFilesSourceInstaller
+import com.riffle.core.data.localfiles.SaveLocalFileMetadataOverrideUseCase
+import com.riffle.core.data.websource.SingletonWebSourceInstaller
+import com.riffle.core.data.websource.WebSourceItemGate
+import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
+import com.riffle.core.database.AnnotationDao
+import com.riffle.core.database.LocalFilesFolderDao
+import com.riffle.core.domain.AnnotationStore
+import com.riffle.core.domain.AnnotationSweepEnqueuer
+import com.riffle.core.domain.AnnotationSyncConfigStore
+import com.riffle.core.domain.AppThemeStore
+import com.riffle.core.domain.AppUpdatePreferencesStore
+import com.riffle.core.domain.AppUpdateRepository
+import com.riffle.core.domain.AudiobookBookmarkStore
+import com.riffle.core.domain.AudiobookCacheRepository
+import com.riffle.core.domain.AudiobookDownloadRepository
+import com.riffle.core.domain.AudiobookPositionStore
+import com.riffle.core.domain.CbzRepository
+import com.riffle.core.domain.ConnectivityObserver
+import com.riffle.core.domain.ContentCacheSettingsStore
+import com.riffle.core.domain.CoverGridDensityStore
+import com.riffle.core.domain.CrashReportRepository
+import com.riffle.core.domain.DeviceIdStore
+import com.riffle.core.domain.DeviceLabelResolver
+import com.riffle.core.domain.DeviceLabelStore
+import com.riffle.core.domain.DispatcherProvider
+import com.riffle.core.domain.DownloadsRepository
+import com.riffle.core.domain.EbookCfiTranslatorFactory
+import com.riffle.core.domain.EpubRepository
+import com.riffle.core.domain.FormattingPreferencesStore
+import com.riffle.core.domain.LastOpenedLibraryStore
+import com.riffle.core.domain.LibraryFilterPreferencesStore
+import com.riffle.core.domain.LibraryItemOfflineAvailability
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.LibraryOrderPreferencesStore
+import com.riffle.core.domain.LibraryRefresher
+import com.riffle.core.domain.LibraryVisibilityPreferencesStore
+import com.riffle.core.domain.ListeningPreferencesStore
+import com.riffle.core.domain.LocalAvailabilityEvents
+import com.riffle.core.domain.PdfRepository
+import com.riffle.core.domain.ReadaloudAudioRepository
+import com.riffle.core.domain.ReadaloudLinkRepository
+import com.riffle.core.domain.ReadaloudPreferencesStore
+import com.riffle.core.domain.ReadaloudReviewRepository
+import com.riffle.core.domain.ReadingSpeedStore
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.domain.VolumeKeyPreferencesStore
+import com.riffle.core.domain.WakeLockPreferencesStore
+import com.riffle.core.domain.comic.ComicFormattingPreferencesStore
+import com.riffle.core.domain.developer.DeveloperOptionsRepository
+import com.riffle.core.domain.usecase.MarkReadAcrossDimensions
+import com.riffle.core.domain.usecase.ReadaloudReviewActions
+import com.riffle.core.domain.usecase.RecordItemOpened
+import com.riffle.core.domain.usecase.RefreshCollections
+import com.riffle.core.domain.usecase.RefreshLibraries
+import com.riffle.core.domain.usecase.RefreshLibraryItems
+import com.riffle.core.domain.usecase.RefreshSeries
+import com.riffle.core.domain.usecase.UpdateReadingProgress
+import com.riffle.core.logging.InMemoryLogBuffer
+import com.riffle.core.models.SourceType
+import com.riffle.core.sources.webdav.WebDavAnnotationSyncTargetFactory
+import com.riffle.core.sync.AnnotationSyncStatusStore
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Named
+
+/**
+ * Hilt entry point that exposes all singleton/factory bindings needed by Koin ViewModel modules
+ * during the Hilt→Koin transition. Remove when #737 registers all core:data bindings in Koin
+ * natively.
+ */
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface KoinBridgeEntryPoint {
+    fun libraryObserver(): LibraryObserver
+    fun refreshLibraryItems(): RefreshLibraryItems
+    fun refreshSeries(): RefreshSeries
+    fun refreshCollections(): RefreshCollections
+    fun refreshLibraries(): RefreshLibraries
+    fun sourceRepository(): SourceRepository
+    fun tokenStorage(): TokenStorage
+    fun libraryItemOfflineAvailability(): LibraryItemOfflineAvailability
+    fun connectivityObserver(): ConnectivityObserver
+    fun toReadRepository(): ToReadRepository
+    fun playlistsRepository(): PlaylistsRepository
+    fun readaloudLinkRepository(): ReadaloudLinkRepository
+    fun coverGridDensityStore(): CoverGridDensityStore
+    fun libraryFilterPreferencesStore(): LibraryFilterPreferencesStore
+    fun annotationStore(): AnnotationStore
+    fun audiobookBookmarkStore(): AudiobookBookmarkStore
+    fun annotationsLibraryRepository(): AnnotationsLibraryRepository
+    fun dispatchers(): DispatcherProvider
+    fun libraryVisibilityPreferencesStore(): LibraryVisibilityPreferencesStore
+    fun lastOpenedLibraryStore(): LastOpenedLibraryStore
+    fun libraryOrderPreferencesStore(): LibraryOrderPreferencesStore
+    fun catalogRegistry(): CatalogRegistry
+    fun nowPlayingNavigator(): NowPlayingNavigator
+    fun nowPlayingStore(): NowPlayingStore
+    fun recordItemOpened(): RecordItemOpened
+    fun updateReadingProgress(): UpdateReadingProgress
+    fun markReadAcrossDimensions(): MarkReadAcrossDimensions
+    fun epubRepository(): EpubRepository
+    fun ebookCfiTranslatorFactory(): EbookCfiTranslatorFactory
+    fun audiobookPositionStore(): AudiobookPositionStore
+    fun pdfRepository(): PdfRepository
+    fun cbzRepository(): CbzRepository
+    fun audiobookDownloadRepository(): AudiobookDownloadRepository
+    fun audiobookCacheRepository(): AudiobookCacheRepository
+    fun localAvailabilityEvents(): LocalAvailabilityEvents
+    fun readaloudAudioRepository(): ReadaloudAudioRepository
+    fun readaloudOfflineDownloader(): ReadaloudOfflineDownloader
+    fun crossEpubIndexBuildTrigger(): CrossEpubIndexBuildTrigger
+    fun readaloudSidecarPrefetcher(): ReadaloudSidecarPrefetcher
+    fun extractEpubTocUseCase(): ExtractEpubTocUseCase
+    fun extractPdfPageCountUseCase(): ExtractPdfPageCountUseCase
+    fun fetchAudiobookChaptersUseCase(): FetchAudiobookChaptersUseCase
+    fun libraryRefresher(): LibraryRefresher
+    fun saveLocalFileMetadataOverride(): SaveLocalFileMetadataOverrideUseCase
+    fun copyCoverImage(): CopyCoverImageUseCase
+    fun readingSpeedStore(): ReadingSpeedStore
+    fun webSourceLibraryItemUpserter(): WebSourceLibraryItemUpserter
+    fun webSourceItemGate(): WebSourceItemGate
+    fun downloadManager(): DownloadManager
+    fun bookImportManager(): BookImportManager
+    fun downloadsRepository(): DownloadsRepository
+    fun readaloudSidecarStore(): ReadaloudSidecarStore
+    fun contentCacheSettingsStore(): ContentCacheSettingsStore
+    fun crashReportRepository(): CrashReportRepository
+    fun formattingPreferencesStore(): FormattingPreferencesStore
+    fun wakeLockPreferencesStore(): WakeLockPreferencesStore
+    fun volumeKeyPreferencesStore(): VolumeKeyPreferencesStore
+    fun listeningPreferencesStore(): ListeningPreferencesStore
+    fun appThemeStore(): AppThemeStore
+    fun readaloudReviewRepository(): ReadaloudReviewRepository
+    fun appUpdateRepository(): AppUpdateRepository
+    fun appUpdatePreferencesStore(): AppUpdatePreferencesStore
+    fun readaloudPreferencesStore(): ReadaloudPreferencesStore
+    fun localFilesFolderDao(): LocalFilesFolderDao
+    fun localFilesFolderRepository(): LocalFilesFolderRepository
+    fun localFilesScanner(): LocalFilesScanner
+    fun localFilesSourceInstaller(): LocalFilesSourceInstaller
+    fun localFilesFolderHealthChecker(): LocalFilesFolderHealthChecker
+    fun comicFormattingPreferencesStore(): ComicFormattingPreferencesStore
+    fun developerOptionsRepository(): DeveloperOptionsRepository
+    fun annotationSyncConfigStore(): AnnotationSyncConfigStore
+    fun annotationSyncStatusStore(): AnnotationSyncStatusStore
+    fun annotationDao(): AnnotationDao
+    fun inMemoryLogBuffer(): InMemoryLogBuffer
+    fun annotationSyncMaintenance(): AnnotationSyncMaintenance
+    fun deviceIdStore(): DeviceIdStore
+    fun deviceLabelStore(): DeviceLabelStore
+    fun deviceLabelResolver(): DeviceLabelResolver
+    fun annotationSweepEnqueuer(): AnnotationSweepEnqueuer
+    fun readaloudReviewActions(): ReadaloudReviewActions
+    fun webDavAnnotationSyncTargetFactory(): WebDavAnnotationSyncTargetFactory
+    fun storytellerReadaloudSyncer(): StorytellerReadaloudSyncer
+    fun readaloudMatchingService(): ReadaloudMatchingService
+    fun authenticators(): Map<SourceType, @JvmSuppressWildcards CredentialedAuthenticator>
+    fun clock(): Clock
+    @Named(AddSourceViewModel.WEBDAV_BANNER_TICKER) fun webdavBannerTicker(): Flow<Unit>
+    fun singletonWebSourceInstaller(): SingletonWebSourceInstaller
+    fun libraryTabVisibilityObserver(): LibraryTabVisibilityObserver
+}

--- a/app/src/main/kotlin/com/riffle/app/di/KoinViewModelModules.kt
+++ b/app/src/main/kotlin/com/riffle/app/di/KoinViewModelModules.kt
@@ -1,0 +1,528 @@
+package com.riffle.app.di
+
+import com.riffle.app.feature.downloads.DownloadsViewModel
+import com.riffle.app.feature.library.AnnotationSearchViewModel
+import com.riffle.app.feature.library.BookImportManager
+import com.riffle.app.feature.library.CollectionDetailViewModel
+import com.riffle.app.feature.library.DownloadManager
+import com.riffle.app.feature.library.ExtractPdfPageCountUseCase
+import com.riffle.app.feature.library.FetchAudiobookChaptersUseCase
+import com.riffle.app.feature.library.FilteredBooksViewModel
+import com.riffle.app.feature.library.LibraryItemDetailViewModel
+import com.riffle.app.feature.library.LibraryItemsViewModel
+import com.riffle.app.feature.library.LibrarySectionViewModel
+import com.riffle.app.feature.library.LibraryTabVisibilityObserver
+import com.riffle.app.feature.library.LibraryTabVisibilityViewModel
+import com.riffle.app.feature.library.SeriesDetailViewModel
+import com.riffle.app.feature.library.playlists.PlaylistDetailViewModel
+import com.riffle.app.feature.navigation.HomeViewModel
+import com.riffle.app.feature.navigation.NavigationDrawerViewModel
+import com.riffle.app.feature.reader.ExtractEpubTocUseCase
+import com.riffle.app.feature.reader.readaloud.ReadaloudOfflineDownloader
+import com.riffle.app.feature.server.AddSourceViewModel
+import com.riffle.app.feature.server.SelectLibrariesViewModel
+import com.riffle.app.feature.server.SourceSetupViewModel
+import com.riffle.app.feature.server.SourceTypePickerViewModel
+import com.riffle.app.feature.settings.SettingsViewModel
+import com.riffle.app.feature.settings.annotationsync.AnnotationSyncMaintenanceViewModel
+import com.riffle.app.feature.settings.debug.DebugLogViewModel
+import com.riffle.app.feature.settings.readaloud.ReadaloudMatchesViewModel
+import com.riffle.app.feature.source.chitanka.AddChitankaViewModel
+import com.riffle.app.feature.source.chitanka.ChitankaBrowseViewModel
+import com.riffle.app.feature.source.chitanka.friendlyErrorMessage as chitankaFriendlyError
+import com.riffle.app.feature.source.gutenberg.AddGutenbergViewModel
+import com.riffle.app.feature.source.gutenberg.GutenbergBrowseViewModel
+import com.riffle.app.feature.source.gutenberg.friendlyErrorMessage as gutenbergFriendlyError
+import com.riffle.app.feature.source.localfiles.AddLocalFilesViewModel
+import com.riffle.app.feature.source.websource.WebSourceLibraryViewModel
+import com.riffle.app.playback.NowPlayingNavigator
+import com.riffle.app.playback.NowPlayingStore
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.chitanka.ChitankaCatalog
+import com.riffle.core.catalog.gutenberg.GutenbergCatalog
+import com.riffle.core.common.Clock
+import com.riffle.core.data.AnnotationSyncMaintenance
+import com.riffle.core.data.AnnotationsLibraryRepository
+import com.riffle.core.data.CrossEpubIndexBuildTrigger
+import com.riffle.core.data.PlaylistsRepository
+import com.riffle.core.data.ReadaloudMatchingService
+import com.riffle.core.data.ReadaloudSidecarPrefetcher
+import com.riffle.core.data.ReadaloudSidecarStore
+import com.riffle.core.data.StorytellerReadaloudSyncer
+import com.riffle.core.data.ToReadRepository
+import com.riffle.core.data.credentialed.CredentialedAuthenticator
+import com.riffle.core.data.localfiles.CopyCoverImageUseCase
+import com.riffle.core.data.localfiles.LocalFilesFolderHealthChecker
+import com.riffle.core.data.localfiles.LocalFilesFolderRepository
+import com.riffle.core.data.localfiles.LocalFilesScanner
+import com.riffle.core.data.localfiles.LocalFilesSourceInstaller
+import com.riffle.core.data.localfiles.SaveLocalFileMetadataOverrideUseCase
+import com.riffle.core.data.websource.SingletonWebSourceInstaller
+import com.riffle.core.data.websource.WebSourceItemGate
+import com.riffle.core.data.websource.WebSourceLibraryItemUpserter
+import com.riffle.core.database.AnnotationDao
+import com.riffle.core.database.LocalFilesFolderDao
+import com.riffle.core.domain.AnnotationStore
+import com.riffle.core.domain.AnnotationSweepEnqueuer
+import com.riffle.core.domain.AnnotationSyncConfigStore
+import com.riffle.core.domain.AppThemeStore
+import com.riffle.core.domain.AppUpdatePreferencesStore
+import com.riffle.core.domain.AppUpdateRepository
+import com.riffle.core.domain.AudiobookBookmarkStore
+import com.riffle.core.domain.AudiobookCacheRepository
+import com.riffle.core.domain.AudiobookDownloadRepository
+import com.riffle.core.domain.AudiobookPositionStore
+import com.riffle.core.domain.CbzRepository
+import com.riffle.core.domain.ConnectivityObserver
+import com.riffle.core.domain.ContentCacheSettingsStore
+import com.riffle.core.domain.CoverGridDensityStore
+import com.riffle.core.domain.CrashReportRepository
+import com.riffle.core.domain.DeviceIdStore
+import com.riffle.core.domain.DeviceLabelResolver
+import com.riffle.core.domain.DeviceLabelStore
+import com.riffle.core.domain.DispatcherProvider
+import com.riffle.core.domain.DownloadsRepository
+import com.riffle.core.domain.EbookCfiTranslatorFactory
+import com.riffle.core.domain.EpubRepository
+import com.riffle.core.domain.FormattingPreferencesStore
+import com.riffle.core.domain.LastOpenedLibraryStore
+import com.riffle.core.domain.LibraryFilterPreferencesStore
+import com.riffle.core.domain.LibraryItemOfflineAvailability
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.LibraryOrderPreferencesStore
+import com.riffle.core.domain.LibraryRefresher
+import com.riffle.core.domain.LibraryVisibilityPreferencesStore
+import com.riffle.core.domain.ListeningPreferencesStore
+import com.riffle.core.domain.LocalAvailabilityEvents
+import com.riffle.core.domain.PdfRepository
+import com.riffle.core.domain.ReadaloudAudioRepository
+import com.riffle.core.domain.ReadaloudLinkRepository
+import com.riffle.core.domain.ReadaloudPreferencesStore
+import com.riffle.core.domain.ReadaloudReviewRepository
+import com.riffle.core.domain.ReadingSpeedStore
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.domain.VolumeKeyPreferencesStore
+import com.riffle.core.domain.WakeLockPreferencesStore
+import com.riffle.core.domain.comic.ComicFormattingPreferencesStore
+import com.riffle.core.domain.developer.DeveloperOptionsRepository
+import com.riffle.core.domain.usecase.MarkReadAcrossDimensions
+import com.riffle.core.domain.usecase.ReadaloudReviewActions
+import com.riffle.core.domain.usecase.RecordItemOpened
+import com.riffle.core.domain.usecase.RefreshCollections
+import com.riffle.core.domain.usecase.RefreshLibraries
+import com.riffle.core.domain.usecase.RefreshLibraryItems
+import com.riffle.core.domain.usecase.RefreshSeries
+import com.riffle.core.domain.usecase.UpdateReadingProgress
+import com.riffle.core.logging.InMemoryLogBuffer
+import com.riffle.core.models.SourceType
+import com.riffle.core.sources.webdav.WebDavAnnotationSyncTargetFactory
+import com.riffle.core.sync.AnnotationSyncStatusStore
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.flow.Flow
+import org.koin.android.ext.koin.androidApplication
+import org.koin.android.ext.koin.androidContext
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.core.module.Module
+import org.koin.core.qualifier.named
+import org.koin.dsl.module
+
+private val bridgeModule = module {
+    single { EntryPointAccessors.fromApplication(androidContext(), KoinBridgeEntryPoint::class.java) }
+}
+
+private val bridgeDepsModule = module {
+    single<LibraryObserver> { get<KoinBridgeEntryPoint>().libraryObserver() }
+    single<RefreshLibraryItems> { get<KoinBridgeEntryPoint>().refreshLibraryItems() }
+    single<RefreshSeries> { get<KoinBridgeEntryPoint>().refreshSeries() }
+    single<RefreshCollections> { get<KoinBridgeEntryPoint>().refreshCollections() }
+    single<RefreshLibraries> { get<KoinBridgeEntryPoint>().refreshLibraries() }
+    single<SourceRepository> { get<KoinBridgeEntryPoint>().sourceRepository() }
+    single<TokenStorage> { get<KoinBridgeEntryPoint>().tokenStorage() }
+    single<LibraryItemOfflineAvailability> { get<KoinBridgeEntryPoint>().libraryItemOfflineAvailability() }
+    single<ConnectivityObserver> { get<KoinBridgeEntryPoint>().connectivityObserver() }
+    single<ToReadRepository> { get<KoinBridgeEntryPoint>().toReadRepository() }
+    single<PlaylistsRepository> { get<KoinBridgeEntryPoint>().playlistsRepository() }
+    single<ReadaloudLinkRepository> { get<KoinBridgeEntryPoint>().readaloudLinkRepository() }
+    single<CoverGridDensityStore> { get<KoinBridgeEntryPoint>().coverGridDensityStore() }
+    single<LibraryFilterPreferencesStore> { get<KoinBridgeEntryPoint>().libraryFilterPreferencesStore() }
+    single<AnnotationStore> { get<KoinBridgeEntryPoint>().annotationStore() }
+    single<AudiobookBookmarkStore> { get<KoinBridgeEntryPoint>().audiobookBookmarkStore() }
+    single<AnnotationsLibraryRepository> { get<KoinBridgeEntryPoint>().annotationsLibraryRepository() }
+    single<DispatcherProvider> { get<KoinBridgeEntryPoint>().dispatchers() }
+    single<LibraryVisibilityPreferencesStore> { get<KoinBridgeEntryPoint>().libraryVisibilityPreferencesStore() }
+    single<LastOpenedLibraryStore> { get<KoinBridgeEntryPoint>().lastOpenedLibraryStore() }
+    single<LibraryOrderPreferencesStore> { get<KoinBridgeEntryPoint>().libraryOrderPreferencesStore() }
+    single<CatalogRegistry> { get<KoinBridgeEntryPoint>().catalogRegistry() }
+    single<NowPlayingNavigator> { get<KoinBridgeEntryPoint>().nowPlayingNavigator() }
+    single<NowPlayingStore> { get<KoinBridgeEntryPoint>().nowPlayingStore() }
+    single<RecordItemOpened> { get<KoinBridgeEntryPoint>().recordItemOpened() }
+    single<UpdateReadingProgress> { get<KoinBridgeEntryPoint>().updateReadingProgress() }
+    single<MarkReadAcrossDimensions> { get<KoinBridgeEntryPoint>().markReadAcrossDimensions() }
+    single<EpubRepository> { get<KoinBridgeEntryPoint>().epubRepository() }
+    single<EbookCfiTranslatorFactory> { get<KoinBridgeEntryPoint>().ebookCfiTranslatorFactory() }
+    single<AudiobookPositionStore> { get<KoinBridgeEntryPoint>().audiobookPositionStore() }
+    single<PdfRepository> { get<KoinBridgeEntryPoint>().pdfRepository() }
+    single<CbzRepository> { get<KoinBridgeEntryPoint>().cbzRepository() }
+    single<AudiobookDownloadRepository> { get<KoinBridgeEntryPoint>().audiobookDownloadRepository() }
+    single<AudiobookCacheRepository> { get<KoinBridgeEntryPoint>().audiobookCacheRepository() }
+    single<LocalAvailabilityEvents> { get<KoinBridgeEntryPoint>().localAvailabilityEvents() }
+    single<ReadaloudAudioRepository> { get<KoinBridgeEntryPoint>().readaloudAudioRepository() }
+    single<ReadaloudOfflineDownloader> { get<KoinBridgeEntryPoint>().readaloudOfflineDownloader() }
+    single<CrossEpubIndexBuildTrigger> { get<KoinBridgeEntryPoint>().crossEpubIndexBuildTrigger() }
+    single<ReadaloudSidecarPrefetcher> { get<KoinBridgeEntryPoint>().readaloudSidecarPrefetcher() }
+    factory<ExtractEpubTocUseCase> { get<KoinBridgeEntryPoint>().extractEpubTocUseCase() }
+    factory<ExtractPdfPageCountUseCase> { get<KoinBridgeEntryPoint>().extractPdfPageCountUseCase() }
+    factory<FetchAudiobookChaptersUseCase> { get<KoinBridgeEntryPoint>().fetchAudiobookChaptersUseCase() }
+    single<LibraryRefresher> { get<KoinBridgeEntryPoint>().libraryRefresher() }
+    factory<SaveLocalFileMetadataOverrideUseCase> { get<KoinBridgeEntryPoint>().saveLocalFileMetadataOverride() }
+    factory<CopyCoverImageUseCase> { get<KoinBridgeEntryPoint>().copyCoverImage() }
+    single<ReadingSpeedStore> { get<KoinBridgeEntryPoint>().readingSpeedStore() }
+    single<WebSourceLibraryItemUpserter> { get<KoinBridgeEntryPoint>().webSourceLibraryItemUpserter() }
+    single<WebSourceItemGate> { get<KoinBridgeEntryPoint>().webSourceItemGate() }
+    single<DownloadManager> { get<KoinBridgeEntryPoint>().downloadManager() }
+    single<BookImportManager> { get<KoinBridgeEntryPoint>().bookImportManager() }
+    single<DownloadsRepository> { get<KoinBridgeEntryPoint>().downloadsRepository() }
+    single<ReadaloudSidecarStore> { get<KoinBridgeEntryPoint>().readaloudSidecarStore() }
+    single<ContentCacheSettingsStore> { get<KoinBridgeEntryPoint>().contentCacheSettingsStore() }
+    single<CrashReportRepository> { get<KoinBridgeEntryPoint>().crashReportRepository() }
+    single<FormattingPreferencesStore> { get<KoinBridgeEntryPoint>().formattingPreferencesStore() }
+    single<WakeLockPreferencesStore> { get<KoinBridgeEntryPoint>().wakeLockPreferencesStore() }
+    single<VolumeKeyPreferencesStore> { get<KoinBridgeEntryPoint>().volumeKeyPreferencesStore() }
+    single<ListeningPreferencesStore> { get<KoinBridgeEntryPoint>().listeningPreferencesStore() }
+    single<AppThemeStore> { get<KoinBridgeEntryPoint>().appThemeStore() }
+    single<ReadaloudReviewRepository> { get<KoinBridgeEntryPoint>().readaloudReviewRepository() }
+    single<AppUpdateRepository> { get<KoinBridgeEntryPoint>().appUpdateRepository() }
+    single<AppUpdatePreferencesStore> { get<KoinBridgeEntryPoint>().appUpdatePreferencesStore() }
+    single<ReadaloudPreferencesStore> { get<KoinBridgeEntryPoint>().readaloudPreferencesStore() }
+    single<LocalFilesFolderDao> { get<KoinBridgeEntryPoint>().localFilesFolderDao() }
+    single<LocalFilesFolderRepository> { get<KoinBridgeEntryPoint>().localFilesFolderRepository() }
+    single<LocalFilesScanner> { get<KoinBridgeEntryPoint>().localFilesScanner() }
+    single<LocalFilesSourceInstaller> { get<KoinBridgeEntryPoint>().localFilesSourceInstaller() }
+    single<LocalFilesFolderHealthChecker> { get<KoinBridgeEntryPoint>().localFilesFolderHealthChecker() }
+    single<ComicFormattingPreferencesStore> { get<KoinBridgeEntryPoint>().comicFormattingPreferencesStore() }
+    single<DeveloperOptionsRepository> { get<KoinBridgeEntryPoint>().developerOptionsRepository() }
+    single<AnnotationSyncConfigStore> { get<KoinBridgeEntryPoint>().annotationSyncConfigStore() }
+    single<AnnotationSyncStatusStore> { get<KoinBridgeEntryPoint>().annotationSyncStatusStore() }
+    single<AnnotationDao> { get<KoinBridgeEntryPoint>().annotationDao() }
+    single<InMemoryLogBuffer> { get<KoinBridgeEntryPoint>().inMemoryLogBuffer() }
+    single<AnnotationSyncMaintenance> { get<KoinBridgeEntryPoint>().annotationSyncMaintenance() }
+    single<DeviceIdStore> { get<KoinBridgeEntryPoint>().deviceIdStore() }
+    single<DeviceLabelStore> { get<KoinBridgeEntryPoint>().deviceLabelStore() }
+    single<DeviceLabelResolver> { get<KoinBridgeEntryPoint>().deviceLabelResolver() }
+    single<AnnotationSweepEnqueuer> { get<KoinBridgeEntryPoint>().annotationSweepEnqueuer() }
+    single<ReadaloudReviewActions> { get<KoinBridgeEntryPoint>().readaloudReviewActions() }
+    single<WebDavAnnotationSyncTargetFactory> { get<KoinBridgeEntryPoint>().webDavAnnotationSyncTargetFactory() }
+    single<StorytellerReadaloudSyncer> { get<KoinBridgeEntryPoint>().storytellerReadaloudSyncer() }
+    single<ReadaloudMatchingService> { get<KoinBridgeEntryPoint>().readaloudMatchingService() }
+    single<Map<SourceType, @JvmSuppressWildcards CredentialedAuthenticator>> { get<KoinBridgeEntryPoint>().authenticators() }
+    single<Clock> { get<KoinBridgeEntryPoint>().clock() }
+    single<Flow<Unit>>(named(AddSourceViewModel.WEBDAV_BANNER_TICKER)) { get<KoinBridgeEntryPoint>().webdavBannerTicker() }
+    single<SingletonWebSourceInstaller> { get<KoinBridgeEntryPoint>().singletonWebSourceInstaller() }
+    single<LibraryTabVisibilityObserver> { get<KoinBridgeEntryPoint>().libraryTabVisibilityObserver() }
+}
+
+private val libraryViewModelModule = module {
+    viewModel {
+        LibraryItemsViewModel(
+            savedStateHandle = get(),
+            libraryObserver = get(),
+            refreshLibraryItemsUseCase = get(),
+            refreshSeriesUseCase = get(),
+            refreshCollectionsUseCase = get(),
+            sourceRepository = get(),
+            tokenStorage = get(),
+            offlineAvailability = get(),
+            connectivityObserver = get(),
+            toReadRepository = get(),
+            playlistsRepository = get(),
+            readaloudLinkRepository = get(),
+            coverGridDensityStore = get(),
+            libraryFilterPreferencesStore = get(),
+            annotationStore = get(),
+            audiobookBookmarkStore = get(),
+            annotationsLibraryRepository = get(),
+            dispatchers = get(),
+        )
+    }
+    viewModel {
+        LibraryItemDetailViewModel(
+            savedStateHandle = get(),
+            libraryObserver = get(),
+            recordItemOpened = get(),
+            updateReadingProgressUseCase = get(),
+            markReadAcrossDimensions = get(),
+            sourceRepository = get(),
+            tokenStorage = get(),
+            epubRepository = get(),
+            ebookCfiTranslatorFactory = get(),
+            audiobookPositionStore = get(),
+            pdfRepository = get(),
+            cbzRepository = get(),
+            toReadRepository = get(),
+            playlistsRepository = get(),
+            readaloudLinkRepository = get(),
+            readaloudAudioRepository = get(),
+            audiobookDownloadRepository = get(),
+            audiobookCacheRepository = get(),
+            localAvailabilityEvents = get(),
+            readaloudOfflineDownloader = get(),
+            connectivityObserver = get(),
+            downloadManager = get(),
+            bookImportManager = get(),
+            crossEpubIndexBuildTrigger = get(),
+            sidecarPrefetcher = get(),
+            extractEpubTocUseCase = get(),
+            extractPdfPageCountUseCase = get(),
+            fetchAudiobookChaptersUseCase = get(),
+            catalogRegistry = get(),
+            libraryRefresher = get(),
+            saveLocalFileMetadataOverride = get(),
+            copyCoverImage = get(),
+            readingSpeedStore = get(),
+            webSourceLibraryItemUpserter = get(),
+        )
+    }
+    viewModel {
+        LibrarySectionViewModel(
+            savedStateHandle = get(),
+            libraryObserver = get(),
+            sourceRepository = get(),
+            tokenStorage = get(),
+        )
+    }
+    viewModel {
+        FilteredBooksViewModel(
+            savedStateHandle = get(),
+            libraryObserver = get(),
+            sourceRepository = get(),
+            tokenStorage = get(),
+            offlineAvailability = get(),
+            connectivityObserver = get(),
+            readaloudLinkRepository = get(),
+        )
+    }
+    viewModel {
+        SeriesDetailViewModel(
+            savedStateHandle = get(),
+            libraryObserver = get(),
+            refreshSeriesUseCase = get(),
+            sourceRepository = get(),
+            tokenStorage = get(),
+            offlineAvailability = get(),
+            connectivityObserver = get(),
+        )
+    }
+    viewModel {
+        CollectionDetailViewModel(
+            savedStateHandle = get(),
+            libraryObserver = get(),
+            refreshCollectionsUseCase = get(),
+            sourceRepository = get(),
+            tokenStorage = get(),
+            offlineAvailability = get(),
+            connectivityObserver = get(),
+            dispatchers = get(),
+        )
+    }
+    viewModel {
+        AnnotationSearchViewModel(
+            savedStateHandle = get(),
+            libraryObserver = get(),
+            annotationStore = get(),
+            audiobookBookmarkStore = get(),
+            sourceRepository = get(),
+            tokenStorage = get(),
+        )
+    }
+    viewModel {
+        PlaylistDetailViewModel(
+            savedStateHandle = get(),
+            playlistsRepository = get(),
+            libraryObserver = get(),
+            sourceRepository = get(),
+            tokenStorage = get(),
+        )
+    }
+    viewModel {
+        LibraryTabVisibilityViewModel(
+            savedStateHandle = get(),
+            observer = get(),
+        )
+    }
+}
+
+private val navigationViewModelModule = module {
+    viewModel {
+        HomeViewModel(
+            sourceRepository = get(),
+            libraryObserver = get(),
+            refreshLibraries = get(),
+            visibilityStore = get(),
+            lastOpenedLibraryStore = get(),
+            dispatchers = get(),
+        )
+    }
+    viewModel {
+        NavigationDrawerViewModel(
+            sourceRepository = get(),
+            libraryObserver = get(),
+            visibilityStore = get(),
+            orderStore = get(),
+            lastOpenedLibraryStore = get(),
+            connectivityObserver = get(),
+            catalogRegistry = get(),
+            nowPlayingNavigator = get(),
+            nowPlayingStore = get(),
+        )
+    }
+}
+
+private val settingsViewModelModule = module {
+    viewModel {
+        SettingsViewModel(
+            context = androidContext(),
+            crashReportRepository = get(),
+            formattingPreferencesStore = get(),
+            sourceRepository = get(),
+            libraryObserver = get(),
+            visibilityStore = get(),
+            orderStore = get(),
+            wakeLockPreferencesStore = get(),
+            volumeKeyPreferencesStore = get(),
+            listeningPreferencesStore = get(),
+            appThemeStore = get(),
+            readaloudReviewRepository = get(),
+            connectivityObserver = get(),
+            appUpdateRepository = get(),
+            appUpdatePreferencesStore = get(),
+            readaloudPreferencesStore = get(),
+            localFilesFolderDao = get(),
+            localFilesFolderRepository = get(),
+            localFilesScanner = get(),
+            localFilesSourceInstaller = get(),
+            localFilesFolderHealthChecker = get(),
+            comicFormattingPreferencesStore = get(),
+            developerOptionsRepository = get(),
+            annotationSyncConfigStore = get(),
+            annotationSyncStatusStore = get(),
+            annotationDao = get(),
+        )
+    }
+    viewModel {
+        DebugLogViewModel(
+            application = androidApplication(),
+            buffer = get(),
+        )
+    }
+    viewModel {
+        AnnotationSyncMaintenanceViewModel(
+            configStore = get(),
+            maintenance = get(),
+            deviceIdStore = get(),
+            deviceLabelStore = get(),
+            deviceLabelResolver = get(),
+            sourceRepository = get(),
+            statusStore = get(),
+        )
+    }
+    viewModel {
+        ReadaloudMatchesViewModel(
+            savedStateHandle = get(),
+            reviewRepository = get(),
+            reviewActions = get(),
+            sourceRepository = get(),
+            tokenStorage = get(),
+        )
+    }
+}
+
+private val serverViewModelModule = module {
+    viewModel {
+        AddSourceViewModel(
+            context = androidContext(),
+            repository = get(),
+            authenticators = get(),
+            webdavConfigStore = get(),
+            webdavTargetFactory = get(),
+            webdavStatusStore = get(),
+            sweepEnqueuer = get(),
+            storytellerSyncer = get(),
+            readaloudMatcher = get(),
+            tokenStorage = get(),
+            clock = get(),
+            annotationDao = get(),
+            bannerTicker = get(named(AddSourceViewModel.WEBDAV_BANNER_TICKER)),
+            savedStateHandle = get(),
+        )
+    }
+    viewModel { SourceSetupViewModel() }
+    viewModel {
+        SelectLibrariesViewModel(
+            context = androidContext(),
+            repository = get(),
+        )
+    }
+    viewModel { SourceTypePickerViewModel(sourceRepository = get()) }
+}
+
+private val sourceViewModelModule = module {
+    viewModel {
+        ChitankaBrowseViewModel(
+            savedStateHandle = get(),
+            sourceRepository = get(),
+            catalogRegistry = get(),
+            libraryItemUpserter = get(),
+            webSourceItemGate = get(),
+            coverGridDensityStore = get(),
+            libraryFilterPreferencesStore = get(),
+            libraryObserver = get(),
+        )
+    }
+    viewModel { AddChitankaViewModel(installer = get()) }
+    viewModel {
+        GutenbergBrowseViewModel(
+            savedStateHandle = get(),
+            sourceRepository = get(),
+            catalogRegistry = get(),
+            libraryItemUpserter = get(),
+            webSourceItemGate = get(),
+            coverGridDensityStore = get(),
+            libraryFilterPreferencesStore = get(),
+            libraryObserver = get(),
+        )
+    }
+    viewModel { AddGutenbergViewModel(installer = get()) }
+    viewModel { AddLocalFilesViewModel(installer = get()) }
+    viewModel {
+        WebSourceLibraryViewModel(
+            savedStateHandle = get(),
+            libraryObserver = get(),
+            toReadRepository = get(),
+        )
+    }
+}
+
+private val downloadsViewModelModule = module {
+    viewModel {
+        DownloadsViewModel(
+            downloadsRepository = get(),
+            libraryObserver = get(),
+            sourceRepository = get(),
+            readaloudLinkRepository = get(),
+            sidecarStore = get(),
+            contentCacheSettingsStore = get(),
+        )
+    }
+}
+
+internal fun riffleViewModelKoinModules(): List<Module> = listOf(
+    bridgeModule,
+    bridgeDepsModule,
+    libraryViewModelModule,
+    navigationViewModelModule,
+    settingsViewModelModule,
+    serverViewModelModule,
+    sourceViewModelModule,
+    downloadsViewModelModule,
+)

--- a/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import com.riffle.app.R
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.core.domain.ContentCacheAutoClear
@@ -59,7 +59,7 @@ fun DownloadsScreen(
     windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onItemSelected: (LibraryItem) -> Unit,
-    viewModel: DownloadsViewModel = hiltViewModel(),
+    viewModel: DownloadsViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
     var showRemoveAllDownloadsDialog by remember { mutableStateOf(false) }

--- a/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsViewModel.kt
@@ -13,12 +13,10 @@ import com.riffle.core.domain.StoredMediaType
 import com.riffle.core.models.LibraryItem
 import com.riffle.core.models.ReadaloudLink
 import com.riffle.core.models.isStorytellerService
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 /** A locally-available item paired with the on-disk size of its file. */
 data class LocalItemUi(
@@ -51,8 +49,7 @@ data class DownloadsUiState(
     val cachedTotalBytes: Long get() = cachedItems.sumOf { it.sizeBytes }
 }
 
-@HiltViewModel
-class DownloadsViewModel @Inject constructor(
+class DownloadsViewModel constructor(
     private val downloadsRepository: DownloadsRepository,
     private val libraryObserver: LibraryObserver,
     private val sourceRepository: SourceRepository,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/AnnotationSearchResultsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/AnnotationSearchResultsScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -30,7 +30,7 @@ fun AnnotationSearchResultsScreen(
     onNavigateBack: () -> Unit,
     onAnnotationSelected: (AnnotationSearchResult) -> Unit,
     onAudiobookBookmarkSelected: (AudiobookBookmarkSearchResult) -> Unit,
-    viewModel: AnnotationSearchViewModel = hiltViewModel(),
+    viewModel: AnnotationSearchViewModel = koinViewModel(),
 ) {
     val results by viewModel.results.collectAsState()
     val bookmarkResults by viewModel.bookmarkResults.collectAsState()

--- a/app/src/main/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/AnnotationSearchViewModel.kt
@@ -8,7 +8,6 @@ import com.riffle.core.domain.AudiobookBookmarkStore
 import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.TokenStorage
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -20,11 +19,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
-import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@HiltViewModel
-class AnnotationSearchViewModel @Inject constructor(
+class AnnotationSearchViewModel constructor(
     savedStateHandle: SavedStateHandle,
     libraryObserver: LibraryObserver,
     annotationStore: AnnotationStore,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/CollectionDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/CollectionDetailScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -30,7 +30,7 @@ fun CollectionDetailScreen(
     collectionName: String,
     onItemSelected: (com.riffle.core.models.LibraryItem) -> Unit,
     onNavigateBack: () -> Unit,
-    viewModel: CollectionDetailViewModel = hiltViewModel(),
+    viewModel: CollectionDetailViewModel = koinViewModel(),
 ) {
     val items by viewModel.items.collectAsState()
     val isOffline by viewModel.isOffline.collectAsState()

--- a/app/src/main/kotlin/com/riffle/app/feature/library/CollectionDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/CollectionDetailViewModel.kt
@@ -14,7 +14,6 @@ import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.usecase.RefreshCollections
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.TokenStorage
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -26,10 +25,8 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class CollectionDetailViewModel @Inject constructor(
+class CollectionDetailViewModel constructor(
     savedStateHandle: SavedStateHandle,
     private val libraryObserver: LibraryObserver,
     private val refreshCollectionsUseCase: RefreshCollections,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/FilteredBooksScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/FilteredBooksScreen.kt
@@ -22,14 +22,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FilteredBooksScreen(
     onItemSelected: (com.riffle.core.models.LibraryItem) -> Unit,
     onNavigateBack: () -> Unit,
-    viewModel: FilteredBooksViewModel = hiltViewModel(),
+    viewModel: FilteredBooksViewModel = koinViewModel(),
 ) {
     val items by viewModel.items.collectAsState()
     val isOffline by viewModel.isOffline.collectAsState()

--- a/app/src/main/kotlin/com/riffle/app/feature/library/FilteredBooksViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/FilteredBooksViewModel.kt
@@ -13,7 +13,6 @@ import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.ReadaloudLinkRepository
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.TokenStorage
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -21,7 +20,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
-import javax.inject.Inject
 
 /**
  * Backs the [FilteredBooksScreen]: lists every Library Item in the current Library matching one
@@ -29,8 +27,7 @@ import javax.inject.Inject
  * offline; when offline, results are further narrowed to locally-available books, mirroring the
  * Series/Collection detail screens.
  */
-@HiltViewModel
-class FilteredBooksViewModel @Inject constructor(
+class FilteredBooksViewModel constructor(
     savedStateHandle: SavedStateHandle,
     private val libraryObserver: LibraryObserver,
     private val sourceRepository: SourceRepository,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -87,7 +87,7 @@ import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.riffle.app.feature.audiobook.CompactDurationLabelTemplates
@@ -116,7 +116,7 @@ fun LibraryItemDetailScreen(
     onListenItemAtSec: (LibraryItem, Double) -> Unit = { _, _ -> },
     onNavigateToFacet: (libraryId: String, facet: FacetType, value: String) -> Unit = { _, _, _ -> },
     onNavigateToSeries: (libraryId: String, seriesId: String, seriesName: String) -> Unit = { _, _, _ -> },
-    viewModel: LibraryItemDetailViewModel = hiltViewModel(),
+    viewModel: LibraryItemDetailViewModel = koinViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val downloadState by viewModel.downloadState.collectAsState()

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -57,7 +57,6 @@ import com.riffle.core.catalog.SeriesCapability
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.TocEntry
 import com.riffle.core.domain.TokenStorage
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -74,7 +73,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.CancellationException
-import javax.inject.Inject
 
 sealed interface LibraryItemDetailUiState {
     data object Loading : LibraryItemDetailUiState
@@ -232,8 +230,7 @@ internal fun estimatedReadingTimeSec(totalPositions: Int, secPerPosition: Double
     return (totalPositions * secPerPosition).toLong().coerceAtLeast(0L)
 }
 
-@HiltViewModel
-class LibraryItemDetailViewModel @Inject constructor(
+class LibraryItemDetailViewModel constructor(
     savedStateHandle: SavedStateHandle,
     private val libraryObserver: LibraryObserver,
     private val recordItemOpened: RecordItemOpened,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -108,7 +108,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -169,7 +169,7 @@ fun LibraryItemsScreen(
     // of executing a library exit/search-clear/tab-reset action.
     isCommittedOnLibraryItems: () -> Boolean = { true },
     onNavigateBack: () -> Unit = {},
-    viewModel: LibraryItemsViewModel = hiltViewModel(),
+    viewModel: LibraryItemsViewModel = koinViewModel(),
 ) {
     val searchQuery by viewModel.searchQuery.collectAsState()
     val projection by viewModel.projection.collectAsState()
@@ -352,7 +352,7 @@ fun LibraryItemsScreen(
                         onCoverScaleChange = onCoverScaleChange,
                     )
                     tabIndexForAnnotations() -> {
-                        val annotationsVm: AnnotationsListViewModel = hiltViewModel()
+                        val annotationsVm: AnnotationsListViewModel = koinViewModel()
                         val annotationsState by annotationsVm.state.collectAsState()
                         AnnotationsListScreen(
                             state = annotationsState,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsViewModel.kt
@@ -27,7 +27,6 @@ import com.riffle.core.data.PlaylistsRepository
 import com.riffle.core.data.ToReadRepository
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.TokenStorage
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -52,11 +51,9 @@ import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
-import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@HiltViewModel
-class LibraryItemsViewModel @Inject constructor(
+class LibraryItemsViewModel constructor(
     private val savedStateHandle: SavedStateHandle,
     private val libraryObserver: LibraryObserver,
     private val refreshLibraryItemsUseCase: RefreshLibraryItems,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibrarySectionScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibrarySectionScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import com.riffle.core.models.LibraryItem
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -32,7 +32,7 @@ fun LibrarySectionScreen(
     sectionType: LibrarySectionType,
     onItemSelected: (LibraryItem) -> Unit,
     onNavigateBack: () -> Unit,
-    viewModel: LibrarySectionViewModel = hiltViewModel(),
+    viewModel: LibrarySectionViewModel = koinViewModel(),
 ) {
     val items by viewModel.items.collectAsState()
     val coversAreSquare by viewModel.coversAreSquare.collectAsState()

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibrarySectionViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibrarySectionViewModel.kt
@@ -10,17 +10,14 @@ import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.TokenStorage
 import com.riffle.core.models.LibraryItem
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class LibrarySectionViewModel @Inject constructor(
+class LibrarySectionViewModel constructor(
     savedStateHandle: SavedStateHandle,
     libraryObserver: LibraryObserver,
     sourceRepository: SourceRepository,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryTabVisibilityObserver.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryTabVisibilityObserver.kt
@@ -83,7 +83,7 @@ class LibraryTabVisibilityObserver @Inject constructor(
  * can wire tab visibility in one line:
  *
  * ```
- * val visibility by hiltViewModel<LibraryTabVisibilityViewModel>().visibility.collectAsState()
+ * val visibility by koinViewModel<LibraryTabVisibilityViewModel>().visibility.collectAsState()
  * ```
  */
 class LibraryTabVisibilityViewModel constructor(

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryTabVisibilityObserver.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryTabVisibilityObserver.kt
@@ -7,7 +7,6 @@ import com.riffle.core.data.AnnotationsLibraryRepository
 import com.riffle.core.data.ToReadRepository
 import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.SourceRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -87,8 +86,7 @@ class LibraryTabVisibilityObserver @Inject constructor(
  * val visibility by hiltViewModel<LibraryTabVisibilityViewModel>().visibility.collectAsState()
  * ```
  */
-@HiltViewModel
-class LibraryTabVisibilityViewModel @Inject constructor(
+class LibraryTabVisibilityViewModel constructor(
     savedStateHandle: SavedStateHandle,
     observer: LibraryTabVisibilityObserver,
 ) : ViewModel() {

--- a/app/src/main/kotlin/com/riffle/app/feature/library/SeriesDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/SeriesDetailScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import com.riffle.core.models.LibraryItem
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -32,7 +32,7 @@ fun SeriesDetailScreen(
     seriesName: String,
     onItemSelected: (com.riffle.core.models.LibraryItem) -> Unit,
     onNavigateBack: () -> Unit,
-    viewModel: SeriesDetailViewModel = hiltViewModel(),
+    viewModel: SeriesDetailViewModel = koinViewModel(),
 ) {
     val items by viewModel.items.collectAsState()
     val isOffline by viewModel.isOffline.collectAsState()

--- a/app/src/main/kotlin/com/riffle/app/feature/library/SeriesDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/SeriesDetailViewModel.kt
@@ -14,7 +14,6 @@ import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.usecase.RefreshSeries
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.TokenStorage
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -25,10 +24,8 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class SeriesDetailViewModel @Inject constructor(
+class SeriesDetailViewModel constructor(
     savedStateHandle: SavedStateHandle,
     private val libraryObserver: LibraryObserver,
     private val refreshSeriesUseCase: RefreshSeries,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/playlists/PlaylistDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/playlists/PlaylistDetailScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import com.riffle.app.feature.library.LibraryItemCard
 import com.riffle.core.models.LibraryItem
 import androidx.compose.foundation.layout.Row
@@ -44,7 +44,7 @@ fun PlaylistDetailScreen(
     onNavigateBack: () -> Unit,
     onItemSelected: (LibraryItem) -> Unit,
     onPlayItem: (LibraryItem) -> Unit = onItemSelected,
-    viewModel: PlaylistDetailViewModel = hiltViewModel(),
+    viewModel: PlaylistDetailViewModel = koinViewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/playlists/PlaylistDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/playlists/PlaylistDetailViewModel.kt
@@ -9,7 +9,6 @@ import com.riffle.core.models.LibraryItem
 import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.TokenStorage
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -21,7 +20,6 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.net.URLDecoder
-import javax.inject.Inject
 
 /**
  * UI state for [PlaylistDetailScreen].
@@ -41,8 +39,7 @@ data class PlaylistDetailUiState(
 )
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@HiltViewModel
-class PlaylistDetailViewModel @Inject constructor(
+class PlaylistDetailViewModel constructor(
     savedStateHandle: SavedStateHandle,
     private val playlistsRepository: PlaylistsRepository,
     private val libraryObserver: LibraryObserver,

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.withResumed
@@ -33,7 +33,7 @@ import kotlinx.coroutines.withContext
 fun HomeScreen(
     onNavigateToAddSource: () -> Unit,
     onNavigateToLibrary: (sourceType: SourceType, libraryId: String, libraryName: String) -> Unit,
-    viewModel: HomeViewModel = hiltViewModel(),
+    viewModel: HomeViewModel = koinViewModel(),
 ) {
     var retryKey by remember { mutableIntStateOf(0) }
     var showRetry by remember { mutableStateOf(false) }

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/HomeViewModel.kt
@@ -9,13 +9,10 @@ import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.usecase.RefreshLibraries
 import com.riffle.core.models.SourceType
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
 
-@HiltViewModel
-class HomeViewModel @Inject constructor(
+class HomeViewModel constructor(
     private val sourceRepository: SourceRepository,
     private val libraryObserver: LibraryObserver,
     private val refreshLibraries: RefreshLibraries,

--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
@@ -19,7 +19,6 @@ import com.riffle.core.catalog.DownloadsCapability
 import com.riffle.app.playback.NowPlaying
 import com.riffle.app.playback.NowPlayingNavigator
 import com.riffle.app.playback.NowPlayingStore
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -34,11 +33,9 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@HiltViewModel
-class NavigationDrawerViewModel @Inject constructor(
+class NavigationDrawerViewModel constructor(
     private val sourceRepository: SourceRepository,
     private val libraryObserver: LibraryObserver,
     private val visibilityStore: LibraryVisibilityPreferencesStore,

--- a/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceScreen.kt
@@ -49,7 +49,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import com.riffle.app.R
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.app.ui.source.SourceTypeIcon
@@ -67,7 +67,7 @@ fun AddSourceScreen(
     onNavigateBack: () -> Unit,
     onAuthenticated: (PendingSource) -> Unit,
     onAutoCompleted: () -> Unit,
-    viewModel: AddSourceViewModel = hiltViewModel(),
+    viewModel: AddSourceViewModel = koinViewModel(),
 ) {
     LaunchedEffect(Unit) {
         viewModel.navigateToSelectLibraries.collect { onAuthenticated(it) }

--- a/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceViewModel.kt
@@ -32,8 +32,6 @@ import com.riffle.core.models.ServerType
 import com.riffle.core.models.SourceType
 import com.riffle.core.models.SourceUrl
 import com.riffle.core.domain.TokenStorage
-import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -43,8 +41,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
-import javax.inject.Named
 
 /**
  * Backend kind selectable in [AddSourceScreen]. WebDAV lives here as a peer to the browsable
@@ -98,9 +94,8 @@ sealed class AddSourceBackend {
     }
 }
 
-@HiltViewModel
-class AddSourceViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+class AddSourceViewModel constructor(
+    private val context: Context,
     private val repository: SourceRepository,
     // Per-SourceType credentialed authenticators (ADR 0053). Injected as a Hilt multibinding —
     // adding a new credentialed source contributes one entry via @IntoMap without touching this
@@ -116,7 +111,7 @@ class AddSourceViewModel @Inject constructor(
     private val tokenStorage: TokenStorage,
     private val clock: Clock,
     private val annotationDao: AnnotationDao,
-    @Named(WEBDAV_BANNER_TICKER) private val bannerTicker: Flow<Unit>,
+    private val bannerTicker: Flow<Unit>,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 

--- a/app/src/main/kotlin/com/riffle/app/feature/server/SelectLibrariesScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/SelectLibrariesScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.core.domain.PendingSource
 
@@ -40,7 +40,7 @@ fun SelectLibrariesScreen(
     pending: PendingSource,
     onNavigateBack: () -> Unit,
     onContinueComplete: () -> Unit,
-    viewModel: SelectLibrariesViewModel = hiltViewModel(),
+    viewModel: SelectLibrariesViewModel = koinViewModel(),
 ) {
     LaunchedEffect(pending) { viewModel.bind(pending) }
     LaunchedEffect(Unit) { viewModel.navigateHome.collect { onContinueComplete() } }

--- a/app/src/main/kotlin/com/riffle/app/feature/server/SelectLibrariesViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/SelectLibrariesViewModel.kt
@@ -11,16 +11,12 @@ import com.riffle.core.domain.CommitSourceResult
 import com.riffle.core.models.Library
 import com.riffle.core.domain.PendingSource
 import com.riffle.core.domain.SourceRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class SelectLibrariesViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+class SelectLibrariesViewModel constructor(
+    private val context: Context,
     private val repository: SourceRepository,
 ) : ViewModel() {
 

--- a/app/src/main/kotlin/com/riffle/app/feature/server/SourceSetupViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/SourceSetupViewModel.kt
@@ -2,8 +2,6 @@ package com.riffle.app.feature.server
 
 import androidx.lifecycle.ViewModel
 import com.riffle.core.domain.PendingSource
-import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 
 /**
  * Scoped to the `server_setup` nested navigation graph. Holds the
@@ -11,7 +9,6 @@ import javax.inject.Inject
  * SelectLibrariesScreen can share it without routing the auth token through
  * nav arguments.
  */
-@HiltViewModel
-class SourceSetupViewModel @Inject constructor() : ViewModel() {
+class SourceSetupViewModel constructor() : ViewModel() {
     var pendingServer: PendingSource? = null
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/SourceTypePickerViewModel.kt
@@ -4,8 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
-import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
@@ -22,8 +20,7 @@ import kotlinx.coroutines.flow.stateIn
  * is nothing to disambiguate a second row from the first, so a duplicate would be a silent no-op
  * or a confusing duplicate library entry.
  */
-@HiltViewModel
-class SourceTypePickerViewModel @Inject constructor(
+class SourceTypePickerViewModel constructor(
     sourceRepository: SourceRepository,
 ) : ViewModel() {
 

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsScreen.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import com.riffle.app.feature.server.AddSourceBackend
 import com.riffle.app.feature.settings.panels.AutoScrollSettingsPanel
 import com.riffle.app.feature.settings.panels.BehaviorSettingsPanel
@@ -80,7 +80,7 @@ fun SettingsScreen(
     onNavigateToDictionaryPacks: () -> Unit = {},
     onNavigateToDebugLogs: () -> Unit = {},
     onNavigateToChangelog: () -> Unit = {},
-    viewModel: SettingsViewModel = hiltViewModel(),
+    viewModel: SettingsViewModel = koinViewModel(),
 ) {
     val globalFormatting by viewModel.globalFormattingPreferences.collectAsState()
     val globalComicFormatting by viewModel.globalComicFormatting.collectAsState()

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/SettingsViewModel.kt
@@ -43,8 +43,6 @@ import com.riffle.core.database.LocalFilesFolderEntity
 import com.riffle.core.domain.VolumeKeyPreferencesStore
 import com.riffle.core.domain.WakeLockPreferencesStore
 import com.riffle.core.domain.SourceRepository
-import dagger.hilt.android.qualifiers.ApplicationContext
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -61,7 +59,6 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 /** UI state for the at-a-glance "WebDAV" row in Settings (ADR 0043). */
 data class AnnotationSyncRowState(
@@ -75,9 +72,8 @@ data class AnnotationSyncRowState(
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@HiltViewModel
-class SettingsViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
+class SettingsViewModel constructor(
+    private val context: Context,
     private val crashReportRepository: CrashReportRepository,
     private val formattingPreferencesStore: FormattingPreferencesStore,
     private val sourceRepository: SourceRepository,

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceScreen.kt
@@ -45,13 +45,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AnnotationSyncMaintenanceScreen(
     onNavigateBack: () -> Unit,
-    viewModel: AnnotationSyncMaintenanceViewModel = hiltViewModel(),
+    viewModel: AnnotationSyncMaintenanceViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
 

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationSyncMaintenanceViewModel.kt
@@ -11,13 +11,11 @@ import com.riffle.core.models.Source
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.domain.SyncNamespace
 import com.riffle.core.domain.WebSourceDescriptors
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 /** Row data for the per-device list in the Maintenance screen. */
 data class MaintenanceDeviceRowUiState(
@@ -77,8 +75,7 @@ data class AnnotationSyncMaintenanceUiState(
     val snack: MaintenanceSnack = MaintenanceSnack.None,
 )
 
-@HiltViewModel
-class AnnotationSyncMaintenanceViewModel @Inject constructor(
+class AnnotationSyncMaintenanceViewModel constructor(
     private val configStore: com.riffle.core.domain.AnnotationSyncConfigStore,
     private val maintenance: AnnotationSyncMaintenance,
     private val deviceIdStore: DeviceIdStore,

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationsSyncSettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/annotationsync/AnnotationsSyncSettingsScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import com.riffle.app.R
 import com.riffle.app.feature.server.AddSourceBackend
 import com.riffle.app.feature.settings.AnnotationSyncBadge
@@ -52,7 +52,7 @@ fun AnnotationsSyncSettingsScreen(
     onNavigateBack: () -> Unit,
     onNavigateToAddSource: (AddSourceBackend, String?) -> Unit,
     onNavigateToMaintenance: () -> Unit,
-    viewModel: SettingsViewModel = hiltViewModel(),
+    viewModel: SettingsViewModel = koinViewModel(),
 ) {
     val row by viewModel.annotationSyncRow.collectAsState()
 

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/debug/DebugLogScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/debug/DebugLogScreen.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import com.riffle.app.R
 import com.riffle.core.logging.InMemoryLogBuffer
 import com.riffle.core.logging.LogChannel
@@ -60,7 +60,7 @@ import java.util.Locale
 @Composable
 fun DebugLogScreen(
     onNavigateBack: () -> Unit,
-    viewModel: DebugLogViewModel = hiltViewModel(),
+    viewModel: DebugLogViewModel = koinViewModel(),
 ) {
     val entries by viewModel.entries.collectAsState()
     val context = LocalContext.current

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/debug/DebugLogViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/debug/DebugLogViewModel.kt
@@ -6,21 +6,18 @@ import androidx.core.content.FileProvider
 import androidx.lifecycle.AndroidViewModel
 import com.riffle.core.logging.InMemoryLogBuffer
 import com.riffle.core.logging.LogChannel
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.StateFlow
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
-import javax.inject.Inject
 
 /**
  * Backs [DebugLogScreen]. Owns no state of its own — the [InMemoryLogBuffer] is the source of truth
  * and its [StateFlow] drives the UI directly. The VM exists to give the Compose screen a stable
  * Hilt-injected handle to the singleton buffer and to package the "share as .txt" workflow.
  */
-@HiltViewModel
-class DebugLogViewModel @Inject constructor(
+class DebugLogViewModel constructor(
     application: Application,
     private val buffer: InMemoryLogBuffer,
 ) : AndroidViewModel(application) {

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesScreen.kt
@@ -51,7 +51,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import androidx.compose.ui.platform.LocalContext
@@ -67,7 +67,7 @@ import com.riffle.app.ui.source.asAuthHeader
 @Composable
 fun ReadaloudMatchesScreen(
     onNavigateBack: () -> Unit,
-    viewModel: ReadaloudMatchesViewModel = hiltViewModel(),
+    viewModel: ReadaloudMatchesViewModel = koinViewModel(),
 ) {
     val review by viewModel.review.collectAsState()
     val tokens by viewModel.tokensByServer.collectAsState()

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesViewModel.kt
@@ -14,7 +14,6 @@ import com.riffle.core.domain.usecase.ReadaloudReviewActions
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.ServerType
 import com.riffle.core.domain.TokenStorage
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,11 +27,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
-@HiltViewModel
-class ReadaloudMatchesViewModel @Inject constructor(
+class ReadaloudMatchesViewModel constructor(
     savedStateHandle: SavedStateHandle,
     private val reviewRepository: ReadaloudReviewRepository,
     private val reviewActions: ReadaloudReviewActions,

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudSettingsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudSettingsScreen.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import com.riffle.app.R
 import com.riffle.app.feature.readersettings.swatchBackdropColor
 import com.riffle.app.feature.server.AddSourceBackend
@@ -69,7 +69,7 @@ fun ReadaloudSettingsScreen(
     onNavigateBack: () -> Unit,
     onNavigateToAddSource: (AddSourceBackend, String?) -> Unit,
     onNavigateToReadaloudMatches: (String) -> Unit,
-    viewModel: SettingsViewModel = hiltViewModel(),
+    viewModel: SettingsViewModel = koinViewModel(),
 ) {
     val servers by viewModel.servers.collectAsState()
     val serverVersions by viewModel.serverVersions.collectAsState()

--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/AddChitankaScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/AddChitankaScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.app.ui.source.SourceTypeIcon
 import com.riffle.core.models.SourceType
@@ -46,7 +46,7 @@ fun AddChitankaScreen(
     windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onDone: () -> Unit,
-    viewModel: AddChitankaViewModel = hiltViewModel(),
+    viewModel: AddChitankaViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
 

--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/AddChitankaViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/AddChitankaViewModel.kt
@@ -4,20 +4,17 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.core.data.websource.SingletonWebSourceInstaller
 import com.riffle.core.models.SourceType
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 /**
  * Drives the zero-config Chitanka install screen. There is no user input — the ViewModel simply
  * calls [SingletonWebSourceInstaller.install] with [SourceType.CHITANKA] on demand and reports
  * the state. The screen observes [state] and calls `onDone` when the install completes.
  */
-@HiltViewModel
-class AddChitankaViewModel @Inject constructor(
+class AddChitankaViewModel constructor(
     private val installer: SingletonWebSourceInstaller,
 ) : ViewModel() {
 

--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import com.riffle.app.feature.annotations.AnnotationsListScreen
 import com.riffle.app.feature.annotations.AnnotationsListViewModel
 import com.riffle.app.feature.library.LocalCoversAreSquare
@@ -85,7 +85,7 @@ fun ChitankaBrowseScreen(
     onSectionSeeMore: (LibrarySectionType) -> Unit,
     onOpenDetail: (itemId: String) -> Unit,
     onAnnotatedBookClick: (sourceId: String, itemId: String) -> Unit,
-    viewModel: ChitankaBrowseViewModel = hiltViewModel(),
+    viewModel: ChitankaBrowseViewModel = koinViewModel(),
 ) {
     var selectedTab by rememberSaveable { mutableIntStateOf(TAB_HOME) }
 
@@ -100,7 +100,7 @@ fun ChitankaBrowseScreen(
     var searchOpen by remember { mutableStateOf(false) }
     val persistedCoverScale by viewModel.coverGridScale.collectAsState()
 
-    val visibility by hiltViewModel<com.riffle.app.feature.library.LibraryTabVisibilityViewModel>()
+    val visibility by koinViewModel<com.riffle.app.feature.library.LibraryTabVisibilityViewModel>()
         .visibility.collectAsState()
     // Annotations are anchored to ebook text — Gramofonche (the audiobook root) can never surface
     // any, so hide the tab there on top of the generic emptiness gate.
@@ -347,7 +347,7 @@ private fun LibraryTabContent(
 @Composable
 private fun ChitankaAnnotationsTab(
     onAnnotatedBookClick: (sourceId: String, itemId: String) -> Unit,
-    viewModel: AnnotationsListViewModel = hiltViewModel(),
+    viewModel: AnnotationsListViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
     AnnotationsListScreen(

--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModel.kt
@@ -11,10 +11,8 @@ import com.riffle.core.domain.LibraryFilterPreferencesStore
 import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
-import dagger.hilt.android.lifecycle.HiltViewModel
 import java.io.IOException
 import java.net.UnknownHostException
-import javax.inject.Inject
 
 /**
  * ViewModel for [ChitankaBrowseScreen]. Delegates to [UnboundedBrowseViewModel] for the shared
@@ -22,8 +20,7 @@ import javax.inject.Inject
  * carries Chitanka-specific tuning — the [SourceType] guard, the default rootId, the page size,
  * and the host-specific error copy.
  */
-@HiltViewModel
-class ChitankaBrowseViewModel @Inject constructor(
+class ChitankaBrowseViewModel constructor(
     savedStateHandle: SavedStateHandle,
     sourceRepository: SourceRepository,
     catalogRegistry: CatalogRegistry,

--- a/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/AddGutenbergScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/AddGutenbergScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import com.riffle.app.ui.TabletContentWidthContainer
 import com.riffle.app.ui.source.SourceTypeIcon
 import com.riffle.core.models.SourceType
@@ -46,7 +46,7 @@ fun AddGutenbergScreen(
     windowSizeClass: WindowSizeClass,
     onNavigateBack: () -> Unit,
     onDone: () -> Unit,
-    viewModel: AddGutenbergViewModel = hiltViewModel(),
+    viewModel: AddGutenbergViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
 

--- a/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/AddGutenbergViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/AddGutenbergViewModel.kt
@@ -4,20 +4,17 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.core.data.websource.SingletonWebSourceInstaller
 import com.riffle.core.models.SourceType
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 /**
  * Drives the zero-config Gutenberg install screen. There is no user input — the ViewModel simply
  * calls [SingletonWebSourceInstaller.install] with [SourceType.GUTENBERG] on demand and reports
  * the state. The screen observes [state] and calls `onDone` when the install completes.
  */
-@HiltViewModel
-class AddGutenbergViewModel @Inject constructor(
+class AddGutenbergViewModel constructor(
     private val installer: SingletonWebSourceInstaller,
 ) : ViewModel() {
 

--- a/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
@@ -49,7 +49,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import com.riffle.app.feature.annotations.AnnotationsListScreen
 import com.riffle.app.feature.annotations.AnnotationsListViewModel
 import com.riffle.app.feature.library.LibrarySectionType
@@ -77,13 +77,13 @@ fun GutenbergBrowseScreen(
     onSectionSeeMore: (LibrarySectionType) -> Unit,
     onOpenDetail: (itemId: String) -> Unit,
     onAnnotatedBookClick: (sourceId: String, itemId: String) -> Unit,
-    viewModel: GutenbergBrowseViewModel = hiltViewModel(),
+    viewModel: GutenbergBrowseViewModel = koinViewModel(),
 ) {
     var selectedTab by rememberSaveable { mutableIntStateOf(TAB_HOME) }
     var searchOpen by remember { mutableStateOf(false) }
     val persistedCoverScale by viewModel.coverGridScale.collectAsState()
 
-    val visibility by hiltViewModel<com.riffle.app.feature.library.LibraryTabVisibilityViewModel>()
+    val visibility by koinViewModel<com.riffle.app.feature.library.LibraryTabVisibilityViewModel>()
         .visibility.collectAsState()
 
     LaunchedEffect(viewModel) {
@@ -398,7 +398,7 @@ private const val GUTENBERG_LANGUAGE_FACET_PREFIX = "language:"
 @Composable
 private fun GutenbergAnnotationsTab(
     onAnnotatedBookClick: (sourceId: String, itemId: String) -> Unit,
-    viewModel: AnnotationsListViewModel = hiltViewModel(),
+    viewModel: AnnotationsListViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
     AnnotationsListScreen(

--- a/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseViewModel.kt
@@ -11,10 +11,8 @@ import com.riffle.core.domain.LibraryFilterPreferencesStore
 import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.SourceType
-import dagger.hilt.android.lifecycle.HiltViewModel
 import java.io.IOException
 import java.net.UnknownHostException
-import javax.inject.Inject
 
 /**
  * ViewModel for [GutenbergBrowseScreen]. Delegates to [UnboundedBrowseViewModel] for the shared
@@ -22,8 +20,7 @@ import javax.inject.Inject
  * carries Gutenberg-specific tuning — the [SourceType] guard, the default rootId, the page
  * size, and the host-specific error copy.
  */
-@HiltViewModel
-class GutenbergBrowseViewModel @Inject constructor(
+class GutenbergBrowseViewModel constructor(
     savedStateHandle: SavedStateHandle,
     sourceRepository: SourceRepository,
     catalogRegistry: CatalogRegistry,

--- a/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/AddLocalFilesScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/AddLocalFilesScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import com.riffle.app.ui.TabletContentWidthContainer
 
 /**
@@ -53,7 +53,7 @@ fun AddLocalFilesScreen(
     windowSizeClass: WindowSizeClass,
     onDone: () -> Unit,
     onNavigateBack: () -> Unit,
-    viewModel: AddLocalFilesViewModel = hiltViewModel(),
+    viewModel: AddLocalFilesViewModel = koinViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
     val launcher = rememberLauncherForActivityResult(PickFolderContract()) { uri ->

--- a/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/AddLocalFilesViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/localfiles/AddLocalFilesViewModel.kt
@@ -5,15 +5,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.riffle.core.data.localfiles.LocalFilesScanner
 import com.riffle.core.data.localfiles.LocalFilesSourceInstaller
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
-@HiltViewModel
-class AddLocalFilesViewModel @Inject constructor(
+class AddLocalFilesViewModel constructor(
     private val installer: LocalFilesSourceInstaller,
 ) : ViewModel() {
 

--- a/app/src/main/kotlin/com/riffle/app/feature/source/radioes/RadioEsBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/radioes/RadioEsBrowseScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import com.riffle.app.R
 import com.riffle.core.catalog.CatalogFacet
 import com.riffle.app.feature.library.LibrarySectionType
@@ -84,7 +85,7 @@ fun RadioEsBrowseScreen(
     var searchOpen by remember { mutableStateOf(false) }
     val persistedCoverScale by viewModel.coverGridScale.collectAsState()
 
-    val visibility by hiltViewModel<com.riffle.app.feature.library.LibraryTabVisibilityViewModel>()
+    val visibility by koinViewModel<com.riffle.app.feature.library.LibraryTabVisibilityViewModel>()
         .visibility.collectAsState()
 
     LaunchedEffect(visibility.toRead) {

--- a/app/src/main/kotlin/com/riffle/app/feature/source/websource/WebSourceLibraryViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/websource/WebSourceLibraryViewModel.kt
@@ -3,7 +3,7 @@ package com.riffle.app.feature.source.websource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -13,13 +13,11 @@ import com.riffle.app.feature.library.ToReadTabContent
 import com.riffle.core.data.ToReadRepository
 import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.models.LibraryItem
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
-import javax.inject.Inject
 
 /**
  * Room-backed acquired-item shelves shared by every Web Source.
@@ -28,8 +26,7 @@ import javax.inject.Inject
  * is represented by the same local `library_items` rows. This ViewModel keeps Home and To Read
  * shelf plumbing out of each concrete Source screen.
  */
-@HiltViewModel
-class WebSourceLibraryViewModel @Inject constructor(
+class WebSourceLibraryViewModel constructor(
     savedStateHandle: SavedStateHandle,
     libraryObserver: LibraryObserver,
     toReadRepository: ToReadRepository,
@@ -67,7 +64,7 @@ fun WebSourceHomeTab(
     onOpenDetail: (itemId: String) -> Unit,
     onSectionSeeMore: (LibrarySectionType) -> Unit,
     onCoverScaleChange: (Float) -> Unit,
-    viewModel: WebSourceLibraryViewModel = hiltViewModel(),
+    viewModel: WebSourceLibraryViewModel = koinViewModel(),
 ) {
     val inProgress by viewModel.inProgress.collectAsState()
     val recentlyAdded by viewModel.recentlyAdded.collectAsState()
@@ -91,7 +88,7 @@ fun WebSourceHomeTab(
 fun WebSourceToReadTab(
     onOpenDetail: (itemId: String) -> Unit,
     onCoverScaleChange: (Float) -> Unit,
-    viewModel: WebSourceLibraryViewModel = hiltViewModel(),
+    viewModel: WebSourceLibraryViewModel = koinViewModel(),
 ) {
     val items by viewModel.toReadItems.collectAsState()
     ToReadTabContent(

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -138,7 +139,7 @@ internal fun libraryEntryRoute(destination: HomeViewModel.StartDestination.Libra
 @Composable
 fun MainScreen(
     windowSizeClass: WindowSizeClass,
-    viewModel: NavigationDrawerViewModel = hiltViewModel(),
+    viewModel: NavigationDrawerViewModel = koinViewModel(),
 ) {
     val startupUpdateVm: com.riffle.app.feature.update.StartupUpdateViewModel = hiltViewModel()
     val updateDialogState by startupUpdateVm.dialogState.collectAsState()

--- a/app/src/main/kotlin/com/riffle/app/navigation/SettingsNavGraph.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/SettingsNavGraph.kt
@@ -2,7 +2,7 @@ package com.riffle.app.navigation
 
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.runtime.remember
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
@@ -60,7 +60,7 @@ internal fun NavGraphBuilder.settingsNavGraph(
         val settingsEntry = remember(backStackEntry) {
             navController.getBackStackEntry(SETTINGS)
         }
-        val settingsVm: SettingsViewModel = hiltViewModel(settingsEntry)
+        val settingsVm: SettingsViewModel = koinViewModel(viewModelStoreOwner = settingsEntry)
         ReadaloudSettingsScreen(
             onNavigateBack = { navController.popBackStackIfTop(backStackEntry) },
             onNavigateToAddSource = { backend, editId ->
@@ -86,7 +86,7 @@ internal fun NavGraphBuilder.settingsNavGraph(
         val settingsEntry = remember(backStackEntry) {
             navController.getBackStackEntry(SETTINGS)
         }
-        val settingsVm: SettingsViewModel = hiltViewModel(settingsEntry)
+        val settingsVm: SettingsViewModel = koinViewModel(viewModelStoreOwner = settingsEntry)
         AnnotationsSyncSettingsScreen(
             onNavigateBack = { navController.popBackStackIfTop(backStackEntry) },
             onNavigateToAddSource = { backend, editId ->
@@ -114,7 +114,7 @@ internal fun NavGraphBuilder.settingsNavGraph(
         val settingsEntry = remember(backStackEntry) {
             navController.getBackStackEntry(SETTINGS)
         }
-        val settingsVm: SettingsViewModel = hiltViewModel(settingsEntry)
+        val settingsVm: SettingsViewModel = koinViewModel(viewModelStoreOwner = settingsEntry)
         DeveloperOptionsScreen(
             onNavigateBack = { navController.popBackStackIfTop(backStackEntry) },
             onNavigateToDebugLogs = { navController.navigate(DEBUG_LOGS) },

--- a/app/src/main/kotlin/com/riffle/app/navigation/SourceNavGraph.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/SourceNavGraph.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import org.koin.androidx.compose.koinViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
@@ -45,7 +45,7 @@ internal fun NavGraphBuilder.sourceNavGraph(
     composable(ADD_SOURCE_TYPE_PICKER) { backStackEntry ->
         val cameFromSettings = navController.previousBackStackEntry
             ?.destination?.route == SETTINGS
-        val pickerViewModel: SourceTypePickerViewModel = hiltViewModel()
+        val pickerViewModel: SourceTypePickerViewModel = koinViewModel()
         val installedTypes by pickerViewModel.installedTypes.collectAsState()
         SourceTypePickerScreen(
             windowSizeClass = windowSizeClass,
@@ -218,7 +218,7 @@ internal fun NavGraphBuilder.sourceNavGraph(
             val parentEntry = remember(backStackEntry) {
                 navController.getBackStackEntry(SOURCE_SETUP_GRAPH)
             }
-            val setupVm: SourceSetupViewModel = hiltViewModel(parentEntry)
+            val setupVm: SourceSetupViewModel = koinViewModel(viewModelStoreOwner = parentEntry)
             // Add-Source can be reached from the main Settings screen or from either of
             // the settings drill-ins (Readaloud → Configure Storyteller; Annotations
             // Sync → Configure WebDAV). All three should pop back to the caller when
@@ -245,7 +245,7 @@ internal fun NavGraphBuilder.sourceNavGraph(
             val parentEntry = remember(backStackEntry) {
                 navController.getBackStackEntry(SOURCE_SETUP_GRAPH)
             }
-            val setupVm: SourceSetupViewModel = hiltViewModel(parentEntry)
+            val setupVm: SourceSetupViewModel = koinViewModel(viewModelStoreOwner = parentEntry)
             val pending = setupVm.pendingServer
             if (pending == null) {
                 LaunchedEffect(Unit) { navController.popBackStackIfTop(backStackEntry) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,7 +83,6 @@ koin-bom = { group = "io.insert-koin", name = "koin-bom", version.ref = "koin" }
 koin-android = { group = "io.insert-koin", name = "koin-android" }
 koin-compose = { group = "io.insert-koin", name = "koin-compose" }
 koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compose" }
-koin-test-android = { group = "io.insert-koin", name = "koin-test-android" }
 acra-core = { group = "ch.acra", name = "acra-core", version.ref = "acra" }
 acra-toast = { group = "ch.acra", name = "acra-toast", version.ref = "acra" }
 acra-dialog = { group = "ch.acra", name = "acra-dialog", version.ref = "acra" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,6 +83,7 @@ koin-bom = { group = "io.insert-koin", name = "koin-bom", version.ref = "koin" }
 koin-android = { group = "io.insert-koin", name = "koin-android" }
 koin-compose = { group = "io.insert-koin", name = "koin-compose" }
 koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compose" }
+koin-test-android = { group = "io.insert-koin", name = "koin-test-android" }
 acra-core = { group = "ch.acra", name = "acra-core", version.ref = "acra" }
 acra-toast = { group = "ch.acra", name = "acra-toast", version.ref = "acra" }
 acra-dialog = { group = "ch.acra", name = "acra-dialog", version.ref = "acra" }


### PR DESCRIPTION
Closes #736

Converts 26 `@HiltViewModel` classes and ~47 `hiltViewModel()` call sites to Koin as part of the incremental Hilt→Koin migration (#735, #736, #737).

## Bridge pattern

Since the data layer (#737) hasn't moved to Koin yet, a transitional bridge is used:

- **`KoinBridgeEntryPoint`** — Hilt `@EntryPoint` that exposes all ~83 singleton/factory bindings needed by the migrated ViewModels.
- **`bridgeDepsModule`** — Koin module that registers every bridged dep as `single<Type> { get<KoinBridgeEntryPoint>().xxx() }`.

Both are removed when #737 converts `core:data` to Koin natively.

## What changed

- Stripped `@HiltViewModel` / `@Inject constructor` / Hilt imports from all 26 in-scope ViewModels (`feature/library`, `feature/navigation`, `feature/settings`, `feature/server`, `feature/source`, `feature/downloads`).
- Updated all call sites to `koinViewModel()` / `koinViewModel(viewModelStoreOwner = entry)` for nav-graph-scoped VMs.
- `LibraryTabVisibilityObserver.kt` has two classes: the `@Singleton` service (left on Hilt) and `LibraryTabVisibilityViewModel` (converted). The observer is exposed through the bridge entry point so Koin can inject it.
- Reader, audiobook player, update, RadioES browse VM, and `StartupUpdateViewModel` remain on Hilt — they are out of scope for this issue.
- Added `KoinModulesTest` instrumentation smoke test that resolves `LibraryObserver` through the bridge and asserts the module list is non-empty.

## Out of scope (still using hiltViewModel)

`EpubReaderScreen`, `PdfReaderScreen`, `CbzReaderScreen`, `AudiobookPlayerScreen`, `ChangelogScreen`, `DictionaryPacksScreen`, `AddRadioEsScreen`, `RadioEsBrowseViewModel` (its own VM), `StartupUpdateViewModel`.