### PR TITLE
feat(panel-detection): bubble-tolerant energy-valley gutter confirmation (#788)

### DIFF
--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetectionConfig.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetectionConfig.kt
@@ -132,4 +132,40 @@ data class PanelDetectionConfig(
      * `(1 - 2 * this)` fraction on the perpendicular axis.
      */
     val internalGutterInnerSampleInset: Double = 0.1,
+
+    // ── Energy-valley gutter confirmation (issue #788) ────────────────────────
+
+    /**
+     * A suspected column gutter (inferred from other non-suspicious row bands) is confirmed when
+     * the minimum luma-gradient energy in the search window is below this fraction of the median
+     * energy across all columns of that row band. Lower = stricter (requires a more pronounced
+     * valley). A genuine blank gutter column has near-zero energy while dithered/art panel
+     * columns are high. Diagonal-layout pages can produce moderate energy at the candidate position
+     * (≈0.29 of median) even when no gutter is present → keep the threshold tight (< 0.25) to
+     * leave enough separation above the diagonal-layout signal and below the real gutter signal.
+     */
+    val energyValleyDepthRatio: Double = 0.25,
+
+    /**
+     * Half-width of the search window around a candidate gutter x (as a fraction of the cropped
+     * page width). The valley minimum is found within [candidateX ± width × this].
+     *
+     * Keep this tight: a large window allows the search to stray into white-space regions of a
+     * genuine full-width panel and cause a false split. The gutter is never more than a few
+     * percent of the width away from the candidate position derived from the non-suspicious row.
+     */
+    val energyValleyWindowFraction: Double = 0.05,
+
+    /**
+     * Minimum fraction of rows in the suspicious band that must have a **flood-fill gutter** pixel
+     * at the candidate column before the energy-valley check is attempted. Flood-fill gutter pixels
+     * are background pixels reachable from the page border — this excludes internal panel
+     * white-space that is enclosed by panel content and not connected to any actual inter-panel gap.
+     * A real bubble occludes only part of the gutter height; rows outside the bubble retain
+     * border-connected background at the gutter column, so this fraction is non-trivial. A genuine
+     * full-width panel's interior white-space is not reachable from the border, so the fraction is
+     * near zero and the check is skipped — preventing false splits on splash rows and real pages
+     * where a full-width panel happens to have a low-energy column at the candidate position.
+     */
+    val energyValleyMinPartialGutterFraction: Double = 0.15,
 )

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetector.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetector.kt
@@ -31,7 +31,7 @@ class PanelDetector(
         require(originalWidth > 0 && originalHeight > 0) { "original dimensions must be positive" }
         val fallback = fitWhole(pageIndex, originalWidth, originalHeight)
         val mask = binarize(grid) ?: return fallback
-        return detectFromMask(mask, grid.width, grid.height, pageIndex, originalWidth, originalHeight, fallback)
+        return detectFromMask(mask, grid.width, grid.height, pageIndex, originalWidth, originalHeight, fallback, grid)
     }
 
     /**
@@ -60,10 +60,11 @@ class PanelDetector(
         originalWidth: Int,
         originalHeight: Int,
         fallback: PagePanels,
+        grid: PixelGrid? = null,
     ): PagePanels {
         val cropped = trimMargin(mask) ?: return fallback
 
-        val projResult = gridByProjection(cropped, pageIndex, originalWidth, originalHeight, downscaledWidth, downscaledHeight)
+        val projResult = gridByProjection(cropped, grid, pageIndex, originalWidth, originalHeight, downscaledWidth, downscaledHeight)
         if (projResult != null) return projResult
 
         // Same repair-before-merge ordering as gridByProjection — see the comment there.
@@ -100,6 +101,7 @@ class PanelDetector(
      */
     private fun gridByProjection(
         cropped: CroppedMask,
+        grid: PixelGrid?,
         pageIndex: Int,
         originalWidth: Int,
         originalHeight: Int,
@@ -147,9 +149,37 @@ class PanelDetector(
         val allSuspicious = bandColBands.all { isSuspicious(it) }
         if (allSuspicious) return null
 
+        // Flood-fill gutter is needed both here (for bubble-tolerant gutter confirmation) and
+        // below (for splitSinglePanelRecursively and repair stages). Compute once and reuse.
+        // A pixel is a flood-fill gutter pixel if it is background (mask=0) AND reachable from
+        // the page border — this reliably excludes internal panel white-space that looks like a
+        // gutter in raw mask data but is not connected to any actual inter-panel gap.
+        val gutter = floodFillGutter(cropped)
+
+        // Bubble-tolerant gutter confirmation (issue #788): when a suspicious band's column
+        // projection fails because bubble/art content crosses the gutter, the gutter column still
+        // has lower luma-gradient energy than the dithered/art panel columns on either side.
+        // Use column gutter positions inferred from the non-suspicious bands as suspects, then
+        // confirm each via an energy valley in the suspicious band's luma profile.
+        val effectiveColBands: List<List<Band>> = if (grid != null) {
+            val candidateXs = bandColBands.indices
+                .filter { !isSuspicious(bandColBands[it]) }
+                .flatMap { i -> gutterCentresFromColBands(bandColBands[i]) }
+                .distinct()
+            bandColBands.mapIndexed { rowIndex, colBands ->
+                if (isSuspicious(colBands) && candidateXs.isNotEmpty()) {
+                    energyValleySplit(grid, gutter, cropped, rowBands[rowIndex], colBands, candidateXs) ?: colBands
+                } else {
+                    colBands
+                }
+            }
+        } else {
+            bandColBands
+        }
+
         val rawBboxes = mutableListOf<Bbox>()
         for ((rowIndex, rowBand) in rowBands.withIndex()) {
-            for (colBand in bandColBands[rowIndex]) {
+            for (colBand in effectiveColBands[rowIndex]) {
                 rawBboxes.add(Bbox(colBand.start, rowBand.start, colBand.end, rowBand.end))
             }
         }
@@ -167,7 +197,6 @@ class PanelDetector(
         //     diagonal boundary (#783) — which also removes the false right-edge difference that
         //     previously made stacked column panels look like a diagonal-spanning pair (#786).
         //  3. mergeDiagonalSpanningPanels after both repairs, so it sees final column geometry.
-        val gutter = floodFillGutter(cropped)
         val projAfterSplit = rawBboxes.flatMap { splitSinglePanelRecursively(it, cropped, gutter, depth = 0, downscaledWidth = downscaledWidth, downscaledHeight = downscaledHeight) }
         val projAfterJunc = repairOneSidedRowJunctions(projAfterSplit, cropped, downscaledWidth, downscaledHeight)
         val projAfterRowRepair = repairDiagonalTwoColumnRows(projAfterJunc, cropped, gutter, downscaledWidth, downscaledHeight)
@@ -1577,6 +1606,86 @@ class PanelDetector(
     }
 
     private data class Band(val start: Int, val end: Int)
+
+    /** Returns the x-centre of each gutter gap between adjacent column bands. */
+    private fun gutterCentresFromColBands(colBands: List<Band>): List<Int> =
+        (0 until colBands.size - 1).map { i -> (colBands[i].end + colBands[i + 1].start) / 2 }
+
+    /**
+     * For a suspicious (full-width) row band, attempts to confirm a vertical gutter boundary
+     * using luma-gradient energy. Each [candidateXs] position is checked with two gates:
+     *
+     * 1. **Flood-fill gutter evidence**: at least [PanelDetectionConfig.energyValleyMinPartialGutterFraction]
+     *    of the band's rows must be flood-fill gutter pixels at the candidate column. Flood-fill
+     *    gutter pixels are background pixels reachable from the page border, which correctly
+     *    excludes internal panel white-space (enclosed by panel content, not border-connected).
+     *    A real bubble occludes only part of the gutter height; rows outside the bubble retain
+     *    border-connected background at the gutter column.
+     *
+     * 2. **Energy valley**: the minimum luma-gradient energy in the search window must be below
+     *    [PanelDetectionConfig.energyValleyDepthRatio] × the median profile energy.
+     *
+     * Returns null if no candidate passes both gates.
+     */
+    private fun energyValleySplit(
+        grid: PixelGrid,
+        gutter: BooleanArray,
+        cropped: CroppedMask,
+        rowBand: Band,
+        colBands: List<Band>,
+        candidateXs: List<Int>,
+    ): List<Band>? {
+        val bandHeight = rowBand.end - rowBand.start + 1
+        val energies = columnLumaEnergyProfile(grid, cropped, rowBand.start, rowBand.end)
+        val sorted = energies.copyOf().also { it.sort() }
+        val medianEnergy = sorted[sorted.size / 2]
+        if (medianEnergy == 0f) return null
+
+        val threshold = medianEnergy * config.energyValleyDepthRatio
+        val windowHalf = (cropped.width * config.energyValleyWindowFraction).toInt().coerceAtLeast(1)
+
+        for (candidateX in candidateXs) {
+            // Gate 1: the gutter must be visible as border-connected background in enough rows.
+            // Using flood-fill pixels (not raw mask) rejects internal panel white-space that is
+            // not connected to the page border and therefore not a real inter-panel gutter.
+            var gutterRows = 0
+            for (cy in rowBand.start..rowBand.end) {
+                if (gutter[cy * cropped.width + candidateX]) gutterRows++
+            }
+            if (gutterRows.toDouble() / bandHeight < config.energyValleyMinPartialGutterFraction) continue
+
+            // Gate 2: energy valley at the candidate position.
+            val wStart = (candidateX - windowHalf).coerceAtLeast(0)
+            val wEnd = (candidateX + windowHalf).coerceAtMost(cropped.width - 1)
+            var minEnergy = Float.MAX_VALUE
+            var minX = candidateX
+            for (x in wStart..wEnd) {
+                if (energies[x] < minEnergy) {
+                    minEnergy = energies[x]
+                    minX = x
+                }
+            }
+            if (minEnergy < threshold) {
+                val left = Band(colBands[0].start, minX - 1)
+                val right = Band(minX + 1, colBands[0].end)
+                if (left.end >= left.start && right.end >= right.start) return listOf(left, right)
+            }
+        }
+        return null
+    }
+
+    /** Sum of |luma[y][x] − luma[y+1][x]| per column for rows [yStart, yEnd) in CroppedMask coords. */
+    private fun columnLumaEnergyProfile(grid: PixelGrid, cropped: CroppedMask, yStart: Int, yEnd: Int): FloatArray =
+        FloatArray(cropped.width) { cx ->
+            val gx = cx + cropped.offsetX
+            var energy = 0f
+            for (cy in yStart until yEnd) {
+                energy += kotlin.math.abs(
+                    grid.get(gx, cy + cropped.offsetY) - grid.get(gx, cy + 1 + cropped.offsetY),
+                ).toFloat()
+            }
+            energy
+        }
 
     /**
      * Given a 1-D projection, return the runs of "content" (values above a threshold derived from

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/comic/panel/PanelDetectorTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/comic/panel/PanelDetectorTest.kt
@@ -1265,6 +1265,101 @@ class PanelDetectorTest {
         assertEquals(setOf(top, bottom), repaired.toSet())
     }
 
+    // --- Energy-valley gutter confirmation (issue #788) ---
+
+    @Test
+    fun `energy valley confirmation splits bubble-blocked column gutter into 4 panels`() {
+        // Reproduces issue #788 projection-path failure: row 1 has two panels separated by a
+        // vertical gutter, but a speech bubble covers the MIDDLE portion of the gutter height,
+        // pushing colContentCount above the 15% cutoff → the column gutter is never found →
+        // row 1 is treated as a single full-width (suspicious) band.
+        //
+        // The bubble covers ~76% of the band height; the gutter is still visible (background)
+        // in the top ~12% and bottom ~12% rows. Crucially, the visible fraction is in the
+        // range [15%, 30%): gate 1 (energyValleyMinPartialGutterFraction=15%) PASSES, but the
+        // flood-fill internal-gutter split (internalGutterFloodFillFraction=30%) CANNOT find it.
+        // Only the energy valley can confirm the split:
+        //   (1) partial gutter evidence: ~24% of rows at the gutter column are background → gate 1 passes.
+        //   (2) energy valley: gutter columns have near-zero luma-gradient (solid-dark → flat)
+        //       while dithered panel columns have high gradient → valley confirmed → split fires.
+        // Without the energy-valley feature, neither the flood-fill nor any other stage finds the
+        // gutter → suspicious band stays full-width → 3 panels instead of 4.
+        val grid = fixture(width = 400, height = 560) { canvas ->
+            canvas.fill(background = LIGHT)
+            // Row band 0 (y=20..269): clean two-panel layout, vertical gutter at x=190..209.
+            canvas.ditheredRect(x = 20, y = 20, w = 170, h = 250, base = DARK, accent = 160.toByte())
+            canvas.ditheredRect(x = 210, y = 20, w = 170, h = 250, base = DARK, accent = 160.toByte())
+            // Row band 1 (y=290..539): same two panels; gutter visible at top+bottom but blocked
+            // in the middle 190 rows by a "bubble" that crosses the gutter columns.
+            canvas.ditheredRect(x = 20, y = 290, w = 170, h = 250, base = DARK, accent = 160.toByte())
+            canvas.ditheredRect(x = 210, y = 290, w = 170, h = 250, base = DARK, accent = 160.toByte())
+            // Bubble blocking the gutter: solid-dark, covers y=320..509 (~76% of band height).
+            // Leaves only ~24% gutter-background rows visible — above the 15% energy-valley gate
+            // but below the 30% flood-fill threshold, so ONLY the energy valley can trigger the
+            // split. Solid DARK has zero vertical gradient → luma energy ≈ 0 → valley fires.
+            canvas.rect(x = 190, y = 320, w = 20, h = 190, color = DARK)
+        }
+
+        val result = detector.detect(grid, pageIndex = 0, originalWidth = 400, originalHeight = 560)
+
+        assertEquals(
+            "bubble-blocked gutter must be confirmed via energy-valley and split into 4 panels; " +
+                "got ${result.panels.size} (source=${result.source})",
+            4, result.panels.size,
+        )
+    }
+
+    @Test
+    fun `energy valley boundary — no partial gutter evidence suppresses split on full-width panel`() {
+        // Both-sides boundary test for energyValleyMinPartialGutterFraction: a genuine full-width
+        // panel (T-layout splash) must not be falsely split, because EVERY row at the candidate
+        // column x has content — there is no partial gutter visible → the fraction-gate blocks it.
+        val grid = fixture(width = 400, height = 560) { canvas ->
+            canvas.fill(background = LIGHT)
+            // Row band 0 (splash, full-width): genuine single panel across the full page.
+            canvas.ditheredRect(x = 20, y = 20, w = 360, h = 250, base = DARK, accent = 160.toByte())
+            // Row band 1 (two panels): provides a candidate column gutter at ≈x=200.
+            canvas.ditheredRect(x = 20, y = 290, w = 170, h = 250, base = DARK, accent = 160.toByte())
+            canvas.ditheredRect(x = 210, y = 290, w = 170, h = 250, base = DARK, accent = 160.toByte())
+        }
+
+        val result = detector.detect(grid, pageIndex = 0, originalWidth = 400, originalHeight = 560)
+
+        // T-layout: splash row must remain a single full-width panel.
+        assertEquals(
+            "genuine full-width splash must NOT be split by energy-valley; expected 3 panels, " +
+                "got ${result.panels.size} (source=${result.source})",
+            3, result.panels.size,
+        )
+    }
+
+    @Test
+    fun `energy valley boundary — high-energy gutter columns suppress the split`() {
+        // Both-sides boundary test for the valley depth ratio: when the gutter columns also have
+        // high energy (dithered like the panels), no valley is found and the suspicious row stays
+        // as a single full-width band → 3 panels total (2 from clean row + 1 full-width from row 1).
+        val grid = fixture(width = 400, height = 560) { canvas ->
+            canvas.fill(background = LIGHT)
+            // Row band 0 (clean): two panels with gutter at x=190..209.
+            canvas.ditheredRect(x = 20, y = 20, w = 170, h = 250, base = DARK, accent = 160.toByte())
+            canvas.ditheredRect(x = 210, y = 20, w = 170, h = 250, base = DARK, accent = 160.toByte())
+            // Row band 1: gutter partially visible (~24% of rows background, satisfying gate 1),
+            // but below the 30% flood-fill threshold so only the energy valley decides.
+            // Dithered gutter: high energy everywhere → no valley → gate 2 fails → no split.
+            canvas.ditheredRect(x = 20, y = 290, w = 170, h = 250, base = DARK, accent = 160.toByte())
+            canvas.ditheredRect(x = 210, y = 290, w = 170, h = 250, base = DARK, accent = 160.toByte())
+            canvas.ditheredRect(x = 190, y = 320, w = 20, h = 190, base = DARK, accent = 160.toByte())
+        }
+
+        val result = detector.detect(grid, pageIndex = 0, originalWidth = 400, originalHeight = 560)
+
+        assertEquals(
+            "high-energy gutter columns must NOT be split by energy valley; expected 3 panels, " +
+                "got ${result.panels.size} (source=${result.source})",
+            3, result.panels.size,
+        )
+    }
+
     /**
      * Builds a [PanelDetector.CroppedMask] and two full-width [PanelDetector.Bbox]es whose
      * vertical separation is exactly [gap] pixels. The gap strip has content on the left half


### PR DESCRIPTION
Closes #788

## What this does

When a speech bubble or panel-spanning art crosses a vertical gutter, the column content count at the gutter position lifts above the 15% projection cutoff, making the row band appear suspicious (full-width). The projection never finds the gutter, so the two sub-panels are merged into one.

This PR adds a **bubble-tolerant energy-valley gutter confirmation** stage. After identifying suspicious row bands, it infers candidate gutter x-positions from the non-suspicious bands and confirms each via two gates:

**Gate 1 — flood-fill gutter evidence.** At least 15% of the band's rows must have a flood-fill gutter pixel at the candidate column — i.e., background pixel reachable from the page border. This rejects internal panel white-space (not border-connected), while accepting bubble-blocked gutters whose unoccluded rows retain border-connection.

**Gate 2 — energy valley.** The minimum luma-gradient energy in a ±5%-width search window around the candidate must be < 25% of the band's median column energy. A blank/flat-colored gutter column has near-zero gradient (≈1% of median). Dithered-art or diagonal-layout artifacts score ≈29% — the 25% threshold cleanly separates them.

## New API surface

`PanelDetectionConfig` gains three parameters (all with documented defaults):
- `energyValleyDepthRatio = 0.25`
- `energyValleyWindowFraction = 0.05`
- `energyValleyMinPartialGutterFraction = 0.15`

`floodFillGutter` is now computed once before both the new energy-valley stage and the existing repair stages (no duplicate work).

## Tests

Three new tests in `PanelDetectorTest`, all using synthetic fixtures with the gutter visible in the 15–30% range (above the 15% energy-valley gate 1 but below the 30% internal-gutter flood-fill threshold, so only the energy valley can split):

1. **`energy valley confirmation splits bubble-blocked column gutter into 4 panels`** — solid-dark bubble; near-zero energy at gutter → gate 2 fires → 4 panels. Without this feature, flood-fill alone can't find the gutter → 3 panels (regression test).
2. **`energy valley boundary — no partial gutter evidence suppresses split on full-width panel`** — T-layout splash row; 0% flood-fill at candidate → gate 1 blocks.
3. **`energy valley boundary — high-energy gutter columns suppress the split`** — dithered bubble; gate 1 passes, gate 2 blocked by high energy → 3 panels.

Existing image regressions verified green: caption-box (issue-751-p66), row-two-right (issue-787-p28), clean-grid, MaskDetectionRoundTripTest.