### PR TITLE
ci: add platform prefixes to check names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build:
-    name: Build
+    name: Android build
     runs-on: ubuntu-latest
     timeout-minutes: 12
     steps:
@@ -36,7 +36,7 @@ jobs:
       - run: ./gradlew assembleDebug
 
   lint:
-    name: Lint
+    name: Android lint
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -112,7 +112,7 @@ jobs:
           if-no-files-found: ignore
 
   integration-test:
-    name: Integration Tests
+    name: Android integration tests
     runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
@@ -147,7 +147,7 @@ jobs:
   # Instrumented Room tests (migrations + DAOs) need an emulator, so they run here on a
   # hardware-accelerated AVD rather than in the JVM jobs above.
   connected-test:
-    name: Database tests (core:database)
+    name: Android database tests (core:database)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -298,7 +298,7 @@ jobs:
           if-no-files-found: ignore
 
   ios-framework:
-    name: iOS framework build
+    name: iOS build
     runs-on: macos-15
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Renames platform-specific CI jobs so every check name carries an explicit Android or iOS prefix, making it immediately clear which platform a failing check belongs to.

| Before | After |
|---|---|
| Build | Android build |
| Lint | Android lint |
| Integration Tests | Android integration tests |
| Database tests (core:database) | Android database tests (core:database) |
| iOS framework build | iOS build |

`Unit Tests` is left unprefixed — it runs `test jvmTest` which covers both JVM and KMP targets and is genuinely cross-platform.