### PR TITLE
feat(radio-es): country filter for radio stations tab

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/source/radioes/RadioEsBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/radioes/RadioEsBrowseScreen.kt
@@ -269,6 +269,16 @@ private fun RadioEsLibraryTabContent(
                         )
                     }
                 }
+                val countryFacets = radioEsCountryFacets(facets)
+                if (countryFacets.isNotEmpty()) {
+                    item {
+                        RadioEsCountryFilterChip(
+                            countryFacets = countryFacets,
+                            selectedFacet = selectedFacet,
+                            onSelectFacet = { viewModel.selectFacet(it) },
+                        )
+                    }
+                }
             }
         }
         Box(modifier = Modifier.fillMaxSize()) {
@@ -371,10 +381,71 @@ private fun RadioEsLanguageFilterChip(
     }
 }
 
+@Composable
+private fun RadioEsCountryFilterChip(
+    countryFacets: List<CatalogFacet>,
+    selectedFacet: String?,
+    onSelectFacet: (String?) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val selectedCountry = countryFacets.firstOrNull { it.key == selectedFacet }
+
+    Box {
+        FilterChip(
+            selected = selectedCountry != null,
+            onClick = { expanded = true },
+            label = {
+                Text(
+                    stringResource(
+                        R.string.ui_country_filter,
+                        selectedCountry?.label ?: stringResource(R.string.ui_any),
+                    ),
+                )
+            },
+            trailingIcon = {
+                Icon(
+                    Icons.Filled.ArrowDropDown,
+                    contentDescription = null,
+                    modifier = Modifier.size(FilterChipDefaults.IconSize),
+                )
+            },
+        )
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.ui_any)) },
+                onClick = {
+                    onSelectFacet(null)
+                    expanded = false
+                },
+                leadingIcon = if (selectedCountry == null) {
+                    { Icon(Icons.Filled.Check, contentDescription = null) }
+                } else null,
+            )
+            countryFacets.forEach { facet ->
+                DropdownMenuItem(
+                    text = { Text(facet.label) },
+                    onClick = {
+                        onSelectFacet(facet.key)
+                        expanded = false
+                    },
+                    leadingIcon = if (facet.key == selectedFacet) {
+                        { Icon(Icons.Filled.Check, contentDescription = null) }
+                    } else null,
+                )
+            }
+        }
+    }
+}
+
 internal fun radioEsLanguageFacets(facets: List<CatalogFacet>): List<CatalogFacet> =
     facets.filter { it.key.startsWith(RADIO_ES_LANGUAGE_FACET_PREFIX) }
 
 internal fun radioEsCategoryFacets(facets: List<CatalogFacet>): List<CatalogFacet> =
     facets.filterNot { it.key.startsWith(RADIO_ES_LANGUAGE_FACET_PREFIX) }
+        .filterNot { it.key.startsWith(RADIO_ES_COUNTRY_FACET_PREFIX) }
+
+internal fun radioEsCountryFacets(facets: List<CatalogFacet>): List<CatalogFacet> =
+    facets.filter { it.key.startsWith(RADIO_ES_COUNTRY_FACET_PREFIX) }
 
 private const val RADIO_ES_LANGUAGE_FACET_PREFIX = "lang:"
+private const val RADIO_ES_COUNTRY_FACET_PREFIX = "country:"

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -350,6 +350,7 @@
     <string name="ui_download_readaloud_audio_size">Изтегляне на аудио за четене на глас (%1$s)</string>
     <string name="ui_words_per_minute">%1$d думи/мин</string>
     <string name="ui_language_filter">Език: %1$s</string>
+    <string name="ui_country_filter">Държава: %1$s</string>
     <string name="error_enter_valid_url">Въведете валиден URL (напр. https://abs.example.com)</string>
     <string name="error_parse_webdav_url">URL адресът не можа да се разчете — трябва да изглежда като https://example.com/dav/path</string>
     <string name="error_auth_failed_check_credentials">Удостоверяването е неуспешно — проверете потребителското име и паролата.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -350,6 +350,7 @@
     <string name="ui_download_readaloud_audio_size">Descargar audio de lectura en voz alta (%1$s)</string>
     <string name="ui_words_per_minute">%1$d ppm</string>
     <string name="ui_language_filter">Idioma: %1$s</string>
+    <string name="ui_country_filter">País: %1$s</string>
     <string name="error_enter_valid_url">Introduce una URL válida (p. ej. https://abs.example.com)</string>
     <string name="error_parse_webdav_url">No se pudo interpretar la URL; debería parecerse a https://example.com/dav/path</string>
     <string name="error_auth_failed_check_credentials">Error de autenticación; comprueba tu usuario y contraseña.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -353,6 +353,7 @@
     <string name="ui_download_readaloud_audio_size">Download readaloud audio (%1$s)</string>
     <string name="ui_words_per_minute">%1$d wpm</string>
     <string name="ui_language_filter">Language: %1$s</string>
+    <string name="ui_country_filter">Country: %1$s</string>
     <string name="error_enter_valid_url">Enter a valid URL (e.g. https://abs.example.com)</string>
     <string name="error_parse_webdav_url">Could not parse URL — it should look like https://example.com/dav/path</string>
     <string name="error_auth_failed_check_credentials">Authentication failed — check your username and password.</string>

--- a/core/catalog-radio-es/src/main/kotlin/com/riffle/core/catalog/radioes/RadioEsCatalog.kt
+++ b/core/catalog-radio-es/src/main/kotlin/com/riffle/core/catalog/radioes/RadioEsCatalog.kt
@@ -51,8 +51,17 @@ class RadioEsCatalog(
     private val facetsMutex = Mutex()
     private var cachedFacets: List<CatalogFacet>? = null
 
-    override suspend fun listFacets(rootId: String): List<CatalogFacet> {
-        if (rootId != ROOT_PODCASTS) return emptyList()
+    private val stationTagsMutex = Mutex()
+    private var cachedCountryFacets: List<CatalogFacet>? = null
+    private var cachedCountryNameBySlug: Map<String, String>? = null
+
+    override suspend fun listFacets(rootId: String): List<CatalogFacet> = when (rootId) {
+        ROOT_PODCASTS -> loadPodcastFacets()
+        ROOT_STATIONS -> loadStationCountryFacets()
+        else -> emptyList()
+    }
+
+    private suspend fun loadPodcastFacets(): List<CatalogFacet> {
         cachedFacets?.let { return it }
         return facetsMutex.withLock {
             cachedFacets?.let { return@withLock it }
@@ -75,6 +84,23 @@ class RadioEsCatalog(
         }
     }
 
+    private suspend fun loadStationCountryFacets(): List<CatalogFacet> {
+        cachedCountryFacets?.let { return it }
+        return stationTagsMutex.withLock {
+            cachedCountryFacets?.let { return@withLock it }
+            val body = runCatching { http.getString("$apiBase/stations/tags") }.getOrNull()
+                ?: return@withLock emptyList()
+            val countries = RadioEsParser.parseStationCountries(body)
+                .filter { it.slug.isNotEmpty() }
+            cachedCountryNameBySlug = countries.associate { it.slug to it.systemName }
+            val facets = countries.mapIndexed { idx, c ->
+                CatalogFacet(key = "country:${c.slug}", label = c.name, sortOrder = idx)
+            }
+            cachedCountryFacets = facets
+            facets
+        }
+    }
+
     // ---- Browse -------------------------------------------------------------
 
     override suspend fun browse(
@@ -86,7 +112,7 @@ class RadioEsCatalog(
     ): List<CatalogItem> {
         return when (rootId) {
             ROOT_PODCASTS -> browsePodcasts(facet, page, pageSize)
-            ROOT_STATIONS -> browseStations(page, pageSize)
+            ROOT_STATIONS -> browseStations(facet, page, pageSize)
             else -> emptyList()
         }
     }
@@ -103,8 +129,19 @@ class RadioEsCatalog(
             .map { it.toCatalogItem() }
     }
 
-    private suspend fun browseStations(page: Int, pageSize: Int): List<CatalogItem> {
+    private suspend fun browseStations(facet: FacetSelection?, page: Int, pageSize: Int): List<CatalogItem> {
         val offset = page * pageSize
+        if (facet != null && facet.key.startsWith("country:")) {
+            val slug = facet.key.removePrefix("country:")
+            val countryName = cachedCountryNameBySlug?.get(slug)
+                ?: slug.replaceFirstChar { it.uppercase() }
+            val encoded = URLEncoder.encode(countryName, "UTF-8")
+            val url = "$apiBase/stations/search?query=$encoded&count=$pageSize&offset=$offset"
+            val body = http.getString(url)
+            return RadioEsParser.parseStations(body).stations
+                .filter { !it.streamUrl.isNullOrBlank() }
+                .map { it.toCatalogItem() }
+        }
         val url = "$apiBase/stations/local?count=$pageSize&offset=$offset"
         val body = http.getString(url)
         return RadioEsParser.parseStations(body).stations

--- a/core/catalog-radio-es/src/main/kotlin/com/riffle/core/catalog/radioes/RadioEsCatalog.kt
+++ b/core/catalog-radio-es/src/main/kotlin/com/riffle/core/catalog/radioes/RadioEsCatalog.kt
@@ -134,7 +134,7 @@ class RadioEsCatalog(
         if (facet != null && facet.key.startsWith("country:")) {
             val slug = facet.key.removePrefix("country:")
             val countryName = cachedCountryNameBySlug?.get(slug)
-                ?: slug.replaceFirstChar { it.uppercase() }
+                ?: slug.split("-").joinToString(" ") { it.replaceFirstChar { c -> c.uppercase() } }
             val encoded = URLEncoder.encode(countryName, "UTF-8")
             val url = "$apiBase/stations/search?query=$encoded&count=$pageSize&offset=$offset"
             val body = http.getString(url)

--- a/core/catalog-radio-es/src/main/kotlin/com/riffle/core/catalog/radioes/RadioEsParser.kt
+++ b/core/catalog-radio-es/src/main/kotlin/com/riffle/core/catalog/radioes/RadioEsParser.kt
@@ -64,6 +64,11 @@ internal object RadioEsParser {
         return parseStation(obj)
     }
 
+    fun parseStationCountries(body: String): List<RadioEsCountryTag> {
+        val root = json.parseToJsonElement(body).jsonObject
+        return root["countries"]?.jsonArray?.mapNotNull { parseCountryTag(it) } ?: emptyList()
+    }
+
     fun parseTags(body: String): RadioEsTagsResult {
         val root = json.parseToJsonElement(body).jsonObject
         val cats = root["categories"]?.jsonArray?.mapNotNull { parseTag(it) } ?: emptyList()
@@ -153,6 +158,14 @@ internal object RadioEsParser {
         val name = obj["name"]?.jsonPrimitive?.contentOrNull.orEmpty()
         val slug = obj["slug"]?.jsonPrimitive?.contentOrNull.orEmpty()
         return RadioEsCategoryTag(systemName = systemName, name = name, slug = slug)
+    }
+
+    private fun parseCountryTag(element: JsonElement): RadioEsCountryTag? {
+        val obj = element as? JsonObject ?: return null
+        val systemName = obj["systemName"]?.jsonPrimitive?.contentOrNull.orEmpty().ifEmpty { return null }
+        val name = obj["name"]?.jsonPrimitive?.contentOrNull.orEmpty()
+        val slug = obj["slug"]?.jsonPrimitive?.contentOrNull.orEmpty()
+        return RadioEsCountryTag(systemName = systemName, name = name, slug = slug)
     }
 
     private fun parseLangTag(element: JsonElement): RadioEsLanguageTag? {

--- a/core/catalog-radio-es/src/main/kotlin/com/riffle/core/catalog/radioes/RadioEsTypes.kt
+++ b/core/catalog-radio-es/src/main/kotlin/com/riffle/core/catalog/radioes/RadioEsTypes.kt
@@ -59,6 +59,12 @@ internal data class RadioEsEpisodesResult(
     val totalCount: Int,
 )
 
+internal data class RadioEsCountryTag(
+    val systemName: String,
+    val name: String,
+    val slug: String,
+)
+
 internal data class RadioEsTagsResult(
     val categories: List<RadioEsCategoryTag>,
     val languages: List<RadioEsLanguageTag>,

--- a/core/catalog-radio-es/src/test/kotlin/com/riffle/core/catalog/radioes/RadioEsCatalogTest.kt
+++ b/core/catalog-radio-es/src/test/kotlin/com/riffle/core/catalog/radioes/RadioEsCatalogTest.kt
@@ -368,6 +368,23 @@ class RadioEsCatalogTest {
         )
     }
 
+    @Test fun `browse stations with multi-word country facet uses space-separated name as search query`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("radioes-stations.json")))
+        catalog.browse(
+            rootId = RadioEsCatalog.ROOT_STATIONS,
+            page = 0,
+            pageSize = 20,
+            facet = FacetSelection(key = "country:united-states"),
+        )
+        val request = server.takeRequest()
+        assertTrue(
+            "/stations/search with query=United+States expected, got: ${request.path}",
+            request.path?.startsWith("/stations/search") == true &&
+                (request.path?.contains("query=United+States") == true ||
+                    request.path?.contains("query=United%20States") == true),
+        )
+    }
+
     @Test fun `browse stations with no facet uses device locale Accept-Language header`() = runTest {
         server.enqueue(MockResponse().setBody(fixture("radioes-stations.json")))
         catalog.browse(rootId = RadioEsCatalog.ROOT_STATIONS, page = 0, pageSize = 20)

--- a/core/catalog-radio-es/src/test/kotlin/com/riffle/core/catalog/radioes/RadioEsCatalogTest.kt
+++ b/core/catalog-radio-es/src/test/kotlin/com/riffle/core/catalog/radioes/RadioEsCatalogTest.kt
@@ -325,9 +325,54 @@ class RadioEsCatalogTest {
         assertTrue(item.isLiveStream)
     }
 
-    @Test fun `listFacets returns empty for stations root`() = runTest {
+    @Test fun `listFacets returns country facets for stations root`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("radioes-station-tags.json")))
         val facets = catalog.listFacets(RadioEsCatalog.ROOT_STATIONS)
-        assertTrue(facets.isEmpty())
+        assertTrue("expected country facets for stations, got: $facets", facets.isNotEmpty())
+        assertTrue(facets.all { it.key.startsWith("country:") })
+        assertTrue(facets.any { it.key == "country:germany" })
+        assertTrue(facets.any { it.key == "country:spain" })
+    }
+
+    @Test fun `listFacets for stations root uses stations tags endpoint not podcast tags`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("radioes-station-tags.json")))
+        catalog.listFacets(RadioEsCatalog.ROOT_STATIONS)
+        val request = server.takeRequest()
+        assertTrue(
+            "/stations/tags expected, got: ${request.path}",
+            request.path?.startsWith("/stations/tags") == true,
+        )
+    }
+
+    @Test fun `listFacets for stations root caches separately from podcast facets`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("radioes-tags.json")))
+        server.enqueue(MockResponse().setBody(fixture("radioes-station-tags.json")))
+        catalog.listFacets(RadioEsCatalog.ROOT_PODCASTS)
+        catalog.listFacets(RadioEsCatalog.ROOT_STATIONS)
+        assertEquals("each root should hit its own tags endpoint once", 2, server.requestCount)
+    }
+
+    @Test fun `browse stations with country facet sends search request with country name`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("radioes-stations.json")))
+        catalog.browse(
+            rootId = RadioEsCatalog.ROOT_STATIONS,
+            page = 0,
+            pageSize = 20,
+            facet = FacetSelection(key = "country:germany"),
+        )
+        val request = server.takeRequest()
+        assertTrue(
+            "/stations/search with query=Germany expected, got: ${request.path}",
+            request.path?.startsWith("/stations/search") == true &&
+                request.path?.contains("query=Germany") == true,
+        )
+    }
+
+    @Test fun `browse stations with no facet uses device locale Accept-Language header`() = runTest {
+        server.enqueue(MockResponse().setBody(fixture("radioes-stations.json")))
+        catalog.browse(rootId = RadioEsCatalog.ROOT_STATIONS, page = 0, pageSize = 20)
+        val request = server.takeRequest()
+        assertEquals("es-ES", request.getHeader("Accept-Language"))
     }
 
     @Test fun `openAudiobook for station returns single-track stream with totalDurationSec zero`() = runTest {

--- a/core/catalog-radio-es/src/test/kotlin/com/riffle/core/catalog/radioes/RadioEsParserTest.kt
+++ b/core/catalog-radio-es/src/test/kotlin/com/riffle/core/catalog/radioes/RadioEsParserTest.kt
@@ -181,6 +181,23 @@ class RadioEsParserTest {
     }
 
     @Test
+    fun `parseStationCountries extracts country list from stations tags body`() {
+        val countries = RadioEsParser.parseStationCountries(fixture("radioes-station-tags.json"))
+        assertEquals(3, countries.size)
+        val germany = countries.first { it.slug == "germany" }
+        assertEquals("Germany", germany.systemName)
+        assertEquals("Germany", germany.name)
+        val us = countries.first { it.slug == "united-states" }
+        assertEquals("United States", us.systemName)
+    }
+
+    @Test
+    fun `parseStationCountries tolerates missing countries key`() {
+        val countries = RadioEsParser.parseStationCountries("""{"languages":[],"topics":[]}""")
+        assertTrue(countries.isEmpty())
+    }
+
+    @Test
     fun `parseTags skips tag entries missing systemName`() {
         val body = """{"categories":[{"name":"NoSystemName"},{"systemName":"CAT_OK","name":"OK"}],"languages":[]}"""
         val result = RadioEsParser.parseTags(body)

--- a/core/catalog-radio-es/src/test/resources/radioes-station-tags.json
+++ b/core/catalog-radio-es/src/test/resources/radioes-station-tags.json
@@ -1,0 +1,17 @@
+{
+  "languages": [
+    { "systemName": "English", "name": "English", "slug": "english" },
+    { "systemName": "German", "name": "German", "slug": "german" }
+  ],
+  "topics": [
+    { "systemName": "News", "name": "News", "slug": "news" }
+  ],
+  "genres": [
+    { "systemName": "Pop", "name": "Pop", "slug": "pop" }
+  ],
+  "countries": [
+    { "systemName": "Germany", "name": "Germany", "slug": "germany", "count": 1234 },
+    { "systemName": "Spain", "name": "Spain", "slug": "spain", "count": 456 },
+    { "systemName": "United States", "name": "United States", "slug": "united-states", "count": 789 }
+  ]
+}


### PR DESCRIPTION
## What

Adds a **Country** dropdown filter chip to the radio.es Library tab (stations root), allowing users to browse radio stations from a specific country.

## How it works

The radio.es `/stations/local` endpoint returns geo-IP-based results and ignores `Accept-Language` for content filtering (only translates country names). The API does expose `/stations/tags` which returns 170 countries with slugs, and `/stations/search?query=CountryName` reliably returns stations from that country.

- `RadioEsParser.parseStationCountries()` reads the `countries` array from `/stations/tags`
- `listFacets(ROOT_STATIONS)` fetches `/stations/tags` via a separate cache (independent of the podcast-tags cache) and returns `country:`-prefixed `CatalogFacet` entries
- `browseStations` with a `country:` facet routes to `search?query=CountryName` (no-facet stays on `/stations/local`)
- `RadioEsCountryFilterChip` dropdown in the Library tab — same pattern as the language chip for podcasts
- Fallback for unpopulated cache splits the slug on hyphens and capitalises each word (`united-states` → `United States`)

## Why not language?

The language-via-`Accept-Language` approach was investigated and confirmed not to work: the server ignores the header for content selection on the `/stations/local` endpoint. Country filtering via search is what the API actually supports.

## Changes

- `RadioEsTypes.kt` — new `RadioEsCountryTag`
- `RadioEsParser.kt` — `parseStationCountries()`
- `RadioEsCatalog.kt` — separate station-tags cache; `ROOT_STATIONS` → country facets; country facet → search routing; multi-word slug fallback
- `RadioEsBrowseScreen.kt` — `RadioEsCountryFilterChip`, `radioEsCountryFacets()`, updated `radioEsCategoryFacets()`
- `strings.xml` (en/bg/es) — `ui_country_filter`
- Tests — `RadioEsParserTest` + `RadioEsCatalogTest` cover country parsing, facet endpoint, cache independence, search routing, multi-word slug fallback