### PR TITLE
feat(ios): wire iOS entry point, Compose UI, and Koin module bindings

### DIFF
--- a/core/logging/build.gradle.kts
+++ b/core/logging/build.gradle.kts
@@ -26,6 +26,9 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.koin.core)
         }
+        iosMain.dependencies {
+            implementation(libs.koin.core)
+        }
         jvmTest.dependencies {
             implementation(libs.junit)
             implementation(libs.kotlinx.coroutines.test)

--- a/core/logging/src/iosMain/kotlin/com/riffle/core/logging/IosLoggingKoinModule.kt
+++ b/core/logging/src/iosMain/kotlin/com/riffle/core/logging/IosLoggingKoinModule.kt
@@ -1,0 +1,7 @@
+package com.riffle.core.logging
+
+import org.koin.dsl.module
+
+val iosLoggingModule = module {
+    single<Logger> { IosLogger() }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "9.3.2"
 kotlin = "2.4.10"
+compose-multiplatform = "1.10.2"
 ksp = "2.3.11"
 coreKtx = "1.19.0"
 lifecycleRuntimeKtx = "2.11.0"
@@ -95,6 +96,9 @@ readium-streamer = { group = "org.readium.kotlin-toolkit", name = "readium-strea
 readium-navigator = { group = "org.readium.kotlin-toolkit", name = "readium-navigator", version.ref = "readium" }
 readium-adapter-pdfium = { group = "org.readium.kotlin-toolkit", name = "readium-adapter-pdfium-navigator", version.ref = "readium" }
 pdfium-android = { group = "com.github.barteksc", name = "pdfium-android", version = "1.9.0" }
+compose-runtime = { group = "org.jetbrains.compose.runtime", name = "runtime", version.ref = "compose-multiplatform" }
+compose-ui = { group = "org.jetbrains.compose.ui", name = "ui", version.ref = "compose-multiplatform" }
+compose-foundation = { group = "org.jetbrains.compose.foundation", name = "foundation", version.ref = "compose-multiplatform" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
 desugar-jdk-libs = { group = "com.android.tools", name = "desugar_jdk_libs", version = "2.1.5" }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1,7 +1,18 @@
 import SwiftUI
+import UIKit
+import Riffle
 
 struct ContentView: View {
     var body: some View {
-        Text("Hello Riffle!")
+        ComposeView()
+            .ignoresSafeArea()
     }
+}
+
+struct ComposeView: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        MainViewControllerKt.MainViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
 }

--- a/iosApp/iosApp/RiffleApp.swift
+++ b/iosApp/iosApp/RiffleApp.swift
@@ -1,7 +1,11 @@
 import SwiftUI
+import Riffle
 
 @main
 struct RiffleApp: App {
+    init() {
+        KoinKt.startKoin()
+    }
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.kotlin.compose)
 }
 
 kotlin {
@@ -25,6 +26,13 @@ kotlin {
         commonMain.dependencies {
             implementation(project(":core:data"))
             implementation(project(":core:logging"))
+            implementation(libs.compose.runtime)
+            implementation(libs.compose.ui)
+            implementation(libs.compose.foundation)
+            implementation(libs.koin.core)
+        }
+        iosMain.dependencies {
+            implementation(libs.ktor.client.darwin)
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/riffle/shared/LibraryBrowsingApp.kt
+++ b/shared/src/commonMain/kotlin/com/riffle/shared/LibraryBrowsingApp.kt
@@ -1,0 +1,15 @@
+package com.riffle.shared
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun LibraryBrowsingApp() {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        BasicText("Riffle")
+    }
+}

--- a/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
@@ -1,0 +1,14 @@
+package com.riffle.shared
+
+import com.riffle.core.data.di.iosDataModule
+import com.riffle.core.logging.iosLoggingModule
+import org.koin.core.context.startKoin as koinStartKoin
+
+fun startKoin() {
+    koinStartKoin {
+        modules(
+            iosLoggingModule,
+            iosDataModule,
+        )
+    }
+}

--- a/shared/src/iosMain/kotlin/com/riffle/shared/MainViewController.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/MainViewController.kt
@@ -1,0 +1,7 @@
+package com.riffle.shared
+
+import androidx.compose.ui.window.ComposeUIViewController
+
+fun MainViewController() = ComposeUIViewController {
+    LibraryBrowsingApp()
+}


### PR DESCRIPTION
Closes #744

## Summary

- Adds JetBrains Compose Multiplatform 1.10.2 (runtime + ui + foundation) as a dependency of the `shared` module
- Creates `LibraryBrowsingApp()` composable in `shared/commonMain` — the cross-platform UI entry point; currently a placeholder (`BasicText("Riffle")`); full nav graph will follow in subsequent KMP migration PRs
- Creates `MainViewController()` in `shared/iosMain` using `ComposeUIViewController` to host `LibraryBrowsingApp()` in the iOS UIKit hierarchy
- Creates `Koin.kt` in `shared/iosMain` exposing `fun startKoin()` (Swift call-site: `KoinKt.startKoin()`) with `iosLoggingModule` + `iosDataModule`
- Adds `iosLoggingModule` to `core/logging/iosMain` binding `IosLogger` as the production `Logger`
- Updates `RiffleApp.swift` to call `KoinKt.startKoin()` on app launch
- Updates `ContentView.swift` to embed `MainViewControllerKt.MainViewController()` via `UIViewControllerRepresentable`

## Test coverage

This PR is pure iOS wiring code (Koin module definitions, `ComposeUIViewController`, Swift UI entry point). The `shared` module has no JVM target — JVM tests are structurally inapplicable. Automated gate: `:shared:compileKotlinIosSimulatorArm64` and `:shared:compileKotlinIosArm64` both pass. Runtime verification requires the iOS simulator (issue task 6).

## Regression risk

Low — Android entry point (`MainActivity`) is unchanged; only new files are added for iOS.