### PR TITLE
feat(library): remove web-source item from library via long-press

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/di/KoinViewModelModules.kt
+++ b/app/src/main/kotlin/com/riffle/app/di/KoinViewModelModules.kt
@@ -417,6 +417,8 @@ private val sourceViewModelModule = module {
             savedStateHandle = get(),
             libraryObserver = get(),
             toReadRepository = get(),
+            libraryMutator = get(),
+            remoteItemFreshness = get(),
         )
     }
     viewModel { AddRadioEsViewModel(installer = get()) }

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -510,9 +511,11 @@ fun BookSectionGrid(
     onSeeMore: (() -> Unit)? = null,
     linkedItemIds: Set<String> = emptySet(),
     showSeriesBadge: Boolean = false,
+    onItemLongPress: ((LibraryItem) -> Unit)? = null,
 ) {
     val minCell = shelfCoverMinCellSize()
     val spacing = 8.dp
+    var longPressedItem by remember { mutableStateOf<LibraryItem?>(null) }
     BoxWithConstraints(Modifier.padding(horizontal = 12.dp)) {
         val columns = max(1, floor((maxWidth + spacing) / (minCell + spacing)).toInt())
         val previewCount = max(1, columns * 2 - 1)
@@ -528,13 +531,30 @@ fun BookSectionGrid(
                 SeeMoreTile(overflowCount = overflowCount, onClick = onSeeMore)
             } else {
                 val item = preview[index]
-                BookCoverTile(
-                    item = item,
-                    token = token,
-                    onClick = { onItemSelected(item) },
-                    hasReadaloudLink = item.id in linkedItemIds,
-                    seriesNameBadge = if (showSeriesBadge) item.seriesName else null,
-                )
+                Box {
+                    BookCoverTile(
+                        item = item,
+                        token = token,
+                        onClick = { onItemSelected(item) },
+                        onLongClick = if (onItemLongPress != null) { { longPressedItem = item } } else null,
+                        hasReadaloudLink = item.id in linkedItemIds,
+                        seriesNameBadge = if (showSeriesBadge) item.seriesName else null,
+                    )
+                    if (onItemLongPress != null) {
+                        DropdownMenu(
+                            expanded = longPressedItem == item,
+                            onDismissRequest = { longPressedItem = null },
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.ui_remove_from_library)) },
+                                onClick = {
+                                    longPressedItem = null
+                                    onItemLongPress(item)
+                                },
+                            )
+                        }
+                    }
+                }
             }
         }
     }
@@ -665,6 +685,7 @@ fun BookCoverTile(
     item: LibraryItem,
     token: String,
     onClick: () -> Unit,
+    onLongClick: (() -> Unit)? = null,
     hasReadaloudLink: Boolean = false,
     seriesNameBadge: String? = null,
 ) {
@@ -677,7 +698,17 @@ fun BookCoverTile(
     Column(
         modifier = Modifier
             .alpha(alpha)
-            .clickable(enabled = item.isPlayable, onClick = onClick),
+            .then(
+                if (onLongClick != null) {
+                    Modifier.combinedClickable(
+                        enabled = item.isPlayable,
+                        onClick = onClick,
+                        onLongClick = onLongClick,
+                    )
+                } else {
+                    Modifier.clickable(enabled = item.isPlayable, onClick = onClick)
+                }
+            ),
     ) {
         Box(
             modifier = Modifier
@@ -1492,6 +1523,7 @@ internal fun HomeTabContent(
     onSectionSeeMore: (LibrarySectionType) -> Unit,
     linkedItemIds: Set<String> = emptySet(),
     onCoverScaleChange: (Float) -> Unit = {},
+    onItemLongPress: ((LibraryItem) -> Unit)? = null,
 ) {
     if (isLoading) return
     if (inProgress.isEmpty() && continueSeries.isEmpty() && recentlyAdded.isEmpty() && finished.isEmpty()) {
@@ -1538,6 +1570,7 @@ internal fun HomeTabContent(
                     onItemSelected = onItemSelected,
                     onSeeMore = { onSectionSeeMore(LibrarySectionType.IN_PROGRESS) },
                     linkedItemIds = linkedItemIds,
+                    onItemLongPress = onItemLongPress,
                 )
             }
         }
@@ -1551,6 +1584,7 @@ internal fun HomeTabContent(
                     onSeeMore = null,
                     linkedItemIds = linkedItemIds,
                     showSeriesBadge = true,
+                    onItemLongPress = onItemLongPress,
                 )
             }
         }
@@ -1563,6 +1597,7 @@ internal fun HomeTabContent(
                     onItemSelected = onItemSelected,
                     onSeeMore = { onSectionSeeMore(LibrarySectionType.RECENTLY_ADDED) },
                     linkedItemIds = linkedItemIds,
+                    onItemLongPress = onItemLongPress,
                 )
             }
         }
@@ -1575,6 +1610,7 @@ internal fun HomeTabContent(
                     onItemSelected = onItemSelected,
                     onSeeMore = { onSectionSeeMore(LibrarySectionType.FINISHED) },
                     linkedItemIds = linkedItemIds,
+                    onItemLongPress = onItemLongPress,
                 )
             }
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/source/websource/WebSourceLibraryViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/websource/WebSourceLibraryViewModel.kt
@@ -11,6 +11,8 @@ import com.riffle.app.feature.library.HomeTabContent
 import com.riffle.feature.library.LibrarySectionType
 import com.riffle.app.feature.library.ToReadTabContent
 import com.riffle.core.data.ToReadRepository
+import com.riffle.core.data.websource.RemoteItemFreshness
+import com.riffle.core.domain.LibraryMutator
 import com.riffle.core.domain.LibraryObserver
 import com.riffle.core.models.LibraryItem
 import kotlinx.coroutines.flow.Flow
@@ -18,6 +20,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
 /**
  * Room-backed acquired-item shelves shared by every Web Source.
@@ -30,6 +33,8 @@ class WebSourceLibraryViewModel constructor(
     savedStateHandle: SavedStateHandle,
     libraryObserver: LibraryObserver,
     toReadRepository: ToReadRepository,
+    private val libraryMutator: LibraryMutator,
+    private val remoteItemFreshness: RemoteItemFreshness,
 ) : ViewModel() {
 
     private val libraryId: String = savedStateHandle.get<String>("libraryId") ?: ""
@@ -50,6 +55,17 @@ class WebSourceLibraryViewModel constructor(
         toReadItemIds = toReadRepository.observeToReadItemIds(libraryId),
         allBooks = libraryObserver.observeAllBooks(libraryId),
     ).stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    fun removeFromLibrary(sourceId: String, itemId: String) {
+        viewModelScope.launch {
+            removeFromLibrary(
+                sourceId = sourceId,
+                itemId = itemId,
+                libraryMutator = libraryMutator,
+                clearFreshness = remoteItemFreshness::clear,
+            )
+        }
+    }
 }
 
 internal fun webSourceToReadItems(
@@ -57,6 +73,16 @@ internal fun webSourceToReadItems(
     allBooks: Flow<List<LibraryItem>>,
 ): Flow<List<LibraryItem>> = combine(toReadItemIds, allBooks) { ids, all ->
     all.filter { it.id in ids }
+}
+
+internal suspend fun removeFromLibrary(
+    sourceId: String,
+    itemId: String,
+    libraryMutator: LibraryMutator,
+    clearFreshness: suspend (String, String) -> Unit,
+) {
+    libraryMutator.deleteItem(sourceId, itemId)
+    clearFreshness(sourceId, itemId)
 }
 
 @Composable
@@ -81,6 +107,7 @@ fun WebSourceHomeTab(
         onItemSelected = { item -> onOpenDetail(item.id) },
         onSectionSeeMore = onSectionSeeMore,
         onCoverScaleChange = onCoverScaleChange,
+        onItemLongPress = { item -> viewModel.removeFromLibrary(item.sourceId, item.id) },
     )
 }
 

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -223,6 +223,7 @@
     <string name="ui_remove_download">Премахване на изтеглянето</string>
     <string name="ui_remove_folder">Премахване на папка?</string>
     <string name="ui_remove_folder_3">Премахване на папка</string>
+    <string name="ui_remove_from_library">Премахване от библиотеката</string>
     <string name="ui_remove_from_playlist">Премахване от плейлиста</string>
     <string name="ui_remove_readaloud_download">Премахнете изтеглянето за четене на глас</string>
     <string name="ui_remove_source">Премахване на източника</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -223,6 +223,7 @@
     <string name="ui_remove_download">Eliminar descarga</string>
     <string name="ui_remove_folder">¿Quitar carpeta?</string>
     <string name="ui_remove_folder_3">Quitar carpeta</string>
+    <string name="ui_remove_from_library">Eliminar de la biblioteca</string>
     <string name="ui_remove_from_playlist">Eliminar de la lista de reproducción</string>
     <string name="ui_remove_readaloud_download">Eliminar descarga de lectura en voz alta</string>
     <string name="ui_remove_source">Eliminar fuente</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -227,6 +227,7 @@
     <string name="ui_remove_download">Remove download</string>
     <string name="ui_remove_folder">Remove folder?</string>
     <string name="ui_remove_folder_3">Remove folder</string>
+    <string name="ui_remove_from_library">Remove from library</string>
     <string name="ui_remove_from_playlist">Remove from playlist</string>
     <string name="ui_remove_readaloud_download">Remove readaloud download</string>
     <string name="ui_remove_source">Remove source</string>

--- a/app/src/test/kotlin/com/riffle/app/feature/source/websource/WebSourceLibraryViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/websource/WebSourceLibraryViewModelTest.kt
@@ -1,11 +1,13 @@
 package com.riffle.app.feature.source.websource
 
+import com.riffle.core.domain.LibraryMutator
 import com.riffle.core.models.EbookFormat
 import com.riffle.core.models.LibraryItem
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class WebSourceLibraryViewModelTest {
@@ -24,6 +26,22 @@ class WebSourceLibraryViewModelTest {
         assertEquals(listOf(first, third), result)
     }
 
+    @Test
+    fun `removeFromLibrary deletes item and clears freshness stamp`() = runTest {
+        val mutator = RecordingLibraryMutator()
+        val cleared = mutableListOf<Pair<String, String>>()
+
+        removeFromLibrary(
+            sourceId = "src-1",
+            itemId = "item-42",
+            libraryMutator = mutator,
+            clearFreshness = { sourceId, itemId -> cleared += sourceId to itemId },
+        )
+
+        assertTrue("deleteItem was not called", mutator.deleted.contains("src-1" to "item-42"))
+        assertTrue("freshness was not cleared", cleared.contains("src-1" to "item-42"))
+    }
+
     private fun item(id: String) = LibraryItem(
         id = id,
         libraryId = "books",
@@ -35,4 +53,12 @@ class WebSourceLibraryViewModelTest {
         isDownloaded = false,
         ebookFormat = EbookFormat.Epub,
     )
+}
+
+private class RecordingLibraryMutator : LibraryMutator {
+    val deleted = mutableListOf<Pair<String, String>>()
+    override suspend fun markItemOpened(itemId: String) = Unit
+    override suspend fun updateReadingProgress(itemId: String, progress: Float) = Unit
+    override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) = Unit
+    override suspend fun deleteItem(sourceId: String, itemId: String) { deleted += sourceId to itemId }
 }

--- a/app/src/test/kotlin/com/riffle/app/testing/LibraryUseCaseFakes.kt
+++ b/app/src/test/kotlin/com/riffle/app/testing/LibraryUseCaseFakes.kt
@@ -30,6 +30,7 @@ object NoopLibraryMutator : LibraryMutator {
     override suspend fun markItemOpened(itemId: String) = Unit
     override suspend fun updateReadingProgress(itemId: String, progress: Float) = Unit
     override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) = Unit
+    override suspend fun deleteItem(sourceId: String, itemId: String) = Unit
 }
 
 object NoopReadingSessionRepository : ReadingSessionRepository {

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/LibraryRepositoryImpl.kt
@@ -168,6 +168,10 @@ class LibraryRepositoryImpl constructor(
         libraryItemDao.updateReadingProgress(sourceId, itemId, progress)
     }
 
+    override suspend fun deleteItem(sourceId: String, itemId: String) {
+        libraryItemDao.deleteById(sourceId, itemId)
+    }
+
     override suspend fun refreshLibraries(): LibraryRefreshResult {
         val source = sourceRepository.getActive() ?: return LibraryRefreshResult.NoActiveServer
         val catalog = catalogRegistry.forSource(source) ?: return LibraryRefreshResult.NoActiveServer

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/LibraryRepository.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/LibraryRepository.kt
@@ -75,6 +75,9 @@ interface LibraryMutator {
 
     /** Writes the new readingProgress to a specific server's local row. Cross-server callers. */
     suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float)
+
+    /** Removes the item row from the local cache. Safe for web-source items (re-openable from catalog). */
+    suspend fun deleteItem(sourceId: String, itemId: String)
 }
 
 /**

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/usecase/MarkReadAcrossDimensionsTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/usecase/MarkReadAcrossDimensionsTest.kt
@@ -37,6 +37,7 @@ class MarkReadAcrossDimensionsTest {
         override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) {
             progressCalls += itemId to progress
         }
+        override suspend fun deleteItem(sourceId: String, itemId: String) = Unit
     }
 
     private class RecordingSession : ReadingSessionRepository {

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/usecase/RecordItemOpenedTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/usecase/RecordItemOpenedTest.kt
@@ -21,6 +21,7 @@ class RecordItemOpenedTest {
         override suspend fun markItemOpened(itemId: String) { openedIds += itemId }
         override suspend fun updateReadingProgress(itemId: String, progress: Float) = Unit
         override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) = Unit
+        override suspend fun deleteItem(sourceId: String, itemId: String) = Unit
     }
 
     private class RecordingSession : ReadingSessionRepository {


### PR DESCRIPTION
## Summary

- Long-pressing a book tile on a web-source Home tab (Chitanka, Gutenberg, Radio-ES) shows a context menu with **Remove from library**.
- Selecting it deletes the `library_items` row and clears the `RemoteItemFreshness` stamp, so re-opening the item from the catalog fetches fresh metadata.
- Non-web-source Home tabs (ABS, Komga, Kavita, Local Files) are unaffected — `onItemLongPress` is `null` there and the long-press gesture is not attached.

## Changes

- `LibraryMutator.deleteItem(sourceId, itemId)` — new interface method
- `LibraryRepositoryImpl` delegates to existing `LibraryItemDao.deleteById`
- `BookCoverTile` accepts optional `onLongClick`; falls back to plain `clickable` when unset
- `BookSectionGrid` shows a `DropdownMenu` when `onItemLongPress` is provided
- `HomeTabContent` threads `onItemLongPress` to every section grid
- `WebSourceHomeTab` opts in; other Home tab callers pass nothing
- String `ui_remove_from_library` added in en/es/bg

## Test plan

- [ ] `WebSourceLibraryViewModelTest.removeFromLibrary deletes item and clears freshness stamp` — verifies `deleteItem` + `clearFreshness` are both called
- [ ] Run `./gradlew test jvmTest` — all JVM tests pass
- [ ] Long-press a book on Chitanka/Gutenberg/Radio-ES Home tab → "Remove from library" appears → tap it → item disappears from shelf
- [ ] Tap the same book from the catalog → it reappears in the library (confirms row was deleted cleanly)
- [ ] Long-press a book on an ABS/Komga Home tab → no context menu (confirm no regression)

## iOS

Web source browse screens (Chitanka, Gutenberg, Radio-ES) are Android-only in `app/`. The iOS shared module has no equivalent home tab for web sources, so no iOS parity change is required.