### PR TITLE
fix(panel-detection): re-enable report button when issue type changes after submit

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportSheet.kt
@@ -346,7 +346,7 @@ internal fun PanelReportSheet(
 
             Button(
                 onClick = onSubmit,
-                enabled = !state.submitting && state.submittedIssueUrl == null,
+                enabled = !state.submitting && (state.submittedIssueUrl == null || state.failureType != state.submittedForFailureType),
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 if (state.submitting) CircularProgressIndicator(modifier = Modifier.size(16.dp))

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModel.kt
@@ -25,6 +25,7 @@ data class PanelReportUiState(
     val orderedPanelIndices: List<Int> = emptyList(),
     val submitting: Boolean = false,
     val submittedIssueUrl: String? = null,
+    val submittedForFailureType: PanelDetectionFailureType? = null,
     val error: String? = null,
 )
 
@@ -46,7 +47,6 @@ class PanelReportViewModel(
         _state.update { it.copy(
             failureType = type,
             error = null,
-            submittedIssueUrl = null,
             tappedX = null,
             tappedY = null,
             tappedPanelIndex = null,
@@ -135,7 +135,7 @@ class PanelReportViewModel(
                 expectedPanelOrder = s.orderedPanelIndices.takeIf { it.isNotEmpty() },
             )
             repository.submit(report, maskPng).fold(
-                onSuccess = { url -> _state.update { it.copy(submitting = false, submittedIssueUrl = url) } },
+                onSuccess = { url -> _state.update { it.copy(submitting = false, submittedIssueUrl = url, submittedForFailureType = ft) } },
                 onFailure = { e -> _state.update { it.copy(submitting = false, error = e.message ?: "Unknown error") } },
             )
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModel.kt
@@ -46,6 +46,7 @@ class PanelReportViewModel(
         _state.update { it.copy(
             failureType = type,
             error = null,
+            submittedIssueUrl = null,
             tappedX = null,
             tappedY = null,
             tappedPanelIndex = null,

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModelTest.kt
@@ -223,6 +223,27 @@ class PanelReportViewModelTest {
     }
 
     @Test
+    fun `setFailureType clears submittedIssueUrl so report button is re-enabled`() = runTest {
+        var submitted = false
+        val repo = object : PanelReportRepository {
+            override suspend fun submit(report: PanelDetectionReport, maskPng: ByteArray): Result<String> {
+                submitted = true
+                return Result.success("https://github.com/pkmetski/riffle/issues/1")
+            }
+        }
+        val vm = makeVm(repository = repo)
+        vm.setFailureType(PanelDetectionFailureType.MissedPanel)
+        vm.submit(maskPng = ByteArray(0))
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(submitted)
+        assertEquals("https://github.com/pkmetski/riffle/issues/1", vm.state.value.submittedIssueUrl)
+
+        // Changing the issue type should allow a new report to be submitted
+        vm.setFailureType(PanelDetectionFailureType.FalsePanel)
+        assertNull(vm.state.value.submittedIssueUrl)
+    }
+
+    @Test
     fun `setFailureType clears tap state`() = runTest {
         val region = PanelRegion(x = 0, y = 0, width = 200, height = 200)
         val vm = makeVm(panels = listOf(region))

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModelTest.kt
@@ -223,24 +223,24 @@ class PanelReportViewModelTest {
     }
 
     @Test
-    fun `setFailureType clears submittedIssueUrl so report button is re-enabled`() = runTest {
-        var submitted = false
+    fun `setFailureType after submit keeps issue URL visible but marks it as for a different type`() = runTest {
         val repo = object : PanelReportRepository {
-            override suspend fun submit(report: PanelDetectionReport, maskPng: ByteArray): Result<String> {
-                submitted = true
-                return Result.success("https://github.com/pkmetski/riffle/issues/1")
-            }
+            override suspend fun submit(report: PanelDetectionReport, maskPng: ByteArray): Result<String> =
+                Result.success("https://github.com/pkmetski/riffle/issues/1")
         }
         val vm = makeVm(repository = repo)
         vm.setFailureType(PanelDetectionFailureType.MissedPanel)
         vm.submit(maskPng = ByteArray(0))
         testDispatcher.scheduler.advanceUntilIdle()
-        assertTrue(submitted)
         assertEquals("https://github.com/pkmetski/riffle/issues/1", vm.state.value.submittedIssueUrl)
+        assertEquals(PanelDetectionFailureType.MissedPanel, vm.state.value.submittedForFailureType)
 
-        // Changing the issue type should allow a new report to be submitted
+        // Changing the issue type re-enables the button (failureType != submittedForFailureType)
+        // but keeps the URL visible for feedback
         vm.setFailureType(PanelDetectionFailureType.FalsePanel)
-        assertNull(vm.state.value.submittedIssueUrl)
+        assertEquals("https://github.com/pkmetski/riffle/issues/1", vm.state.value.submittedIssueUrl)
+        assertEquals(PanelDetectionFailureType.FalsePanel, vm.state.value.failureType)
+        assertEquals(PanelDetectionFailureType.MissedPanel, vm.state.value.submittedForFailureType)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- After successfully submitting a panel detection report, selecting a different issue type from the dropdown now re-enables the Submit button, allowing the user to report a second issue on the same page.

## Root cause

`setFailureType()` reset all interaction state (tap position, drawn panels/boundaries, ordered indices) but left `submittedIssueUrl` intact. The Submit button's `enabled` condition is `!submitting && submittedIssueUrl == null`, so it stayed permanently disabled after any successful report.

## Fix

Clear `submittedIssueUrl` inside `setFailureType()` alongside the rest of the interaction state.

## Tests

Added `setFailureType clears submittedIssueUrl so report button is re-enabled` to `PanelReportViewModelTest` — asserts that `submittedIssueUrl` is null after changing issue type post-submit (would fail red if the fix were reverted).