### PR TITLE
fix(downloads): show progress percentage for multi-track audiobook sources

### DIFF
--- a/core/data/src/androidHostTest/kotlin/com/riffle/core/data/AudiobookCacheRepositoryImplTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/riffle/core/data/AudiobookCacheRepositoryImplTest.kt
@@ -11,8 +11,10 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -122,8 +124,14 @@ class AudiobookCacheRepositoryImplTest {
         val server = MockWebServer()
         server.start()
         try {
-            server.enqueue(MockResponse().setBody("audio-track-0"))
-            server.enqueue(MockResponse().setBody("audio-track-1"))
+            // HEAD pre-scan runs in parallel before downloads; returning 405 tells it the server
+            // doesn't support HEAD, so the pre-scan skips gracefully and downloads proceed normally.
+            server.dispatcher = object : Dispatcher() {
+                private val getQueue = ArrayDeque(listOf("audio-track-0", "audio-track-1"))
+                override fun dispatch(request: RecordedRequest): MockResponse =
+                    if (request.method == "HEAD") MockResponse().setResponseCode(405)
+                    else MockResponse().setBody(getQueue.removeFirst())
+            }
             val session = AudiobookSession(
                 trackUrls = listOf(
                     server.url("/track-0.mp3").toString(),

--- a/core/data/src/androidHostTest/kotlin/com/riffle/core/data/AudiobookTrackDownloaderTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/riffle/core/data/AudiobookTrackDownloaderTest.kt
@@ -24,6 +24,120 @@ class AudiobookTrackDownloaderTest {
     val tmp = TemporaryFolder()
 
     @Test
+    fun `multi-track download shows deterministic progress when server supports HEAD`() = runTest {
+        // Server that responds to HEAD with Content-Length and GET with the actual body.
+        // This mirrors podcast CDNs (e.g. Radio.es) that serve static MP3 files.
+        val server = HttpServer.create(InetSocketAddress(0), 0).apply {
+            executor = Executors.newCachedThreadPool()
+            createContext("/") { exchange ->
+                val body = File(exchange.requestURI.path).name.toByteArray()
+                when (exchange.requestMethod) {
+                    "HEAD" -> {
+                        exchange.responseHeaders.set("Content-Length", body.size.toString())
+                        exchange.sendResponseHeaders(200, -1)
+                    }
+                    "GET" -> {
+                        exchange.sendResponseHeaders(200, body.size.toLong())
+                        exchange.responseBody.use { it.write(body) }
+                    }
+                    else -> exchange.sendResponseHeaders(405, -1)
+                }
+                exchange.close()
+            }
+            start()
+        }
+        try {
+            val baseUrl = "http://127.0.0.1:${server.address.port}"
+            val session = AudiobookSession(
+                trackUrls = listOf("$baseUrl/track-0.mp3", "$baseUrl/track-1.mp3"),
+                tracks = listOf(
+                    AudiobookTrackSpan(0, 0.0, 10.0),
+                    AudiobookTrackSpan(1, 10.0, 20.0),
+                ),
+                timeline = AudiobookTimeline(durationSec = 30.0, chapters = emptyList()),
+                serverCurrentTimeSec = 0.0,
+            )
+            val progressUpdates = mutableListOf<Pair<Long, Long>>()
+            val downloader = AudiobookTrackDownloader(
+                createStreamingHttpClient(),
+                com.riffle.core.domain.DefaultDispatcherProvider,
+            )
+
+            downloader.download(
+                session = session,
+                dir = tmp.newFolder(),
+                progress = CumulativeDownloadProgress(0L, onProgress = { d, t -> progressUpdates.add(d to t) }),
+            )
+
+            // HEAD pre-scan must have established a positive total before the first byte flowed.
+            // If this assertion flips red, the pre-scan is broken and progress would show a spinner
+            // instead of a percentage for any multi-track source without a fingerprint (e.g. Radio.es).
+            val expectedTotal = "track-0.mp3".length.toLong() + "track-1.mp3".length.toLong()
+            assert(progressUpdates.isNotEmpty()) { "Expected at least one progress callback" }
+            assert(progressUpdates.first().second == expectedTotal) {
+                "First progress callback must have total=$expectedTotal (from HEAD pre-scan), " +
+                    "got total=${progressUpdates.first().second}"
+            }
+            assert(progressUpdates.all { (_, t) -> t == expectedTotal }) {
+                "Total must remain stable throughout the download"
+            }
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun `multi-track download stays indeterminate when server does not support HEAD`() = runTest {
+        val server = HttpServer.create(InetSocketAddress(0), 0).apply {
+            executor = Executors.newCachedThreadPool()
+            createContext("/") { exchange ->
+                // HEAD returns 405 — server doesn't support it
+                if (exchange.requestMethod == "HEAD") {
+                    exchange.sendResponseHeaders(405, -1)
+                    exchange.close()
+                    return@createContext
+                }
+                val body = File(exchange.requestURI.path).name.toByteArray()
+                exchange.sendResponseHeaders(200, body.size.toLong())
+                exchange.responseBody.use { it.write(body) }
+                exchange.close()
+            }
+            start()
+        }
+        try {
+            val baseUrl = "http://127.0.0.1:${server.address.port}"
+            val session = AudiobookSession(
+                trackUrls = listOf("$baseUrl/track-0.mp3", "$baseUrl/track-1.mp3"),
+                tracks = listOf(
+                    AudiobookTrackSpan(0, 0.0, 10.0),
+                    AudiobookTrackSpan(1, 10.0, 20.0),
+                ),
+                timeline = AudiobookTimeline(durationSec = 30.0, chapters = emptyList()),
+                serverCurrentTimeSec = 0.0,
+            )
+            val progressUpdates = mutableListOf<Pair<Long, Long>>()
+            val downloader = AudiobookTrackDownloader(
+                createStreamingHttpClient(),
+                com.riffle.core.domain.DefaultDispatcherProvider,
+            )
+
+            downloader.download(
+                session = session,
+                dir = tmp.newFolder(),
+                progress = CumulativeDownloadProgress(0L, onProgress = { d, t -> progressUpdates.add(d to t) }),
+            )
+
+            // Without HEAD support, all progress updates must have total=0 (indeterminate).
+            assert(progressUpdates.isNotEmpty())
+            assert(progressUpdates.all { (_, t) -> t == 0L }) {
+                "Total must remain 0 (indeterminate) when HEAD is not supported"
+            }
+        } finally {
+            server.stop(0)
+        }
+    }
+
+    @Test
     fun `download serializes track requests for servers that reject concurrent pulls`() = runTest {
         val overlappingRequests = AtomicBoolean(false)
         val activeRequests = AtomicInteger(0)
@@ -71,6 +185,14 @@ class AudiobookTrackDownloaderTest {
         activeRequests: AtomicInteger,
         overlappingRequests: AtomicBoolean,
     ) {
+        val body = File(exchange.requestURI.path).name.toByteArray()
+        // HEAD pre-scans are intentionally parallel; only GET downloads must be serial.
+        if (exchange.requestMethod == "HEAD") {
+            exchange.responseHeaders.set("Content-Length", body.size.toString())
+            exchange.sendResponseHeaders(200, -1)
+            exchange.close()
+            return
+        }
         val inFlight = activeRequests.incrementAndGet()
         try {
             if (inFlight > 1) {
@@ -79,7 +201,6 @@ class AudiobookTrackDownloaderTest {
                 return
             }
             Thread.sleep(150)
-            val body = File(exchange.requestURI.path).name.toByteArray()
             exchange.sendResponseHeaders(200, body.size.toLong())
             exchange.responseBody.use { it.write(body) }
         } finally {

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/AudiobookTrackDownloader.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/AudiobookTrackDownloader.kt
@@ -4,6 +4,12 @@ import com.riffle.core.domain.AudiobookSession
 import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.network.withHttpByteStream
 import io.ktor.client.HttpClient
+import io.ktor.client.request.prepareHead
+import io.ktor.http.contentLength
+import io.ktor.http.isSuccess
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.IOException
@@ -25,6 +31,20 @@ class AudiobookTrackDownloader constructor(
         dir: File,
         progress: CumulativeDownloadProgress,
     ): List<AudiobookDownloadManifest.ManifestTrack> = withContext(dispatchers.io) {
+        // For multi-track sources (e.g. Radio.es podcasts) whose catalog doesn't provide a
+        // fingerprint size, pre-scan all track URLs in parallel via HEAD to establish the cumulative
+        // total before any bytes flow. Skipped when a fingerprint-based total is already known so
+        // sources like ABS don't pay extra HEAD round-trips. If any track lacks a Content-Length
+        // the pre-scan is skipped and progress stays indeterminate for that download.
+        if (session.trackUrls.size > 1 && !progress.hasKnownTotal()) {
+            val headLengths = coroutineScope {
+                session.trackUrls.map { url -> async { headContentLength(url) } }.awaitAll()
+            }
+            if (headLengths.all { it != null && it > 0L }) {
+                progress.establishTotal(headLengths.sumOf { it!! })
+            }
+        }
+
         buildList(session.trackUrls.size) {
             session.trackUrls.forEachIndexed { i, url ->
                 val fileName = "track-$i"
@@ -60,4 +80,10 @@ class AudiobookTrackDownloader constructor(
             }
         }
     }
+
+    private suspend fun headContentLength(url: String): Long? = runCatching {
+        httpClient.prepareHead(url).execute { response ->
+            if (response.status.isSuccess()) response.contentLength() else null
+        }
+    }.getOrNull()
 }

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/CumulativeDownloadProgress.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/CumulativeDownloadProgress.kt
@@ -18,6 +18,10 @@ internal class CumulativeDownloadProgress(
     private var downloaded = initialDownloaded.coerceAtLeast(0L)
     private var total = total.takeIf { it > 0L } ?: 0L
 
+    /** Returns true when a positive total is already known (from fingerprint or a prior call). */
+    @Synchronized
+    fun hasKnownTotal(): Boolean = total > 0L
+
     /** Establishes an initially unknown total exactly once. */
     @Synchronized
     fun establishTotal(candidate: Long?) {


### PR DESCRIPTION
## Summary

- Multi-track sources without a fingerprint API (e.g. Radio.es podcasts) always showed an indeterminate spinner during downloads because `AudiobookTrackDownloader` only called `establishTotal` for single-track sessions, leaving `total=0` for every multi-track download regardless of HTTP `Content-Length` headers.
- Added a parallel HEAD pre-scan phase that fires before the download loop when `trackUrls.size > 1` and no fingerprint total is already known. If all tracks return a positive `Content-Length`, their sum is established as the cumulative total before the first byte flows — giving a deterministic progress ring instead of a spinner.
- Skips pre-scan automatically when `hasKnownTotal()` is true (e.g. ABS fingerprint), so sources that already have a total pay no extra round-trips.
- Falls back gracefully to indeterminate behavior when any track lacks `Content-Length` or HEAD is unsupported.

## Test plan

- [ ] `AudiobookTrackDownloaderTest`: two new tests — deterministic progress when HEAD is supported, graceful fallback to `total=0` (indeterminate) when HEAD returns 405
- [ ] `AudiobookCacheRepositoryImplTest`: updated to route HEAD requests to 405 via a custom `Dispatcher` so the pre-scan skips without consuming enqueued GET responses
- [ ] `./gradlew :core:data:testAndroidHostTest` passes (1075 tests, 0 failures)
- [ ] Manually trigger a Radio.es podcast download and confirm the percentage ring appears instead of an indeterminate spinner