### PR TITLE
fix(di): restore full Koin graph after Hilt→Koin migration — missing bindings, erased-generic collisions, graph verification test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,13 @@ jobs:
   android-harness-test-phone:
     name: Android harness tests (phone)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # TEMPORARY bump 20→35 (revert tracked in #845): a green run
+    # takes ~13-15 min, but each *failing* test adds ~25-30s of crash-recovery overhead,
+    # so a run with many failures blows past 20 min and gets CANCELLED — which skips the
+    # report/logcat uploads and hides the actual failures (this is exactly how the
+    # Hilt→Koin missing-binding regressions surfaced as opaque cancelled runs). Restore
+    # to 20 once post-Koin harness runs are stably green.
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v6

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -196,6 +196,8 @@ dependencies {
     testImplementation("androidx.arch.core:core-testing:2.2.0")
     testImplementation(libs.json)
     testImplementation(libs.okhttp.mockwebserver)
+    testImplementation(koinBom)
+    testImplementation(libs.koin.test)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(composeBom)

--- a/app/src/main/kotlin/com/riffle/app/di/AppKoinModules.kt
+++ b/app/src/main/kotlin/com/riffle/app/di/AppKoinModules.kt
@@ -8,9 +8,9 @@ import com.riffle.app.feature.audio.BundleZipItemRestorer
 import com.riffle.app.feature.audio.DefaultMediaSessionConnector
 import com.riffle.app.feature.audio.FileAudioSourceFactory
 import com.riffle.app.feature.audio.HttpAudioSourceFactory
-import com.riffle.app.feature.audio.MediaItemRestorer
+import com.riffle.app.feature.audio.MediaItemRestorerRegistry
 import com.riffle.app.feature.audio.MediaSessionConnector
-import com.riffle.app.feature.audio.MediaSourceFactory
+import com.riffle.app.feature.audio.MediaSourceRegistry
 import com.riffle.app.feature.audio.StreamingReadaloudItemRestorer
 import com.riffle.app.feature.audiobook.AudiobookController
 import com.riffle.app.feature.audiobook.AudiobookHandoffState
@@ -70,8 +70,6 @@ import com.riffle.core.domain.DefaultDispatcherProvider
 import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.EbookCfiTranslatorFactory
 import com.riffle.core.domain.appearance.AppearanceCoordinator
-import com.riffle.core.logging.AndroidLogger
-import com.riffle.core.logging.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
@@ -125,9 +123,7 @@ val appKoinModule: Module = module {
         isDevVersionName(com.riffle.app.BuildConfig.VERSION_NAME)
     }
 
-    // ---- Logging ------------------------------------------------------------------------------
-
-    single<Logger> { AndroidLogger(get()) }
+    // ---- Logging: Logger/InMemoryLogBuffer are bound by loggingKoinModule (core:logging) ------
 
     // ---- Readium ------------------------------------------------------------------------------
 
@@ -202,18 +198,26 @@ val appKoinModule: Module = module {
 
     // ---- Audio source factories / restorers -------------------------------------------------
 
-    single<List<MediaSourceFactory>> {
-        listOf(
-            HttpAudioSourceFactory(),
-            FileAudioSourceFactory(),
-            BundleAudioSourceFactory(get()),
+    // The factory/restorer lists are inlined into their registries rather than bound as
+    // single<List<...>>: Koin indexes definitions by ERASED KClass, so two unqualified
+    // List<...> definitions silently override each other (the same erasure collision that
+    // handed DefaultCatalogRegistry a Map of SourceAdapters).
+    single {
+        MediaSourceRegistry(
+            listOf(
+                HttpAudioSourceFactory(),
+                FileAudioSourceFactory(),
+                BundleAudioSourceFactory(get()),
+            ),
         )
     }
-    single<List<MediaItemRestorer>> {
-        listOf(
-            StreamingReadaloudItemRestorer(),
-            AudiobookHttpItemRestorer(),
-            BundleZipItemRestorer(),
+    single {
+        MediaItemRestorerRegistry(
+            listOf(
+                StreamingReadaloudItemRestorer(),
+                AudiobookHttpItemRestorer(),
+                BundleZipItemRestorer(),
+            ),
         )
     }
 

--- a/app/src/main/kotlin/com/riffle/app/di/AppKoinModules.kt
+++ b/app/src/main/kotlin/com/riffle/app/di/AppKoinModules.kt
@@ -19,9 +19,11 @@ import com.riffle.app.feature.audiobook.AudiobookResumeResolver
 import com.riffle.app.feature.audiobook.FollowLoopOrchestrator
 import com.riffle.app.feature.library.BookImportManager
 import com.riffle.app.feature.library.DownloadManager
+import com.riffle.app.feature.library.LibraryTabVisibilityObserver
 import com.riffle.app.feature.reader.EbookCfiTranslatorFactoryImpl
 import com.riffle.app.feature.reader.ProgressFlushScope
 import com.riffle.app.feature.reader.ReaderStateHolder
+import com.riffle.app.feature.reader.ReaderSyncFactory
 import com.riffle.app.feature.reader.VolumeNavigationController
 import com.riffle.app.feature.reader.autoscroll.AutoScrollController
 import com.riffle.app.feature.reader.cadence.CadenceController
@@ -29,6 +31,7 @@ import com.riffle.app.feature.reader.controllers.BookmarksController
 import com.riffle.app.feature.reader.controllers.SearchController
 import com.riffle.app.feature.reader.controllers.VolumeKeyDispatcher
 import com.riffle.app.feature.reader.controllers.WakeLockController
+import com.riffle.app.feature.reader.highlights.HighlightsPdfExporter
 import com.riffle.app.feature.reader.highlights.HighlightsPublicationFactory
 import com.riffle.app.feature.reader.FiguresInRangeResolver
 import com.riffle.app.feature.reader.NoopFiguresInRangeResolver
@@ -260,6 +263,31 @@ val appKoinModule: Module = module {
     single<PdfMetadataExtractor> { PdfiumPdfMetadataExtractor(context = androidContext()) }
 
     // ---- Audiobook state --------------------------------------------------------------------
+
+    factory {
+        ReaderSyncFactory(
+            linkRepository = get(),
+            sourceRepository = get(),
+            catalogRegistry = get(),
+            indexStore = get(),
+            libraryObserver = get(),
+            cacheStore = get(named("epubCacheStore")),
+            downloadsStore = get(named("epubDownloadsStore")),
+            crossEpubIndexBuildTrigger = get(),
+            sidecarCache = get(),
+            clock = get(),
+            logger = get(),
+        )
+    }
+    factory { HighlightsPdfExporter(context = androidContext(), factory = get()) }
+    single {
+        LibraryTabVisibilityObserver(
+            libraryObserver = get(),
+            toReadRepository = get(),
+            annotationsLibraryRepository = get(),
+            sourceRepository = get(),
+        )
+    }
 
     single { AudiobookHandoffState() }
     single { FollowLoopOrchestrator(clock = get(), progressFlushScope = get()) }

--- a/app/src/main/kotlin/com/riffle/app/di/KoinViewModelModules.kt
+++ b/app/src/main/kotlin/com/riffle/app/di/KoinViewModelModules.kt
@@ -129,6 +129,7 @@ import org.koin.android.ext.koin.androidApplication
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.module.Module
+import com.riffle.core.data.di.SOURCE_ADAPTERS_BY_SOURCE_TYPE
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
@@ -359,7 +360,7 @@ private val serverViewModelModule = module {
         AddSourceViewModel(
             context = androidContext(),
             repository = get(),
-            authenticators = get(),
+            authenticators = get(named(SOURCE_ADAPTERS_BY_SOURCE_TYPE)),
             webdavConfigStore = get(),
             webdavTargetFactory = get(),
             webdavStatusStore = get(),

--- a/app/src/main/kotlin/com/riffle/app/di/KoinViewModelModules.kt
+++ b/app/src/main/kotlin/com/riffle/app/di/KoinViewModelModules.kt
@@ -53,10 +53,8 @@ import com.riffle.core.data.AnnotationSyncMaintenance
 import com.riffle.core.data.AnnotationsLibraryRepository
 import com.riffle.core.data.CrossEpubIndexBuildTrigger
 import com.riffle.core.data.PlaylistsRepository
-import com.riffle.core.data.ReadaloudMatchingService
 import com.riffle.core.data.ReadaloudSidecarPrefetcher
 import com.riffle.core.data.ReadaloudSidecarStore
-import com.riffle.core.data.StorytellerReadaloudSyncer
 import com.riffle.core.data.ToReadRepository
 import com.riffle.core.data.credentialed.CredentialedAuthenticator
 import com.riffle.core.data.localfiles.CopyCoverImageUseCase

--- a/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/server/AddSourceViewModel.kt
@@ -13,10 +13,10 @@ import com.riffle.app.feature.annotationsync.AnnotationSyncKind
 import com.riffle.app.feature.annotationsync.deriveAnnotationSyncKind
 import com.riffle.core.sync.AnnotationSyncStatusStore
 import com.riffle.core.sync.CycleOutcome
-import com.riffle.core.data.ReadaloudMatchingService
+import com.riffle.core.domain.ReadaloudLinkReconciler
 import com.riffle.core.data.credentialed.CredentialedAuthenticator
 import com.riffle.core.database.AnnotationDao
-import com.riffle.core.data.StorytellerReadaloudSyncer
+import com.riffle.core.domain.StorytellerReadaloudCacheSyncer
 import com.riffle.core.sources.webdav.TestConnectionResult
 import com.riffle.core.sources.webdav.WebDavAnnotationSyncTargetFactory
 import com.riffle.core.domain.AnnotationSweepEnqueuer
@@ -97,8 +97,8 @@ sealed class AddSourceBackend {
 class AddSourceViewModel constructor(
     private val context: Context,
     private val repository: SourceRepository,
-    // Per-SourceType credentialed authenticators (ADR 0053). Injected as a Hilt multibinding —
-    // adding a new credentialed source contributes one entry via @IntoMap without touching this
+    // Per-SourceType credentialed authenticators (ADR 0053). Injected as a Koin map binding —
+    // adding a new credentialed source contributes one entry to the map without touching this
     // ViewModel. Kept out of SourceRepository to avoid rippling a `sourceType` param through
     // every anonymous test fake for a Kotlin interface method with a single production caller.
     private val authenticators: Map<SourceType, @JvmSuppressWildcards CredentialedAuthenticator>,
@@ -106,8 +106,8 @@ class AddSourceViewModel constructor(
     private val webdavTargetFactory: WebDavAnnotationSyncTargetFactory,
     private val webdavStatusStore: AnnotationSyncStatusStore,
     private val sweepEnqueuer: AnnotationSweepEnqueuer,
-    private val storytellerSyncer: StorytellerReadaloudSyncer,
-    private val readaloudMatcher: ReadaloudMatchingService,
+    private val storytellerSyncer: StorytellerReadaloudCacheSyncer,
+    private val readaloudMatcher: ReadaloudLinkReconciler,
     private val tokenStorage: TokenStorage,
     private val clock: Clock,
     private val annotationDao: AnnotationDao,
@@ -404,11 +404,7 @@ class AddSourceViewModel constructor(
     }
 
     companion object {
-        /**
-         * Hilt qualifier for the [webdavBanner]'s wall-clock ticker. See [WebdavBannerTickerModule]
-         * for the production ticker (once a minute), and [AddSourceViewModelTest] for the test
-         * override.
-         */
+        /** Koin named qualifier for the [webdavBanner]'s wall-clock ticker (once a minute). */
         const val WEBDAV_BANNER_TICKER = "webdavBannerTicker"
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/di/KoinModuleVerificationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/di/KoinModuleVerificationTest.kt
@@ -98,6 +98,34 @@ class KoinModuleVerificationTest {
             }
         }
 
+        // Duplicate index keys: Koin indexes by ERASED KClass + qualifier, so e.g. two
+        // unqualified Map<...> definitions collide and the last-loaded silently overrides
+        // the first for EVERY injection point of that erased type (this handed
+        // DefaultCatalogRegistry a map of SourceAdapters → ClassCastException). Generic
+        // bindings must carry a named() qualifier.
+        val duplicates = modules.flatMap { it.mappings.keys }
+            .groupingBy { it }.eachCount().filterValues { it > 1 }
+        duplicates.forEach { (key, count) ->
+            problems += "index key '$key' is defined $count times — later definitions silently override earlier ones"
+        }
+
+        // Types resolved via field injection (by inject() in Activities/Services) or
+        // GlobalContext.get() in RiffleApplication — no constructor for reflection to
+        // walk, so pin them explicitly. LocalFilesFolderWatcher going unbound crashed
+        // the production app at startup while the harness (plain test Application)
+        // stayed green.
+        val fieldInjected = listOf(
+            "com.riffle.core.data.localfiles.LocalFilesFolderWatcher", // RiffleApplication.onCreate
+            "com.riffle.app.feature.audio.MediaSourceRegistry", // AudioPlayerService
+            "com.riffle.app.feature.audio.MediaItemRestorerRegistry", // AudioPlayerService
+            "com.riffle.core.data.LocalStoreMigrator", // RiffleApplication.onCreate
+            "com.riffle.core.data.AnnotationSweep", // RiffleApplication.onCreate
+            "com.riffle.core.sync.ProgressSweep", // RiffleApplication.onCreate
+        )
+        fieldInjected.forEach { type ->
+            if (type !in index) problems += "'$type' is resolved via inject()/get() at a field or startup site but has no Koin definition"
+        }
+
         if (problems.isNotEmpty()) {
             fail(
                 "Koin graph has ${problems.size} unresolvable constructor dependenc" +

--- a/app/src/test/kotlin/com/riffle/app/di/KoinModuleVerificationTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/di/KoinModuleVerificationTest.kt
@@ -1,0 +1,110 @@
+package com.riffle.app.di
+
+import com.riffle.app.riffleKoinModules
+import org.junit.Assert.fail
+import org.junit.Test
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.module.Module
+import org.koin.core.module.flatten
+import kotlin.reflect.KVisibility
+import kotlin.reflect.full.primaryConstructor
+
+/**
+ * Verifies the full production Koin graph resolves: for every definition bound to a
+ * concrete class, each primary-constructor parameter type must be bound somewhere in
+ * [riffleKoinModules] (any qualifier).
+ *
+ * Hilt validated the DI graph at compile time; Koin resolves lazily at runtime, so a
+ * missing binding otherwise only surfaces as an InstanceCreationException when a user
+ * (or a 20-minute CI harness run) first navigates to the affected screen — this is
+ * exactly how the AddSourceViewModel and LibraryItemsViewModel crashes shipped after
+ * the Hilt→Koin migration. This test restores that validation at JVM unit-test speed.
+ *
+ * Koin's own `Module.verify()` is not usable here: it reflects over ALL public
+ * constructors of platform-bound definitions too (e.g. the qualifier-bound `File`
+ * cache-dir singletons), and its circular-injection check false-positives on
+ * `File(File, String)` with no public escape hatch. This verifier applies the same
+ * constructor-vs-index technique to app classes only.
+ *
+ * Limitation (same as Koin's verify): definitions whose bound type is an interface
+ * have no constructor to reflect, so their lambda bodies are not checked. All
+ * ViewModel definitions bind concrete classes, which is where every runtime DI crash
+ * so far has occurred.
+ */
+class KoinModuleVerificationTest {
+
+    /** Types legitimately resolvable at runtime but invisible to the module index. */
+    private val allowedTypes = setOf(
+        "android.content.Context", // provided by androidContext() at startKoin time
+        "android.app.Application",
+        "androidx.lifecycle.SavedStateHandle", // provided by Koin's viewModel factory
+    )
+
+    /**
+     * `<definition class>.<param>` pairs whose Koin lambda constructs the value inline
+     * (not via get()) — reflection can't see lambda bodies, so these would be flagged
+     * as missing. Keep in sync with the module definitions.
+     */
+    private val inlineProvidedParams = setOf(
+        "com.riffle.core.sync.ProgressSweep.ebookReconciler",
+        "com.riffle.core.sync.ProgressSweep.audioReconciler",
+        "com.riffle.core.sync.ProgressSweep.bookmarkLedger",
+        "com.riffle.core.sync.ProgressSweep.bookmarkReconcile",
+        "com.riffle.core.data.dictionary.PackDownloader.converter",
+    )
+
+    @OptIn(KoinInternalApi::class)
+    @Test
+    fun productionKoinGraphResolves() {
+        val modules: Set<Module> = flatten(riffleKoinModules())
+        // Index of bound type names, normalized for EXACT matching: an IndexKey is
+        // "<binary class name>[:qualifier...]", and binary names use '$' for nested
+        // classes (FormattingSession$Factory) where KClass.qualifiedName uses '.'.
+        // Exact matching matters: substring matching would let a bound concrete
+        // 'AudiobookBundleApiImpl' shadow a missing 'AudiobookBundleApi' interface
+        // binding — precisely the bug class this test exists to catch.
+        val index: Set<String> = modules
+            .flatMap { it.mappings.keys }
+            .map { it.substringBefore(':').replace('$', '.') }
+            .toSet()
+        val problems = mutableListOf<String>()
+
+        val factories = modules.flatMap { it.mappings.values }.toSet()
+        check(factories.size > 100) { "Suspiciously small Koin graph (${factories.size} definitions) — did module aggregation change?" }
+
+        factories.forEach { factory ->
+            val boundType = factory.beanDefinition.primaryType
+            val name = boundType.qualifiedName ?: return@forEach
+            // Only reflect on our own classes: third-party bound types (ktor, Readium…)
+            // are constructed by their lambdas with values the index can't see.
+            if (!name.startsWith("com.riffle.")) return@forEach
+            if (boundType.java.isInterface) return@forEach
+
+            val constructor = boundType.primaryConstructor ?: return@forEach
+            if (constructor.visibility != KVisibility.PUBLIC) return@forEach
+
+            constructor.parameters.forEach params@{ param ->
+                if (param.isOptional) return@params
+                val paramType = param.type.classifier as? kotlin.reflect.KClass<*> ?: return@params
+                val paramName = paramType.qualifiedName ?: return@params
+                // Platform/stdlib param types (String, List, Function0, CoroutineScope…)
+                // are supplied inline by definition lambdas, not resolved from the graph.
+                if (!paramName.startsWith("com.riffle.") && !paramName.startsWith("org.readium.")) return@params
+                if (paramName in allowedTypes) return@params
+                if ("$name.${param.name}" in inlineProvidedParams) return@params
+                if (paramName !in index) {
+                    problems += "'$name' needs '${param.name}: $paramName' but no Koin definition binds that type"
+                }
+            }
+        }
+
+        if (problems.isNotEmpty()) {
+            fail(
+                "Koin graph has ${problems.size} unresolvable constructor dependenc" +
+                    (if (problems.size == 1) "y" else "ies") +
+                    " (would crash with InstanceCreationException at runtime):\n" +
+                    problems.joinToString("\n") { "  - $it" },
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/server/AddSourceViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/server/AddSourceViewModelTest.kt
@@ -15,6 +15,8 @@ import com.riffle.core.domain.AnnotationSyncConfig
 import com.riffle.core.domain.AnnotationSyncConfigStore
 import com.riffle.core.domain.AuthenticateResult
 import com.riffle.core.domain.CommitSourceResult
+import com.riffle.core.domain.ReadaloudLinkReconciler
+import com.riffle.core.domain.StorytellerReadaloudCacheSyncer
 import com.riffle.core.models.InsecureConnectionType
 import com.riffle.core.models.Library
 import com.riffle.core.domain.PendingSource
@@ -183,6 +185,11 @@ class AddSourceViewModelTest {
         clock: com.riffle.core.common.Clock = MutableClock(),
         annotationDao: AnnotationDao = stubAnnotationDao(pendingBookCount = 0),
         bannerTicker: Flow<Unit> = flowOf(Unit),
+        // Explicit interface types here pin the Koin binding contract: the graph registers
+        // StorytellerReadaloudCacheSyncer and ReadaloudLinkReconciler (not the concrete classes).
+        // If AddSourceViewModel is changed back to request the concrete types, this won't compile.
+        storytellerSyncer: StorytellerReadaloudCacheSyncer = io.mockk.mockk(relaxed = true),
+        readaloudMatcher: ReadaloudLinkReconciler = io.mockk.mockk(relaxed = true),
     ): AddSourceViewModel = AddSourceViewModel(
         context = fakeContext(),
         repository = repository,
@@ -196,8 +203,8 @@ class AddSourceViewModelTest {
         webdavTargetFactory = io.mockk.mockk(relaxed = true),
         webdavStatusStore = statusStore,
         sweepEnqueuer = AnnotationSweepEnqueuer { },
-        storytellerSyncer = io.mockk.mockk(relaxed = true),
-        readaloudMatcher = io.mockk.mockk(relaxed = true),
+        storytellerSyncer = storytellerSyncer,
+        readaloudMatcher = readaloudMatcher,
         tokenStorage = tokenStorage,
         clock = clock,
         annotationDao = annotationDao,

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/CoreDataKoinModules.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/CoreDataKoinModules.kt
@@ -111,7 +111,14 @@ import com.riffle.core.data.localfiles.AndroidCopyInService
 import com.riffle.core.data.localfiles.CopyInService
 import com.riffle.core.data.localfiles.FolderWalker
 import com.riffle.core.data.localfiles.LocalFilesCatalogFactory
+import com.riffle.core.data.localfiles.LocalFilesFolderHealthChecker
+import com.riffle.core.data.localfiles.LocalFilesFolderRepository
+import com.riffle.core.data.localfiles.LocalFilesScanner
+import com.riffle.core.data.localfiles.LocalFilesSourceInstaller
 import com.riffle.core.data.localfiles.SafFolderWalker
+import com.riffle.core.data.websource.RemoteItemFreshness
+import com.riffle.core.data.websource.SingletonWebSourceInstaller
+import com.riffle.core.data.websource.WebSourceItemGate
 import com.riffle.core.data.readaloudLinksByAbsItemKey
 import com.riffle.core.data.sync.AbsRemoteUserIdResolver
 import com.riffle.core.data.sync.KomgaRemoteUserIdResolver
@@ -212,6 +219,7 @@ import com.riffle.core.network.AbsLibraryApi
 import com.riffle.core.network.AbsPlaybackApi
 import com.riffle.core.network.AbsServerInfoApi
 import com.riffle.core.network.AbsSessionApi
+import com.riffle.core.network.AudiobookBundleApi
 import com.riffle.core.network.AudiobookBundleApiImpl
 import com.riffle.core.network.GitHubReleaseApi
 import com.riffle.core.network.JvmHttpClientPool
@@ -219,7 +227,9 @@ import com.riffle.core.network.KomgaServerInfoApi
 import com.riffle.core.network.KomgaServerInfoApiClient
 import com.riffle.core.network.StorytellerApi
 import com.riffle.core.network.StorytellerApiClient
+import com.riffle.core.network.StorytellerBundleApi
 import com.riffle.core.network.StorytellerBundleApiImpl
+import com.riffle.core.network.StorytellerBundleProbeApi
 import com.riffle.core.network.StorytellerLibraryApi
 import com.riffle.core.network.StorytellerPositionApi
 import com.riffle.core.network.StorytellerPositionApiImpl
@@ -239,6 +249,7 @@ import com.riffle.core.sync.DirtyAnnotationLedger as SyncDirtyAnnotationLedger
 import com.riffle.core.sync.DirtyBookmarkLedger
 import com.riffle.core.sync.DirtyProgressLedger
 import com.riffle.core.sync.OpenReconcileTargets
+import com.riffle.core.sync.PostSweepMaterializer
 import com.riffle.core.sync.ProgressRemoteFactory
 import com.riffle.core.sync.ProgressSweep
 import com.riffle.core.sync.ReconcileLocks
@@ -596,7 +607,9 @@ private val coreDataNetworkModule = module {
     single<StorytellerLibraryApi> { get<StorytellerApiClient>() }
 
     single { StorytellerBundleApiImpl(get()) }
-    single { AudiobookBundleApiImpl(get(named(STREAMING_HTTP_CLIENT))) }
+    single<StorytellerBundleApi> { get<StorytellerBundleApiImpl>() }
+    single<StorytellerBundleProbeApi> { get<StorytellerBundleApiImpl>() }
+    single<AudiobookBundleApi> { AudiobookBundleApiImpl(get(named(STREAMING_HTTP_CLIENT))) }
     single<StorytellerPositionApi> { StorytellerPositionApiImpl(get()) }
 
     single<KomgaServerInfoApi> { KomgaServerInfoApiClient(get()) }
@@ -1073,6 +1086,7 @@ private val coreDataSyncModule = module {
             upserter = get(),
         )
     }
+    single<PostSweepMaterializer> { get<WebSourceLibraryItemMaterializer>() }
 
     single { AbsBookmarkAnnotationSyncTargetFactory(get(), get()) }
     single<RemoteUserIdResolver>(named("abs")) { AbsRemoteUserIdResolver(get()) }
@@ -1139,6 +1153,57 @@ private val coreDataMiscModule = module {
     // LocalFiles
     single<FolderWalker> { SafFolderWalker(androidContext()) }
     single<CopyInService> { AndroidCopyInService(androidContext()) }
+    single {
+        LocalFilesFolderRepository(
+            context = androidContext(),
+            folderDao = get(),
+            libraryDao = get(),
+            fileFolderDao = get(),
+            clock = get(),
+        )
+    }
+    factory {
+        LocalFilesScanner(
+            folderDao = get(),
+            fileDao = get(),
+            fileFolderDao = get(),
+            libraryItemDao = get(),
+            walker = get(),
+            copyIn = get(),
+            pdfMetadata = get(),
+            clock = get(),
+            logger = get(),
+        )
+    }
+    single {
+        LocalFilesSourceInstaller(
+            sourceDao = get(),
+            folderRepository = get(),
+            scanner = get(),
+            logger = get(),
+        )
+    }
+    single { LocalFilesFolderHealthChecker(context = androidContext()) }
+
+    // WebSource install/browse plumbing (WebSourceLibraryItemUpserter is bound in
+    // coreDataRepositoriesModule)
+    factory { RemoteItemFreshness(dao = get(), clock = get()) }
+    factory {
+        WebSourceItemGate(
+            libraryObserver = get(),
+            freshness = get(),
+            upserter = get(),
+            logger = get(),
+        )
+    }
+    single {
+        SingletonWebSourceInstaller(
+            sourceDao = get(),
+            libraryDao = get(),
+            registry = get(),
+            logger = get(),
+        )
+    }
 
     // CredentialedAuthenticator (Map<SourceType, SourceAdapter>)
     single<Map<SourceType, SourceAdapter>> {

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/CoreDataKoinModules.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/CoreDataKoinModules.kt
@@ -113,6 +113,7 @@ import com.riffle.core.data.localfiles.FolderWalker
 import com.riffle.core.data.localfiles.LocalFilesCatalogFactory
 import com.riffle.core.data.localfiles.LocalFilesFolderHealthChecker
 import com.riffle.core.data.localfiles.LocalFilesFolderRepository
+import com.riffle.core.data.localfiles.LocalFilesFolderWatcher
 import com.riffle.core.data.localfiles.LocalFilesScanner
 import com.riffle.core.data.localfiles.LocalFilesSourceInstaller
 import com.riffle.core.data.localfiles.SafFolderWalker
@@ -265,6 +266,15 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.Module
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+
+// Public qualifier names for generic Map bindings. Koin indexes definitions by ERASED
+// KClass, so unqualified Map<...> definitions silently override each other — the last
+// loaded one wins for EVERY Map injection point (this handed DefaultCatalogRegistry a
+// map of SourceAdapters and crashed with ClassCastException). Every generic binding
+// must carry a qualifier; consumers resolve with get(named(...)).
+const val CATALOG_FACTORIES_BY_SOURCE_TYPE = "catalogFactoriesBySourceType"
+const val REMOTE_USER_ID_RESOLVERS_BY_SOURCE_TYPE = "remoteUserIdResolversBySourceType"
+const val SOURCE_ADAPTERS_BY_SOURCE_TYPE = "sourceAdaptersBySourceType"
 
 // Named qualifier strings for File instances
 private const val EPUB_CACHE_DIR = "epubCacheDir"
@@ -630,7 +640,7 @@ private val coreDataRepositoriesModule = module {
             filesCleaner = get(),
             sidecarCache = { get<ReadaloudSidecarCache>() },
             installer = get(),
-            remoteUserIdResolvers = get(),
+            remoteUserIdResolvers = get(named(REMOTE_USER_ID_RESOLVERS_BY_SOURCE_TYPE)),
         )
     }
 
@@ -733,7 +743,7 @@ private val coreDataRepositoriesModule = module {
 }
 
 private val coreDataCatalogModule = module {
-    single<Map<SourceType, CatalogFactory>> {
+    single<Map<SourceType, CatalogFactory>>(named(CATALOG_FACTORIES_BY_SOURCE_TYPE)) {
         mapOf(
             SourceType.LOCAL_FILES to LocalFilesCatalogFactory(
                 folderDao = get(),
@@ -774,7 +784,7 @@ private val coreDataCatalogModule = module {
             ),
         )
     }
-    single<CatalogRegistry> { DefaultCatalogRegistry(get(), get()) }
+    single<CatalogRegistry> { DefaultCatalogRegistry(get(named(CATALOG_FACTORIES_BY_SOURCE_TYPE)), get()) }
 }
 
 private val coreDataStreamingAudioModule = module {
@@ -1091,7 +1101,7 @@ private val coreDataSyncModule = module {
     single { AbsBookmarkAnnotationSyncTargetFactory(get(), get()) }
     single<RemoteUserIdResolver>(named("abs")) { AbsRemoteUserIdResolver(get()) }
     single<RemoteUserIdResolver>(named("komga")) { KomgaRemoteUserIdResolver(get()) }
-    single<Map<SourceType, RemoteUserIdResolver>> {
+    single<Map<SourceType, RemoteUserIdResolver>>(named(REMOTE_USER_ID_RESOLVERS_BY_SOURCE_TYPE)) {
         mapOf(
             SourceType.ABS to get(named("abs")),
             SourceType.KOMGA to get(named("komga")),
@@ -1184,6 +1194,16 @@ private val coreDataMiscModule = module {
         )
     }
     single { LocalFilesFolderHealthChecker(context = androidContext()) }
+    single {
+        LocalFilesFolderWatcher(
+            context = androidContext(),
+            sourceRepository = get(),
+            folderDao = get(),
+            scanner = get(),
+            applicationScope = get(),
+            logger = get(),
+        )
+    }
 
     // WebSource install/browse plumbing (WebSourceLibraryItemUpserter is bound in
     // coreDataRepositoriesModule)
@@ -1206,7 +1226,7 @@ private val coreDataMiscModule = module {
     }
 
     // CredentialedAuthenticator (Map<SourceType, SourceAdapter>)
-    single<Map<SourceType, SourceAdapter>> {
+    single<Map<SourceType, SourceAdapter>>(named(SOURCE_ADAPTERS_BY_SOURCE_TYPE)) {
         mapOf(
             SourceType.ABS to get<AbsSourceAdapter>(),
             SourceType.KOMGA to get<KomgaSourceAdapter>(),

--- a/core/data/src/main/kotlin/com/riffle/core/data/di/CoreDataKoinModules.kt
+++ b/core/data/src/main/kotlin/com/riffle/core/data/di/CoreDataKoinModules.kt
@@ -194,6 +194,7 @@ import com.riffle.core.domain.StorytellerReadaloudCacheSyncer
 import com.riffle.core.domain.SyncPositionStore
 import com.riffle.core.domain.TocRepository
 import com.riffle.core.domain.TokenStorage
+import com.riffle.core.domain.UiProgressSink
 import com.riffle.core.domain.VolumeKeyPreferencesStore
 import com.riffle.core.domain.WakeLockPreferencesStore
 import com.riffle.core.domain.WebSourceDescriptors
@@ -1097,6 +1098,7 @@ private val coreDataSyncModule = module {
         )
     }
     single<PostSweepMaterializer> { get<WebSourceLibraryItemMaterializer>() }
+    single<UiProgressSink> { get<LibraryItemUiProgressSink>() }
 
     single { AbsBookmarkAnnotationSyncTargetFactory(get(), get()) }
     single<RemoteUserIdResolver>(named("abs")) { AbsRemoteUserIdResolver(get()) }

--- a/core/data/src/test/kotlin/com/riffle/core/data/CatalogModuleQualifierTest.kt
+++ b/core/data/src/test/kotlin/com/riffle/core/data/CatalogModuleQualifierTest.kt
@@ -24,9 +24,11 @@ class CatalogModuleQualifierTest {
     fun `every unbounded-catalog provider uses the WebSource OkHttp qualifier`() {
         val source = koinModulesSource()
 
-        // Find the catalog map block (single<Map<SourceType, CatalogFactory>> { mapOf(...) })
+        // Find the catalog map block — single<Map<SourceType, CatalogFactory>>(named(...)) { mapOf(...) }
+        // (the named() qualifier is required: Koin indexes by erased KClass, so unqualified
+        // Map<...> definitions silently override each other)
         val catalogMapRegex = Regex(
-            """single<Map<SourceType,\s*CatalogFactory>>\s*\{(.*?)^    \}""",
+            """single<Map<SourceType,\s*CatalogFactory>>(?:\(named\([^)]*\)\))?\s*\{(.*?)^    \}""",
             setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.MULTILINE),
         )
         val catalogBlock = catalogMapRegex.find(source)?.groupValues?.get(1)


### PR DESCRIPTION
## Problem

Since the Hilt→Koin migration (#840), every phone harness run on main has been killed by its 20-min timeout and reported **cancelled** — with no test report or logcat uploaded. Underneath, 26–29 navigation-based harness tests were failing with `InstanceCreationException`, and the production app crashes at startup. Hilt validated the DI graph at compile time; Koin resolves lazily at runtime, so every gap the migration left only surfaces when a screen (or app startup) first touches it.

## Root causes fixed (all Koin-migration fallout)

**Missing bindings** (Hilt auto-provided these via `@Inject`; the migration's hand-written modules missed them):
- `AudiobookBundleApi`, `StorytellerBundleApi`/`StorytellerBundleProbeApi`, `UiProgressSink`, `PostSweepMaterializer` — interfaces whose implementations were bound only under their concrete types
- `ReaderSyncFactory`, `HighlightsPdfExporter`, `LibraryTabVisibilityObserver`, `RemoteItemFreshness`, `WebSourceItemGate`, `SingletonWebSourceInstaller`, `LocalFilesFolderRepository`/`Scanner`/`SourceInstaller`/`FolderHealthChecker` — never bound at all
- `LocalFilesFolderWatcher` — `RiffleApplication.onCreate` `get()`s it, so the **production app crashed at launch**; the harness never caught this because the instrumentation runner boots a plain `Application`
- `MediaSourceRegistry`/`MediaItemRestorerRegistry` — field-injected by `AudioPlayerService`
- `AddSourceViewModel` requested concrete types where Koin binds interfaces (first commit)

**Erased-generic collisions**: Koin indexes definitions by erased `KClass`, so the three unqualified `Map<SourceType, *>` singles silently overrode each other — `DefaultCatalogRegistry` received a map of `SourceAdapter`s and crashed with `ClassCastException`. All generic `Map` bindings now carry `named()` qualifiers; the two colliding `List` bindings are inlined into their registries. A duplicate `Logger` binding is removed (core:logging owns it since #842).

## Regression net

- **`KoinModuleVerificationTest`** (JVM): verifies every com.riffle definition's primary-constructor dependencies resolve against the module index with exact type-name matching, fails on duplicate index keys, and pins the field-injected startup types. Red with 20 findings before the fixes; any reverted binding flips it red in seconds on every `test` run. (Koin's own `verify()` is unusable here — it false-positives on the qualifier-bound `File` singletons with no escape hatch.)
- `CatalogModuleQualifierTest`: mechanical regex-anchor update to accept the new `named()` qualifier on the catalog map (no assertion changed).

## CI resilience

Phone harness `timeout-minutes` temporarily raised 20→35 so failure-heavy runs finish **red with report+logcat artifacts** instead of opaquely cancelled. Revert tracked in #845.

## Validation

- Full phone harness on the dedicated AVD: **350 tests, 0 failures** (1 skipped) — was 29 failures before the fixes.
- `./gradlew test jvmTest`: green, including the new graph verification test.