### PR TITLE
i18n(library): translate "Upload completed" snackbar message

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/BookImportManager.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/BookImportManager.kt
@@ -1,5 +1,7 @@
 package com.riffle.app.feature.library
 
+import androidx.annotation.StringRes
+import com.riffle.app.R
 import com.riffle.core.catalog.CatalogImportPhase
 import com.riffle.core.catalog.CatalogImportProgress
 import com.riffle.core.catalog.CatalogImportResult
@@ -28,10 +30,9 @@ sealed interface BookImportState {
     data class Failed(val message: String) : BookImportState
 }
 
-internal const val BOOK_IMPORT_COMPLETED_MESSAGE = "Upload completed"
-
-internal fun bookImportSnackbarMessage(state: BookImportState): String? =
-    if (state is BookImportState.Completed) BOOK_IMPORT_COMPLETED_MESSAGE else null
+@StringRes
+internal fun bookImportSnackbarMessage(state: BookImportState): Int? =
+    if (state is BookImportState.Completed) R.string.ui_upload_completed else null
 
 /** Application-scoped owner for uploads started from a detail screen. */
 class BookImportManager constructor(

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -147,8 +147,9 @@ fun LibraryItemDetailScreen(
         }
     }
 
+    val bookImportSnackbar = bookImportSnackbarMessage(bookImportState)?.let { stringResource(it) }
     LaunchedEffect(bookImportState) {
-        bookImportSnackbarMessage(bookImportState)?.let { message ->
+        bookImportSnackbar?.let { message ->
             snackbarHostState.showSnackbar(
                 message = message,
                 duration = SnackbarDuration.Short,

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -295,6 +295,7 @@
     <string name="ui_unowned">Без собственик</string>
     <string name="ui_update">Актуализиране</string>
     <string name="ui_update_available">Налична е актуализация</string>
+    <string name="ui_upload_completed">Качването завърши</string>
     <string name="ui_upload_failed">Качването е неуспешно</string>
     <string name="ui_upload_to">Качване в...</string>
     <string name="ui_upload_unavailable">Качването не е налично</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -295,6 +295,7 @@
     <string name="ui_unowned">Sin propietario</string>
     <string name="ui_update">Actualizar</string>
     <string name="ui_update_available">Actualización disponible</string>
+    <string name="ui_upload_completed">Subida completada</string>
     <string name="ui_upload_failed">Error al subir</string>
     <string name="ui_upload_to">Subir a…</string>
     <string name="ui_upload_unavailable">Subida no disponible</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -298,6 +298,7 @@
     <string name="ui_unowned">Unowned</string>
     <string name="ui_update">Update</string>
     <string name="ui_update_available">Update available</string>
+    <string name="ui_upload_completed">Upload completed</string>
     <string name="ui_upload_failed">Upload failed</string>
     <string name="ui_upload_to">Upload to…</string>
     <string name="ui_upload_unavailable">Upload unavailable</string>

--- a/app/src/test/kotlin/com/riffle/app/feature/library/BookImportManagerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/BookImportManagerTest.kt
@@ -18,7 +18,7 @@ class BookImportManagerTest {
     @Test
     fun `completed import produces a success message`() {
         assertEquals(
-            BOOK_IMPORT_COMPLETED_MESSAGE,
+            com.riffle.app.R.string.ui_upload_completed,
             bookImportSnackbarMessage(BookImportState.Completed),
         )
     }


### PR DESCRIPTION
## Summary

- Extracts the hardcoded `"Upload completed"` string from `BookImportManager.kt` into `R.string.ui_upload_completed`
- Adds translations: **es** → "Subida completada", **bg** → "Качването завърши"
- `bookImportSnackbarMessage` now returns `@StringRes Int?`; the Composable call site resolves it with `stringResource()` before the `LaunchedEffect`
- Test updated to compare against the resource ID

## Test plan
- [ ] `./gradlew :app:test` — `BookImportManagerTest` passes
- [ ] Switch device language to Spanish or Bulgarian; upload a local file; confirm snackbar reads in the target language