### PR TITLE
fix(cbz): eliminate senseless pan on single-panel pages in Panel View

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -446,7 +446,7 @@ private fun CbzPage(
     var offsetY by remember(pageIndex) { mutableStateOf(0f) }
     val scope = rememberCoroutineScope()
     var zoomAnimJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
-    val decode by produceState(initialValue = CbzPageDecodeState(), key1 = pageIndex, key2 = source) {
+    val rawDecode by produceState(initialValue = CbzPageDecodeState(), key1 = pageIndex, key2 = source) {
         val result = decodeWithRetry(attempts = decodeAttemptsFor(source)) {
             withContext(Dispatchers.IO) {
                 runCatching { decodeSampledBitmap(source, pageIndex, MAX_PAGE_DIMENSION) }.getOrNull()
@@ -454,6 +454,10 @@ private fun CbzPage(
         }
         value = CbzPageDecodeState(bitmap = result, settled = true, forPage = pageIndex)
     }
+    // Each pager slot has a fixed pageIndex so this gate is currently a no-op, but applying it
+    // keeps the "decode must belong to the page it renders for" contract enforced everywhere
+    // CbzPageDecodeState is consumed, not just in CbzPanelViewer.
+    val decode = decodeForPage(rawDecode, pageIndex)
     val bitmap = decode.bitmap
     val context = LocalContext.current
 
@@ -543,7 +547,7 @@ private fun CbzPage(
         // otherwise show a fully blank page with no feedback until the download completes.
         // Once the decode has settled without a bitmap (retry budget spent, or an undecodable
         // page in a local archive), show an error instead of an infinite spinner.
-        when (cbzPageContent(bitmap, decode.settled)) {
+        when (cbzPageContent(bitmap != null, decode.settled)) {
             CbzPageContent.Loading -> CircularProgressIndicator()
             CbzPageContent.Error -> Text(
                 text = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.error_comic_page_load_failed),
@@ -673,11 +677,12 @@ private fun CbzPanelViewer(
         // the spec we want (snap) is always overwritten to tween by the time the internal
         // LaunchedEffect coroutine reads it. Animatable gives explicit snapTo/animateTo control.
         //
-        // The key insight: remember(currentPage, viewportW, viewportH) { Animatable(target) }
-        // re-creates each Animatable — initialized to the CORRECT target — whenever the page or
-        // viewport size changes. That means on first viewport measurement (0→real) and on every
-        // page turn, the Animatable already starts at the right value; no animation is needed.
-        // Only panel-index navigation on an already-measured page goes through animateTo.
+        // The key insight: remember(currentPage, pagePanels, viewportW, viewportH) re-creates
+        // each Animatable — initialized to the CORRECT target — whenever the page, the resolved
+        // panel set, or the viewport size changes. That means on first viewport measurement
+        // (0→real), on every page turn, AND when detection results arrive (pagePanels null→value
+        // is load-bearing here!), the Animatable already starts at the right value; no animation
+        // runs. Only panel-index navigation on an already-measured page goes through animateTo.
         val reduceMotion = remember(context) { isReduceMotionEnabled(context) }
         val tweenSpec = remember(panelAnimationSpeedMs) { tween<Float>(durationMillis = panelAnimationSpeedMs) }
         val scaleAnim = remember(currentPage, pagePanels, viewportW, viewportH) { Animatable(zoomScale) }
@@ -709,19 +714,15 @@ private fun CbzPanelViewer(
         // panels are ready avoids that — the image first appears already at the correct position.
         // Fallback pages (pagePanels.isFallback) mean detection completed and found no panels;
         // they use the whole-page view and must pass through.
-        val panelsReady = pagePanels != null
-        when (cbzPageContent(bitmap, decode.settled)) {
+        val imageRequest = remember(bitmap) { ImageRequest.Builder(context).data(bitmap).build() }
+        when (cbzPageContent(bitmap != null, decode.settled, panelsReady = pagePanels != null)) {
             CbzPageContent.Loading -> CircularProgressIndicator()
             CbzPageContent.Error -> Text(
                 text = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.error_comic_page_load_failed),
                 color = MaterialTheme.colorScheme.onSurface,
             )
-            CbzPageContent.Image -> if (!panelsReady) {
-                CircularProgressIndicator()
-            } else SubcomposeAsyncImage(
-                model = ImageRequest.Builder(context)
-                    .data(bitmap)
-                    .build(),
+            CbzPageContent.Image -> SubcomposeAsyncImage(
+                model = imageRequest,
                 contentDescription = androidx.compose.ui.res.stringResource(
                     com.riffle.app.R.string.ui_comic_page_panel,
                     currentPage + 1,
@@ -730,12 +731,14 @@ private fun CbzPanelViewer(
                 loading = { CircularProgressIndicator() },
                 modifier = Modifier
                     .fillMaxSize()
-                    .graphicsLayer(
-                        scaleX = scaleAnim.value,
-                        scaleY = scaleAnim.value,
-                        translationX = txAnim.value,
-                        translationY = tyAnim.value,
-                    ),
+                    // Lambda form: reads the Animatable values at draw time, so animation frames
+                    // don't recompose the Coil subcompose tree.
+                    .graphicsLayer {
+                        scaleX = scaleAnim.value
+                        scaleY = scaleAnim.value
+                        this.translationX = txAnim.value
+                        this.translationY = tyAnim.value
+                    },
             )
         }
 
@@ -820,12 +823,22 @@ internal fun decodeForPage(decode: CbzPageDecodeState, currentPage: Int): CbzPag
     if (decode.forPage == currentPage) decode else CbzPageDecodeState()
 
 /**
- * What a comic page slot should render. A null bitmap with the decode still running must show a
- * loading indicator, never a blank page; a null bitmap after the decode settled (retry budget
- * spent, or an undecodable page) must show an error, never an infinite spinner.
+ * What a comic page slot should render. A missing bitmap with the decode still running must show
+ * a loading indicator, never a blank page; a missing bitmap after the decode settled (retry
+ * budget spent, or an undecodable page) must show an error, never an infinite spinner.
+ *
+ * [panelsReady] is the Panel View gate: while panel detection is still resolving, a decoded
+ * bitmap must NOT render — it would appear at Identity (whole-page) and then jump to the
+ * panel-focused transform when detection lands (the "spurious pan"). The panel viewer passes
+ * `pagePanels != null`; the plain pager always passes true.
  */
-internal fun cbzPageContent(bitmap: Bitmap?, decodeSettled: Boolean): CbzPageContent = when {
-    bitmap != null -> CbzPageContent.Image
+internal fun cbzPageContent(
+    hasBitmap: Boolean,
+    decodeSettled: Boolean,
+    panelsReady: Boolean = true,
+): CbzPageContent = when {
+    hasBitmap && panelsReady -> CbzPageContent.Image
+    hasBitmap -> CbzPageContent.Loading
     decodeSettled -> CbzPageContent.Error
     else -> CbzPageContent.Loading
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -6,8 +6,8 @@ import android.util.LruCache
 import android.view.WindowManager
 import android.provider.Settings
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.animate
-import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
@@ -452,7 +452,7 @@ private fun CbzPage(
                 runCatching { decodeSampledBitmap(source, pageIndex, MAX_PAGE_DIMENSION) }.getOrNull()
             }
         }
-        value = CbzPageDecodeState(bitmap = result, settled = true)
+        value = CbzPageDecodeState(bitmap = result, settled = true, forPage = pageIndex)
     }
     val bitmap = decode.bitmap
     val context = LocalContext.current
@@ -595,14 +595,20 @@ private fun CbzPanelViewer(
         }
     }
 
-    val decode by produceState(initialValue = CbzPageDecodeState(), key1 = currentPage, key2 = state.imageSource) {
+    val rawDecode by produceState(initialValue = CbzPageDecodeState(), key1 = currentPage, key2 = state.imageSource) {
+        // Drop the previous page's bitmap immediately — the gate below already hides it, but
+        // clearing the reference frees the native allocation sooner (API-25 bitmaps live
+        // outside the GC heap).
+        value = CbzPageDecodeState()
         val result = decodeWithRetry(attempts = decodeAttemptsFor(state.imageSource)) {
             withContext(Dispatchers.IO) {
                 runCatching { decodeSampledBitmap(state.imageSource, currentPage, MAX_PAGE_DIMENSION) }.getOrNull()
             }
         }
-        value = CbzPageDecodeState(bitmap = result, settled = true)
+        value = CbzPageDecodeState(bitmap = result, settled = true, forPage = currentPage)
     }
+    // Never render another page's bitmap through this page's panel transform (zoom flash).
+    val decode = decodeForPage(rawDecode, currentPage)
     val bitmap = decode.bitmap
 
     var viewportW by remember { mutableStateOf(0) }
@@ -659,38 +665,60 @@ private fun CbzPanelViewer(
         val translationX = transform.translationX
         val translationY = transform.translationY
 
-        // Animate scale + translation between panels. Declarative — Compose interpolates
-        // whenever the target values change, and a mid-flight change simply re-targets
-        // (interrupt semantics — ADR 0055 §4). Reduce Motion collapses to a snap.
+        // Animate scale + translation between panels. Reduce Motion collapses to a snap.
+        //
+        // We use Animatable directly (not animateFloatAsState) to avoid the spurious pan on
+        // first load. The problem with animateFloatAsState: it uses rememberUpdatedState for the
+        // animationSpec, so any spec change takes effect only after the next recomposition —
+        // the spec we want (snap) is always overwritten to tween by the time the internal
+        // LaunchedEffect coroutine reads it. Animatable gives explicit snapTo/animateTo control.
+        //
+        // The key insight: remember(currentPage, viewportW, viewportH) { Animatable(target) }
+        // re-creates each Animatable — initialized to the CORRECT target — whenever the page or
+        // viewport size changes. That means on first viewport measurement (0→real) and on every
+        // page turn, the Animatable already starts at the right value; no animation is needed.
+        // Only panel-index navigation on an already-measured page goes through animateTo.
         val reduceMotion = remember(context) { isReduceMotionEnabled(context) }
-        val animationSpec = remember(reduceMotion, panelAnimationSpeedMs) {
-            if (reduceMotion || panelAnimationSpeedMs == 0) snap<Float>() else tween<Float>(durationMillis = panelAnimationSpeedMs)
+        val tweenSpec = remember(panelAnimationSpeedMs) { tween<Float>(durationMillis = panelAnimationSpeedMs) }
+        val scaleAnim = remember(currentPage, pagePanels, viewportW, viewportH) { Animatable(zoomScale) }
+        val txAnim = remember(currentPage, pagePanels, viewportW, viewportH) { Animatable(translationX) }
+        val tyAnim = remember(currentPage, pagePanels, viewportW, viewportH) { Animatable(translationY) }
+        LaunchedEffect(zoomScale, translationX, translationY) {
+            if (viewportW <= 0 || viewportH <= 0) return@LaunchedEffect
+            // Skip if Animatables were just initialized to this same target (viewport/page change)
+            if (zoomScale == scaleAnim.targetValue &&
+                translationX == txAnim.targetValue &&
+                translationY == tyAnim.targetValue) return@LaunchedEffect
+            if (reduceMotion || panelAnimationSpeedMs == 0) {
+                scaleAnim.snapTo(zoomScale)
+                txAnim.snapTo(translationX)
+                tyAnim.snapTo(translationY)
+            } else {
+                launch { scaleAnim.animateTo(zoomScale, tweenSpec) }
+                launch { txAnim.animateTo(translationX, tweenSpec) }
+                launch { tyAnim.animateTo(translationY, tweenSpec) }
+            }
         }
-        val animatedScale by animateFloatAsState(
-            targetValue = zoomScale,
-            animationSpec = animationSpec,
-            label = "cbz_panel_scale",
-        )
-        val animatedTx by animateFloatAsState(
-            targetValue = translationX,
-            animationSpec = animationSpec,
-            label = "cbz_panel_tx",
-        )
-        val animatedTy by animateFloatAsState(
-            targetValue = translationY,
-            animationSpec = animationSpec,
-            label = "cbz_panel_ty",
-        )
 
         // Same null-bitmap contract as CbzPage: render the spinner ourselves — Coil treats a
         // null model as an instant (empty) error, not a loading state.
+        //
+        // When pagePanels is null the detector hasn't finished yet.  Showing the image at
+        // Identity (whole-page) and then jumping to the panel-focused transform once panels
+        // arrive is exactly the "spurious pan" the user sees.  Holding on a spinner until
+        // panels are ready avoids that — the image first appears already at the correct position.
+        // Fallback pages (pagePanels.isFallback) mean detection completed and found no panels;
+        // they use the whole-page view and must pass through.
+        val panelsReady = pagePanels != null
         when (cbzPageContent(bitmap, decode.settled)) {
             CbzPageContent.Loading -> CircularProgressIndicator()
             CbzPageContent.Error -> Text(
                 text = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.error_comic_page_load_failed),
                 color = MaterialTheme.colorScheme.onSurface,
             )
-            CbzPageContent.Image -> SubcomposeAsyncImage(
+            CbzPageContent.Image -> if (!panelsReady) {
+                CircularProgressIndicator()
+            } else SubcomposeAsyncImage(
                 model = ImageRequest.Builder(context)
                     .data(bitmap)
                     .build(),
@@ -703,10 +731,10 @@ private fun CbzPanelViewer(
                 modifier = Modifier
                     .fillMaxSize()
                     .graphicsLayer(
-                        scaleX = animatedScale,
-                        scaleY = animatedScale,
-                        translationX = animatedTx,
-                        translationY = animatedTy,
+                        scaleX = scaleAnim.value,
+                        scaleY = scaleAnim.value,
+                        translationX = txAnim.value,
+                        translationY = tyAnim.value,
                     ),
             )
         }
@@ -773,7 +801,23 @@ internal enum class CbzPageGestureAction { Ignore, Zoom, PanZoomed }
 internal enum class CbzPageContent { Loading, Image, Error }
 
 /** Result of a page decode attempt: [settled] flips true once the retry budget is spent. */
-internal data class CbzPageDecodeState(val bitmap: Bitmap? = null, val settled: Boolean = false)
+internal data class CbzPageDecodeState(
+    val bitmap: Bitmap? = null,
+    val settled: Boolean = false,
+    /** The page this decode belongs to; -1 until a decode settles. */
+    val forPage: Int = -1,
+)
+
+/**
+ * Returns [decode] only when it belongs to [currentPage]; otherwise an empty (loading) state.
+ *
+ * CbzPanelViewer is a single composable reused across pages, and produceState keeps its last
+ * value while the restarted producer decodes the new page. Without this gate the previous
+ * page's bitmap is briefly rendered through the NEW page's panel transform — an unnecessary
+ * zoom flash right before every page change.
+ */
+internal fun decodeForPage(decode: CbzPageDecodeState, currentPage: Int): CbzPageDecodeState =
+    if (decode.forPage == currentPage) decode else CbzPageDecodeState()
 
 /**
  * What a comic page slot should render. A null bitmap with the decode still running must show a

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
@@ -37,6 +37,7 @@ import com.riffle.core.domain.comic.panel.PanelMaskService
 import com.riffle.core.domain.comic.panel.PanelOverflowTransform
 import com.riffle.core.domain.comic.panel.PanelRegion
 import com.riffle.core.domain.comic.panel.PanelReportRepository
+import com.riffle.core.domain.comic.panel.PanelSource
 import com.riffle.core.domain.comic.panel.PanelViewPreferencesStore
 import com.riffle.core.domain.developer.DeveloperOptionsRepository
 import com.riffle.core.domain.usecase.UpdateReadingProgress
@@ -51,6 +52,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -100,6 +102,9 @@ class CbzReaderViewModel constructor(
     // Cancel-and-replace the in-flight panel resolve on every page change so a stale resolver
     // can't overwrite a newer page's PagePanels result.
     private var panelResolveJob: Job? = null
+    // previousPanel's cross-page landing-index job — tracked separately so it never orphans
+    // the page resolve launched by gotoPage (both must be cancellable on the next page change).
+    private var panelLandingJob: Job? = null
     // Guard so background prefetches skip store writes after the archive is closed on
     // onCleared, otherwise a stale coroutine calling into a closed ZipFile persists a bogus
     // 1x1 Fallback that would poison the next open's cache.
@@ -174,8 +179,9 @@ class CbzReaderViewModel constructor(
     val currentPagePanels: StateFlow<PagePanels?> = _currentPagePanels
 
     /**
-     * Effective panels after applying the overflow transform (e.g. SPLIT). Used for panel
-     * navigation logic. The screen reads [currentPagePanels] (raw) for rendering.
+     * Effective panels after applying the overflow transform (e.g. SPLIT). This is what the
+     * screen renders AND what panel navigation walks — a null emission here keeps the screen
+     * in its loading state (the SMART_SPLIT seam hold below relies on that contract).
      */
     val effectivePanels: StateFlow<PagePanels?> = combine(
         _currentPagePanels,
@@ -203,7 +209,11 @@ class CbzReaderViewModel constructor(
             },
         )
         pagePanels.copy(panels = transformed)
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+    }
+        // applyOverflow's SMART_SPLIT sampler scans pixels — keep it off the main thread,
+        // especially now that the seam hold puts this emission on the first-render path.
+        .flowOn(Dispatchers.Default)
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     private val _currentPanelIndex = MutableStateFlow(0)
     /** 0-based index into [currentPagePanels]. Advances with next/prev-panel gestures. */
@@ -502,6 +512,10 @@ class CbzReaderViewModel constructor(
      */
     fun nextPanel() {
         if (!panelViewOn.value) return nextPage()
+        // Seam hold: raw panels are known but effectivePanels is withheld while the SMART_SPLIT
+        // seam decode runs. Falling through to nextPage() here would skip a page the user never
+        // saw a single panel of — swallow the tap instead; the hold lasts tens of milliseconds.
+        if (effectivePanels.value == null && _currentPagePanels.value != null) return
         val panels = effectivePanels.value?.panels
         if (panels.isNullOrEmpty() || effectivePanels.value?.isFallback == true) return nextPage()
         val nextIndex = _currentPanelIndex.value + 1
@@ -514,6 +528,8 @@ class CbzReaderViewModel constructor(
 
     fun previousPanel() {
         if (!panelViewOn.value) return previousPage()
+        // Same seam-hold swallow as nextPanel — don't turn a withheld emission into a page jump.
+        if (effectivePanels.value == null && _currentPagePanels.value != null) return
         val panels = effectivePanels.value?.panels
         if (panels.isNullOrEmpty() || effectivePanels.value?.isFallback == true) return previousPage()
         val prevIndex = _currentPanelIndex.value - 1
@@ -527,7 +543,11 @@ class CbzReaderViewModel constructor(
             val newPage = (_currentPage.value - 1).coerceAtLeast(0)
             if (newPage == _currentPage.value) return
             gotoPage(newPage)
-            panelResolveJob = viewModelScope.launch {
+            // Track this landing-index job separately: overwriting panelResolveJob here would
+            // orphan the resolve gotoPage just launched (whose sampler/prefetch work must stay
+            // cancellable by the NEXT page change).
+            panelLandingJob?.cancel()
+            panelLandingJob = viewModelScope.launch {
                 val book = panelBook ?: return@launch
                 val pagePanels = withContext(Dispatchers.Default) {
                     runCatching { book.resolvePage(newPage) }.getOrNull()
@@ -585,20 +605,39 @@ class CbzReaderViewModel constructor(
             EnergySamplerState.Resolved(null)
         }
         panelResolveJob = viewModelScope.launch {
-            val current = withContext(Dispatchers.Default) {
+            val resolved = withContext(Dispatchers.Default) {
                 runCatching { book.resolvePage(pageIndex) }.getOrNull()
-            } ?: return@launch
+            }
             if (archiveClosed || _currentPage.value != pageIndex) return@launch
+            if (resolved == null) {
+                // Detection failed (corrupt/unreadable page). Emit a synthetic fallback so the
+                // viewer shows the page fit-whole instead of an endless spinner — the image
+                // gate holds while pagePanels is null, and null would otherwise stay forever.
+                // Resolve the sampler too so a Pending state can't outlive its decode.
+                _currentPagePanels.value = failedDetectionFallback(pageIndex)
+                _energySampler.value = EnergySamplerState.Resolved(null)
+                return@launch
+            }
+            val current = resolved
             _currentPagePanels.value = current
-            // Only decode when SMART_SPLIT is active — the energy sampler is not needed
-            // for OFF or SPLIT, and the decode is non-trivial even at ≤300px. A failed decode
-            // resolves to a null sampler (centre-split fallback), never stays Pending.
-            if (effectiveComicFormatting.value.panelOverflow == PanelOverflowBehavior.SMART_SPLIT) {
-                _energySampler.value = EnergySamplerState.Resolved(
-                    withContext(Dispatchers.Default) {
-                        computeEnergySampler(pageIndex, current.imageWidth, current.imageHeight)
-                    },
-                )
+            // Resolve the seam sampler whenever this page set Pending — keyed on the STATE, not
+            // a re-read of the formatting: if the user toggles SMART_SPLIT off (or off and back
+            // on) mid-decode, a formatting re-check would strand Pending forever and the seam
+            // hold would spin until the next page turn. A failed decode resolves to a null
+            // sampler (centre-split fallback), never stays Pending.
+            if (_energySampler.value == EnergySamplerState.Pending) {
+                val computed = withContext(Dispatchers.Default) {
+                    computeEnergySampler(pageIndex, current.imageWidth, current.imageHeight)
+                }
+                if (archiveClosed || _currentPage.value != pageIndex) {
+                    // Page moved on while we scanned — this result belongs to a page that is no
+                    // longer current; publishing it would release the new page's hold with a
+                    // stale seam and clobber the tracked bitmap.
+                    computed?.second?.let { if (!it.isRecycled) it.recycle() }
+                    return@launch
+                }
+                energySamplerBitmap = computed?.second
+                _energySampler.value = EnergySamplerState.Resolved(computed?.first)
             }
             // Prefetch the next two pages.
             withContext(Dispatchers.Default) {
@@ -681,11 +720,17 @@ class CbzReaderViewModel constructor(
         energySamplerBitmap = null
     }
 
+    /**
+     * Returns the seam-energy sampler and the low-res bitmap it reads, or null when the page
+     * can't be decoded. The CALLER owns the bitmap: register it in [energySamplerBitmap] when
+     * the page is still current, or recycle it immediately when it's stale — this function must
+     * not touch the field itself, or a stale compute could clobber the tracked bitmap.
+     */
     private fun computeEnergySampler(
         pageIndex: Int,
         imageWidth: Int,
         imageHeight: Int,
-    ): ((PanelRegion, Boolean) -> FloatArray)? {
+    ): Pair<(PanelRegion, Boolean) -> FloatArray, Bitmap>? {
         val source = (_state.value as? CbzReaderState.Ready)?.imageSource ?: return null
         // Bounds-only pass.
         val boundsOpts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
@@ -705,14 +750,13 @@ class CbzReaderViewModel constructor(
 
         val scaleX = bitmap.width.toFloat() / imageWidth
         val scaleY = bitmap.height.toFloat() / imageHeight
-        // Register the bitmap so onCurrentPageChanged / onCleared can explicitly recycle it.
-        energySamplerBitmap = bitmap
         // The split axis is decided by PanelOverflowTransform (max zoom gain), not here — the
         // sampler just computes energies along whichever axis the transform asks for.
-        return { panel, splitHorizontally ->
+        val sampler: (PanelRegion, Boolean) -> FloatArray = { panel, splitHorizontally ->
             if (splitHorizontally) columnEnergies(bitmap, panel, scaleX, scaleY)
             else rowEnergies(bitmap, panel, scaleX, scaleY)
         }
+        return sampler to bitmap
     }
 
     private fun columnEnergies(
@@ -806,6 +850,19 @@ internal fun mergeComicFormattingOverrides(
 internal fun clampPageForSwap(currentPage: Int, actualPageCount: Int): Int? =
     if (actualPageCount > 0 && currentPage >= actualPageCount) actualPageCount - 1 else null
 
+/**
+ * Synthetic PagePanels for a page whose panel detection failed (corrupt/unreadable page).
+ * isFallback routes the viewer to the fit-whole path, whose transform is Identity — the fake
+ * 1×1 dimensions are never used for camera math.
+ */
+internal fun failedDetectionFallback(pageIndex: Int): PagePanels = PagePanels(
+    pageIndex = pageIndex,
+    imageWidth = 1,
+    imageHeight = 1,
+    panels = listOf(PanelRegion(0, 0, 1, 1)),
+    source = PanelSource.Fallback,
+)
+
 /** SMART_SPLIT seam-sampler resolution state for the current page. */
 internal sealed interface EnergySamplerState {
     /** Page changed with SMART_SPLIT active; the low-res seam decode hasn't finished yet. */
@@ -830,8 +887,10 @@ internal fun shouldHoldForSmartSeam(
     viewportW: Int,
     viewportH: Int,
 ): Boolean = overflow == PanelOverflowBehavior.SMART_SPLIT && samplerPending &&
-    pagePanels.panels.any {
-        PanelOverflowTransform.isOverflowing(
-            it, pagePanels.imageWidth, pagePanels.imageHeight, viewportW, viewportH,
-        )
-    }
+    // Probe with the transform itself (SPLIT = centre seam, same split decision as SMART_SPLIT)
+    // rather than a separate predicate, so "would this page split?" can never drift from what
+    // applyOverflow actually does when the hold releases.
+    PanelOverflowTransform.applyOverflow(
+        pagePanels.panels, pagePanels.imageWidth, pagePanels.imageHeight,
+        viewportW, viewportH, PanelOverflowBehavior.SPLIT,
+    ).size != pagePanels.panels.size

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderViewModel.kt
@@ -158,8 +158,8 @@ class CbzReaderViewModel constructor(
         _viewportSize.value = w to h
     }
 
-    /** Low-resolution page bitmap sampler for SMART_SPLIT seam detection. Null until decoded. */
-    private val _energySampler = MutableStateFlow<((PanelRegion) -> FloatArray)?>(null)
+    /** Low-resolution page bitmap sampler for SMART_SPLIT seam detection. */
+    private val _energySampler = MutableStateFlow<EnergySamplerState>(EnergySamplerState.Resolved(null))
     // Strong reference to the bitmap captured by the current sampler lambda so it can be
     // explicitly recycled on page change or ViewModel teardown. API-25 allocates bitmaps in
     // native memory outside the GC heap, so waiting for GC to collect them causes OOM.
@@ -182,15 +182,25 @@ class CbzReaderViewModel constructor(
         effectiveComicFormatting,
         _viewportSize,
         _energySampler,
-    ) { pagePanels, formatting, (vpW, vpH), energySampler ->
+    ) { pagePanels, formatting, (vpW, vpH), samplerState ->
         if (pagePanels == null || pagePanels.isFallback || !formatting.panelViewOn) return@combine pagePanels
         val overflow = formatting.panelOverflow
         if ((overflow != PanelOverflowBehavior.SPLIT && overflow != PanelOverflowBehavior.SMART_SPLIT) ||
             vpW == 0 || vpH == 0) return@combine pagePanels
+        // While the SMART_SPLIT seam decode is still in flight, emitting a centre-split interim
+        // result would render the page and then visibly re-split it when the real seam arrives.
+        // Hold (null → screen keeps its loading state) until the sampler resolves instead.
+        if (shouldHoldForSmartSeam(overflow, samplerState is EnergySamplerState.Pending, pagePanels, vpW, vpH)) {
+            return@combine null
+        }
         val transformed = PanelOverflowTransform.applyOverflow(
             pagePanels.panels, pagePanels.imageWidth, pagePanels.imageHeight, vpW, vpH,
             overflow,
-            energySampler = if (overflow == PanelOverflowBehavior.SMART_SPLIT) energySampler else null,
+            energySampler = if (overflow == PanelOverflowBehavior.SMART_SPLIT) {
+                (samplerState as? EnergySamplerState.Resolved)?.sampler
+            } else {
+                null
+            },
         )
         pagePanels.copy(panels = transformed)
     }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
@@ -559,11 +569,21 @@ class CbzReaderViewModel constructor(
         // Cancel any prior in-flight resolve/prefetch so a stale coroutine can't clobber
         // `_currentPagePanels` with an older page's result under rapid navigation.
         panelResolveJob?.cancel()
-        // Recycle before nulling — sampler lambda holds a strong bitmap ref; after null the
-        // combine in effectivePanels will no longer call it, so the recycle is safe.
+        // Recycle before replacing — sampler lambda holds a strong bitmap ref; once the state
+        // no longer exposes it, the combine in effectivePanels can't call it, so the recycle
+        // is safe.
         energySamplerBitmap?.let { if (!it.isRecycled) it.recycle() }
         energySamplerBitmap = null
-        _energySampler.value = null
+        // Pending only when a seam decode will actually follow (SMART_SPLIT); otherwise mark
+        // resolved immediately so effectivePanels never holds waiting for a decode that will
+        // never run.
+        _energySampler.value = if (
+            effectiveComicFormatting.value.panelOverflow == PanelOverflowBehavior.SMART_SPLIT
+        ) {
+            EnergySamplerState.Pending
+        } else {
+            EnergySamplerState.Resolved(null)
+        }
         panelResolveJob = viewModelScope.launch {
             val current = withContext(Dispatchers.Default) {
                 runCatching { book.resolvePage(pageIndex) }.getOrNull()
@@ -571,11 +591,14 @@ class CbzReaderViewModel constructor(
             if (archiveClosed || _currentPage.value != pageIndex) return@launch
             _currentPagePanels.value = current
             // Only decode when SMART_SPLIT is active — the energy sampler is not needed
-            // for OFF or SPLIT, and the decode is non-trivial even at ≤300px.
+            // for OFF or SPLIT, and the decode is non-trivial even at ≤300px. A failed decode
+            // resolves to a null sampler (centre-split fallback), never stays Pending.
             if (effectiveComicFormatting.value.panelOverflow == PanelOverflowBehavior.SMART_SPLIT) {
-                _energySampler.value = withContext(Dispatchers.Default) {
-                    computeEnergySampler(pageIndex, current.imageWidth, current.imageHeight)
-                }
+                _energySampler.value = EnergySamplerState.Resolved(
+                    withContext(Dispatchers.Default) {
+                        computeEnergySampler(pageIndex, current.imageWidth, current.imageHeight)
+                    },
+                )
             }
             // Prefetch the next two pages.
             withContext(Dispatchers.Default) {
@@ -662,7 +685,7 @@ class CbzReaderViewModel constructor(
         pageIndex: Int,
         imageWidth: Int,
         imageHeight: Int,
-    ): ((PanelRegion) -> FloatArray)? {
+    ): ((PanelRegion, Boolean) -> FloatArray)? {
         val source = (_state.value as? CbzReaderState.Ready)?.imageSource ?: return null
         // Bounds-only pass.
         val boundsOpts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
@@ -684,10 +707,10 @@ class CbzReaderViewModel constructor(
         val scaleY = bitmap.height.toFloat() / imageHeight
         // Register the bitmap so onCurrentPageChanged / onCleared can explicitly recycle it.
         energySamplerBitmap = bitmap
-        return { panel ->
-            val widthRatio = panel.width.toFloat() / imageWidth
-            val heightRatio = panel.height.toFloat() / imageHeight
-            if (widthRatio >= heightRatio) columnEnergies(bitmap, panel, scaleX, scaleY)
+        // The split axis is decided by PanelOverflowTransform (max zoom gain), not here — the
+        // sampler just computes energies along whichever axis the transform asks for.
+        return { panel, splitHorizontally ->
+            if (splitHorizontally) columnEnergies(bitmap, panel, scaleX, scaleY)
             else rowEnergies(bitmap, panel, scaleX, scaleY)
         }
     }
@@ -782,3 +805,33 @@ internal fun mergeComicFormattingOverrides(
  */
 internal fun clampPageForSwap(currentPage: Int, actualPageCount: Int): Int? =
     if (actualPageCount > 0 && currentPage >= actualPageCount) actualPageCount - 1 else null
+
+/** SMART_SPLIT seam-sampler resolution state for the current page. */
+internal sealed interface EnergySamplerState {
+    /** Page changed with SMART_SPLIT active; the low-res seam decode hasn't finished yet. */
+    data object Pending : EnergySamplerState
+
+    /** Decode finished (or not needed). [sampler] is null when the page couldn't be decoded. */
+    data class Resolved(
+        val sampler: ((panel: PanelRegion, splitHorizontally: Boolean) -> FloatArray)?,
+    ) : EnergySamplerState
+}
+
+/**
+ * True when effectivePanels must withhold its result because the SMART_SPLIT seam decode is
+ * still in flight AND at least one panel on the page would actually be split. Emitting an
+ * interim centre-split would render the page and then visibly re-split (a focus jump) when
+ * the real seam arrives; holding keeps the screen in its loading state until the seam is known.
+ */
+internal fun shouldHoldForSmartSeam(
+    overflow: PanelOverflowBehavior,
+    samplerPending: Boolean,
+    pagePanels: PagePanels,
+    viewportW: Int,
+    viewportH: Int,
+): Boolean = overflow == PanelOverflowBehavior.SMART_SPLIT && samplerPending &&
+    pagePanels.panels.any {
+        PanelOverflowTransform.isOverflowing(
+            it, pagePanels.imageWidth, pagePanels.imageHeight, viewportW, viewportH,
+        )
+    }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/CbzPageContentTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/CbzPageContentTest.kt
@@ -14,11 +14,27 @@ import org.junit.Test
 class CbzPageContentTest {
 
     @Test fun `null bitmap while decoding renders the loading indicator, not a blank page`() {
-        assertEquals(CbzPageContent.Loading, cbzPageContent(null, decodeSettled = false))
+        assertEquals(CbzPageContent.Loading, cbzPageContent(hasBitmap = false, decodeSettled = false))
     }
 
     @Test fun `null bitmap after the decode settled renders an error, not an infinite spinner`() {
-        assertEquals(CbzPageContent.Error, cbzPageContent(null, decodeSettled = true))
+        assertEquals(CbzPageContent.Error, cbzPageContent(hasBitmap = false, decodeSettled = true))
+    }
+
+    @Test fun `decoded bitmap with panels still resolving renders loading, never the unpositioned image`() {
+        // Rendering the bitmap before panel detection lands would show it at Identity and then
+        // jump to the panel transform — the spurious pan. The gate must hold on Loading.
+        assertEquals(
+            CbzPageContent.Loading,
+            cbzPageContent(hasBitmap = true, decodeSettled = true, panelsReady = false),
+        )
+    }
+
+    @Test fun `decoded bitmap with panels ready renders the image`() {
+        assertEquals(
+            CbzPageContent.Image,
+            cbzPageContent(hasBitmap = true, decodeSettled = true, panelsReady = true),
+        )
     }
 
     // --- retry budget per source ---

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelShouldSnapTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelShouldSnapTest.kt
@@ -1,0 +1,28 @@
+package com.riffle.app.feature.reader.cbz
+
+import com.riffle.core.domain.comic.panel.PanelFitTransform
+import com.riffle.core.domain.comic.panel.PanelRegion
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the viewport half of the "spurious pan" contract in CbzPanelViewer: while the viewport
+ * is unmeasured, PanelFitTransform must return Identity so the Animatables (re-keyed on
+ * viewport size) initialize to a neutral transform and never interpolate from garbage.
+ * The overflow-split half of the bug (a full-page splash panel being sliced into
+ * pan-only segments) is pinned in PanelOverflowTransformTest.
+ */
+class PanelShouldSnapTest {
+
+    @Test
+    fun zero_viewport_produces_identity_transform() {
+        val t = PanelFitTransform.compute(
+            viewportWidth = 0,
+            viewportHeight = 0,
+            imageWidth = 1080,
+            imageHeight = 1920,
+            panel = PanelRegion(100, 100, 800, 1000),
+        )
+        assertEquals(PanelFitTransform.Identity, t)
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/SmartSeamHoldTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/SmartSeamHoldTest.kt
@@ -1,0 +1,71 @@
+package com.riffle.app.feature.reader.cbz
+
+import com.riffle.core.domain.comic.PanelOverflowBehavior
+import com.riffle.core.domain.comic.panel.PagePanels
+import com.riffle.core.domain.comic.panel.PanelRegion
+import com.riffle.core.domain.comic.panel.PanelSource
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [shouldHoldForSmartSeam]: while the SMART_SPLIT seam decode is in flight, effectivePanels
+ * must withhold its result for pages that would actually split — otherwise the screen renders an
+ * interim centre-split and visibly re-splits (a focus jump) when the real seam arrives.
+ */
+class SmartSeamHoldTest {
+
+    private val vpW = 1080
+    private val vpH = 1920
+
+    // Full-width banner on a 1080×1500 page — genuinely splittable in portrait.
+    private val splittablePage = PagePanels(
+        pageIndex = 0,
+        imageWidth = 1080,
+        imageHeight = 1500,
+        panels = listOf(PanelRegion(0, 0, 1080, 300)),
+        source = PanelSource.Auto,
+    )
+
+    // Normal half-width panel — nothing on the page would split.
+    private val unsplittablePage = splittablePage.copy(
+        panels = listOf(PanelRegion(0, 300, 540, 600)),
+    )
+
+    @Test
+    fun holds_when_smart_split_pending_and_page_would_split() {
+        assertTrue(
+            shouldHoldForSmartSeam(
+                PanelOverflowBehavior.SMART_SPLIT, samplerPending = true, splittablePage, vpW, vpH,
+            ),
+        )
+    }
+
+    @Test
+    fun does_not_hold_once_sampler_resolved() {
+        assertFalse(
+            shouldHoldForSmartSeam(
+                PanelOverflowBehavior.SMART_SPLIT, samplerPending = false, splittablePage, vpW, vpH,
+            ),
+        )
+    }
+
+    @Test
+    fun does_not_hold_for_plain_split() {
+        // SPLIT never uses the sampler; waiting for it would be a pointless delay.
+        assertFalse(
+            shouldHoldForSmartSeam(
+                PanelOverflowBehavior.SPLIT, samplerPending = true, splittablePage, vpW, vpH,
+            ),
+        )
+    }
+
+    @Test
+    fun does_not_hold_when_nothing_on_the_page_would_split() {
+        assertFalse(
+            shouldHoldForSmartSeam(
+                PanelOverflowBehavior.SMART_SPLIT, samplerPending = true, unsplittablePage, vpW, vpH,
+            ),
+        )
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/StalePageDecodeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/StalePageDecodeTest.kt
@@ -1,0 +1,37 @@
+package com.riffle.app.feature.reader.cbz
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the stale-bitmap gate in CbzPanelViewer. produceState keeps its last value while the
+ * restarted producer decodes the new page, so right after a page change the state still holds
+ * the PREVIOUS page's bitmap while the new page's panels may already be resolved. Rendering
+ * that pairing shows the old image through the new page's panel transform — an unnecessary
+ * zoom flash on every page change. The gate must treat any decode that doesn't belong to the
+ * current page as still-loading.
+ */
+class StalePageDecodeTest {
+
+    @Test
+    fun `decode settled for a previous page is treated as loading, never rendered`() {
+        val stale = CbzPageDecodeState(bitmap = null, settled = true, forPage = 3)
+        val gated = decodeForPage(stale, currentPage = 4)
+        assertEquals(CbzPageDecodeState(), gated)
+        // And the derived content state is Loading — not Error, not Image.
+        assertEquals(CbzPageContent.Loading, cbzPageContent(gated.bitmap, gated.settled))
+    }
+
+    @Test
+    fun `decode for the current page passes through untouched`() {
+        val fresh = CbzPageDecodeState(bitmap = null, settled = true, forPage = 4)
+        assertEquals(fresh, decodeForPage(fresh, currentPage = 4))
+    }
+
+    @Test
+    fun `initial state belongs to no page and is treated as loading`() {
+        val initial = CbzPageDecodeState()
+        val gated = decodeForPage(initial, currentPage = 0)
+        assertEquals(CbzPageContent.Loading, cbzPageContent(gated.bitmap, gated.settled))
+    }
+}

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/StalePageDecodeTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/StalePageDecodeTest.kt
@@ -19,7 +19,7 @@ class StalePageDecodeTest {
         val gated = decodeForPage(stale, currentPage = 4)
         assertEquals(CbzPageDecodeState(), gated)
         // And the derived content state is Loading — not Error, not Image.
-        assertEquals(CbzPageContent.Loading, cbzPageContent(gated.bitmap, gated.settled))
+        assertEquals(CbzPageContent.Loading, cbzPageContent(gated.bitmap != null, gated.settled))
     }
 
     @Test
@@ -32,6 +32,6 @@ class StalePageDecodeTest {
     fun `initial state belongs to no page and is treated as loading`() {
         val initial = CbzPageDecodeState()
         val gated = decodeForPage(initial, currentPage = 0)
-        assertEquals(CbzPageContent.Loading, cbzPageContent(gated.bitmap, gated.settled))
+        assertEquals(CbzPageContent.Loading, cbzPageContent(gated.bitmap != null, gated.settled))
     }
 }

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/panel/PanelOverflowTransform.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/panel/PanelOverflowTransform.kt
@@ -1,10 +1,60 @@
 package com.riffle.core.domain.comic.panel
 
 import com.riffle.core.domain.comic.PanelOverflowBehavior
+import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
 
 object PanelOverflowTransform {
+
+    /**
+     * Minimum zoom gain a half-split must achieve for a panel to be split.
+     * A true banner (wide+short in portrait) roughly doubles its zoom when halved (gain ≈ 2.0).
+     * Splitting a panel along an axis that is not its binding constraint gains nothing (≈ 1.0):
+     * the "slices" are the same fit view merely panned with black voids — the senseless pan
+     * reported on single-panel pages. 1.5 sits between the two. Note the gain is viewport
+     * dependent: a full-page splash panel splits left/right on a tall 20:9 phone (gain ≈ 1.57,
+     * each half genuinely magnified) but stays whole on a 16:9 display (gain ≈ 1.25).
+     */
+    private const val MIN_SPLIT_ZOOM_GAIN = 1.5f
+
+    /** A panel must span at least this fraction of the page along the viewport's long axis. */
+    private const val SPAN_THRESHOLD = 0.85f
+
+    /**
+     * Decides whether [panel] should be split and along which axis. Returns `true` for a
+     * horizontal (left/right) split, `false` for a vertical (top/bottom) split, or `null` when
+     * the panel should stay whole.
+     *
+     * The direction is the axis whose half-split yields the larger zoom gain — i.e. the axis
+     * that is the binding constraint of the whole-panel fit. Splitting is only worthwhile when
+     * that gain clears [MIN_SPLIT_ZOOM_GAIN]; otherwise the slices render at (nearly) the same
+     * zoom as the whole panel and the extra tap conveys nothing.
+     */
+    private fun splitHorizontallyOrNull(
+        panel: PanelRegion,
+        imageWidth: Int,
+        imageHeight: Int,
+        viewportWidth: Int,
+        viewportHeight: Int,
+    ): Boolean? {
+        if (viewportWidth <= 0 || viewportHeight <= 0 || imageWidth <= 0 || imageHeight <= 0) return null
+        val widthRatio = panel.width.toFloat() / imageWidth
+        val heightRatio = panel.height.toFloat() / imageHeight
+        val isPortrait = viewportHeight > viewportWidth
+        val isLandscape = viewportWidth > viewportHeight
+        val spansSplitAxis = (isPortrait && widthRatio >= SPAN_THRESHOLD) ||
+            (isLandscape && heightRatio >= SPAN_THRESHOLD)
+        if (!spansSplitAxis) return null
+        val fitScale = min(viewportWidth.toFloat() / imageWidth, viewportHeight.toFloat() / imageHeight)
+        val panelDisplayW = panel.width * fitScale
+        val panelDisplayH = panel.height * fitScale
+        val zoomWhole = min(viewportWidth / panelDisplayW, viewportHeight / panelDisplayH)
+        val gainHorizontal = min(viewportWidth / (panelDisplayW / 2f), viewportHeight / panelDisplayH) / zoomWhole
+        val gainVertical = min(viewportWidth / panelDisplayW, viewportHeight / (panelDisplayH / 2f)) / zoomWhole
+        if (max(gainHorizontal, gainVertical) < MIN_SPLIT_ZOOM_GAIN) return null
+        return gainHorizontal >= gainVertical
+    }
 
     fun isOverflowing(
         panel: PanelRegion,
@@ -12,27 +62,18 @@ object PanelOverflowTransform {
         imageHeight: Int,
         viewportWidth: Int,
         viewportHeight: Int,
-    ): Boolean {
-        val fitScale = min(viewportWidth.toFloat() / imageWidth, viewportHeight.toFloat() / imageHeight)
-        val panelDisplayW = panel.width * fitScale
-        val panelDisplayH = panel.height * fitScale
-        val widthRatio = panel.width.toFloat() / imageWidth
-        val heightRatio = panel.height.toFloat() / imageHeight
-        val isPortrait = viewportHeight > viewportWidth
-        val isLandscape = viewportWidth > viewportHeight
-        val isWideOverflow = isPortrait && widthRatio >= 0.85f && panelDisplayW < viewportHeight
-        val isTallOverflow = isLandscape && heightRatio >= 0.85f && panelDisplayH < viewportWidth
-        return isWideOverflow || isTallOverflow
-    }
+    ): Boolean = splitHorizontallyOrNull(panel, imageWidth, imageHeight, viewportWidth, viewportHeight) != null
 
     /**
      * Applies the overflow behavior to the panel list. For SPLIT and SMART_SPLIT, overflowing
-     * panels are divided into two halves. SMART_SPLIT uses [energySampler] to find the
-     * lowest-energy seam in the panel; falls back to dead-centre when the sampler is null.
+     * panels are divided into two halves along the axis that maximises zoom gain. SMART_SPLIT
+     * uses [energySampler] to find the lowest-energy seam in the panel; falls back to
+     * dead-centre when the sampler is null.
      *
-     * @param energySampler Returns a FloatArray of energies along the split axis (columns for
-     * wide panels, rows for tall panels). Length may differ from the panel's pixel dimension —
-     * the split position is derived by normalising the index back to panel pixel space.
+     * @param energySampler Returns a FloatArray of energies along the requested split axis
+     * (columns when `splitHorizontally` is true, rows otherwise). Length may differ from the
+     * panel's pixel dimension — the split position is derived by normalising the index back to
+     * panel pixel space.
      */
     fun applyOverflow(
         panels: List<PanelRegion>,
@@ -41,21 +82,17 @@ object PanelOverflowTransform {
         viewportWidth: Int,
         viewportHeight: Int,
         behavior: PanelOverflowBehavior,
-        energySampler: ((PanelRegion) -> FloatArray)? = null,
+        energySampler: ((panel: PanelRegion, splitHorizontally: Boolean) -> FloatArray)? = null,
     ): List<PanelRegion> {
         if (behavior == PanelOverflowBehavior.OFF) return panels
         return panels.flatMap { panel ->
-            if (isOverflowing(panel, imageWidth, imageHeight, viewportWidth, viewportHeight)) {
-                val widthRatio = panel.width.toFloat() / imageWidth
-                val heightRatio = panel.height.toFloat() / imageHeight
-                val isWide = widthRatio >= heightRatio
-                if (behavior == PanelOverflowBehavior.SMART_SPLIT && energySampler != null) {
-                    panel.splitAtSmartSeam(energySampler(panel), isWide)
-                } else {
-                    panel.splitAtCenter(isWide)
-                }
-            } else {
-                listOf(panel)
+            val splitHorizontally =
+                splitHorizontallyOrNull(panel, imageWidth, imageHeight, viewportWidth, viewportHeight)
+            when {
+                splitHorizontally == null -> listOf(panel)
+                behavior == PanelOverflowBehavior.SMART_SPLIT && energySampler != null ->
+                    panel.splitAtSmartSeam(energySampler(panel, splitHorizontally), splitHorizontally)
+                else -> panel.splitAtCenter(splitHorizontally)
             }
         }
     }

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/panel/PanelOverflowTransform.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/panel/PanelOverflowTransform.kt
@@ -46,12 +46,15 @@ object PanelOverflowTransform {
         val spansSplitAxis = (isPortrait && widthRatio >= SPAN_THRESHOLD) ||
             (isLandscape && heightRatio >= SPAN_THRESHOLD)
         if (!spansSplitAxis) return null
-        val fitScale = min(viewportWidth.toFloat() / imageWidth, viewportHeight.toFloat() / imageHeight)
-        val panelDisplayW = panel.width * fitScale
-        val panelDisplayH = panel.height * fitScale
-        val zoomWhole = min(viewportWidth / panelDisplayW, viewportHeight / panelDisplayH)
-        val gainHorizontal = min(viewportWidth / (panelDisplayW / 2f), viewportHeight / panelDisplayH) / zoomWhole
-        val gainVertical = min(viewportWidth / panelDisplayW, viewportHeight / (panelDisplayH / 2f)) / zoomWhole
+        // Measure the gain with the SAME function the renderer uses for the camera, so the
+        // split decision can never drift from the zoom the split actually delivers.
+        fun zoomFor(p: PanelRegion) =
+            PanelFitTransform.compute(viewportWidth, viewportHeight, imageWidth, imageHeight, p).scale
+        val zoomWhole = zoomFor(panel)
+        val gainHorizontal =
+            zoomFor(panel.copy(width = (panel.width / 2).coerceAtLeast(1))) / zoomWhole
+        val gainVertical =
+            zoomFor(panel.copy(height = (panel.height / 2).coerceAtLeast(1))) / zoomWhole
         if (max(gainHorizontal, gainVertical) < MIN_SPLIT_ZOOM_GAIN) return null
         return gainHorizontal >= gainVertical
     }

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/comic/panel/PanelOverflowTransformTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/comic/panel/PanelOverflowTransformTest.kt
@@ -119,7 +119,7 @@ class PanelOverflowTransformTest {
         // Synthetic sampler returns zero energy at index 400 out of 1080,
         // which is in the middle third [360, 720). Split must land at x=400.
         val targetCol = 400
-        val sampler: (PanelRegion) -> FloatArray = { panel ->
+        val sampler: (PanelRegion, Boolean) -> FloatArray = { panel, _ ->
             FloatArray(panel.width) { col -> if (col == targetCol) 0f else 1_000f }
         }
         val result = PanelOverflowTransform.applyOverflow(
@@ -139,7 +139,7 @@ class PanelOverflowTransformTest {
         // The seam finder must ignore it and pick the best seam within the middle third.
         val outsideCol = 50
         val insideCol = 500  // inside middle third, second lowest energy
-        val sampler: (PanelRegion) -> FloatArray = { panel ->
+        val sampler: (PanelRegion, Boolean) -> FloatArray = { panel, _ ->
             FloatArray(panel.width) { col ->
                 when (col) {
                     outsideCol -> 0f       // lowest energy overall, but outside middle third
@@ -162,6 +162,107 @@ class PanelOverflowTransformTest {
         val result = PanelOverflowTransform.applyOverflow(panels, imgW, imgH, vpW, vpH, PanelOverflowBehavior.SPLIT)
         // widePanelBanner splits into 2, normalPanel stays as 1 → total 3
         assertEquals(3, result.size)
+    }
+
+    // --- Splash-page regression (never split without real zoom gain) ---
+    //
+    // A full-page splash panel must never be split top/bottom: both slices stay width-bound at
+    // the same zoom as the whole panel, so the "split" is the same fit view merely panned
+    // vertically with black voids — the senseless pan reported on single-panel pages. Whether
+    // it splits LEFT/RIGHT depends on the viewport: on a tall 20:9 phone each half genuinely
+    // magnifies (gain ≈ 1.57 ≥ 1.5), on a 16:9 display it doesn't (gain ≈ 1.25 < 1.5).
+
+    // Full-page splash: 95% width, 97% height of the image.
+    private val splashPanel = PanelRegion(x = 27, y = 22, width = 1026, height = 1455)
+
+    @Test
+    fun isOverflowingReturnsFalseForFullPageSplashPanelOn16To9Viewport() {
+        assertFalse(PanelOverflowTransform.isOverflowing(splashPanel, imgW, imgH, vpW, vpH))
+    }
+
+    @Test
+    fun applyOverflowLeavesFullPageSplashPanelUnsplitOn16To9Viewport() {
+        val split = PanelOverflowTransform.applyOverflow(
+            listOf(splashPanel), imgW, imgH, vpW, vpH, PanelOverflowBehavior.SPLIT,
+        )
+        assertEquals(listOf(splashPanel), split)
+        val smart = PanelOverflowTransform.applyOverflow(
+            listOf(splashPanel), imgW, imgH, vpW, vpH, PanelOverflowBehavior.SMART_SPLIT,
+            energySampler = { panel, _ -> FloatArray(panel.width) { 1f } },
+        )
+        assertEquals(listOf(splashPanel), smart)
+    }
+
+    @Test
+    fun isOverflowingReturnsTrueForFullPageSplashPanelOnTall20To9Viewport() {
+        // vp 1080×2400: whole-panel zoom = 1080/1026 ≈ 1.05 (width-bound); left/right half
+        // zoom = 2400/1455 ≈ 1.65 → gain ≈ 1.57 ≥ 1.5 → splitting genuinely magnifies.
+        assertTrue(PanelOverflowTransform.isOverflowing(splashPanel, imgW, imgH, 1080, 2400))
+    }
+
+    @Test
+    fun applyOverflowSplitsSplashPanelLeftRightOnTall20To9Viewport() {
+        // The split direction must be the max-gain axis (horizontal), never top/bottom —
+        // a top/bottom split of a splash panel has zero zoom gain (the senseless pan).
+        val result = PanelOverflowTransform.applyOverflow(
+            listOf(splashPanel), imgW, imgH, 1080, 2400, PanelOverflowBehavior.SPLIT,
+        )
+        assertEquals(2, result.size)
+        val left = result[0]
+        val right = result[1]
+        assertEquals(splashPanel.x, left.x)
+        assertEquals(splashPanel.y, left.y)
+        assertEquals(513, left.width)
+        assertEquals(splashPanel.height, left.height)
+        assertEquals(splashPanel.x + 513, right.x)
+        assertEquals(splashPanel.y, right.y)
+        assertEquals(513, right.width)
+        assertEquals(splashPanel.height, right.height)
+    }
+
+    @Test
+    fun smartSplitRequestsColumnEnergiesForSplashPanelOnTallViewport() {
+        // The sampler must be asked for the transform's max-gain axis (columns for a
+        // horizontal split), not the panel's own aspect (which would pick rows here).
+        var requestedHorizontal: Boolean? = null
+        val result = PanelOverflowTransform.applyOverflow(
+            listOf(splashPanel), imgW, imgH, 1080, 2400, PanelOverflowBehavior.SMART_SPLIT,
+            energySampler = { panel, splitHorizontally ->
+                requestedHorizontal = splitHorizontally
+                FloatArray(panel.width) { 1f }
+            },
+        )
+        assertEquals(true, requestedHorizontal)
+        assertEquals(2, result.size)
+        // Uniform energies → seam at the middle-third minimum scan start… whichever index wins,
+        // both halves must be non-empty vertical slices of the full panel height.
+        assertTrue(result.all { it.height == splashPanel.height })
+        assertEquals(splashPanel.width, result[0].width + result[1].width)
+    }
+
+    // --- Zoom-gain boundary (MIN_SPLIT_ZOOM_GAIN = 1.5) ---
+    //
+    // Wide panels at full image width; zoom-whole is width-bound at 1.0, and a half-split's
+    // zoom is min(2.0, vpH / panelDisplayH). Gain crosses 1.5 exactly when the displayed panel
+    // height is vpH / 1.5 = 1280: taller → gain < 1.5 (no split), shorter → gain > 1.5 (split).
+
+    @Test
+    fun isOverflowingReturnsTrueJustBelowGainBoundary() {
+        // height 1200 → half-split zoom = min(2.0, 1920/1200 = 1.6) → gain 1.6 ≥ 1.5 → split.
+        val panel = PanelRegion(x = 0, y = 0, width = 1080, height = 1200)
+        assertTrue(PanelOverflowTransform.isOverflowing(panel, imgW, imgH, vpW, vpH))
+    }
+
+    @Test
+    fun isOverflowingReturnsFalseJustAboveGainBoundary() {
+        // height 1350 → half-split zoom = min(2.0, 1920/1350 ≈ 1.42) → gain 1.42 < 1.5 → whole.
+        val panel = PanelRegion(x = 0, y = 0, width = 1080, height = 1350)
+        assertFalse(PanelOverflowTransform.isOverflowing(panel, imgW, imgH, vpW, vpH))
+    }
+
+    @Test
+    fun isOverflowingReturnsFalseForZeroViewport() {
+        assertFalse(PanelOverflowTransform.isOverflowing(widePanelBanner, imgW, imgH, 0, 0))
     }
 
     @Test


### PR DESCRIPTION
## What changed

Panel View was panning up-and-down (or showing an unnecessary zoom flash) on pages containing a single large splash panel. Four distinct root causes were fixed:

### 1. Zero-gain splits on full-page panels (`PanelOverflowTransform`)

`isOverflowing` was splitting any panel that spanned the viewport's long axis — including full-page splash panels — regardless of whether halving it produced any real zoom gain. On a 20:9 phone a vertical (top/bottom) split of a tall panel gives gain ≈ 1.0 (the slices show the same zoom level, just panned), so the viewer panned between two identical-looking views for no reason.

Fix: `splitHorizontallyOrNull` now measures both horizontal and vertical half-split gains using the renderer's own `PanelFitTransform.compute` formula, picks the axis with the higher gain, and suppresses the split entirely when the best gain is below `MIN_SPLIT_ZOOM_GAIN = 1.5f`. A genuine horizontal banner (gain ≈ 2.0) still splits; a left/right split on a 20:9 splash page (gain ≈ 1.57) splits correctly; a 16:9 splash page (gain ≈ 1.25) stays whole.

### 2. Stale bitmap rendered through the new page's panel transform (`CbzReaderScreen`)

`produceState` keeps its last value while the restarted producer decodes the new page. After a page turn, the state still held the previous page's bitmap while the new page's panels were already resolved — so the old image was briefly rendered at the new panel's zoom/translation, causing a flash.

Fix: `CbzPageDecodeState` now carries a `forPage: Int` field. `decodeForPage(decode, currentPage)` returns an empty (loading) state whenever `forPage` doesn't match. `CbzPanelViewer` also resets the state to empty at producer start so the stale reference is dropped as early as possible. The unified `cbzPageContent` helper adds a `panelsReady` parameter — `Loading` is returned until panels arrive, preventing the identity-transform flash.

### 3. Seam-hold state machine hardening (`CbzReaderViewModel`)

The `EnergySamplerState` sealed interface (`Pending` / `Resolved`) replaces the nullable sampler `StateFlow`. The `effectivePanels` combine now holds `null` while the SMART_SPLIT seam decode is in flight for a page that would actually split, preventing panel navigation during decode. A separate `panelLandingJob` prevents the cross-page backward navigation path from silently overwriting the active seam-resolve job. `nextPanel`/`previousPanel` swallow taps during hold. Pixel scanning runs on `Dispatchers.Default`.

### 4. Code-review hardening (review findings commit)

`failedDetectionFallback()` ensures the viewer doesn't spin forever when `resolvePage` throws. Post-decode page guard prevents a slow decode from landing on the wrong page's seam state. `computeEnergySampler` returns `Pair<sampler, bitmap>?` so the caller owns bitmap lifetime.

## Tests added

- `PanelOverflowTransformTest` — splash panel no-split (16:9), correct left/right split (20:9), zoom-gain boundary (height 1200 splits / 1350 doesn't), sampler-axis confirmation
- `SmartSeamHoldTest` — 4 tests for `shouldHoldForSmartSeam`
- `StalePageDecodeTest` — 3 tests for the `decodeForPage` gate
- `CbzPageContentTest` — `panelsReady=false` → Loading, `panelsReady=true` → Image

## Verification

Smoke-tested on AVD (Harness_Medium_Phone, API 25) against a Komga comic with 36 pages:
- Cover splash page splits correctly left/right (no top/bottom pan)
- Page turn shows spinner (no stale bitmap flash)
- Backward cross-page lands on the correct slice