### PR TITLE
feat(panel-report): support marking multiple false panels in issue view

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -349,6 +349,7 @@ fun CbzReaderScreen(
     if (reportSheetOpen && data != null) {
         val (mask, maskPng) = data
         val selectFailureTypeMessage = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.error_select_failure_type)
+        val markFalsePanelMessage = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.error_mark_false_panel)
         val maskBitmap = remember(mask) {
             val pixels = PanelMaskEncoder.toArgbPixels(mask)
             android.graphics.Bitmap.createBitmap(pixels, mask.width, mask.height, android.graphics.Bitmap.Config.ARGB_8888)
@@ -371,6 +372,7 @@ fun CbzReaderScreen(
                 detectedSource = rawPanels?.source ?: PanelSource.Fallback,
                 repository = viewModel.panelReportRepository,
                 selectFailureTypeMessage = selectFailureTypeMessage,
+                markFalsePanelMessage = markFalsePanelMessage,
             )
         }
         PanelReportSheet(

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportSheet.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportSheet.kt
@@ -71,6 +71,7 @@ internal fun PanelReportSheet(
         cutOffMode
     val drawsRectangle = drawsRectangle(state.failureType)
     val orderMode = state.failureType == PanelDetectionFailureType.WrongPanelOrder
+    val falsePanelMode = state.failureType == PanelDetectionFailureType.FalsePanel
 
     ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
         Column(
@@ -154,6 +155,11 @@ internal fun PanelReportSheet(
                     style = androidx.compose.material3.MaterialTheme.typography.bodySmall,
                 )
             }
+            if (falsePanelMode) {
+                Text("Tap to mark or unmark panels as false detections",
+                    style = androidx.compose.material3.MaterialTheme.typography.bodySmall,
+                )
+            }
 
             Box(
                 modifier = Modifier
@@ -161,7 +167,7 @@ internal fun PanelReportSheet(
                     .aspectRatio(mask.width.toFloat() / mask.height.toFloat())
                     .border(1.dp, Color.Gray)
                     .onSizeChanged { canvasSize = it }
-                    .pointerInput(cutOffMode, drawMode, orderMode, state.failureType, canvasSize) {
+                    .pointerInput(cutOffMode, drawMode, orderMode, falsePanelMode, state.failureType, canvasSize) {
                         when {
                             cutOffMode -> awaitEachGesture {
                                 val down = awaitFirstDown(requireUnconsumed = false)
@@ -226,10 +232,10 @@ internal fun PanelReportSheet(
                                 if (scaleX > 0f && scaleY > 0f) {
                                     val ix = (offset.x / scaleX).toInt().coerceIn(0, mask.width - 1)
                                     val iy = (offset.y / scaleY).toInt().coerceIn(0, mask.height - 1)
-                                    if (orderMode) {
-                                        viewModel.tapForOrder(ix, iy)
-                                    } else {
-                                        viewModel.onTap(tappedImageX = ix, tappedImageY = iy)
+                                    when {
+                                        orderMode -> viewModel.tapForOrder(ix, iy)
+                                        falsePanelMode -> viewModel.toggleFalsePanel(ix, iy)
+                                        else -> viewModel.onTap(tappedImageX = ix, tappedImageY = iy)
                                     }
                                 }
                             }
@@ -246,7 +252,7 @@ internal fun PanelReportSheet(
                     viewModel.detectedPanels.forEachIndexed { i, p ->
                         val orderPos = orderedIndexMap[i]
                         val isOrdered = orderPos != null
-                        val selected = state.tappedPanelIndex == i
+                        val selected = if (falsePanelMode) i in state.falsePanelIndices else state.tappedPanelIndex == i
                         drawPanelReportOutline(
                             topLeft = Offset(p.x * scaleX, p.y * scaleY),
                             size = Size(p.width * scaleX, p.height * scaleY),

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModel.kt
@@ -39,6 +39,7 @@ class PanelReportViewModel(
     val detectedSource: PanelSource,
     private val repository: PanelReportRepository,
     private val selectFailureTypeMessage: String,
+    private val markFalsePanelMessage: String,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(PanelReportUiState())
@@ -127,6 +128,10 @@ class PanelReportViewModel(
         val ft = _state.value.failureType
         if (ft == null) {
             _state.update { it.copy(error = selectFailureTypeMessage) }
+            return
+        }
+        if (ft == PanelDetectionFailureType.FalsePanel && _state.value.falsePanelIndices.isEmpty()) {
+            _state.update { it.copy(error = markFalsePanelMessage) }
             return
         }
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModel.kt
@@ -23,6 +23,7 @@ data class PanelReportUiState(
     val drawnPanels: List<PanelRegion> = emptyList(),
     val drawnBoundaries: List<PanelBoundaryLine> = emptyList(),
     val orderedPanelIndices: List<Int> = emptyList(),
+    val falsePanelIndices: Set<Int> = emptySet(),
     val submitting: Boolean = false,
     val submittedIssueUrl: String? = null,
     val submittedForFailureType: PanelDetectionFailureType? = null,
@@ -53,6 +54,7 @@ class PanelReportViewModel(
             drawnPanels = emptyList(),
             drawnBoundaries = emptyList(),
             orderedPanelIndices = emptyList(),
+            falsePanelIndices = emptySet(),
         ) }
     }
 
@@ -76,6 +78,18 @@ class PanelReportViewModel(
     fun tapForOrder(ix: Int, iy: Int) {
         val panelIndex = panelIndexAt(ix, iy)
         if (panelIndex >= 0) addOrRemoveOrderedPanel(panelIndex)
+    }
+
+    fun toggleFalsePanel(ix: Int, iy: Int) {
+        val panelIndex = panelIndexAt(ix, iy)
+        if (panelIndex < 0) return
+        _state.update { s ->
+            val updated = if (panelIndex in s.falsePanelIndices)
+                s.falsePanelIndices - panelIndex
+            else
+                s.falsePanelIndices + panelIndex
+            s.copy(falsePanelIndices = updated)
+        }
     }
 
     private fun panelIndexAt(x: Int, y: Int): Int =
@@ -133,6 +147,7 @@ class PanelReportViewModel(
                 drawnPanels = s.drawnPanels,
                 drawnBoundaries = s.drawnBoundaries,
                 expectedPanelOrder = s.orderedPanelIndices.takeIf { it.isNotEmpty() },
+                falsePanelIndices = s.falsePanelIndices.sorted().takeIf { it.isNotEmpty() },
             )
             repository.submit(report, maskPng).fold(
                 onSuccess = { url -> _state.update { it.copy(submitting = false, submittedIssueUrl = url, submittedForFailureType = ft) } },

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -360,6 +360,7 @@
     <string name="error_connected_library_load_failed">Свързано, но библиотеките не можаха да се заредят: %1$s</string>
     <string name="error_comic_page_load_failed">Тази страница не можа да се зареди</string>
     <string name="error_select_failure_type">Изберете тип проблем преди изпращане</string>
+    <string name="error_mark_false_panel">Маркирайте поне един фалшив панел преди изпращане</string>
     <string name="crash_report_title">Доклад за срив</string>
     <string name="crash_report_text">Riffle се срина. Отворете Настройки → Доклади за сривове, за да видите или споделите подробностите.</string>
     <string name="ui_seconds_short">%1$d сек</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -360,6 +360,7 @@
     <string name="error_connected_library_load_failed">Conectado, pero no se pudieron cargar las bibliotecas: %1$s</string>
     <string name="error_comic_page_load_failed">No se pudo cargar esta página</string>
     <string name="error_select_failure_type">Selecciona un tipo de problema antes de enviar</string>
+    <string name="error_mark_false_panel">Marca al menos un panel falso antes de enviar</string>
     <string name="crash_report_title">Informe de fallo</string>
     <string name="crash_report_text">Riffle falló. Abre Ajustes → Informes de fallos para ver o compartir los detalles.</string>
     <string name="ui_seconds_short">%1$d s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -363,6 +363,7 @@
     <string name="error_connected_library_load_failed">Connected, but couldn\'t load libraries: %1$s</string>
     <string name="error_comic_page_load_failed">Couldn\'t load this page</string>
     <string name="error_select_failure_type">Select a failure type before submitting</string>
+    <string name="error_mark_false_panel">Mark at least one panel as false before submitting</string>
     <string name="crash_report_title">Crash report</string>
     <string name="crash_report_text">Riffle crashed. Open Settings → Crash reports to view or share the details.</string>
     <string name="ui_seconds_short">%1$ds</string>

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModelTest.kt
@@ -244,6 +244,70 @@ class PanelReportViewModelTest {
     }
 
     @Test
+    fun `toggleFalsePanel adds panel index to falsePanelIndices`() = runTest {
+        val panels = listOf(
+            PanelRegion(x = 0, y = 0, width = 100, height = 100),
+            PanelRegion(x = 100, y = 0, width = 100, height = 100),
+        )
+        val vm = makeVm(panels = panels)
+        vm.setFailureType(PanelDetectionFailureType.FalsePanel)
+        vm.toggleFalsePanel(ix = 50, iy = 50)   // inside panel 0
+        vm.toggleFalsePanel(ix = 150, iy = 50)  // inside panel 1
+        assertEquals(setOf(0, 1), vm.state.value.falsePanelIndices)
+    }
+
+    @Test
+    fun `toggleFalsePanel removes panel when already selected`() = runTest {
+        val panels = listOf(PanelRegion(x = 0, y = 0, width = 100, height = 100))
+        val vm = makeVm(panels = panels)
+        vm.setFailureType(PanelDetectionFailureType.FalsePanel)
+        vm.toggleFalsePanel(ix = 50, iy = 50)
+        vm.toggleFalsePanel(ix = 50, iy = 50)
+        assertTrue(vm.state.value.falsePanelIndices.isEmpty())
+    }
+
+    @Test
+    fun `toggleFalsePanel outside all panels does nothing`() = runTest {
+        val panels = listOf(PanelRegion(x = 0, y = 0, width = 100, height = 100))
+        val vm = makeVm(panels = panels)
+        vm.setFailureType(PanelDetectionFailureType.FalsePanel)
+        vm.toggleFalsePanel(ix = 500, iy = 500)
+        assertTrue(vm.state.value.falsePanelIndices.isEmpty())
+    }
+
+    @Test
+    fun `setFailureType clears falsePanelIndices`() = runTest {
+        val panels = listOf(PanelRegion(x = 0, y = 0, width = 100, height = 100))
+        val vm = makeVm(panels = panels)
+        vm.setFailureType(PanelDetectionFailureType.FalsePanel)
+        vm.toggleFalsePanel(ix = 50, iy = 50)
+        vm.setFailureType(PanelDetectionFailureType.MissedPanel)
+        assertTrue(vm.state.value.falsePanelIndices.isEmpty())
+    }
+
+    @Test
+    fun `submit passes falsePanelIndices to report`() = runTest {
+        var capturedReport: PanelDetectionReport? = null
+        val repo = object : PanelReportRepository {
+            override suspend fun submit(report: PanelDetectionReport, maskPng: ByteArray): Result<String> {
+                capturedReport = report
+                return Result.success("https://github.com/pkmetski/riffle/issues/1")
+            }
+        }
+        val panels = listOf(
+            PanelRegion(x = 0, y = 0, width = 100, height = 100),
+            PanelRegion(x = 100, y = 0, width = 100, height = 100),
+        )
+        val vm = makeVm(panels = panels, repository = repo)
+        vm.setFailureType(PanelDetectionFailureType.FalsePanel)
+        vm.toggleFalsePanel(ix = 50, iy = 50)   // panel 0
+        vm.toggleFalsePanel(ix = 150, iy = 50)  // panel 1
+        vm.submit(maskPng = ByteArray(0))
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(listOf(0, 1), capturedReport?.falsePanelIndices)
+    }
+
+    @Test
     fun `setFailureType clears tap state`() = runTest {
         val region = PanelRegion(x = 0, y = 0, width = 200, height = 200)
         val vm = makeVm(panels = listOf(region))

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/cbz/PanelReportViewModelTest.kt
@@ -321,6 +321,23 @@ class PanelReportViewModelTest {
     }
 
     @Test
+    fun `submit FalsePanel with no panels marked shows error`() = runTest {
+        var submitted = false
+        val repo = object : PanelReportRepository {
+            override suspend fun submit(report: PanelDetectionReport, maskPng: ByteArray): Result<String> {
+                submitted = true
+                return Result.success("https://github.com/pkmetski/riffle/issues/1")
+            }
+        }
+        val vm = makeVm(repository = repo)
+        vm.setFailureType(PanelDetectionFailureType.FalsePanel)
+        vm.submit(maskPng = ByteArray(0))
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertFalse(submitted)
+        assertEquals("Mark at least one panel as false before submitting", vm.state.value.error)
+    }
+
+    @Test
     fun `submit requires failure type`() = runTest {
         val vm = makeVm()
         vm.submit(maskPng = ByteArray(0))
@@ -344,5 +361,6 @@ class PanelReportViewModelTest {
         detectedSource = PanelSource.Auto,
         repository = repository,
         selectFailureTypeMessage = "Select a failure type before submitting",
+        markFalsePanelMessage = "Mark at least one panel as false before submitting",
     )
 }

--- a/core/data/src/androidHostTest/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepositoryTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepositoryTest.kt
@@ -145,6 +145,29 @@ class GitHubPanelReportRepositoryTest {
     }
 
     @Test
+    fun `gist metadata contains false panel indices when FalsePanel report submitted`() = runTest {
+        server.enqueue(MockResponse().setBody(
+            gistResponse("https://gist.github.com/pkmetski/abc123", "https://gist.githubusercontent.com/raw/mask.b64")
+        ).setResponseCode(201))
+        server.enqueue(MockResponse().setBody("""{"html_url":"https://github.com/pkmetski/riffle/issues/99"}""").setResponseCode(201))
+
+        val reportWithFalsePanels = fakeReport.copy(
+            failureType = PanelDetectionFailureType.FalsePanel,
+            falsePanelIndices = listOf(0, 2),
+        )
+        repo().submit(reportWithFalsePanels, ByteArray(0))
+
+        val gistRequest = server.takeRequest()
+        val gistBody = Json { ignoreUnknownKeys = true }
+            .parseToJsonElement(gistRequest.body.readUtf8()).jsonObject
+        val metadata = gistBody["files"]!!.jsonObject["metadata.json"]!!
+            .jsonObject["content"]!!.jsonPrimitive.content
+        assertTrue("metadata contains falsePanelIndices", metadata.contains("falsePanelIndices"))
+        assertTrue("metadata contains panel 0", metadata.contains("0"))
+        assertTrue("metadata contains panel 2", metadata.contains("2"))
+    }
+
+    @Test
     fun `issue body contains false panel indices when FalsePanel report submitted`() = runTest {
         server.enqueue(MockResponse().setBody(
             gistResponse("https://gist.github.com/pkmetski/abc123", "https://gist.githubusercontent.com/raw/mask.b64")

--- a/core/data/src/androidHostTest/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepositoryTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepositoryTest.kt
@@ -145,6 +145,26 @@ class GitHubPanelReportRepositoryTest {
     }
 
     @Test
+    fun `issue body contains false panel indices when FalsePanel report submitted`() = runTest {
+        server.enqueue(MockResponse().setBody(
+            gistResponse("https://gist.github.com/pkmetski/abc123", "https://gist.githubusercontent.com/raw/mask.b64")
+        ).setResponseCode(201))
+        server.enqueue(MockResponse().setBody("""{"html_url":"https://github.com/pkmetski/riffle/issues/99"}""").setResponseCode(201))
+
+        val reportWithFalsePanels = fakeReport.copy(
+            failureType = PanelDetectionFailureType.FalsePanel,
+            falsePanelIndices = listOf(0, 2),
+        )
+        repo().submit(reportWithFalsePanels, ByteArray(0))
+
+        server.takeRequest() // consume gist
+        val issueRequest = server.takeRequest()
+        val parsedBody = Json { ignoreUnknownKeys = true }
+            .parseToJsonElement(issueRequest.body.readUtf8()).jsonObject["body"]?.jsonPrimitive?.content ?: ""
+        assertTrue("body contains false panel indices", parsedBody.contains("[0, 2]"))
+    }
+
+    @Test
     fun `submit returns failure when API call fails`() = runTest {
         server.enqueue(MockResponse().setResponseCode(401).setBody("""{"message":"Bad credentials"}"""))
 

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepository.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepository.kt
@@ -125,6 +125,11 @@ class GitHubPanelReportRepository(
             appendLine("**Expected panel order:** $order")
             appendLine()
         }
+        val falsePanels = report.falsePanelIndices
+        if (falsePanels != null) {
+            appendLine("**False panels:** $falsePanels")
+            appendLine()
+        }
         appendLine("**Detected panels:**")
         report.detectedPanels.forEachIndexed { i, p ->
             appendLine("- [$i] x=${p.x} y=${p.y} w=${p.width} h=${p.height}")

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepository.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/comic/panel/GitHubPanelReportRepository.kt
@@ -78,6 +78,9 @@ class GitHubPanelReportRepository(
                 report.expectedPanelOrder?.let { order ->
                     put("expectedPanelOrder", JsonArray(order.map { JsonPrimitive(it) }))
                 }
+                report.falsePanelIndices?.let { indices ->
+                    put("falsePanelIndices", JsonArray(indices.map { JsonPrimitive(it) }))
+                }
             }
         ).toString()
 

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetectionReport.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/comic/panel/PanelDetectionReport.kt
@@ -21,4 +21,5 @@ data class PanelDetectionReport(
     val drawnPanels: List<PanelRegion> = emptyList(),
     val drawnBoundaries: List<PanelBoundaryLine> = emptyList(),
     val expectedPanelOrder: List<Int>? = null,
+    val falsePanelIndices: List<Int>? = null,
 )


### PR DESCRIPTION
## Summary

- The FalsePanel issue type previously allowed selecting only a single panel. Tapping now toggles panels in/out of a multi-selection set; all selected panels are highlighted red on the canvas simultaneously.
- A new hint text ("Tap to mark or unmark panels as false detections") appears when FalsePanel is chosen.
- Submit is now guarded: selecting FalsePanel but tapping no panels shows an inline error rather than filing an empty report.
- `falsePanelIndices` is serialised in both the GitHub issue body ("**False panels:** [0, 2]") and the structured `metadata.json` gist file so automated tooling can read it without parsing prose.

## Changes

- `PanelDetectionReport` — new `falsePanelIndices: List<Int>? = null` field
- `PanelReportUiState` — new `falsePanelIndices: Set<Int>` field, cleared on failure-type change
- `PanelReportViewModel` — new `toggleFalsePanel(ix, iy)` method; submit validates the set is non-empty for FalsePanel; `markFalsePanelMessage` constructor param for the error string
- `PanelReportSheet` — FalsePanel taps route to `toggleFalsePanel`; canvas `selected` check uses `falsePanelIndices` in FalsePanel mode; hint text added
- `GitHubPanelReportRepository` — `falsePanelIndices` in issue body and `buildMetadata`

## Tests

7 new unit tests: toggle add/remove/outside-panel/clear-on-type-change/submit-populates-report/empty-submit-guard (ViewModel) + 2 repository tests (issue body and gist metadata contain the indices).