### PR TITLE
fix(panel-detection): replace shortest-member row rule with union+exile gate (#791)

### DIFF
--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/comic/panel/JsonPanelStore.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/comic/panel/JsonPanelStore.kt
@@ -297,7 +297,7 @@ class JsonPanelStore constructor(
          *      check to fail. Pages with a falling-right diagonal boundary where a horizontal gutter
          *      row sits above the diagonal start now have the correct wider bottom-left panel.
          */
-        internal const val CURRENT_SCHEMA_VERSION: Int = 34
+        internal const val CURRENT_SCHEMA_VERSION: Int = 35
 
         private val UNSAFE = Regex("[^A-Za-z0-9._-]")
     }

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/panel/PanelOrderer.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/panel/PanelOrderer.kt
@@ -35,17 +35,29 @@ class PanelOrderer(
     }
 
     private fun sharesRowWith(row: List<PanelRegion>, candidate: PanelRegion): Boolean {
-        // A candidate belongs to a row if it y-overlaps the SHORTEST panel in the row by at least
-        // [rowOverlapFraction] of the shorter of (candidate, shortest-panel). Using the shortest
-        // panel (not the cumulative row extent) prevents tall spanning panels — e.g. a left-column
-        // panel that spans two reading rows — from pulling lower-row panels into the same row band
-        // and then having them sorted by x rather than by y (which produces the wrong reading order).
-        val shortest = row.minByOrNull { it.height } ?: return false
-        val overlapTop = maxOf(shortest.y, candidate.y)
-        val overlapBottom = minOf(shortest.bottom, candidate.bottom)
+        // Base: candidate must y-overlap the row's cumulative y-extent by at least
+        // [rowOverlapFraction] of the shorter of (row extent, candidate height).
+        val rowTop = row.minOf { it.y }
+        val rowBottom = row.maxOf { it.bottom }
+        val overlapTop = maxOf(rowTop, candidate.y)
+        val overlapBottom = minOf(rowBottom, candidate.bottom)
         if (overlapBottom <= overlapTop) return false
         val overlap = overlapBottom - overlapTop
-        val shorter = minOf(shortest.height, candidate.height)
-        return overlap.toDouble() / shorter.toDouble() >= rowOverlapFraction
+        val shorter = minOf(rowBottom - rowTop, candidate.height)
+        if (overlap.toDouble() / shorter.toDouble() < rowOverlapFraction) return false
+        // Exile: a row member that x-overlaps the candidate, starts at or above it, and whose
+        // y-range overlaps ≥ [rowOverlapFraction] of the candidate's height while NOT fully
+        // containing the candidate (member.bottom ≤ candidate.bottom — the candidate's tail
+        // sticks out below) signals the candidate is "spilling below" a spanning panel and
+        // belongs in the next row. This fixes #780 (tall-left absorbs lower-right despite
+        // lower-right starting 310 px below upper-right) while leaving mixed-height single-band
+        // layouts intact (#791): in those cases either the member doesn't x-overlap the
+        // candidate, or the overlap fraction is below the threshold because the panels are
+        // y-adjacent rather than y-overlapping.
+        return row.none { member ->
+            member.right > candidate.x && member.x < candidate.right &&
+                member.y <= candidate.y && member.bottom <= candidate.bottom &&
+                (member.bottom - candidate.y).toDouble() / candidate.height.toDouble() >= rowOverlapFraction
+        }
     }
 }

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/comic/panel/PanelOrdererTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/comic/panel/PanelOrdererTest.kt
@@ -65,4 +65,92 @@ class PanelOrdererTest {
         assertEquals(20, ordered[0].x)
         assertEquals(210, ordered[1].x)
     }
+
+    // --- Regression tests for issue #791 ---
+    // The shortest-member sharesRowWith rule (introduced for #780) is order-dependent and breaks
+    // the three layouts below. All three should be a single row sorted left-to-right.
+
+    @Test
+    fun `split middle column does not exile the bottom-half continuation panel`() {
+        // CE1 from issue #791 (800×1200 page).
+        // A tall left (A) and tall right (D) flank a short top-middle (B) and a taller
+        // bottom-middle (C). B joining first makes it the shortest member; C then has zero
+        // overlap with B and is wrongly exiled, producing A,B,D,C instead of A,B,C,D.
+        val a = PanelRegion(x = 20, y = 40, width = 240, height = 560)   // tall left
+        val b = PanelRegion(x = 280, y = 40, width = 240, height = 170)  // short mid-top
+        val c = PanelRegion(x = 280, y = 230, width = 240, height = 370) // taller mid-bot
+        val d = PanelRegion(x = 540, y = 40, width = 240, height = 560)  // tall right
+        val ordered = orderer.order(listOf(a, b, d, c))                  // deliberately shuffled
+        assertEquals("all four panels should be in one row sorted left-to-right",
+            listOf(20, 280, 280, 540), ordered.map { it.x })
+        assertEquals("within same x, top panel (B) precedes continuation (C)",
+            listOf(40, 40, 230, 40), ordered.map { it.y })
+    }
+
+    @Test
+    fun `leftward-descending terrace reads left-to-right as a single band`() {
+        // CE2 from issue #791 (terrace: each panel starts a little lower and further left).
+        // Under the shortest-member rule A is exiled because it overlaps C (the shortest
+        // member, h=200) by only 40% → output B,C,A instead of A,B,C.
+        val a = PanelRegion(x = 0, y = 120, width = 180, height = 280)   // bottom-left
+        val b = PanelRegion(x = 200, y = 60, width = 180, height = 280)  // middle
+        val c = PanelRegion(x = 400, y = 0, width = 180, height = 200)   // short top-right
+        val ordered = orderer.order(listOf(c, b, a))                     // deliberately shuffled
+        assertEquals("terrace panels form one row, read left-to-right",
+            listOf(0, 200, 400), ordered.map { it.x })
+    }
+
+    @Test
+    fun `caption strip does not collapse the band and exile the panel below it`() {
+        // CE3 from issue #791.
+        // A thin caption (D, h=40) joins the row first and becomes the shortest member.
+        // B (which starts below D's bottom) then has zero overlap with D and is exiled,
+        // producing A,D,C,B instead of A,D,B,C.
+        val a = PanelRegion(x = 20, y = 20, width = 180, height = 280)  // tall left
+        val d = PanelRegion(x = 220, y = 20, width = 180, height = 40)  // thin caption
+        val b = PanelRegion(x = 220, y = 80, width = 180, height = 220) // panel below caption
+        val c = PanelRegion(x = 620, y = 20, width = 180, height = 280) // tall right
+        val ordered = orderer.order(listOf(a, d, c, b))                 // deliberately shuffled
+        assertEquals("all four in one row, left-to-right (d before b at same x by y)",
+            listOf(20, 220, 220, 620), ordered.map { it.x })
+        assertEquals("D (top) precedes B (below it) at the same x column",
+            listOf(20, 20, 80, 20), ordered.map { it.y })
+    }
+
+    @Test
+    fun `CE1 result is stable regardless of input emission order`() {
+        // Issue #791 also notes the shortest-member rule is order-dependent; verify the fix
+        // produces A,B,C,D for all permutations of the equal-y triplet.
+        val a = PanelRegion(x = 20, y = 40, width = 240, height = 560)
+        val b = PanelRegion(x = 280, y = 40, width = 240, height = 170)
+        val c = PanelRegion(x = 280, y = 230, width = 240, height = 370)
+        val d = PanelRegion(x = 540, y = 40, width = 240, height = 560)
+        val expectedX = listOf(20, 280, 280, 540)
+        val expectedY = listOf(40, 40, 230, 40)
+        for (input in listOf(
+            listOf(a, b, c, d), listOf(d, b, a, c), listOf(b, d, a, c), listOf(a, d, b, c),
+        )) {
+            val ordered = orderer.order(input)
+            assertEquals("emission order $input → wrong x sequence", expectedX, ordered.map { it.x })
+            assertEquals("emission order $input → wrong y sequence", expectedY, ordered.map { it.y })
+        }
+    }
+
+    @Test
+    fun `tall spanning panel still exiles the lower panel in its own column (issue 780 shape)`() {
+        // Regression guard: the union+exile fix must not re-introduce the #780 bug.
+        // Mirrors the real fixture geometry from the #780 test in PanelDetectorImageTest:
+        //   tall-left   x=0..460,  y=200..1080
+        //   upper-right x=520..800, y=200..510  (no x-overlap with tall-left)
+        //   lower-right x=446..800, y=510..1120 (x-overlaps tall-left; extends past its bottom)
+        // Correct order: tall-left → upper-right → lower-right.
+        val tallLeft = PanelRegion(x = 0, y = 200, width = 460, height = 880)    // x=0..460, y=200..1080
+        val upperRight = PanelRegion(x = 520, y = 200, width = 280, height = 310) // x=520..800, y=200..510
+        val lowerRight = PanelRegion(x = 446, y = 510, width = 354, height = 610) // x=446..800, y=510..1120
+        val ordered = orderer.order(listOf(lowerRight, upperRight, tallLeft))     // shuffled
+        assertEquals(3, ordered.size)
+        assertEquals("tall-left must be first", tallLeft, ordered[0])
+        assertEquals("upper-right must be second", upperRight, ordered[1])
+        assertEquals("lower-right must be last", lowerRight, ordered[2])
+    }
 }


### PR DESCRIPTION
Closes #791

## What changed

`PanelOrderer.sharesRowWith` previously compared a candidate against the **shortest row member** (introduced by #780) to decide if it belongs to the current band. That rule was order-dependent and broke three mixed-height single-band layouts:

- **CE1**: A short middle-top panel (h=170) joined first, poisoning the band — the middle-bottom continuation panel (y-adjacent, same column) had zero overlap with the short member and was wrongly exiled to a new row.
- **CE2**: A leftward-descending terrace was split into separate rows because the topmost (shortest) panel had < 50 % y-overlap with the leftmost panel.
- **CE3**: A thin caption strip (h=40) joined first; the panel directly below it (y-adjacent) was exiled, producing wrong reading order.

The new rule:

1. **Base**: candidate must y-overlap the row's cumulative union extent by ≥ 50 % of the shorter of (union height, candidate height) — restoring the pre-#780 union behaviour.
2. **Exile gate**: exile the candidate only when a row member (a) x-overlaps it, (b) starts at or above it (`member.y ≤ candidate.y`), (c) does **not** fully contain it (`member.bottom ≤ candidate.bottom` — the candidate's tail sticks out below), and (d) the member's y-range covers ≥ 50 % of the candidate's height. This fires precisely on the #780 shape (tall-left x-overlaps lower-right and covers ~90 % of its height) and not on the CE cases (the "short" members are y-adjacent to the candidate, so the overlap fraction is ≤ 0).

## Tests

Five new `PanelOrdererTest` cases:

- `split middle column does not exile the bottom-half continuation panel` (CE1)
- `leftward-descending terrace reads left-to-right as a single band` (CE2)
- `caption strip does not collapse the band and exile the panel below it` (CE3)
- `CE1 result is stable regardless of input emission order` (emission-order invariance for 4 input permutations)
- `tall spanning panel still exiles the lower panel in its own column (issue 780 shape)` — regression guard against re-introducing #780

All 694 `core:domain` JVM tests pass, including `PanelDetectorImageTest.tall left panel spanning two row bands is ordered before the stacked right panels`.

## Cache invalidation

`JsonPanelStore.CURRENT_SCHEMA_VERSION` bumped 34 → 35 so stale per-book order caches (which may hold wrong panel sequences) are invalidated and re-detected on next open.