### PR TITLE
fix(reader): extend SPINE_FILENAME_REGEX to 2+ digits so ch06/ch10 filenames fall back to Chapter N

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -4111,10 +4111,11 @@ internal fun elidedChapterTitle(href: String, derived: String, toc: List<TocEntr
 private val UUID_TITLE_REGEX =
     Regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 
-// Matches auto-generated EPUB spine filenames: letters/underscores/hyphens followed by 3+
-// digits (e.g. "part0010", "item003", "text00001"). Human-readable titles never end in
-// zero-padded digit runs of this length, so these are safe to treat as unhelpful.
-private val SPINE_FILENAME_REGEX = Regex("^[a-zA-Z][a-zA-Z0-9_-]*\\d{3,}$")
+// Matches auto-generated EPUB spine filenames: letters/underscores/hyphens followed by 2+
+// digits (e.g. "part0010", "item003", "text00001", "ch06", "ch10"). Human-readable titles
+// never end in zero-padded digit runs of this length, so these are safe to treat as unhelpful.
+// Two-digit minimum covers common patterns like "ch06"/"ch10" that only have two-digit padding.
+private val SPINE_FILENAME_REGEX = Regex("^[a-zA-Z][a-zA-Z0-9_-]*\\d{2,}$")
 
 internal fun looksUnhelpfulTitle(title: String): Boolean =
     title.isBlank() || title.equals("Chapter", ignoreCase = true) ||

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelHighlightsSourceTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/EpubReaderViewModelHighlightsSourceTest.kt
@@ -163,6 +163,9 @@ class EpubReaderViewModelHighlightsSourceTest {
         assertTrue(looksUnhelpfulTitle("item003"))
         assertTrue(looksUnhelpfulTitle("text00001"))
         assertTrue(looksUnhelpfulTitle("SECTION_012"))
+        assertTrue(looksUnhelpfulTitle("ch03"))       // 2-digit spine ID — also unhelpful
+        assertTrue(looksUnhelpfulTitle("ch06"))       // regression: showed verbatim when TOC cold
+        assertTrue(looksUnhelpfulTitle("ch10"))       // regression: showed verbatim when TOC cold
     }
 
     @Test
@@ -170,7 +173,6 @@ class EpubReaderViewModelHighlightsSourceTest {
         assertFalse(looksUnhelpfulTitle("The Nature of Complexity"))
         assertFalse(looksUnhelpfulTitle("Introduction"))
         assertFalse(looksUnhelpfulTitle("Epilogue"))
-        assertFalse(looksUnhelpfulTitle("ch03"))       // short but no 3-digit run
         assertFalse(looksUnhelpfulTitle("Act2"))       // only one trailing digit
         assertFalse(looksUnhelpfulTitle("Part3"))
     }
@@ -181,6 +183,9 @@ class EpubReaderViewModelHighlightsSourceTest {
         // and was displayed verbatim as the chapter heading.
         assertEquals("Chapter 1", elidedChapterTitle("OEBPS/part0010.xhtml", "part0010", emptyList(), 0))
         assertEquals("Chapter 3", elidedChapterTitle("OEBPS/item003.xhtml", "item003", emptyList(), 2))
+        // Regression: 2-digit-suffix filenames (ch06, ch10) showed verbatim when TOC cache cold.
+        assertEquals("Chapter 1", elidedChapterTitle("OEBPS/ch06.xhtml", "ch06", emptyList(), 0))
+        assertEquals("Chapter 3", elidedChapterTitle("OEBPS/ch10.xhtml", "ch10", emptyList(), 2))
     }
 
     @Test


### PR DESCRIPTION
## What

`SPINE_FILENAME_REGEX` required 3+ trailing digits, so 2-digit-suffix EPUB spine filenames like `ch06.xhtml` and `ch10.xhtml` passed `looksUnhelpfulTitle` as `false` — treated as "helpful" titles — and were displayed verbatim in the elided view when the TOC cache was cold.

## Why it regressed

`MIGRATION_55_56` added a `cachedAt` column to `toc_cache` with `DEFAULT 0`, making every pre-migration row stale on next read. After that migration the TOC is cold for any book not subsequently opened in full-book mode. When cold, `resolveChapterTitle` returns null, and whether the user sees "ch06" or "Chapter 6" depends entirely on `looksUnhelpfulTitle`. The 3+ digit rule let 2-digit patterns through.

## Why no test caught it

The test at line 173 **actively asserted the wrong behavior** — `assertFalse(looksUnhelpfulTitle("ch03")) // short but no 3-digit run`. The test matched the code: both were wrong. There was no failing test to catch the gap because the wrong assertion was the documentation of the intentional (but incorrect) design decision.

## Fix

- Change `SPINE_FILENAME_REGEX` from `\\d{3,}` to `\\d{2,}` — 2-digit-suffix patterns are caught.
- Single-digit suffixes (`Act2`, `Part3`) remain unaffected — still considered real titles.
- Move `ch03` to the "unhelpful" set; add `ch06`/`ch10` regression cases; add matching `elidedChapterTitle` assertions for the cold-TOC scenario.