### PR TITLE
feat(ios): wire iOS Koin bindings and HomeScreen for library browsing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,6 +109,9 @@ tasks.register("checkRiffleInfraSeams") {
             // unenforced). Same sweep-follow-up rationale as the blocks above.
             // DefaultDispatcherProvider moved main → jvmMain in the core carve-out (#576).
             "core/domain/src/jvmMain/kotlin/com/riffle/core/domain/DefaultDispatcherProvider.kt",
+            // iOS DispatcherProvider implementation — maps abstract dispatcher names to platform
+            // dispatchers. This IS the seam; it's the leaf that calls Dispatchers.* directly.
+            "core/domain/src/iosMain/kotlin/com/riffle/core/domain/IosDispatcherProvider.kt",
             // Catalog adapters: network/parse work pinned to Dispatchers.IO/Default.
             "core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaCatalog.kt",
             "core/catalog-gutenberg/src/main/kotlin/com/riffle/core/catalog/gutenberg/GutenbergCatalog.kt",

--- a/buildSrc/src/main/kotlin/com/riffle/buildlogic/ServerReferenceLint.kt
+++ b/buildSrc/src/main/kotlin/com/riffle/buildlogic/ServerReferenceLint.kt
@@ -104,6 +104,9 @@ object ServerReferenceLint {
         // Resource-ID resolver for add-source copy maps ServerType → string resource per ABS variant.
         "app/src/main/kotlin/com/riffle/app/ui/source/WebSourceUi.kt",
         "app/src/main/kotlin/com/riffle/app/feature/annotations/AnnotationsListViewModel.kt",
+        // iOS SourceRepository mirrors CredentialedSourceInstaller's toDomain() and threads
+        // the same grandfathered ServerType field through. Same rationale as androidMain impl.
+        "core/data/src/iosMain/kotlin/com/riffle/core/data/IosSourceRepositoryImpl.kt",
     )
 
     data class Offender(

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -55,6 +55,7 @@ kotlin {
             implementation(libs.ktor.client.darwin)
             implementation(libs.koin.core)
             implementation(project(":core:database"))
+            implementation(project(":core:net"))
         }
         getByName("androidHostTest").dependencies {
             implementation(libs.junit)

--- a/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLastOpenedLibraryStoreImpl.kt
+++ b/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLastOpenedLibraryStoreImpl.kt
@@ -1,0 +1,25 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.LastOpenedLibraryStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import platform.Foundation.NSUserDefaults
+
+class IosLastOpenedLibraryStoreImpl : LastOpenedLibraryStore {
+    private val defaults = NSUserDefaults.standardUserDefaults
+    private val flows = mutableMapOf<String, MutableStateFlow<String?>>()
+
+    override fun lastOpenedLibrary(sourceId: String): Flow<String?> = stateFor(sourceId)
+
+    override suspend fun setLastOpenedLibrary(sourceId: String, libraryId: String) {
+        defaults.setObject(libraryId, forKey = key(sourceId))
+        stateFor(sourceId).value = libraryId
+    }
+
+    private fun stateFor(sourceId: String): MutableStateFlow<String?> =
+        flows.getOrPut(sourceId) {
+            MutableStateFlow(defaults.stringForKey(key(sourceId)))
+        }
+
+    private fun key(sourceId: String) = "last_lib:$sourceId"
+}

--- a/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLastOpenedLibraryStoreImpl.kt
+++ b/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLastOpenedLibraryStoreImpl.kt
@@ -16,6 +16,7 @@ class IosLastOpenedLibraryStoreImpl : LastOpenedLibraryStore {
         stateFor(sourceId).value = libraryId
     }
 
+    @Synchronized
     private fun stateFor(sourceId: String): MutableStateFlow<String?> =
         flows.getOrPut(sourceId) {
             MutableStateFlow(defaults.stringForKey(key(sourceId)))

--- a/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLastOpenedLibraryStoreImpl.kt
+++ b/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLastOpenedLibraryStoreImpl.kt
@@ -3,10 +3,12 @@ package com.riffle.core.data
 import com.riffle.core.domain.LastOpenedLibraryStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import platform.Foundation.NSLock
 import platform.Foundation.NSUserDefaults
 
 class IosLastOpenedLibraryStoreImpl : LastOpenedLibraryStore {
     private val defaults = NSUserDefaults.standardUserDefaults
+    private val lock = NSLock()
     private val flows = mutableMapOf<String, MutableStateFlow<String?>>()
 
     override fun lastOpenedLibrary(sourceId: String): Flow<String?> = stateFor(sourceId)
@@ -16,11 +18,16 @@ class IosLastOpenedLibraryStoreImpl : LastOpenedLibraryStore {
         stateFor(sourceId).value = libraryId
     }
 
-    @Synchronized
-    private fun stateFor(sourceId: String): MutableStateFlow<String?> =
-        flows.getOrPut(sourceId) {
-            MutableStateFlow(defaults.stringForKey(key(sourceId)))
+    private fun stateFor(sourceId: String): MutableStateFlow<String?> {
+        lock.lock()
+        try {
+            return flows.getOrPut(sourceId) {
+                MutableStateFlow(defaults.stringForKey(key(sourceId)))
+            }
+        } finally {
+            lock.unlock()
         }
+    }
 
     private fun key(sourceId: String) = "last_lib:$sourceId"
 }

--- a/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLibraryObserverImpl.kt
+++ b/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLibraryObserverImpl.kt
@@ -1,0 +1,53 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.LibraryDao
+import com.riffle.core.database.LibraryEntity
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.models.Library
+import com.riffle.core.models.LibraryItem
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+
+class IosLibraryObserverImpl(
+    private val libraryDao: LibraryDao,
+    private val sourceRepository: SourceRepository,
+) : LibraryObserver {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun observeLibraries(): Flow<List<Library>> =
+        sourceRepository.observeAll()
+            .map { sources -> sources.firstOrNull { it.isActive }?.id }
+            .distinctUntilChanged()
+            .flatMapLatest { sourceId ->
+                if (sourceId == null) flowOf(emptyList())
+                else libraryDao.observeBySourceId(sourceId).map { list -> list.map { it.toDomain() } }
+            }
+
+    override fun observeLibraries(sourceId: String): Flow<List<Library>> =
+        libraryDao.observeBySourceId(sourceId).map { list -> list.map { it.toDomain() } }
+
+    override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+    override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+    override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+    override fun observeFinishedItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+    override fun observeRecentlyAddedItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+    override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+    override fun observeSeries(libraryId: String): Flow<List<com.riffle.core.models.Series>> = flowOf(emptyList())
+    override fun observeCollections(libraryId: String): Flow<List<com.riffle.core.models.Collection>> = flowOf(emptyList())
+    override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+    override fun observeContinueSeriesItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+    override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+
+    override suspend fun getItem(itemId: String): LibraryItem? = null
+    override fun observeItem(itemId: String): Flow<LibraryItem?> = flowOf(null)
+    override suspend fun getItem(sourceId: String, itemId: String): LibraryItem? = null
+    override suspend fun getLibrary(libraryId: String): Library? = null
+    override suspend fun getSeriesIdForItem(sourceId: String, itemId: String): String? = null
+}
+
+private fun LibraryEntity.toDomain() = Library(id = id, name = name, mediaType = mediaType, isUnsupported = isUnsupported)

--- a/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLibraryObserverImpl.kt
+++ b/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLibraryObserverImpl.kt
@@ -24,8 +24,11 @@ class IosLibraryObserverImpl(
             .map { sources -> sources.firstOrNull { it.isActive }?.id }
             .distinctUntilChanged()
             .flatMapLatest { sourceId ->
-                if (sourceId == null) flowOf(emptyList())
-                else libraryDao.observeBySourceId(sourceId).map { list -> list.map { it.toDomain() } }
+                if (sourceId == null) {
+                    flowOf(emptyList())
+                } else {
+                    libraryDao.observeBySourceId(sourceId).map { list -> list.map { it.toDomain() } }
+                }
             }
 
     override fun observeLibraries(sourceId: String): Flow<List<Library>> =

--- a/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLibraryRefresherImpl.kt
+++ b/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLibraryRefresherImpl.kt
@@ -1,0 +1,52 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.LibraryDao
+import com.riffle.core.database.LibraryEntity
+import com.riffle.core.domain.LibraryRefreshResult
+import com.riffle.core.domain.LibraryRefresher
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.network.AbsLibraryApi
+import com.riffle.core.network.NetworkResult
+
+class IosLibraryRefresherImpl(
+    private val sourceRepository: SourceRepository,
+    private val tokenStorage: TokenStorage,
+    private val absLibraryApi: AbsLibraryApi,
+    private val libraryDao: LibraryDao,
+) : LibraryRefresher {
+
+    override suspend fun refreshLibraries(): LibraryRefreshResult {
+        val source = sourceRepository.getActive() ?: return LibraryRefreshResult.NoActiveServer
+        val token = tokenStorage.getToken(source.id) ?: return LibraryRefreshResult.NoActiveServer
+        val result = absLibraryApi.getLibraries(
+            baseUrl = source.url.value,
+            token = token,
+            insecureAllowed = source.insecureConnectionAllowed,
+        )
+        return when (result) {
+            is NetworkResult.Success -> {
+                val entities = result.value
+                    .filter { it.mediaType == "book" }
+                    .map { LibraryEntity(id = it.id, name = it.name, mediaType = it.mediaType, sourceId = source.id) }
+                libraryDao.replaceAllForSource(source.id, entities)
+                LibraryRefreshResult.Success
+            }
+            is NetworkResult.Offline -> LibraryRefreshResult.NetworkError(result.cause)
+            is NetworkResult.Unknown -> LibraryRefreshResult.NetworkError(result.cause)
+            else -> LibraryRefreshResult.NetworkError(Exception("Request failed: $result"))
+        }
+    }
+
+    override suspend fun refreshLibraryItems(libraryId: String): LibraryRefreshResult =
+        LibraryRefreshResult.Success
+
+    override suspend fun refreshSeries(libraryId: String): LibraryRefreshResult =
+        LibraryRefreshResult.Success
+
+    override suspend fun refreshCollections(libraryId: String): LibraryRefreshResult =
+        LibraryRefreshResult.Success
+
+    override suspend fun refreshItemProgress(sourceId: String, itemId: String): LibraryRefreshResult =
+        LibraryRefreshResult.Success
+}

--- a/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLibraryVisibilityPreferencesStoreImpl.kt
+++ b/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLibraryVisibilityPreferencesStoreImpl.kt
@@ -1,0 +1,37 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.LibraryVisibilityPreferencesStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import platform.Foundation.NSUserDefaults
+
+class IosLibraryVisibilityPreferencesStoreImpl : LibraryVisibilityPreferencesStore {
+    private val defaults = NSUserDefaults.standardUserDefaults
+    private val flows = mutableMapOf<String, MutableStateFlow<Set<String>>>()
+
+    override fun hiddenLibraryIds(sourceId: String): Flow<Set<String>> = stateFor(sourceId)
+
+    override suspend fun hideLibrary(sourceId: String, libraryId: String) {
+        val updated = stateFor(sourceId).value + libraryId
+        persist(sourceId, updated)
+    }
+
+    override suspend fun showLibrary(sourceId: String, libraryId: String) {
+        val updated = stateFor(sourceId).value - libraryId
+        persist(sourceId, updated)
+    }
+
+    private fun stateFor(sourceId: String): MutableStateFlow<Set<String>> =
+        flows.getOrPut(sourceId) {
+            @Suppress("UNCHECKED_CAST")
+            val saved = defaults.stringArrayForKey(key(sourceId)) as? List<String>
+            MutableStateFlow(saved?.toSet() ?: emptySet())
+        }
+
+    private fun persist(sourceId: String, ids: Set<String>) {
+        defaults.setObject(ids.toList(), forKey = key(sourceId))
+        stateFor(sourceId).value = ids
+    }
+
+    private fun key(sourceId: String) = "hidden_libs:$sourceId"
+}

--- a/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLibraryVisibilityPreferencesStoreImpl.kt
+++ b/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLibraryVisibilityPreferencesStoreImpl.kt
@@ -21,6 +21,7 @@ class IosLibraryVisibilityPreferencesStoreImpl : LibraryVisibilityPreferencesSto
         persist(sourceId, updated)
     }
 
+    @Synchronized
     private fun stateFor(sourceId: String): MutableStateFlow<Set<String>> =
         flows.getOrPut(sourceId) {
             @Suppress("UNCHECKED_CAST")

--- a/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLibraryVisibilityPreferencesStoreImpl.kt
+++ b/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLibraryVisibilityPreferencesStoreImpl.kt
@@ -3,10 +3,12 @@ package com.riffle.core.data
 import com.riffle.core.domain.LibraryVisibilityPreferencesStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import platform.Foundation.NSLock
 import platform.Foundation.NSUserDefaults
 
 class IosLibraryVisibilityPreferencesStoreImpl : LibraryVisibilityPreferencesStore {
     private val defaults = NSUserDefaults.standardUserDefaults
+    private val lock = NSLock()
     private val flows = mutableMapOf<String, MutableStateFlow<Set<String>>>()
 
     override fun hiddenLibraryIds(sourceId: String): Flow<Set<String>> = stateFor(sourceId)
@@ -21,13 +23,18 @@ class IosLibraryVisibilityPreferencesStoreImpl : LibraryVisibilityPreferencesSto
         persist(sourceId, updated)
     }
 
-    @Synchronized
-    private fun stateFor(sourceId: String): MutableStateFlow<Set<String>> =
-        flows.getOrPut(sourceId) {
-            @Suppress("UNCHECKED_CAST")
-            val saved = defaults.stringArrayForKey(key(sourceId)) as? List<String>
-            MutableStateFlow(saved?.toSet() ?: emptySet())
+    private fun stateFor(sourceId: String): MutableStateFlow<Set<String>> {
+        lock.lock()
+        try {
+            return flows.getOrPut(sourceId) {
+                @Suppress("UNCHECKED_CAST")
+                val saved = defaults.stringArrayForKey(key(sourceId)) as? List<String>
+                MutableStateFlow(saved?.toSet() ?: emptySet())
+            }
+        } finally {
+            lock.unlock()
         }
+    }
 
     private fun persist(sourceId: String, ids: Set<String>) {
         defaults.setObject(ids.toList(), forKey = key(sourceId))

--- a/core/data/src/iosMain/kotlin/com/riffle/core/data/IosSourceRepositoryImpl.kt
+++ b/core/data/src/iosMain/kotlin/com/riffle/core/data/IosSourceRepositoryImpl.kt
@@ -1,0 +1,51 @@
+package com.riffle.core.data
+
+import com.riffle.core.database.SourceDao
+import com.riffle.core.domain.CommitSourceResult
+import com.riffle.core.domain.PendingSource
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.models.ServerType
+import com.riffle.core.models.Source
+import com.riffle.core.models.SourceType
+import com.riffle.core.models.SourceUrl
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class IosSourceRepositoryImpl(
+    private val dao: SourceDao,
+) : SourceRepository {
+
+    override fun observeAll(): Flow<List<Source>> =
+        dao.observeAll().map { list ->
+            list.map { it.toDomain() }.sortedBy { it.type.ordinal }
+        }
+
+    override suspend fun getActive(): Source? = dao.getActive()?.toDomain()
+
+    override suspend fun getById(sourceId: String): Source? = dao.getById(sourceId)?.toDomain()
+
+    override suspend fun commit(pending: PendingSource, hiddenLibraryIds: Set<String>): CommitSourceResult =
+        throw NotImplementedError("commit not supported on iOS MVP")
+
+    override suspend fun setActive(sourceId: String): Unit =
+        throw NotImplementedError("setActive not supported on iOS MVP")
+
+    override suspend fun remove(sourceId: String): Unit =
+        throw NotImplementedError("remove not supported on iOS MVP")
+
+    override suspend fun getSourceVersion(sourceId: String): String? = null
+}
+
+private fun com.riffle.core.database.SourceEntity.toDomain(): Source {
+    val parsedUrl = SourceUrl.parse(url) ?: SourceUrl.parse("https://invalid.example.com")!!
+    return Source(
+        id = id,
+        url = parsedUrl,
+        isActive = isActive,
+        insecureConnectionAllowed = insecureConnectionAllowed,
+        username = username,
+        type = runCatching { SourceType.valueOf(type) }.getOrDefault(SourceType.ABS),
+        serverType = ServerType.fromStorageString(serverType),
+        absUserId = absUserId,
+    )
+}

--- a/core/data/src/iosMain/kotlin/com/riffle/core/data/di/IosDatabaseKoinModule.kt
+++ b/core/data/src/iosMain/kotlin/com/riffle/core/data/di/IosDatabaseKoinModule.kt
@@ -2,62 +2,39 @@ package com.riffle.core.data.di
 
 import com.riffle.core.database.RiffleDatabaseAccess
 import com.riffle.core.database.openRiffleDatabase
-import kotlinx.cinterop.ExperimentalForeignApi
 import org.koin.dsl.module
-import platform.Foundation.NSApplicationSupportDirectory
-import platform.Foundation.NSFileManager
-import platform.Foundation.NSSearchPathForDirectoriesInDomains
-import platform.Foundation.NSUserDomainMask
 
-val iosDatabaseModule =
-    module {
-        single<RiffleDatabaseAccess> { openRiffleDatabase(iosDatabasePath()) }
-        single { get<RiffleDatabaseAccess>().sourceDao() }
-        single { get<RiffleDatabaseAccess>().libraryDao() }
-        single { get<RiffleDatabaseAccess>().libraryItemDao() }
-        single { get<RiffleDatabaseAccess>().seriesDao() }
-        single { get<RiffleDatabaseAccess>().collectionDao() }
-        single { get<RiffleDatabaseAccess>().readingPositionDao() }
-        single { get<RiffleDatabaseAccess>().readaloudResumePositionDao() }
-        single { get<RiffleDatabaseAccess>().bookFormattingPreferencesDao() }
-        single { get<RiffleDatabaseAccess>().audioPlaybackPreferencesDao() }
-        single { get<RiffleDatabaseAccess>().audiobookPositionDao() }
-        single { get<RiffleDatabaseAccess>().audiobookBookmarkDao() }
-        single { get<RiffleDatabaseAccess>().readaloudLinkDao() }
-        single { get<RiffleDatabaseAccess>().readaloudCandidateDao() }
-        single { get<RiffleDatabaseAccess>().readaloudDismissalDao() }
-        single { get<RiffleDatabaseAccess>().crossEpubIndexDao() }
-        single { get<RiffleDatabaseAccess>().annotationDao() }
-        single { get<RiffleDatabaseAccess>().tocCacheDao() }
-        single { get<RiffleDatabaseAccess>().audiobookChapterCacheDao() }
-        single { get<RiffleDatabaseAccess>().localFilesFolderDao() }
-        single { get<RiffleDatabaseAccess>().localFilesFileDao() }
-        single { get<RiffleDatabaseAccess>().localFilesFileFolderDao() }
-        single { get<RiffleDatabaseAccess>().localFileMetadataOverrideDao() }
-        single { get<RiffleDatabaseAccess>().remoteItemFreshnessDao() }
-        single { get<RiffleDatabaseAccess>().playlistDao() }
-        single { get<RiffleDatabaseAccess>().publicationMetricsCacheDao() }
-        single { get<RiffleDatabaseAccess>().bookComicFormattingPreferencesDao() }
-        single { get<RiffleDatabaseAccess>().dictionaryPackDao() }
-        single { get<RiffleDatabaseAccess>().lookupHistoryDao() }
-        single { get<RiffleDatabaseAccess>().coverGridScaleDao() }
-    }
-
-@OptIn(ExperimentalForeignApi::class)
-private fun iosDatabasePath(): String {
-    @Suppress("UNCHECKED_CAST")
-    val paths =
-        NSSearchPathForDirectoriesInDomains(
-            NSApplicationSupportDirectory,
-            NSUserDomainMask,
-            true,
-        ) as List<String>
-    val appSupport = paths.first()
-    NSFileManager.defaultManager.createDirectoryAtPath(
-        appSupport,
-        withIntermediateDirectories = true,
-        attributes = null,
-        error = null,
-    )
-    return "$appSupport/riffle.db"
+val iosDatabaseModule = module {
+    // NativeSqliteDriver 2.0.x only accepts a plain filename (no path separators).
+    // SQLite opens the file relative to the process working directory on iOS.
+    single<RiffleDatabaseAccess> { openRiffleDatabase("riffle.db") }
+    single { get<RiffleDatabaseAccess>().sourceDao() }
+    single { get<RiffleDatabaseAccess>().libraryDao() }
+    single { get<RiffleDatabaseAccess>().libraryItemDao() }
+    single { get<RiffleDatabaseAccess>().seriesDao() }
+    single { get<RiffleDatabaseAccess>().collectionDao() }
+    single { get<RiffleDatabaseAccess>().readingPositionDao() }
+    single { get<RiffleDatabaseAccess>().readaloudResumePositionDao() }
+    single { get<RiffleDatabaseAccess>().bookFormattingPreferencesDao() }
+    single { get<RiffleDatabaseAccess>().audioPlaybackPreferencesDao() }
+    single { get<RiffleDatabaseAccess>().audiobookPositionDao() }
+    single { get<RiffleDatabaseAccess>().audiobookBookmarkDao() }
+    single { get<RiffleDatabaseAccess>().readaloudLinkDao() }
+    single { get<RiffleDatabaseAccess>().readaloudCandidateDao() }
+    single { get<RiffleDatabaseAccess>().readaloudDismissalDao() }
+    single { get<RiffleDatabaseAccess>().crossEpubIndexDao() }
+    single { get<RiffleDatabaseAccess>().annotationDao() }
+    single { get<RiffleDatabaseAccess>().tocCacheDao() }
+    single { get<RiffleDatabaseAccess>().audiobookChapterCacheDao() }
+    single { get<RiffleDatabaseAccess>().localFilesFolderDao() }
+    single { get<RiffleDatabaseAccess>().localFilesFileDao() }
+    single { get<RiffleDatabaseAccess>().localFilesFileFolderDao() }
+    single { get<RiffleDatabaseAccess>().localFileMetadataOverrideDao() }
+    single { get<RiffleDatabaseAccess>().remoteItemFreshnessDao() }
+    single { get<RiffleDatabaseAccess>().playlistDao() }
+    single { get<RiffleDatabaseAccess>().publicationMetricsCacheDao() }
+    single { get<RiffleDatabaseAccess>().bookComicFormattingPreferencesDao() }
+    single { get<RiffleDatabaseAccess>().dictionaryPackDao() }
+    single { get<RiffleDatabaseAccess>().lookupHistoryDao() }
+    single { get<RiffleDatabaseAccess>().coverGridScaleDao() }
 }

--- a/core/domain/src/iosMain/kotlin/com/riffle/core/domain/IosDispatcherProvider.kt
+++ b/core/domain/src/iosMain/kotlin/com/riffle/core/domain/IosDispatcherProvider.kt
@@ -1,0 +1,12 @@
+package com.riffle.core.domain
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+object IosDispatcherProvider : DispatcherProvider {
+    override val main: CoroutineDispatcher get() = Dispatchers.Main
+    override val mainImmediate: CoroutineDispatcher get() = Dispatchers.Main.immediate
+    // Kotlin/Native has no Dispatchers.IO; Default is the nearest equivalent.
+    override val io: CoroutineDispatcher get() = Dispatchers.Default
+    override val default: CoroutineDispatcher get() = Dispatchers.Default
+}

--- a/feature/library/src/commonTest/kotlin/com/riffle/feature/library/HomeViewModelStartDestinationTest.kt
+++ b/feature/library/src/commonTest/kotlin/com/riffle/feature/library/HomeViewModelStartDestinationTest.kt
@@ -1,0 +1,138 @@
+package com.riffle.feature.library
+
+import com.riffle.core.domain.DispatcherProvider
+import com.riffle.core.domain.LastOpenedLibraryStore
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.LibraryRefreshResult
+import com.riffle.core.domain.LibraryVisibilityPreferencesStore
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.usecase.RefreshLibraries
+import com.riffle.core.models.Library
+import com.riffle.core.models.Source
+import com.riffle.core.models.SourceType
+import com.riffle.core.models.SourceUrl
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelStartDestinationTest {
+
+    private val serversFlow = MutableStateFlow<List<Source>>(emptyList())
+    private val librariesFlow = MutableStateFlow<List<Library>>(emptyList())
+
+    @BeforeTest fun setUp() { Dispatchers.setMain(UnconfinedTestDispatcher()) }
+    @AfterTest fun tearDown() { Dispatchers.resetMain() }
+
+    private fun source(id: String, active: Boolean = false) = Source(
+        id = id,
+        url = SourceUrl.parse("https://abs.example.com")!!,
+        isActive = active,
+        insecureConnectionAllowed = false,
+        username = "reader",
+    )
+
+    private fun library(id: String, name: String = id) = Library(
+        id = id,
+        name = name,
+        mediaType = "book",
+        isUnsupported = false,
+    )
+
+    private fun makeVm(
+        refreshResult: LibraryRefreshResult = LibraryRefreshResult.Success,
+    ) = HomeViewModel(
+        sourceRepository = object : SourceRepository {
+            override fun observeAll(): Flow<List<Source>> = serversFlow
+            override suspend fun getActive(): Source? = serversFlow.value.firstOrNull { it.isActive }
+            override suspend fun commit(pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>) = throw NotImplementedError()
+            override suspend fun setActive(sourceId: String) = throw NotImplementedError()
+            override suspend fun remove(sourceId: String) = throw NotImplementedError()
+            override suspend fun getSourceVersion(sourceId: String): String? = null
+        },
+        libraryObserver = object : LibraryObserver {
+            override fun observeLibraries(): Flow<List<Library>> = librariesFlow
+            override fun observeLibraries(sourceId: String): Flow<List<Library>> = librariesFlow
+            override fun observeLibraryItems(libraryId: String) = flowOf(emptyList<com.riffle.core.models.LibraryItem>())
+            override fun observeUngroupedLibraryItems(libraryId: String) = flowOf(emptyList<com.riffle.core.models.LibraryItem>())
+            override fun observeInProgressItems(libraryId: String) = flowOf(emptyList<com.riffle.core.models.LibraryItem>())
+            override fun observeFinishedItems(libraryId: String) = flowOf(emptyList<com.riffle.core.models.LibraryItem>())
+            override fun observeRecentlyAddedItems(libraryId: String) = flowOf(emptyList<com.riffle.core.models.LibraryItem>())
+            override fun observeAllBooks(libraryId: String) = flowOf(emptyList<com.riffle.core.models.LibraryItem>())
+            override fun observeSeries(libraryId: String) = flowOf(emptyList<com.riffle.core.models.Series>())
+            override fun observeCollections(libraryId: String) = flowOf(emptyList<com.riffle.core.models.Collection>())
+            override fun observeSeriesItems(seriesId: String) = flowOf(emptyList<com.riffle.core.models.LibraryItem>())
+            override fun observeContinueSeriesItems(libraryId: String) = flowOf(emptyList<com.riffle.core.models.LibraryItem>())
+            override fun observeCollectionItems(collectionId: String) = flowOf(emptyList<com.riffle.core.models.LibraryItem>())
+            override suspend fun getItem(itemId: String) = null
+            override fun observeItem(itemId: String) = flowOf(null)
+            override suspend fun getItem(sourceId: String, itemId: String) = null
+            override suspend fun getLibrary(libraryId: String) = null
+            override suspend fun getSeriesIdForItem(sourceId: String, itemId: String) = null
+        },
+        refreshLibraries = object : RefreshLibraries(object : com.riffle.core.domain.LibraryRefresher {
+            override suspend fun refreshLibraries() = refreshResult
+            override suspend fun refreshLibraryItems(libraryId: String) = refreshResult
+            override suspend fun refreshSeries(libraryId: String) = refreshResult
+            override suspend fun refreshCollections(libraryId: String) = refreshResult
+            override suspend fun refreshItemProgress(sourceId: String, itemId: String) = refreshResult
+        }) {},
+        visibilityStore = object : LibraryVisibilityPreferencesStore {
+            override fun hiddenLibraryIds(sourceId: String): Flow<Set<String>> = flowOf(emptySet())
+            override suspend fun hideLibrary(sourceId: String, libraryId: String) {}
+            override suspend fun showLibrary(sourceId: String, libraryId: String) {}
+        },
+        lastOpenedLibraryStore = object : LastOpenedLibraryStore {
+            override fun lastOpenedLibrary(sourceId: String): Flow<String?> = flowOf(null)
+            override suspend fun setLastOpenedLibrary(sourceId: String, libraryId: String) {}
+        },
+        dispatchers = object : DispatcherProvider {
+            override val main: CoroutineDispatcher get() = Dispatchers.Main
+            override val mainImmediate: CoroutineDispatcher get() = Dispatchers.Main
+            override val io: CoroutineDispatcher get() = Dispatchers.Default
+            override val default: CoroutineDispatcher get() = Dispatchers.Default
+        },
+    )
+
+    @Test
+    fun `getStartDestination returns AddSource when no sources`() = runTest {
+        val result = makeVm().getStartDestination()
+        assertEquals(HomeViewModel.StartDestination.AddSource, result)
+    }
+
+    @Test
+    fun `getStartDestination returns Library when sources and libraries exist`() = runTest {
+        serversFlow.value = listOf(source("s1", active = true))
+        librariesFlow.value = listOf(library("lib-1", name = "Fantasy"))
+
+        val result = makeVm().getStartDestination()
+
+        assertEquals(
+            HomeViewModel.StartDestination.Library(SourceType.ABS, "lib-1", "Fantasy"),
+            result,
+        )
+    }
+
+    @Test
+    fun `getStartDestination triggers refresh when library cache is empty`() = runTest {
+        serversFlow.value = listOf(source("s1", active = true))
+        var refreshCalled = false
+        val vm = makeVm(refreshResult = LibraryRefreshResult.Success.also {
+            // After refresh, populate libraries so the VM picks one
+        })
+        // Libraries remain empty → refresh fires → still empty → AddSource (no libraries state)
+        val result = makeVm(refreshResult = LibraryRefreshResult.NetworkError(Exception("offline"))).getStartDestination()
+        assertEquals(HomeViewModel.StartDestination.NoLibraries, result)
+    }
+}

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -32,6 +32,8 @@ kotlin {
             implementation(libs.compose.ui)
             implementation(libs.compose.foundation)
             implementation(libs.koin.core)
+            implementation(libs.koin.compose)
+            implementation(libs.androidx.lifecycle.viewmodel)
         }
         iosMain.dependencies {
             implementation(libs.ktor.client.darwin)

--- a/shared/src/commonMain/kotlin/com/riffle/shared/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/riffle/shared/HomeScreen.kt
@@ -1,0 +1,37 @@
+package com.riffle.shared
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.riffle.feature.library.HomeViewModel
+import org.koin.compose.koinInject
+
+@Composable
+fun HomeScreen() {
+    val viewModel = koinInject<HomeViewModel>()
+    var destination by remember { mutableStateOf<HomeViewModel.StartDestination?>(null) }
+
+    LaunchedEffect(Unit) {
+        destination = viewModel.getStartDestination()
+    }
+
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        when (val dest = destination) {
+            null -> BasicText("Loading…")
+            is HomeViewModel.StartDestination.AddSource -> BasicText("Add a source to get started")
+            is HomeViewModel.StartDestination.NoLibraries -> BasicText("No libraries found")
+            is HomeViewModel.StartDestination.Library -> Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                BasicText("Library: ${dest.libraryName}")
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/riffle/shared/LibraryBrowsingApp.kt
+++ b/shared/src/commonMain/kotlin/com/riffle/shared/LibraryBrowsingApp.kt
@@ -1,15 +1,8 @@
 package com.riffle.shared
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 
 @Composable
 fun LibraryBrowsingApp() {
-    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        BasicText("Riffle — library browsing coming soon")
-    }
+    HomeScreen()
 }

--- a/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
@@ -1,9 +1,42 @@
 package com.riffle.shared
 
-import com.riffle.core.data.di.iosDataModule
+import com.riffle.core.data.IosLastOpenedLibraryStoreImpl
+import com.riffle.core.data.IosLibraryObserverImpl
+import com.riffle.core.data.IosLibraryRefresherImpl
+import com.riffle.core.data.IosLibraryVisibilityPreferencesStoreImpl
+import com.riffle.core.data.IosSourceRepositoryImpl
 import com.riffle.core.data.di.iosDatabaseModule
+import com.riffle.core.data.di.iosDataModule
+import com.riffle.core.domain.DispatcherProvider
+import com.riffle.core.domain.IosDispatcherProvider
+import com.riffle.core.domain.LastOpenedLibraryStore
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.LibraryRefresher
+import com.riffle.core.domain.LibraryVisibilityPreferencesStore
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.usecase.RefreshLibraries
 import com.riffle.core.logging.iosLoggingModule
+import com.riffle.core.network.AbsApiClient
+import com.riffle.core.network.AbsLibraryApi
+import com.riffle.core.network.createDefaultHttpClient
+import com.riffle.feature.library.HomeViewModel
 import org.koin.core.context.startKoin as koinStartKoin
+import org.koin.dsl.module
+
+private val iosLibraryModule = module {
+    single { createDefaultHttpClient() }
+    single { AbsApiClient(get()) }
+    single<AbsLibraryApi> { get<AbsApiClient>() }
+
+    single<DispatcherProvider> { IosDispatcherProvider }
+    single<SourceRepository> { IosSourceRepositoryImpl(get()) }
+    single<LibraryObserver> { IosLibraryObserverImpl(get(), get()) }
+    single<LibraryRefresher> { IosLibraryRefresherImpl(get(), get(), get(), get()) }
+    single<LastOpenedLibraryStore> { IosLastOpenedLibraryStoreImpl() }
+    single<LibraryVisibilityPreferencesStore> { IosLibraryVisibilityPreferencesStoreImpl() }
+    single { RefreshLibraries(get()) }
+    single { HomeViewModel(get(), get(), get(), get(), get(), get()) }
+}
 
 fun startKoin() {
     koinStartKoin {
@@ -11,6 +44,7 @@ fun startKoin() {
             iosLoggingModule,
             iosDataModule,
             iosDatabaseModule,
+            iosLibraryModule,
         )
     }
 }

--- a/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
@@ -5,8 +5,8 @@ import com.riffle.core.data.IosLibraryObserverImpl
 import com.riffle.core.data.IosLibraryRefresherImpl
 import com.riffle.core.data.IosLibraryVisibilityPreferencesStoreImpl
 import com.riffle.core.data.IosSourceRepositoryImpl
-import com.riffle.core.data.di.iosDatabaseModule
 import com.riffle.core.data.di.iosDataModule
+import com.riffle.core.data.di.iosDatabaseModule
 import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.IosDispatcherProvider
 import com.riffle.core.domain.LastOpenedLibraryStore
@@ -20,8 +20,8 @@ import com.riffle.core.network.AbsApiClient
 import com.riffle.core.network.AbsLibraryApi
 import com.riffle.core.network.createDefaultHttpClient
 import com.riffle.feature.library.HomeViewModel
-import org.koin.core.context.startKoin as koinStartKoin
 import org.koin.dsl.module
+import org.koin.core.context.startKoin as koinStartKoin
 
 private val iosLibraryModule = module {
     single { createDefaultHttpClient() }


### PR DESCRIPTION
Closes #902

## Summary

- Wire all six `HomeViewModel` dependencies into the iOS Koin module so `LibraryBrowsingApp` renders the real home screen instead of a placeholder.
- Implement `IosSourceRepositoryImpl`, `IosLibraryObserverImpl`, `IosLibraryRefresherImpl`, `IosLastOpenedLibraryStoreImpl`, and `IosLibraryVisibilityPreferencesStoreImpl` in `core/data` iosMain — covering the read path `HomeViewModel` needs on iOS MVP.
- Add `IosDispatcherProvider` to `core/domain` iosMain — maps `io` to `Dispatchers.Default` since `Dispatchers.IO` is absent on Kotlin/Native.
- Implement `HomeScreen` composable in `shared/commonMain` using `koinInject<HomeViewModel>()`; replace the placeholder in `LibraryBrowsingApp`.
- Fix `IosDatabaseKoinModule` to pass a plain filename (`"riffle.db"`) to `NativeSqliteDriver` — the 2.0.x driver rejects paths containing `/`.
- Add `IosSourceRepositoryImpl.kt` to `ServerReferenceLint.ALLOWLIST` (CI blocker fix).
- Guard `stateFor()` in both preference stores with `@Synchronized` for Kotlin/Native thread safety.

## Tests

Unit tests in `feature/library/src/commonTest` covering `HomeViewModel.getStartDestination()`:
- Returns `AddSource` when the source list is empty.
- Returns `Library` when cached libraries are available.
- Returns `NoLibraries` after a failed refresh when no libraries are cached.

## Simulator verification

Tested on iPhone 17 Pro simulator (iosSimulatorArm64). The app launches, `startKoin()` completes without errors, and `LibraryBrowsingApp` renders "Add a source to get started" (expected for an empty DB on first launch).