### PR TITLE
fix(gramofonche): strip /Label suffix from track chapter titles

### DIFF
--- a/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraper.kt
+++ b/core/catalog-chitanka/src/main/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraper.kt
@@ -270,6 +270,14 @@ internal object GramofoncheScraper {
     private val CATEGORY_PATH_PATTERN = Regex("^/(prikazki|pesnicki|zagolemi)/[^/]+/$")
 
     /**
+     * Splits Gramofonche link text at the first `(` or `/` (preceded by optional whitespace),
+     * which separates the human-readable title from metadata suffixes like `(narrator)` or
+     * `/Балкантон`. Used identically in listing and detail parsing.
+     */
+    private val TITLE_SUFFIX_SPLIT = Regex("\\s*[(/]")
+    private fun extractTitle(text: String): String = text.split(TITLE_SUFFIX_SPLIT)[0].trim()
+
+    /**
      * Captures a Gramofonche duration span in either the listing "..NNмин" line or the detail
      * page. Supports the three shapes the site uses in the wild:
      *   - minutes only: `43мин`
@@ -299,8 +307,8 @@ internal object GramofoncheScraper {
             // Text excluding the <i>-wrapped subtitle
             val clone = linkEl.clone()
             clone.select("i").remove()
-            val fullText = clone.text().trim()
-            val title = fullText.split(Regex("\\s*[(/]"))[0].trim()
+            val fullText = clone.text()
+            val title = extractTitle(fullText)
 
             val authors = mutableListOf<String>()
             val iText = linkEl.selectFirst("i")?.text()?.trim().orEmpty()
@@ -376,7 +384,7 @@ internal object GramofoncheScraper {
             val href = el.attr("href").ifEmpty { return@forEach }
             val clone = el.clone()
             clone.select("i").remove()
-            val trackTitle = clone.text().replace(Regex("\\s*\\(.*$"), "").trim()
+            val trackTitle = extractTitle(clone.text())
             downloads += ChitankaDownload(url = ChitankaScraper.toAbsolute(href, pageUrl), title = trackTitle)
         }
 

--- a/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraperTest.kt
+++ b/core/catalog-chitanka/src/test/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraperTest.kt
@@ -197,6 +197,35 @@ class GramofoncheScraperTest {
     }
 
     /**
+     * Regression: multi-track Balkanton-disc pages have anchor text like "Title/Балкантон"
+     * (no narrator parenthetical). The old `replace(Regex("\\s*\\(.*$"), "")` only strips from
+     * `(` onwards, so it left "/Балкантон" in place. That dirty title was then stored verbatim
+     * as a chapter title when the book was imported into ABS, causing the chapter drawer to show
+     * "Track/Балкантон" instead of "Track". The fix splits at the first `(` or `/`, matching
+     * the same approach used by `parseSearchResults`. These three shapes cover all cases observed
+     * on the live site: slash-only, paren-only, and paren-then-slash.
+     */
+    @Test
+    fun `track title strips slash-label suffix from mp3 anchor text`() {
+        fun parse(anchorText: String): String {
+            val html = """
+                <html><body><div id="content-wrapper">
+                  <h1>Book</h1>
+                  <a href="./track.mp3">$anchorText</a>
+                </div></body></html>
+            """.trimIndent()
+            return GramofoncheScraper.parseDetailPage(html, "https://gramofonche.chitanka.info/prikazki/foo/")
+                .downloads.first().title
+        }
+        // Slash-only: "/Балкантон" must be stripped.
+        assertEquals("Клан-недоклан", parse("Клан-недоклан/Балкантон"))
+        // Paren-only: "(narrator)" must be stripped.
+        assertEquals("Аладин и вълшебната лампа", parse("Аладин и вълшебната лампа (Шехерезада, реж. Мария Нанчева)"))
+        // Paren-then-slash: both must be stripped when the narrator comes before the label.
+        assertEquals("Щъркел и лисица", parse("Щъркел и лисица (<i>изпълнение: X</i>)/Балкантон"))
+    }
+
+    /**
      * Regression: the duration regex used to be `(\d+)мин` and re-materialised the value as
      * `"${minutes}мин"`, silently dropping the hour component from combined spans and yielding
      * an empty string for hour-only entries. Both shapes exist on the live site — pin the


### PR DESCRIPTION
## Problem

When uploading a Gramofonche multi-track audiobook to ABS, chapter titles were stored verbatim from the HTML anchor text. For discs like the Балкантон 14-story collection, some track links have bare `"Title/Балкантон"` anchor text with no narrator parenthetical. The old cleanup regex `\s*\(.*$` only strips from `(` onwards, so `/Балкантон` stayed in the title. Those dirty titles were propagated into ABS chapter metadata by `LibraryItemDetailViewModel.buildImportRequest`, causing the chapter drawer to show "Track/Балкантон" instead of "Track".

The native Gramofonche source was coincidentally correct when the narrator parenthetical came before the label (e.g. `"Title (narrator)/Балкантон"`) because `.*$` is greedy and consumed the label too — but tracks with no narrator were affected.

## Fix

`GramofoncheScraper.parseDetailPage` now uses `split(Regex("\\s*[(/]"))[0].trim()` — the same approach `parseSearchResults` already used for listing items. Both call sites are unified via a new private `extractTitle()` helper backed by a `TITLE_SUFFIX_SPLIT` constant to avoid the duplication.

## Test

`GramofoncheScraperTest.track title strips slash-label suffix from mp3 anchor text` covers the three shapes observed in the wild:
- Slash-only: `"Title/Балкантон"` → `"Title"`
- Paren-only: `"Title (narrator)"` → `"Title"`
- Paren-then-slash: `"Title (narrator)/Балкантон"` → `"Title"`