### PR TITLE
feat(ios): implement offline availability and download status in library browser

### DIFF
--- a/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLibraryItemOfflineAvailabilityImpl.kt
+++ b/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLibraryItemOfflineAvailabilityImpl.kt
@@ -1,0 +1,51 @@
+package com.riffle.core.data
+
+import com.riffle.core.common.FileStore
+import com.riffle.core.domain.LibraryItemOfflineAvailability
+import com.riffle.core.models.EbookFormat
+import com.riffle.core.models.LibraryItem
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSFileManager
+
+// Path namespaces for iOS local book storage, mirroring Android's LocalStoreImpl convention:
+// files live at <Documents>/<namespace>/<sourceId>/<itemId>.<ext>.
+const val NS_EPUB_DOWNLOADS = "epub-downloads"
+const val NS_EPUB_CACHE = "epub-cache"
+const val NS_PDF_DOWNLOADS = "pdf-downloads"
+const val NS_PDF_CACHE = "pdf-cache"
+const val NS_CBZ_DOWNLOADS = "cbz-downloads"
+const val NS_CBZ_CACHE = "cbz-cache"
+// Audiobook downloads are a directory (multiple track files) keyed by <sourceId>/<itemId>.
+const val NS_AUDIOBOOK_DOWNLOADS = "audiobook-downloads"
+
+@OptIn(ExperimentalForeignApi::class)
+class IosLibraryItemOfflineAvailabilityImpl(
+    private val fileStore: FileStore,
+) : LibraryItemOfflineAvailability {
+
+    override fun isAvailableOffline(item: LibraryItem): Boolean {
+        val ebookAvailable = when (item.ebookFormat) {
+            EbookFormat.Epub ->
+                fileExists(NS_EPUB_DOWNLOADS, item.sourceId, item.id, ".epub") ||
+                    fileExists(NS_EPUB_CACHE, item.sourceId, item.id, ".epub")
+            EbookFormat.Pdf ->
+                fileExists(NS_PDF_DOWNLOADS, item.sourceId, item.id, ".pdf") ||
+                    fileExists(NS_PDF_CACHE, item.sourceId, item.id, ".pdf")
+            EbookFormat.Cbz ->
+                fileExists(NS_CBZ_DOWNLOADS, item.sourceId, item.id, ".cbz") ||
+                    fileExists(NS_CBZ_CACHE, item.sourceId, item.id, ".cbz")
+            EbookFormat.Unsupported -> false
+        }
+        return ebookAvailable || audiobookDownloaded(item.sourceId, item.id)
+    }
+
+    private fun fileExists(namespace: String, sourceId: String, itemId: String, extension: String): Boolean {
+        val path = fileStore.resolve(namespace, "$sourceId/$itemId$extension")
+        return NSFileManager.defaultManager.fileExistsAtPath(path)
+    }
+
+    private fun audiobookDownloaded(sourceId: String, itemId: String): Boolean {
+        val path = fileStore.resolve(NS_AUDIOBOOK_DOWNLOADS, "$sourceId/$itemId")
+        return NSFileManager.defaultManager.fileExistsAtPath(path)
+    }
+}

--- a/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLibraryItemOfflineAvailabilityImpl.kt
+++ b/core/data/src/iosMain/kotlin/com/riffle/core/data/IosLibraryItemOfflineAvailabilityImpl.kt
@@ -7,15 +7,12 @@ import com.riffle.core.models.LibraryItem
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSFileManager
 
-// Path namespaces for iOS local book storage, mirroring Android's LocalStoreImpl convention:
-// files live at <Documents>/<namespace>/<sourceId>/<itemId>.<ext>.
 const val NS_EPUB_DOWNLOADS = "epub-downloads"
 const val NS_EPUB_CACHE = "epub-cache"
 const val NS_PDF_DOWNLOADS = "pdf-downloads"
 const val NS_PDF_CACHE = "pdf-cache"
 const val NS_CBZ_DOWNLOADS = "cbz-downloads"
 const val NS_CBZ_CACHE = "cbz-cache"
-// Audiobook downloads are a directory (multiple track files) keyed by <sourceId>/<itemId>.
 const val NS_AUDIOBOOK_DOWNLOADS = "audiobook-downloads"
 
 @OptIn(ExperimentalForeignApi::class)

--- a/docs/testing/ios-scenarios/4-offline-availability.md
+++ b/docs/testing/ios-scenarios/4-offline-availability.md
@@ -1,0 +1,59 @@
+# iOS Scenario: Offline Availability and Download Status (Issue #914)
+
+Covers `IosLibraryItemOfflineAvailabilityImpl` wired into `LibraryItemsScreen` on iOS.
+
+## Preconditions
+- App is configured with an Audiobookshelf source that has a library containing books.
+- App launches to `HomeScreen`.
+
+## Scenarios
+
+### 4.1 — Offline filter hides items with no local files
+
+**Steps:**
+1. Launch the app with a configured ABS source.
+2. Wait for the library to load.
+3. Toggle the offline filter (go offline or simulate offline via airplane mode).
+
+**Expected:**
+- When offline and no books are locally stored, the "All Books" / section grids are empty.
+- No books appear in sections that the filter applies to.
+
+### 4.2 — Offline filter shows items with a downloaded EPUB
+
+**Steps:**
+1. Place a valid file at `<Documents>/epub-downloads/<sourceId>/<itemId>.epub` (e.g., via Xcode Devices
+   file transfer or a test helper).
+2. Toggle the offline filter.
+
+**Expected:**
+- The book whose `sourceId`/`itemId` matches the file path appears in the library.
+- Other books (with no local file) are hidden.
+
+### 4.3 — Offline filter shows items with a cached EPUB
+
+**Steps:**
+1. Place a file at `<Documents>/epub-cache/<sourceId>/<itemId>.epub`.
+2. Toggle the offline filter.
+
+**Expected:**
+- The book appears (cached is treated as offline-available, same as downloaded).
+
+### 4.4 — Download badge appears on tiles with downloaded books
+
+**Steps:**
+1. Ensure a book's DB row has `isDownloaded = true` (set by a future iOS download feature).
+2. Observe the library grid.
+
+**Expected:**
+- A small purple dot badge is visible on the top-right corner of the book tile.
+- Books with `isCached = true` show a lighter dot badge.
+- Books with neither flag show no badge.
+
+### 4.5 — Download badge absent when book is not downloaded
+
+**Steps:**
+1. Observe a book tile where `isDownloaded = false` and `isCached = false`.
+
+**Expected:**
+- No badge is rendered on the tile.

--- a/iosApp/iosAppTests/OfflineAvailabilityTests.swift
+++ b/iosApp/iosAppTests/OfflineAvailabilityTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+import Riffle
+
+// Covers scenarios from docs/testing/ios-scenarios/4-offline-availability.md
+//
+// Scenarios 4.1–4.4 require a running ABS instance or simulator file injection and must be
+// verified manually. The tests below pin the filesystem path convention defined by
+// IosLibraryItemOfflineAvailabilityImpl so that a future iOS download implementation
+// uses consistent namespaces.
+final class OfflineAvailabilityTests: XCTestCase {
+
+    // Regression: if the EPUB downloads namespace changes, the offline filter silently
+    // breaks for all previously-downloaded books — they remain on disk but are no longer
+    // found by the availability check.
+    func testEpubDownloadsNamespace() {
+        XCTAssertEqual(IosLibraryItemOfflineAvailabilityImplKt.NS_EPUB_DOWNLOADS, "epub-downloads")
+    }
+
+    func testEpubCacheNamespace() {
+        XCTAssertEqual(IosLibraryItemOfflineAvailabilityImplKt.NS_EPUB_CACHE, "epub-cache")
+    }
+
+    func testPdfDownloadsNamespace() {
+        XCTAssertEqual(IosLibraryItemOfflineAvailabilityImplKt.NS_PDF_DOWNLOADS, "pdf-downloads")
+    }
+
+    func testPdfCacheNamespace() {
+        XCTAssertEqual(IosLibraryItemOfflineAvailabilityImplKt.NS_PDF_CACHE, "pdf-cache")
+    }
+
+    func testCbzDownloadsNamespace() {
+        XCTAssertEqual(IosLibraryItemOfflineAvailabilityImplKt.NS_CBZ_DOWNLOADS, "cbz-downloads")
+    }
+
+    func testCbzCacheNamespace() {
+        XCTAssertEqual(IosLibraryItemOfflineAvailabilityImplKt.NS_CBZ_CACHE, "cbz-cache")
+    }
+
+    func testAudiobookDownloadsNamespace() {
+        XCTAssertEqual(IosLibraryItemOfflineAvailabilityImplKt.NS_AUDIOBOOK_DOWNLOADS, "audiobook-downloads")
+    }
+
+    // Integration: place a real file at the expected EPUB download path and verify the
+    // implementation detects it as available offline.
+    func testDetectsEpubDownloadFile() throws {
+        let fm = FileManager.default
+        let docs = try fm.url(
+            for: .documentDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        let sourceId = "test-source"
+        let itemId = "test-item"
+        let dir = docs
+            .appendingPathComponent("epub-downloads")
+            .appendingPathComponent(sourceId)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        let epub = dir.appendingPathComponent("\(itemId).epub")
+        try "epub-placeholder".write(to: epub, atomically: true, encoding: .utf8)
+        defer { try? fm.removeItem(at: docs.appendingPathComponent("epub-downloads")) }
+
+        let impl = IosLibraryItemOfflineAvailabilityImpl(fileStore: IosFileStore())
+        let item = LibraryItem(
+            id: itemId,
+            libraryId: "lib",
+            title: "Test Book",
+            author: "Author",
+            coverUrl: nil,
+            readingProgress: 0,
+            isCached: false,
+            isDownloaded: false,
+            ebookFormat: EbookFormat.epub,
+            ebookFileIno: nil,
+            hasAudio: false,
+            audioDurationSec: 0,
+            description: nil,
+            seriesName: nil,
+            publishedYear: nil,
+            genres: [],
+            publisher: nil,
+            language: nil,
+            lastOpenedAt: nil,
+            addedAt: nil,
+            isbn: nil,
+            asin: nil,
+            sourceId: sourceId,
+            pageCount: nil
+        )
+        XCTAssertTrue(impl.isAvailableOffline(item: item),
+                      "Item with epub file at epub-downloads path must be available offline")
+    }
+
+    // Integration: item with no local files must NOT be available offline.
+    func testNoFilesReturnsFalse() {
+        let impl = IosLibraryItemOfflineAvailabilityImpl(fileStore: IosFileStore())
+        let item = LibraryItem(
+            id: "no-such-item",
+            libraryId: "lib",
+            title: "Ghost Book",
+            author: "Author",
+            coverUrl: nil,
+            readingProgress: 0,
+            isCached: false,
+            isDownloaded: false,
+            ebookFormat: EbookFormat.epub,
+            ebookFileIno: nil,
+            hasAudio: false,
+            audioDurationSec: 0,
+            description: nil,
+            seriesName: nil,
+            publishedYear: nil,
+            genres: [],
+            publisher: nil,
+            language: nil,
+            lastOpenedAt: nil,
+            addedAt: nil,
+            isbn: nil,
+            asin: nil,
+            sourceId: "no-such-source",
+            pageCount: nil
+        )
+        XCTAssertFalse(impl.isAvailableOffline(item: item),
+                       "Item with no local files must not be available offline")
+    }
+}

--- a/shared/src/commonMain/kotlin/com/riffle/shared/library/LibraryItemsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/riffle/shared/library/LibraryItemsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
@@ -18,6 +19,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
@@ -250,6 +252,12 @@ fun BookCoverTile(
             isAudiobook = item.isListenable && !item.isReadable,
             modifier = Modifier.fillMaxSize(),
         )
+        if (item.isDownloaded || item.isCached) {
+            DownloadedBadge(
+                downloaded = item.isDownloaded,
+                modifier = Modifier.align(Alignment.TopEnd).padding(4.dp),
+            )
+        }
     }
 }
 
@@ -345,4 +353,15 @@ private fun CollectionTile(
             style = TextStyle(color = Color.White, fontSize = 11.sp),
         )
     }
+}
+
+@Composable
+private fun DownloadedBadge(downloaded: Boolean, modifier: Modifier = Modifier) {
+    val color = if (downloaded) Color(0xFF6650A4) else Color(0xFFB0A0D0)
+    Box(
+        modifier = modifier
+            .size(8.dp)
+            .clip(CircleShape)
+            .background(color),
+    )
 }

--- a/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
@@ -2,6 +2,7 @@ package com.riffle.shared
 
 import com.riffle.core.data.AnnotationsLibraryRepository
 import com.riffle.core.data.IosLastOpenedLibraryStoreImpl
+import com.riffle.core.data.IosLibraryItemOfflineAvailabilityImpl
 import com.riffle.core.data.IosLibraryObserverImpl
 import com.riffle.core.data.IosLibraryRefresherImpl
 import com.riffle.core.data.IosLibraryVisibilityPreferencesStoreImpl
@@ -44,7 +45,6 @@ import com.riffle.feature.library.HomeViewModel
 import com.riffle.feature.library.LibrarySectionViewModel
 import com.riffle.feature.library.SeriesDetailViewModel
 import com.riffle.shared.library.AnnotationsListViewModel
-import com.riffle.core.data.IosLibraryItemOfflineAvailabilityImpl
 import com.riffle.shared.library.IosNoOpAnnotationStore
 import com.riffle.shared.library.IosNoOpAnnotationsLibraryRepository
 import com.riffle.shared.library.IosNoOpApplicationScope
@@ -56,8 +56,8 @@ import com.riffle.shared.library.IosNoOpReadaloudReconciler
 import com.riffle.shared.library.IosNoOpStorytellerSyncer
 import com.riffle.shared.library.LibraryItemDetailViewModel
 import com.riffle.shared.library.LibraryItemsViewModel
-import org.koin.dsl.module
 import org.koin.core.context.startKoin as koinStartKoin
+import org.koin.dsl.module
 
 private val iosLibraryModule = module {
     single { createDefaultHttpClient() }

--- a/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
@@ -56,8 +56,8 @@ import com.riffle.shared.library.IosNoOpReadaloudReconciler
 import com.riffle.shared.library.IosNoOpStorytellerSyncer
 import com.riffle.shared.library.LibraryItemDetailViewModel
 import com.riffle.shared.library.LibraryItemsViewModel
-import org.koin.core.context.startKoin as koinStartKoin
 import org.koin.dsl.module
+import org.koin.core.context.startKoin as koinStartKoin
 
 private val iosLibraryModule = module {
     single { createDefaultHttpClient() }

--- a/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
@@ -44,13 +44,13 @@ import com.riffle.feature.library.HomeViewModel
 import com.riffle.feature.library.LibrarySectionViewModel
 import com.riffle.feature.library.SeriesDetailViewModel
 import com.riffle.shared.library.AnnotationsListViewModel
+import com.riffle.core.data.IosLibraryItemOfflineAvailabilityImpl
 import com.riffle.shared.library.IosNoOpAnnotationStore
 import com.riffle.shared.library.IosNoOpAnnotationsLibraryRepository
 import com.riffle.shared.library.IosNoOpApplicationScope
 import com.riffle.shared.library.IosNoOpAudiobookBookmarkStore
 import com.riffle.shared.library.IosNoOpCoverGridDensityStore
 import com.riffle.shared.library.IosNoOpLibraryFilterPreferencesStore
-import com.riffle.shared.library.IosNoOpLibraryItemOfflineAvailability
 import com.riffle.shared.library.IosNoOpReadaloudLinkRepository
 import com.riffle.shared.library.IosNoOpReadaloudReconciler
 import com.riffle.shared.library.IosNoOpStorytellerSyncer
@@ -78,7 +78,7 @@ private val iosLibraryModule = module {
 
     single<PlaylistsRepository> { IosPlaylistsRepositoryImpl(get(), get(), get(), get()) }
     single<ToReadRepository> { IosToReadRepositoryImpl(get(), get(), get(), get()) }
-    single<LibraryItemOfflineAvailability> { IosNoOpLibraryItemOfflineAvailability() }
+    single<LibraryItemOfflineAvailability> { IosLibraryItemOfflineAvailabilityImpl(get()) }
     single<StorytellerReadaloudCacheSyncer> { IosNoOpStorytellerSyncer }
     single<ReadaloudLinkReconciler> { IosNoOpReadaloudReconciler }
     single<ApplicationScope> { IosNoOpApplicationScope }

--- a/shared/src/iosMain/kotlin/com/riffle/shared/library/IosNoOpImpls.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/library/IosNoOpImpls.kt
@@ -8,7 +8,6 @@ import com.riffle.core.domain.AudiobookBookmarkStore
 import com.riffle.core.domain.CoverGridDensityStore
 import com.riffle.core.domain.LibraryFilterPreferences
 import com.riffle.core.domain.LibraryFilterPreferencesStore
-import com.riffle.core.domain.LibraryItemOfflineAvailability
 import com.riffle.core.domain.ReadaloudLinkReconciler
 import com.riffle.core.domain.ReadaloudLinkRepository
 import com.riffle.core.domain.StorytellerReadaloudCacheSyncer
@@ -16,7 +15,6 @@ import com.riffle.core.models.Annotation
 import com.riffle.core.models.AudiobookBookmark
 import com.riffle.core.models.AudiobookIdentityResult
 import com.riffle.core.models.EmbeddedFigure
-import com.riffle.core.models.LibraryItem
 import com.riffle.core.models.ReadaloudLink
 import com.riffle.core.models.ScreenDimensionBucket
 import kotlinx.coroutines.CoroutineDispatcher
@@ -27,10 +25,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
-
-internal class IosNoOpLibraryItemOfflineAvailability : LibraryItemOfflineAvailability {
-    override fun isAvailableOffline(item: LibraryItem): Boolean = false
-}
 
 internal object IosNoOpStorytellerSyncer : StorytellerReadaloudCacheSyncer {
     override suspend fun syncStale() {}


### PR DESCRIPTION
Closes #914

## What changed

- **`IosLibraryItemOfflineAvailabilityImpl`** (new) — checks the iOS Documents filesystem for ebook and audiobook local files across six namespaces (`epub-downloads`, `epub-cache`, `pdf-downloads`, `pdf-cache`, `cbz-downloads`, `cbz-cache`) and an audiobook downloads directory. Path convention matches Android's `LocalStoreImpl` (`<namespace>/<sourceId>/<itemId>.<ext>`).
- **`iosLibraryModule` (Koin)** — replaces the always-false `IosNoOpLibraryItemOfflineAvailability` with the real implementation; `FileStore` is already in the graph.
- **`IosNoOpImpls.kt`** — `IosNoOpLibraryItemOfflineAvailability` class removed.
- **Shared `LibraryItemsScreen.kt`** — `BookCoverTile` now renders a small dot badge (purple for downloaded, lighter for cached) using `item.isDownloaded` / `item.isCached`, mirroring the Android library grid.
- **`docs/testing/ios-scenarios/4-offline-availability.md`** — five offline-filter and badge scenarios.
- **`iosApp/iosAppTests/OfflineAvailabilityTests.swift`** — seven namespace-pin regression tests + two integration tests (file-present → true, no-file → false).

## Notes

With no iOS ebook download feature yet, the filesystem checks will always return false in practice — which is the correct current answer. The implementation and path conventions are in place so a future iOS download PR can write to these paths and the offline filter/badge will work automatically.

Code-review findings were all in pre-existing `app/src/main/` files not touched by this branch; dismissed as out of scope.