### PR TITLE
fix(upload): Radio.es podcast upload, live-stream gate, Chitanka getItem crash

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModel.kt
@@ -368,7 +368,11 @@ class LibraryItemDetailViewModel constructor(
                 _uploadPreflight.value = UploadPreflight.Blocked("The item is not loaded yet")
                 return@launch
             }
-            val sourceItem = catalogRegistry.forSourceId(item.sourceId)?.getItem(item.id)
+            val sourceItem = try {
+                catalogRegistry.forSourceId(item.sourceId)?.getItem(item.id)
+            } catch (_: Throwable) {
+                null
+            }
             val destinationCatalog = catalogRegistry.forSourceId(destination.sourceId)
             if (sourceItem == null || destinationCatalog !is BookImportCapability) {
                 _uploadPreflight.value = UploadPreflight.Blocked("This item cannot be prepared for upload")
@@ -670,7 +674,8 @@ class LibraryItemDetailViewModel constructor(
                     // versa. Raw `is` checks (see LibraryItemsViewModel.tabVisibility for the
                     // JVM-target rationale).
                     val catalog = catalogRegistry.forSourceId(item.sourceId)
-                    val canUploadToConfiguredSource = canUploadWebSourceItem(
+                    val isLiveStream = (catalog as? LiveStreamCapability)?.isLiveStream(item.id) == true
+                    val canUploadToConfiguredSource = !isLiveStream && canUploadWebSourceItem(
                         catalog?.sourceType,
                         sourceRepository.observeAll().first().any { destination ->
                             destination.id != item.sourceId &&

--- a/app/src/test/kotlin/com/riffle/app/feature/library/UploadDestinationVisibilityTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/UploadDestinationVisibilityTest.kt
@@ -20,4 +20,14 @@ class UploadDestinationVisibilityTest {
     fun `server source item cannot upload through this action`() {
         assertFalse(canUploadWebSourceItem(SourceType.ABS, hasImportDestination = true))
     }
+
+    @Test
+    fun `radio-es podcast item with an import destination can upload`() {
+        assertTrue(canUploadWebSourceItem(SourceType.RADIO_ES, hasImportDestination = true))
+    }
+
+    @Test
+    fun `radio-es item without configured destination cannot upload`() {
+        assertFalse(canUploadWebSourceItem(SourceType.RADIO_ES, hasImportDestination = false))
+    }
 }

--- a/core/catalog-radio-es/src/main/kotlin/com/riffle/core/catalog/radioes/RadioEsCatalog.kt
+++ b/core/catalog-radio-es/src/main/kotlin/com/riffle/core/catalog/radioes/RadioEsCatalog.kt
@@ -9,6 +9,7 @@ import com.riffle.core.catalog.CatalogAudiobookChapter
 import com.riffle.core.catalog.CatalogAudiobookStream
 import com.riffle.core.catalog.CatalogFacet
 import com.riffle.core.catalog.CatalogFileHandle
+import com.riffle.core.catalog.CatalogFileRetryPolicy
 import com.riffle.core.catalog.CatalogFileStream
 import com.riffle.core.catalog.CatalogHealth
 import com.riffle.core.catalog.CatalogItem
@@ -19,15 +20,18 @@ import com.riffle.core.catalog.LiveStreamCapability
 import com.riffle.core.catalog.OfflineBrowseCapability
 import com.riffle.core.catalog.SortKey
 import com.riffle.core.catalog.ToReadListCapability
+import com.riffle.core.catalog.withCatalogFileStream
 import com.riffle.core.common.Clock
 import com.riffle.core.common.SystemClock
 import com.riffle.core.models.SourceType
+import io.ktor.client.HttpClient
 import java.net.URLEncoder
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 class RadioEsCatalog(
     private val http: RadioEsHttpClient,
+    private val bytesClient: HttpClient,
     private val apiBase: String = RadioEsParser.BASE,
     private val clock: Clock = SystemClock,
 ) : Catalog,
@@ -181,6 +185,29 @@ class RadioEsCatalog(
         handleHint: String?,
         block: suspend (CatalogFileStream) -> T,
     ): T = throw RadioEsException("radio.es is audio-only — use AudiobookMediaCapability per episode")
+
+    // ---- Track streaming (upload support) -----------------------------------
+
+    override suspend fun <T> withTrackStream(
+        itemId: String,
+        trackIno: String,
+        block: suspend (CatalogFileStream) -> T,
+    ): T {
+        if (isLiveStream(itemId)) {
+            throw RadioEsException("Live radio streams cannot be uploaded — only podcast episodes can")
+        }
+        return bytesClient.withCatalogFileStream(
+            handle = CatalogFileHandle.Stream(url = trackIno, format = BookFormat.Audiobook),
+            retryPolicy = CatalogFileRetryPolicy(
+                statusCodes = setOf(429, 503),
+                delaysMs = RadioEsHttpClient.DEFAULT_RETRY_DELAYS_MS,
+            ),
+            httpFailure = { failure ->
+                RadioEsHttpException(failure.code, failure.url, failure.description)
+            },
+            block = block,
+        )
+    }
 
     // ---- Connectivity -------------------------------------------------------
 

--- a/core/catalog-radio-es/src/main/kotlin/com/riffle/core/catalog/radioes/RadioEsCatalogFactory.kt
+++ b/core/catalog-radio-es/src/main/kotlin/com/riffle/core/catalog/radioes/RadioEsCatalogFactory.kt
@@ -20,6 +20,6 @@ class RadioEsCatalogFactory(
             userAgent = userAgent,
             acceptLanguage = acceptLanguage,
         )
-        return RadioEsCatalog(http = http)
+        return RadioEsCatalog(http = http, bytesClient = httpClient)
     }
 }

--- a/core/catalog-radio-es/src/test/kotlin/com/riffle/core/catalog/radioes/RadioEsCatalogTest.kt
+++ b/core/catalog-radio-es/src/test/kotlin/com/riffle/core/catalog/radioes/RadioEsCatalogTest.kt
@@ -32,14 +32,16 @@ class RadioEsCatalogTest {
 
     @Before fun setUp() {
         server = MockWebServer().also { it.start() }
+        val httpClient = HttpClient(OkHttp)
         val http = RadioEsHttpClient(
-            client = HttpClient(OkHttp),
+            client = httpClient,
             userAgent = "Riffle/test",
             acceptLanguage = "es-ES",
             retryDelaysMs = emptyList(),
         )
         catalog = RadioEsCatalog(
             http = http,
+            bytesClient = httpClient,
             apiBase = server.url("").toString().trimEnd('/'),
         )
     }
@@ -360,5 +362,33 @@ class RadioEsCatalogTest {
         val health = catalog.connectivityCheck()
         assertNotNull(health)
         assertTrue(health.isReachable)
+    }
+
+    // ---- withTrackStream (upload support) -----------------------------------
+
+    @Test fun `withTrackStream streams podcast episode bytes from episode URL`() = runTest {
+        val audioBytes = byteArrayOf(0x49, 0x44, 0x33) // ID3 magic bytes
+        server.enqueue(MockResponse().setResponseCode(200).setBody(okio.Buffer().write(audioBytes)))
+        val trackIno = server.url("/episodes/test.mp3").toString()
+        val received = catalog.withTrackStream(
+            itemId = "the-daily",
+            trackIno = trackIno,
+        ) { stream ->
+            stream.byteStream().readBytes()
+        }
+        assertEquals(audioBytes.toList(), received.toList())
+    }
+
+    @Test fun `withTrackStream throws for live stream station items`() = runTest {
+        var threwExpected = false
+        try {
+            catalog.withTrackStream(
+                itemId = "s:cope-madrid",
+                trackIno = "https://stream.example.com/live.m3u8",
+            ) { }
+        } catch (e: RadioEsException) {
+            threwExpected = true
+        }
+        assertTrue("expected RadioEsException for live stream", threwExpected)
     }
 }


### PR DESCRIPTION
## What changed

Three bugs causing ABS upload to fail for Radio.es, Gramofonche, and Chitanka:

**1. Radio.es podcast episodes couldn't be uploaded (`withTrackStream` not implemented)**
`RadioEsCatalog` inherited the default `withTrackStream` from `AudiobookMediaCapability`, which always throws `UnsupportedOperationException`. Implemented it using `withCatalogFileStream` (the same pattern as Chitanka), injecting `bytesClient: HttpClient` via constructor.

**2. Upload button appeared on Radio.es live-stream station items**
`canUploadToConfiguredSource` in `LibraryItemDetailViewModel` didn't check `isLiveStream`. Live radio streams can't be materialized (no fixed file to upload) — the button should be hidden for them. Fixed by gating on `!isLiveStream`.

**3. `checkUploadDestination` crashed silently for Chitanka / Gramofonche**
`catalogRegistry.forSourceId(item.sourceId)?.getItem(item.id)` had no error handling. If Chitanka scraping threw (network error, rate-limit, HTML parse failure), the coroutine crashed silently and the UI would hang in "Checking..." forever. Wrapped in `try-catch`.

## Tests

- `RadioEsCatalogTest.withTrackStream streams podcast episode bytes from episode URL` — verifies bytes flow end-to-end through a `MockWebServer`
- `RadioEsCatalogTest.withTrackStream throws for live stream station items` — pins the live-stream guard
- `UploadDestinationVisibilityTest.radio-es podcast item with an import destination can upload`
- `UploadDestinationVisibilityTest.radio-es item without configured destination cannot upload`

The assertions that would flip red on revert:
- Remove `withTrackStream` → `withTrackStream streams podcast episode bytes` throws `UnsupportedOperationException`
- Remove `isLiveStream` gate → no test directly catches ViewModel-level gate, but `withTrackStream throws for live stream` pins the underlying guard
- Remove `try { } catch` → no JVM-level test (ViewModel scope; extraction would be disproportionate — caught in harness)