### PR TITLE
feat(deps): upgrade Coil v2 → v3 for KMP image loading

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -166,6 +166,7 @@ dependencies {
     implementation(libs.koin.androidx.compose)
 
     implementation(libs.coil.compose)
+    implementation(libs.coil.network.okhttp)
     implementation(libs.okhttp)
 
     implementation(libs.media3.exoplayer)

--- a/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
+++ b/app/src/main/kotlin/com/riffle/app/RiffleApplication.kt
@@ -2,9 +2,12 @@ package com.riffle.app
 
 import android.app.Application
 import android.content.Context
-import coil.ImageLoader
-import coil.ImageLoaderFactory
-import coil.disk.DiskCache
+import coil3.ImageLoader
+import coil3.PlatformContext
+import coil3.SingletonImageLoader
+import coil3.disk.DiskCache
+import coil3.disk.directory
+import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import com.riffle.app.di.riffleViewModelKoinModules
 import com.riffle.core.data.di.coreDataKoinModules
 import com.riffle.core.logging.loggingKoinModule
@@ -25,7 +28,7 @@ import org.acra.config.limiter
 import org.acra.ktx.initAcra
 import java.util.concurrent.TimeUnit
 
-class RiffleApplication : Application(), ImageLoaderFactory {
+class RiffleApplication : Application(), SingletonImageLoader.Factory {
 
     private var logger: com.riffle.core.logging.Logger = com.riffle.core.logging.NoopLogger
 
@@ -147,9 +150,11 @@ class RiffleApplication : Application(), ImageLoaderFactory {
         }
     }
 
-    override fun newImageLoader(): ImageLoader =
-        ImageLoader.Builder(this)
-            .okHttpClient { createImageLoaderOkHttpClient() }
+    override fun newImageLoader(context: PlatformContext): ImageLoader =
+        ImageLoader.Builder(context)
+            .components {
+                add(OkHttpNetworkFetcherFactory(callFactory = { createImageLoaderOkHttpClient() }))
+            }
             .diskCache {
                 DiskCache.Builder()
                     .directory(cacheDir.resolve("image_cache"))

--- a/app/src/main/kotlin/com/riffle/app/feature/annotations/AnnotationsListScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/annotations/AnnotationsListScreen.kt
@@ -32,8 +32,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import org.koin.androidx.compose.koinViewModel
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
+import coil3.compose.AsyncImage
+import coil3.network.NetworkHeaders
+import coil3.network.httpHeaders
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.riffle.app.feature.library.coverGridMinCellSize
 import com.riffle.app.ui.fadingScrollbar
 import com.riffle.core.data.AnnotatedBook
@@ -133,7 +136,7 @@ private fun AnnotatedBookCoverTile(
                 AsyncImage(
                     model = ImageRequest.Builder(LocalContext.current)
                         .data(book.coverUrl)
-                        .addHeader("Authorization", token.asAuthHeader())
+                        .httpHeaders(NetworkHeaders.Builder().add("Authorization", token.asAuthHeader()).build())
                         .crossfade(true)
                         .build(),
                     contentDescription = book.title,

--- a/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/audio/PlayerSurface.kt
@@ -61,8 +61,10 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
+import coil3.compose.AsyncImage
+import coil3.network.NetworkHeaders
+import coil3.network.httpHeaders
+import coil3.request.ImageRequest
 import com.riffle.app.ui.DefaultCoverPlaceholder
 import com.riffle.app.feature.audiobook.SleepTimerMode
 import com.riffle.app.feature.audiobook.formatCountdown
@@ -217,7 +219,7 @@ private fun PlayerCover(state: PlayerSurfaceState, modifier: Modifier) {
         AsyncImage(
             model = ImageRequest.Builder(LocalContext.current)
                 .data(state.coverUrl)
-                .addHeader("Authorization", "Bearer ${state.authToken}")
+                .httpHeaders(NetworkHeaders.Builder().add("Authorization", "Bearer ${state.authToken}").build())
                 .build(),
             contentDescription = null,
             contentScale = ContentScale.Crop,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/EditLocalFileMetadataDialog.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/EditLocalFileMetadataDialog.kt
@@ -33,8 +33,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
 import com.riffle.core.models.LibraryItem
 
 @Composable

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -88,8 +88,10 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import org.koin.androidx.compose.koinViewModel
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
+import coil3.compose.AsyncImage
+import coil3.network.NetworkHeaders
+import coil3.network.httpHeaders
+import coil3.request.ImageRequest
 import com.riffle.app.feature.audiobook.CompactDurationLabelTemplates
 import com.riffle.app.feature.audiobook.formatCompactDuration
 import com.riffle.app.feature.readersettings.TocPanel
@@ -612,7 +614,7 @@ internal fun LibraryItemDetailContent(
                 AsyncImage(
                     model = ImageRequest.Builder(LocalContext.current)
                         .data(item.coverUrl)
-                        .addHeader("Authorization", token.asAuthHeader())
+                        .httpHeaders(NetworkHeaders.Builder().add("Authorization", token.asAuthHeader()).build())
                         .instrumentCover("detail", item.id, item.coverUrl)
                         .build(),
                     contentDescription = null,
@@ -976,7 +978,7 @@ internal fun LibraryItemDetailContentTablet(
                     AsyncImage(
                         model = ImageRequest.Builder(LocalContext.current)
                             .data(item.coverUrl)
-                            .addHeader("Authorization", token.asAuthHeader())
+                            .httpHeaders(NetworkHeaders.Builder().add("Authorization", token.asAuthHeader()).build())
                             .instrumentCover("detail", item.id, item.coverUrl)
                             .build(),
                         contentDescription = null,
@@ -1182,7 +1184,7 @@ internal fun LibraryItemDetailContentPhoneLandscape(
                     AsyncImage(
                         model = ImageRequest.Builder(LocalContext.current)
                             .data(item.coverUrl)
-                            .addHeader("Authorization", token.asAuthHeader())
+                            .httpHeaders(NetworkHeaders.Builder().add("Authorization", token.asAuthHeader()).build())
                             .instrumentCover("detail", item.id, item.coverUrl)
                             .build(),
                         contentDescription = null,

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -114,8 +114,11 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.res.painterResource
 import android.util.Log
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
+import coil3.compose.AsyncImage
+import coil3.network.NetworkHeaders
+import coil3.network.httpHeaders
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.riffle.app.R
 import com.riffle.app.feature.annotations.AnnotationsListScreen
 import com.riffle.app.feature.annotations.AnnotationsListViewModel
@@ -685,7 +688,7 @@ fun BookCoverTile(
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
                     .data(item.coverUrl)
-                    .addHeader("Authorization", token.asAuthHeader())
+                    .httpHeaders(NetworkHeaders.Builder().add("Authorization", token.asAuthHeader()).build())
                     .crossfade(true)
                     .instrumentCover("item", item.id, item.coverUrl)
                     .build(),
@@ -775,7 +778,7 @@ fun SeriesCoverTile(
             AsyncImage(
                 model = ImageRequest.Builder(LocalContext.current)
                     .data(resolvedCoverUrl)
-                    .addHeader("Authorization", token.asAuthHeader())
+                    .httpHeaders(NetworkHeaders.Builder().add("Authorization", token.asAuthHeader()).build())
                     .crossfade(true)
                     .instrumentCover("series", series.id, resolvedCoverUrl)
                     .build(),
@@ -852,7 +855,7 @@ private fun CollectionCoverImage(url: String?, token: String, modifier: Modifier
     AsyncImage(
         model = ImageRequest.Builder(LocalContext.current)
             .data(url)
-            .addHeader("Authorization", token.asAuthHeader())
+            .httpHeaders(NetworkHeaders.Builder().add("Authorization", token.asAuthHeader()).build())
             .crossfade(true)
             .instrumentCover("collection", null, url)
             .build(),
@@ -915,7 +918,7 @@ private fun SearchSeriesRow(series: Series, token: String, coverUrl: String? = n
                 AsyncImage(
                     model = ImageRequest.Builder(LocalContext.current)
                         .data(resolvedCoverUrl)
-                        .addHeader("Authorization", token.asAuthHeader())
+                        .httpHeaders(NetworkHeaders.Builder().add("Authorization", token.asAuthHeader()).build())
                         .crossfade(true)
                         .build(),
                     contentDescription = series.name,
@@ -1016,7 +1019,7 @@ internal fun AnnotationResultRow(
                     AsyncImage(
                         model = ImageRequest.Builder(LocalContext.current)
                             .data(result.bookCoverUrl)
-                            .addHeader("Authorization", token.asAuthHeader())
+                            .httpHeaders(NetworkHeaders.Builder().add("Authorization", token.asAuthHeader()).build())
                             .crossfade(true)
                             .build(),
                         placeholder = ColorPainter(MaterialTheme.colorScheme.surfaceVariant),
@@ -1071,7 +1074,7 @@ internal fun AudiobookBookmarkResultRow(
                     AsyncImage(
                         model = ImageRequest.Builder(LocalContext.current)
                             .data(result.bookCoverUrl)
-                            .addHeader("Authorization", token.asAuthHeader())
+                            .httpHeaders(NetworkHeaders.Builder().add("Authorization", token.asAuthHeader()).build())
                             .crossfade(true)
                             .build(),
                         placeholder = ColorPainter(MaterialTheme.colorScheme.surfaceVariant),
@@ -1275,7 +1278,7 @@ internal fun LibraryItemCard(
                 AsyncImage(
                     model = ImageRequest.Builder(LocalContext.current)
                         .data(item.coverUrl)
-                        .addHeader("Authorization", token.asAuthHeader())
+                        .httpHeaders(NetworkHeaders.Builder().add("Authorization", token.asAuthHeader()).build())
                         .crossfade(true)
                         .instrumentCover("card", item.id, item.coverUrl)
                         .build(),

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -68,8 +68,8 @@ import org.koin.androidx.compose.koinViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import coil.compose.SubcomposeAsyncImage
-import coil.request.ImageRequest
+import coil3.compose.SubcomposeAsyncImage
+import coil3.request.ImageRequest
 import androidx.compose.ui.graphics.asImageBitmap
 import com.riffle.app.feature.reader.ChapterMapOverlay
 import com.riffle.app.feature.reader.VolumeNavEvent
@@ -552,7 +552,6 @@ private fun CbzPage(
             CbzPageContent.Image -> SubcomposeAsyncImage(
                 model = ImageRequest.Builder(context)
                     .data(bitmap)
-                    .crossfade(false)
                     .build(),
                 contentDescription = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.ui_comic_page_number, pageIndex + 1),
                 loading = { CircularProgressIndicator() },
@@ -694,7 +693,6 @@ private fun CbzPanelViewer(
             CbzPageContent.Image -> SubcomposeAsyncImage(
                 model = ImageRequest.Builder(context)
                     .data(bitmap)
-                    .crossfade(false)
                     .build(),
                 contentDescription = androidx.compose.ui.res.stringResource(
                     com.riffle.app.R.string.ui_comic_page_panel,

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzThumbnailStrip.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzThumbnailStrip.kt
@@ -30,9 +30,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
-import coil.size.Size as CoilSize
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.size.Size as CoilSize
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -127,7 +127,6 @@ private fun CbzThumbnail(
                 model = ImageRequest.Builder(context)
                     .data(currentBitmap)
                     .size(CoilSize(264, 360))
-                    .crossfade(false)
                     .build(),
                 contentDescription = null,
                 modifier = Modifier.fillMaxSize(),

--- a/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/settings/readaloud/ReadaloudMatchesScreen.kt
@@ -52,8 +52,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import org.koin.androidx.compose.koinViewModel
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
+import coil3.compose.AsyncImage
+import coil3.network.NetworkHeaders
+import coil3.network.httpHeaders
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import androidx.compose.ui.platform.LocalContext
 import com.riffle.core.domain.AbsCandidate
 import com.riffle.core.domain.AbsFormatFilter
@@ -523,7 +526,7 @@ private fun Cover(coverUrl: String?, token: String?) {
     AsyncImage(
         model = ImageRequest.Builder(LocalContext.current)
             .data(coverUrl)
-            .apply { if (token != null) addHeader("Authorization", token.asAuthHeader()) }
+            .apply { if (token != null) httpHeaders(NetworkHeaders.Builder().add("Authorization", token.asAuthHeader()).build()) }
             .crossfade(true)
             .build(),
         placeholder = ColorPainter(MaterialTheme.colorScheme.surfaceVariant),

--- a/app/src/main/kotlin/com/riffle/app/feature/source/websource/WebSourceCatalogItemCard.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/websource/WebSourceCatalogItemCard.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
+import coil3.compose.AsyncImage
 import com.riffle.app.ui.DefaultCoverPlaceholder
 import com.riffle.core.catalog.CatalogItem
 

--- a/app/src/main/kotlin/com/riffle/app/ui/source/SourceIcon.kt
+++ b/app/src/main/kotlin/com/riffle/app/ui/source/SourceIcon.kt
@@ -13,15 +13,16 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import coil.compose.SubcomposeAsyncImage
-import coil.request.ImageRequest
+import coil3.compose.SubcomposeAsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.riffle.core.models.ServerType
 import com.riffle.core.models.Source
 import com.riffle.core.models.SourceType
 
 /**
  * Renders the icon for a configured [Source]: fetches the server's favicon via Coil (using the
- * app-scope [coil.ImageLoader] with its disk cache) and falls back to the bundled monogram
+ * app-scope [coil3.ImageLoader] with its disk cache) and falls back to the bundled monogram
  * drawable while loading or on any error / decode failure. For sources without a network host
  * (e.g. [SourceType.LOCAL_FILES]) the bundled drawable is rendered directly.
  */

--- a/app/src/test/kotlin/com/riffle/app/RiffleImageLoaderTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/RiffleImageLoaderTest.kt
@@ -1,5 +1,6 @@
 package com.riffle.app
 
+import coil3.SingletonImageLoader
 import com.riffle.core.network.COVER_CACHE_CONTROL_INTERCEPTOR
 import com.riffle.core.network.createImageLoaderOkHttpClient
 import okhttp3.Authenticator
@@ -18,6 +19,7 @@ import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.net.Proxy
 import java.net.ProxySelector
@@ -27,6 +29,15 @@ import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.X509TrustManager
 
 class RiffleImageLoaderTest {
+
+    @Test
+    fun `RiffleApplication implements Coil v3 SingletonImageLoader Factory not v2 ImageLoaderFactory`() {
+        // Pin the Coil v3 factory interface. If someone reverts to coil.ImageLoaderFactory (v2),
+        // the class no longer implements SingletonImageLoader.Factory and this test flips red.
+        assertTrue(
+            RiffleApplication::class.java.interfaces.any { it == SingletonImageLoader.Factory::class.java },
+        )
+    }
 
     @Test
     fun `cover OkHttp client has no disk Cache so it cannot collide with Coil's DiskCache`() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ espressoCore = "3.7.0"
 androidxTest = "1.6.2"
 coroutines = "1.11.0"
 kotlinx-serialization = "1.7.3"
-coil = "2.7.0"
+coil = "3.1.0"
 jsoup = "1.23.2"
 media3 = "1.11.0"
 webkit = "1.16.0"
@@ -105,7 +105,8 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitExt" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
+coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
+coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3" }
 media3-exoplayer-hls = { group = "androidx.media3", name = "media3-exoplayer-hls", version.ref = "media3" }


### PR DESCRIPTION
Closes #741

Migrates the image loading stack from Coil 2 (`io.coil-kt:coil-*`) to Coil 3 (`io.coil-kt.coil3:coil-*`), which is the KMP-ready artifact.

## What changed

- **`gradle/libs.versions.toml`** — bump version `2.7.0 → 3.1.0`, switch group to `io.coil-kt.coil3`, add `coil-network-okhttp` artifact
- **`app/build.gradle.kts`** — add `coil-network-okhttp` dependency (OkHttp fetcher is now a separate artifact in v3)
- **`RiffleApplication.kt`** — implement `SingletonImageLoader.Factory` (v3) instead of `ImageLoaderFactory` (v2); wire OkHttp via `OkHttpNetworkFetcherFactory`; migrate `DiskCache.Builder` to v3 API using `coil3.disk.directory` extension
- **All Coil call sites** — update all `coil.*` imports to `coil3.*`; replace `addHeader()` with `httpHeaders(NetworkHeaders.Builder()…)` (v3 API); add explicit `import coil3.request.crossfade` where needed (top-level extension in v3); remove no-op `.crossfade(false)` calls

## Regression test

`RiffleImageLoaderTest` — pins that `RiffleApplication` implements `SingletonImageLoader.Factory` (v3); flips red if someone reverts to the v2 `ImageLoaderFactory`.

## Files changed

`gradle/libs.versions.toml`, `app/build.gradle.kts`, `RiffleApplication.kt`, `SourceIcon.kt`, `CbzThumbnailStrip.kt`, `CbzReaderScreen.kt`, `ReadaloudMatchesScreen.kt`, `LibraryItemsScreen.kt`, `LibraryItemDetailScreen.kt`, `PlayerSurface.kt`, `AnnotationsListScreen.kt`, `WebSourceCatalogItemCard.kt`, `EditLocalFileMetadataDialog.kt`, `RiffleImageLoaderTest.kt`