### PR TITLE
feat(ios): wire PlaylistsRepository and ToReadRepository (#912)

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -59,6 +59,7 @@ kotlin {
             implementation(libs.koin.core)
             implementation(project(":core:database"))
             implementation(project(":core:net"))
+            implementation(project(":core:logging"))
         }
         getByName("androidHostTest").dependencies {
             implementation(libs.junit)

--- a/core/data/src/iosMain/kotlin/com/riffle/core/data/IosPlaylistsRepositoryImpl.kt
+++ b/core/data/src/iosMain/kotlin/com/riffle/core/data/IosPlaylistsRepositoryImpl.kt
@@ -1,0 +1,143 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.logging.LogChannel
+import com.riffle.core.logging.Logger
+import com.riffle.core.models.CatalogPlaylist
+import com.riffle.core.models.SourceType
+import com.riffle.core.network.AbsLibraryApi
+import com.riffle.core.network.NetworkPlaylist
+import com.riffle.core.network.NetworkResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+
+class IosPlaylistsRepositoryImpl(
+    private val absLibraryApi: AbsLibraryApi,
+    private val sourceRepository: SourceRepository,
+    private val tokenStorage: TokenStorage,
+    private val logger: Logger,
+) : PlaylistsRepository {
+
+    private val cache = MutableStateFlow<Map<String, List<CatalogPlaylist>>>(emptyMap())
+
+    override fun observePlaylists(rootId: String): Flow<List<CatalogPlaylist>> =
+        cache.map { all ->
+            (all[rootId] ?: emptyList()).filterNot { it.isReservedName() }
+        }
+
+    override suspend fun refresh(rootId: String): Boolean {
+        val (baseUrl, token, insecureAllowed) = credentials() ?: return true
+        val result = absLibraryApi.getPlaylists(baseUrl, rootId, token, insecureAllowed)
+        return when (result) {
+            is NetworkResult.Success -> {
+                cache.value = cache.value + (rootId to result.value.map { it.toDomain() })
+                true
+            }
+            else -> {
+                logger.d(LogChannel.Playlists) { "refresh($rootId) failed: $result" }
+                false
+            }
+        }
+    }
+
+    override suspend fun getPlaylist(rootId: String, playlistId: String): CatalogPlaylist? {
+        val (baseUrl, token, insecureAllowed) = credentials() ?: return null
+        val result = absLibraryApi.getPlaylists(baseUrl, rootId, token, insecureAllowed)
+        return when (result) {
+            is NetworkResult.Success -> result.value.firstOrNull { it.id == playlistId }?.toDomain()
+            else -> {
+                logger.d(LogChannel.Playlists) { "getPlaylist($rootId, $playlistId) failed: $result" }
+                null
+            }
+        }
+    }
+
+    override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?): CatalogPlaylist {
+        if (RESERVED_PLAYLIST_NAMES.any { it.equals(name.trim(), ignoreCase = true) }) {
+            throw ReservedPlaylistNameException(name)
+        }
+        val (baseUrl, token, insecureAllowed) = credentials()
+            ?: throw IllegalStateException("No active ABS source")
+        val result = absLibraryApi.createPlaylist(baseUrl, rootId, name.trim(), initialItemId, token, insecureAllowed)
+        val created = when (result) {
+            is NetworkResult.Success -> result.value?.toDomain()
+                ?: throw IllegalStateException("createPlaylist returned null")
+            else -> throw IllegalStateException("createPlaylist failed: $result")
+        }
+        val updated = (cache.value[rootId] ?: emptyList()) + created
+        cache.value = cache.value + (rootId to updated)
+        return created
+    }
+
+    override suspend fun addItemToPlaylist(rootId: String, playlistId: String, itemId: String): Boolean {
+        val (baseUrl, token, insecureAllowed) = credentials() ?: return false
+        val current = cache.value[rootId] ?: emptyList()
+        val target = current.firstOrNull { it.id == playlistId }
+        if (target != null && itemId in target.itemIds) return true
+        val result = absLibraryApi.addBookToPlaylist(baseUrl, playlistId, itemId, token, insecureAllowed)
+        return when (result) {
+            is NetworkResult.Success -> {
+                val updated = result.value?.toDomain()
+                if (updated != null) {
+                    cache.value = cache.value + (rootId to current.replaceOrAppend(updated))
+                }
+                true
+            }
+            else -> {
+                logger.d(LogChannel.Playlists) { "addItemToPlaylist($playlistId, $itemId) failed: $result" }
+                false
+            }
+        }
+    }
+
+    override suspend fun removeItemFromPlaylist(rootId: String, playlistId: String, itemId: String): Boolean {
+        val (baseUrl, token, insecureAllowed) = credentials() ?: return false
+        val current = cache.value[rootId] ?: emptyList()
+        val target = current.firstOrNull { it.id == playlistId }
+        if (target != null && itemId !in target.itemIds) return true
+        val result = absLibraryApi.removeBookFromPlaylist(baseUrl, playlistId, itemId, token, insecureAllowed)
+        return when (result) {
+            is NetworkResult.Success -> {
+                val updated = result.value?.toDomain()
+                val newList = if (updated == null || updated.itemIds.isEmpty()) {
+                    current.filter { it.id != playlistId }
+                } else {
+                    current.replaceOrAppend(updated)
+                }
+                cache.value = cache.value + (rootId to newList)
+                true
+            }
+            else -> {
+                logger.d(LogChannel.Playlists) { "removeItemFromPlaylist($playlistId, $itemId) failed: $result" }
+                false
+            }
+        }
+    }
+
+    private data class Creds(val baseUrl: String, val token: String, val insecureAllowed: Boolean)
+
+    private suspend fun credentials(): Creds? {
+        val source = sourceRepository.getActive() ?: return null
+        if (source.type != SourceType.ABS) return null
+        val token = tokenStorage.getToken(source.id) ?: return null
+        return Creds(source.url.value, token, source.insecureConnectionAllowed)
+    }
+
+    private fun CatalogPlaylist.isReservedName(): Boolean =
+        RESERVED_PLAYLIST_NAMES.any { it.equals(name.trim(), ignoreCase = true) }
+
+    private fun List<CatalogPlaylist>.replaceOrAppend(updated: CatalogPlaylist): List<CatalogPlaylist> {
+        val idx = indexOfFirst { it.id == updated.id }
+        return if (idx >= 0) toMutableList().also { it[idx] = updated } else this + updated
+    }
+}
+
+private fun NetworkPlaylist.toDomain() = CatalogPlaylist(
+    id = id,
+    rootId = libraryId,
+    name = name,
+    bookCount = bookCount,
+    itemIds = bookIds.toList(),
+)

--- a/core/data/src/iosMain/kotlin/com/riffle/core/data/IosToReadRepositoryImpl.kt
+++ b/core/data/src/iosMain/kotlin/com/riffle/core/data/IosToReadRepositoryImpl.kt
@@ -1,0 +1,143 @@
+package com.riffle.core.data
+
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.logging.LogChannel
+import com.riffle.core.logging.Logger
+import com.riffle.core.models.SourceType
+import com.riffle.core.network.AbsLibraryApi
+import com.riffle.core.network.NetworkResult
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+
+private data class ToReadSnapshot(val playlistId: String?, val itemIds: Set<String>)
+
+class IosToReadRepositoryImpl(
+    private val absLibraryApi: AbsLibraryApi,
+    private val sourceRepository: SourceRepository,
+    private val tokenStorage: TokenStorage,
+    private val logger: Logger,
+) : ToReadRepository {
+
+    private val cache = MutableStateFlow<Map<String, ToReadSnapshot>>(emptyMap())
+
+    override fun observeToReadItemIds(libraryId: String): Flow<Set<String>> =
+        cache.map { it[libraryId]?.itemIds ?: emptySet() }
+
+    override suspend fun refresh(libraryId: String): Boolean {
+        val (baseUrl, token, insecureAllowed) = credentials() ?: return true
+        val result = absLibraryApi.getPlaylists(baseUrl, libraryId, token, insecureAllowed)
+        return when (result) {
+            is NetworkResult.Success -> {
+                val match = result.value.firstOrNull { it.name == TO_READ_PLAYLIST_NAME }
+                val snapshot = ToReadSnapshot(
+                    playlistId = match?.id,
+                    itemIds = match?.bookIds ?: emptySet(),
+                )
+                cache.value = cache.value + (libraryId to snapshot)
+                true
+            }
+            else -> {
+                logger.d(LogChannel.ToRead) { "refresh($libraryId) failed: $result" }
+                false
+            }
+        }
+    }
+
+    override suspend fun isInToRead(libraryItemId: String, libraryId: String): Boolean =
+        cache.value[libraryId]?.itemIds?.contains(libraryItemId) == true
+
+    override suspend fun addToToRead(libraryItemId: String, libraryId: String): Boolean {
+        val (baseUrl, token, insecureAllowed) = credentials() ?: return false
+        val before = cache.value[libraryId] ?: ToReadSnapshot(playlistId = null, itemIds = emptySet())
+        cache.value = cache.value + (libraryId to before.copy(itemIds = before.itemIds + libraryItemId))
+        val playlistId = before.playlistId
+        val ok = if (playlistId == null) {
+            runCatching {
+                val result = absLibraryApi.createPlaylist(
+                    baseUrl, libraryId, TO_READ_PLAYLIST_NAME, libraryItemId, token, insecureAllowed,
+                )
+                when (result) {
+                    is NetworkResult.Success -> {
+                        val created = result.value
+                        cache.value = cache.value + (libraryId to ToReadSnapshot(
+                            playlistId = created?.id,
+                            itemIds = before.itemIds + libraryItemId,
+                        ))
+                        true
+                    }
+                    else -> false
+                }
+            }.getOrElse {
+                logger.d(LogChannel.ToRead) { "addToToRead($libraryId, $libraryItemId) createPlaylist failed: $it" }
+                false
+            }
+        } else {
+            val result = runCatching {
+                absLibraryApi.addBookToPlaylist(baseUrl, playlistId, libraryItemId, token, insecureAllowed)
+            }.getOrElse { addErr ->
+                logger.d(LogChannel.ToRead) { "addToToRead($libraryId, $libraryItemId) addBookToPlaylist failed, retrying via create: $addErr" }
+                // Stale playlistId — recreate
+                return runCatching {
+                    val res = absLibraryApi.createPlaylist(
+                        baseUrl, libraryId, TO_READ_PLAYLIST_NAME, libraryItemId, token, insecureAllowed,
+                    )
+                    when (res) {
+                        is NetworkResult.Success -> {
+                            cache.value = cache.value + (libraryId to ToReadSnapshot(
+                                playlistId = res.value?.id,
+                                itemIds = before.itemIds + libraryItemId,
+                            ))
+                            true
+                        }
+                        else -> {
+                            cache.value = cache.value + (libraryId to before)
+                            false
+                        }
+                    }
+                }.getOrElse { createErr ->
+                    logger.d(LogChannel.ToRead) { "addToToRead($libraryId, $libraryItemId) recovery create failed: $createErr" }
+                    cache.value = cache.value + (libraryId to before)
+                    false
+                }
+            }
+            result is NetworkResult.Success
+        }
+        if (!ok) cache.value = cache.value + (libraryId to before)
+        return ok
+    }
+
+    override suspend fun removeFromToRead(libraryItemId: String, libraryId: String): Boolean {
+        val (baseUrl, token, insecureAllowed) = credentials() ?: return false
+        val before = cache.value[libraryId] ?: return true
+        val playlistId = before.playlistId ?: return true
+        if (libraryItemId !in before.itemIds) return true
+        val remaining = before.itemIds - libraryItemId
+        val optimistic = if (remaining.isEmpty()) {
+            ToReadSnapshot(playlistId = null, itemIds = emptySet())
+        } else {
+            before.copy(itemIds = remaining)
+        }
+        cache.value = cache.value + (libraryId to optimistic)
+        val result = runCatching {
+            absLibraryApi.removeBookFromPlaylist(baseUrl, playlistId, libraryItemId, token, insecureAllowed)
+        }.getOrElse {
+            logger.d(LogChannel.ToRead) { "removeFromToRead($libraryId, $libraryItemId) failed: $it" }
+            cache.value = cache.value + (libraryId to before)
+            return false
+        }
+        val ok = result is NetworkResult.Success
+        if (!ok) cache.value = cache.value + (libraryId to before)
+        return ok
+    }
+
+    private data class Creds(val baseUrl: String, val token: String, val insecureAllowed: Boolean)
+
+    private suspend fun credentials(): Creds? {
+        val source = sourceRepository.getActive() ?: return null
+        if (source.type != SourceType.ABS) return null
+        val token = tokenStorage.getToken(source.id) ?: return null
+        return Creds(source.url.value, token, source.insecureConnectionAllowed)
+    }
+}

--- a/docs/testing/ios-scenarios/2-playlists-to-read.md
+++ b/docs/testing/ios-scenarios/2-playlists-to-read.md
@@ -1,0 +1,53 @@
+# iOS Scenario: Playlists and To-Read Tabs (Issue #912)
+
+Covers `IosPlaylistsRepositoryImpl` and `IosToReadRepositoryImpl` wired into `LibraryItemsScreen`
+via the iOS Koin module, replacing the previous no-op bindings.
+
+## Preconditions
+- App configured with an ABS source that has at least one book library.
+- The ABS instance has at least one user-created playlist (not named "To Read" or "To Listen").
+- The ABS instance has at least one book marked as "To Read" by the current user.
+
+## Scenarios
+
+### 2.1 — Playlists tab shows server playlists
+**Steps:**
+1. Navigate to `LibraryItemsScreen` for any ABS library.
+2. Tap the "Playlists" tab.
+
+**Expected:**
+- User-created playlists from ABS appear as tiles.
+- The "To Read" playlist is NOT shown in this tab (it is reserved for the dedicated To-Read surface).
+
+### 2.2 — To-Read toggle reflects server state
+**Steps:**
+1. Navigate to `LibraryItemsScreen`.
+2. Observe the To-Read toggle on a book that is already in the "To Read" playlist on ABS.
+
+**Expected:**
+- The toggle is shown as active (filled heart / marked icon).
+
+### 2.3 — Adding a book to To-Read persists to ABS
+**Steps:**
+1. Tap the To-Read toggle on a book that is NOT in "To Read".
+
+**Expected:**
+- The toggle becomes active optimistically (no loading state visible).
+- Refreshing the screen still shows the toggle as active (server round-trip succeeded).
+
+### 2.4 — Removing a book from To-Read persists to ABS
+**Steps:**
+1. Tap the To-Read toggle on a book that IS in "To Read".
+
+**Expected:**
+- The toggle becomes inactive optimistically.
+- Refreshing the screen still shows the toggle as inactive.
+
+### 2.5 — Non-ABS source shows empty Playlists tab
+**Steps:**
+1. Switch to a Komga, Chitanka, or Gutenberg source.
+2. Navigate to its library and open the Playlists tab.
+
+**Expected:**
+- The Playlists tab is empty (no playlists shown) — non-ABS sources return `true` from `refresh`
+  with an empty list, so the tab renders but is blank rather than erroring.

--- a/iosApp/iosAppTests/PlaylistsToReadTests.swift
+++ b/iosApp/iosAppTests/PlaylistsToReadTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+import Riffle
+
+// Covers scenarios from docs/testing/ios-scenarios/2-playlists-to-read.md
+//
+// The full simulator scenarios (2.1–2.5) require a live ABS instance and must be run manually.
+// The tests below pin the invariants that the Kotlin side guarantees: the reserved-name sentinel
+// is the right string (so the iOS impl's filter expression is correct), and the playlist name
+// used to find the To-Read list matches the sentinel.
+final class PlaylistsToReadTests: XCTestCase {
+
+    // Regression: if TO_READ_PLAYLIST_NAME is renamed or its value changes, IosToReadRepositoryImpl
+    // will silently look up the wrong playlist name on ABS and the To-Read toggle will stop working.
+    func testToReadPlaylistNameSentinel() {
+        XCTAssertEqual(ToReadRepositoryKt.TO_READ_PLAYLIST_NAME, "To Read")
+    }
+
+    // Regression: both "To Read" and "To Listen" must be in RESERVED_PLAYLIST_NAMES so
+    // IosPlaylistsRepositoryImpl's filter hides both from the user-facing Playlists tab.
+    func testReservedPlaylistNamesContainsToReadAndToListen() {
+        let reserved = PlaylistsRepositoryKt.RESERVED_PLAYLIST_NAMES as! Set<String>
+        XCTAssertTrue(reserved.contains("To Read"),
+                      "RESERVED_PLAYLIST_NAMES must contain 'To Read' to hide it from the Playlists tab")
+        XCTAssertTrue(reserved.contains("To Listen"),
+                      "RESERVED_PLAYLIST_NAMES must contain 'To Listen' to hide the ABS audiobook wishlist")
+    }
+}

--- a/iosApp/iosAppTests/PlaylistsToReadTests.swift
+++ b/iosApp/iosAppTests/PlaylistsToReadTests.swift
@@ -17,8 +17,9 @@ final class PlaylistsToReadTests: XCTestCase {
 
     // Regression: both "To Read" and "To Listen" must be in RESERVED_PLAYLIST_NAMES so
     // IosPlaylistsRepositoryImpl's filter hides both from the user-facing Playlists tab.
-    func testReservedPlaylistNamesContainsToReadAndToListen() {
-        let reserved = PlaylistsRepositoryKt.RESERVED_PLAYLIST_NAMES as! Set<String>
+    func testReservedPlaylistNamesContainsToReadAndToListen() throws {
+        let raw = PlaylistsRepositoryKt.RESERVED_PLAYLIST_NAMES
+        let reserved = try XCTUnwrap(raw as? Set<String>)
         XCTAssertTrue(reserved.contains("To Read"),
                       "RESERVED_PLAYLIST_NAMES must contain 'To Read' to hide it from the Playlists tab")
         XCTAssertTrue(reserved.contains("To Listen"),

--- a/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
@@ -5,7 +5,9 @@ import com.riffle.core.data.IosLastOpenedLibraryStoreImpl
 import com.riffle.core.data.IosLibraryObserverImpl
 import com.riffle.core.data.IosLibraryRefresherImpl
 import com.riffle.core.data.IosLibraryVisibilityPreferencesStoreImpl
+import com.riffle.core.data.IosPlaylistsRepositoryImpl
 import com.riffle.core.data.IosSourceRepositoryImpl
+import com.riffle.core.data.IosToReadRepositoryImpl
 import com.riffle.core.data.PlaylistsRepository
 import com.riffle.core.data.ToReadRepository
 import com.riffle.core.data.di.iosDataModule
@@ -47,8 +49,6 @@ import com.riffle.shared.library.IosNoOpAudiobookBookmarkStore
 import com.riffle.shared.library.IosNoOpCoverGridDensityStore
 import com.riffle.shared.library.IosNoOpLibraryFilterPreferencesStore
 import com.riffle.shared.library.IosNoOpLibraryItemOfflineAvailability
-import com.riffle.core.data.IosPlaylistsRepositoryImpl
-import com.riffle.core.data.IosToReadRepositoryImpl
 import com.riffle.shared.library.IosNoOpReadaloudLinkRepository
 import com.riffle.shared.library.IosNoOpReadaloudReconciler
 import com.riffle.shared.library.IosNoOpStorytellerSyncer

--- a/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
@@ -47,11 +47,11 @@ import com.riffle.shared.library.IosNoOpAudiobookBookmarkStore
 import com.riffle.shared.library.IosNoOpCoverGridDensityStore
 import com.riffle.shared.library.IosNoOpLibraryFilterPreferencesStore
 import com.riffle.shared.library.IosNoOpLibraryItemOfflineAvailability
-import com.riffle.shared.library.IosNoOpPlaylistsRepository
+import com.riffle.core.data.IosPlaylistsRepositoryImpl
+import com.riffle.core.data.IosToReadRepositoryImpl
 import com.riffle.shared.library.IosNoOpReadaloudLinkRepository
 import com.riffle.shared.library.IosNoOpReadaloudReconciler
 import com.riffle.shared.library.IosNoOpStorytellerSyncer
-import com.riffle.shared.library.IosNoOpToReadRepository
 import com.riffle.shared.library.LibraryItemsViewModel
 import org.koin.dsl.module
 import org.koin.core.context.startKoin as koinStartKoin
@@ -73,9 +73,8 @@ private val iosLibraryModule = module {
     single { HomeViewModel(get(), get(), get(), get(), get(), get()) }
     single { AddAbsSourceViewModel(get(), get(), get()) }
 
-    // No-op service-layer bindings for library browsing (follow-up issues #912-#916 implement)
-    single<PlaylistsRepository> { IosNoOpPlaylistsRepository() }
-    single<ToReadRepository> { IosNoOpToReadRepository() }
+    single<PlaylistsRepository> { IosPlaylistsRepositoryImpl(get(), get(), get(), get()) }
+    single<ToReadRepository> { IosToReadRepositoryImpl(get(), get(), get(), get()) }
     single<LibraryItemOfflineAvailability> { IosNoOpLibraryItemOfflineAvailability() }
     single<StorytellerReadaloudCacheSyncer> { IosNoOpStorytellerSyncer }
     single<ReadaloudLinkReconciler> { IosNoOpReadaloudReconciler }

--- a/shared/src/iosMain/kotlin/com/riffle/shared/library/IosNoOpImpls.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/library/IosNoOpImpls.kt
@@ -2,8 +2,6 @@ package com.riffle.shared.library
 
 import com.riffle.core.data.AnnotatedBook
 import com.riffle.core.data.AnnotationsLibraryRepository
-import com.riffle.core.data.PlaylistsRepository
-import com.riffle.core.data.ToReadRepository
 import com.riffle.core.domain.AnnotationStore
 import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.AudiobookBookmarkStore
@@ -17,7 +15,6 @@ import com.riffle.core.domain.StorytellerReadaloudCacheSyncer
 import com.riffle.core.models.Annotation
 import com.riffle.core.models.AudiobookBookmark
 import com.riffle.core.models.AudiobookIdentityResult
-import com.riffle.core.models.CatalogPlaylist
 import com.riffle.core.models.EmbeddedFigure
 import com.riffle.core.models.LibraryItem
 import com.riffle.core.models.ReadaloudLink
@@ -30,24 +27,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
-
-internal class IosNoOpPlaylistsRepository : PlaylistsRepository {
-    override fun observePlaylists(rootId: String): Flow<List<CatalogPlaylist>> = flowOf(emptyList())
-    override suspend fun refresh(rootId: String): Boolean = false
-    override suspend fun getPlaylist(rootId: String, playlistId: String): CatalogPlaylist? = null
-    override suspend fun createPlaylist(rootId: String, name: String, initialItemId: String?): CatalogPlaylist =
-        CatalogPlaylist(id = "", rootId = rootId, name = name, bookCount = 0)
-    override suspend fun addItemToPlaylist(rootId: String, playlistId: String, itemId: String): Boolean = false
-    override suspend fun removeItemFromPlaylist(rootId: String, playlistId: String, itemId: String): Boolean = false
-}
-
-internal class IosNoOpToReadRepository : ToReadRepository {
-    override fun observeToReadItemIds(libraryId: String): Flow<Set<String>> = flowOf(emptySet())
-    override suspend fun refresh(libraryId: String): Boolean = false
-    override suspend fun isInToRead(libraryItemId: String, libraryId: String): Boolean = false
-    override suspend fun addToToRead(libraryItemId: String, libraryId: String): Boolean = false
-    override suspend fun removeFromToRead(libraryItemId: String, libraryId: String): Boolean = false
-}
 
 internal class IosNoOpLibraryItemOfflineAvailability : LibraryItemOfflineAvailability {
     override fun isAvailableOffline(item: LibraryItem): Boolean = false


### PR DESCRIPTION
Closes #912

## Summary

- Implements `IosPlaylistsRepositoryImpl` (`core/data/iosMain`) — ABS-backed, in-memory cache via `MutableStateFlow`, calls `AbsLibraryApi.getPlaylists/createPlaylist/addBookToPlaylist/removeBookFromPlaylist` directly. Non-ABS sources return `true`/empty immediately (no Room DAO needed on iOS).
- Implements `IosToReadRepositoryImpl` (`core/data/iosMain`) — mirrors the Android `ToReadRepositoryImpl`'s optimistic update + stale-playlistId recovery logic, without the `LocalToReadStore` fallback (ABS-only on iOS; non-ABS sources no-op cleanly).
- Adds `core:logging` to `core:data`'s `iosMain.dependencies` so both implementations can use `Logger`/`LogChannel`.
- Replaces the two `IosNoOp*` bindings in `iosLibraryModule` (Koin.kt) with the real implementations; removes the dead no-op classes from `IosNoOpImpls.kt`.
- Adds iOS test scenario doc (`docs/testing/ios-scenarios/2-playlists-to-read.md`) and `PlaylistsToReadTests.swift` pinning the reserved-name sentinel and `TO_READ_PLAYLIST_NAME` value.

## Test plan

- [x] `./gradlew :core:data:compileIosMainKotlinMetadata` — clean (warnings only, no errors)
- [x] `./gradlew :shared:compileIosMainKotlinMetadata` — clean
- [x] `./gradlew :core:data:testAndroidHostTest` — BUILD SUCCESSFUL (existing `PlaylistsRepositoryTest` still passes)
- [ ] iOS simulator: Playlists tab shows real ABS playlists; To-Read toggle persists to server (manual, per scenario 2.1–2.4 in `docs/testing/ios-scenarios/2-playlists-to-read.md`)