### PR TITLE
fix(panel-report): draw rectangle for MergedPanels instead of a line

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportSheet.kt
@@ -69,8 +69,7 @@ internal fun PanelReportSheet(
         state.failureType == PanelDetectionFailureType.MergedPanels ||
         state.failureType == PanelDetectionFailureType.SplitPanel ||
         cutOffMode
-    val drawsRectangle = state.failureType == PanelDetectionFailureType.MissedPanel ||
-        state.failureType == PanelDetectionFailureType.SplitPanel
+    val drawsRectangle = drawsRectangle(state.failureType)
     val orderMode = state.failureType == PanelDetectionFailureType.WrongPanelOrder
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
@@ -142,7 +141,8 @@ internal fun PanelReportSheet(
             if (drawMode) {
                 val hint = when (state.failureType) {
                     PanelDetectionFailureType.MissedPanel,
-                    PanelDetectionFailureType.SplitPanel -> "Draw the correct panel boundary"
+                    PanelDetectionFailureType.SplitPanel,
+                    PanelDetectionFailureType.MergedPanels -> "Draw the correct panel boundaries"
                     PanelDetectionFailureType.CutPanelCutOff ->
                         "Tap the cut-off panel to identify it; drag to draw its correct boundary"
                     else -> "Draw panel boundary lines"
@@ -386,6 +386,11 @@ internal fun panelReportOutlineStyle(
         foregroundWidth = foregroundWidth,
     )
 }
+
+internal fun drawsRectangle(failureType: PanelDetectionFailureType?): Boolean =
+    failureType == PanelDetectionFailureType.MissedPanel ||
+        failureType == PanelDetectionFailureType.SplitPanel ||
+        failureType == PanelDetectionFailureType.MergedPanels
 
 private fun DrawScope.drawPanelReportOutline(
     topLeft: Offset,

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportOutlineStyleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportOutlineStyleTest.kt
@@ -1,7 +1,9 @@
 package com.riffle.app.feature.reader.cbz
 
 import androidx.compose.ui.graphics.Color
+import com.riffle.core.domain.comic.panel.PanelDetectionFailureType
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -25,5 +27,21 @@ class PanelReportOutlineStyleTest {
     fun `selected and ordered outlines keep their semantic colors`() {
         assertEquals(Color.Red, panelReportOutlineStyle(selected = true, ordered = false).foregroundColor)
         assertEquals(Color(0xFFFF9800), panelReportOutlineStyle(selected = false, ordered = true).foregroundColor)
+    }
+
+    @Test
+    fun `drawsRectangle returns true for MergedPanels MissedPanel and SplitPanel`() {
+        // Regression: MergedPanels was excluded, causing the drag to draw a line instead of a rect.
+        assertTrue(drawsRectangle(PanelDetectionFailureType.MergedPanels))
+        assertTrue(drawsRectangle(PanelDetectionFailureType.MissedPanel))
+        assertTrue(drawsRectangle(PanelDetectionFailureType.SplitPanel))
+    }
+
+    @Test
+    fun `drawsRectangle returns false for non-rect failure types`() {
+        assertFalse(drawsRectangle(null))
+        assertFalse(drawsRectangle(PanelDetectionFailureType.WrongPanelOrder))
+        assertFalse(drawsRectangle(PanelDetectionFailureType.FalsePanel))
+        assertFalse(drawsRectangle(PanelDetectionFailureType.CutPanelCutOff))
     }
 }


### PR DESCRIPTION
## Summary

- `MergedPanels` was included in `drawMode` but excluded from `drawsRectangle`, so dragging on the panel report canvas called `addDrawnBoundary` (line) instead of `addDrawnPanel` (rect).
- The in-progress drag preview also showed a line for `MergedPanels`.
- Extracted the routing decision into a testable internal `drawsRectangle(failureType)` function and added `MergedPanels` alongside `MissedPanel` and `SplitPanel`.
- Updated the hint text for `MergedPanels` from "Draw panel boundary lines" to "Draw the correct panel boundaries".

## Test plan

- [ ] New `drawsRectangle returns true for MergedPanels MissedPanel and SplitPanel` and `drawsRectangle returns false for non-rect failure types` tests in `PanelReportOutlineStyleTest` pass (covered by `:app:testDebugUnitTest`).
- [ ] Manually: open Panel Report sheet, select "Merged panels", drag → should draw a yellow rectangle preview and commit a green rectangle (not a line).