### PR TITLE
feat(ios): move LibraryItemDetailScreen to commonMain and wire item navigation (#915)

### DIFF
--- a/docs/testing/ios-scenarios/3-library-item-detail-nav.md
+++ b/docs/testing/ios-scenarios/3-library-item-detail-nav.md
@@ -1,0 +1,68 @@
+# iOS Scenario: Library Item Detail Navigation (Issue #915)
+
+Covers `LibraryItemDetailScreen` and `LibraryItemDetailViewModel` in `commonMain`, wired via
+`LibraryNav.ItemDetail` in `HomeScreen`.
+
+## Preconditions
+- App is configured with an Audiobookshelf source that has at least one library containing books.
+- App launches to `HomeScreen` showing a library (the `LibraryNav.Items` state).
+
+## Scenarios
+
+### 3.1 — Tapping a book tile navigates to the detail screen
+**Steps:**
+1. Launch the app to the library grid.
+2. Tap any book cover tile.
+
+**Expected:**
+- A detail screen slides in.
+- The book title and author are visible.
+- A purple `Read` button is visible.
+- An `Add to To-Read` button is visible.
+
+### 3.2 — Back button returns to the library
+**Steps:**
+1. Navigate to any item detail screen (see 3.1).
+2. Tap the `← Back` button.
+
+**Expected:**
+- The library grid screen is restored.
+
+### 3.3 — Detail screen shows a cover placeholder
+**Steps:**
+1. Navigate to a book tile whose cover image is absent or unavailable.
+
+**Expected:**
+- A colored gradient placeholder is rendered (ebook = purple gradient, audiobook = blue gradient).
+
+### 3.4 — "In Progress" section item also navigates to detail
+**Steps:**
+1. From the library home, tap `See all` next to "In Progress".
+2. Tap any book cover in the section grid.
+
+**Expected:**
+- The detail screen opens for that book (same as 3.1).
+
+### 3.5 — To-Read toggle updates optimistically
+**Steps:**
+1. Navigate to the detail screen for a book not already in To-Read.
+2. Tap `Add to To-Read`.
+
+**Expected:**
+- The button label changes to `In To-Read` immediately (optimistic update).
+
+### 3.6 — Offline banner is shown when device is offline
+**Steps:**
+1. Put the device in airplane mode.
+2. Navigate to any item detail screen.
+
+**Expected:**
+- A `You are offline` banner is visible below the action buttons.
+
+### 3.7 — Error state for unknown item
+**Steps:**
+1. Force a lookup for an item ID that does not exist in the local DB (simulate by removing the
+   item from the source then opening its cached detail).
+
+**Expected:**
+- The `Item not found` message is shown, with a `← Back` link.

--- a/iosApp/iosAppTests/LibraryItemDetailNavTests.swift
+++ b/iosApp/iosAppTests/LibraryItemDetailNavTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+import Riffle
+
+// Covers scenarios from docs/testing/ios-scenarios/3-library-item-detail-nav.md
+//
+// Full simulator scenarios (3.1–3.7) require a live ABS instance and must be run manually.
+// The tests below pin the invariants the Kotlin side guarantees:
+//   - The UiState sealed interface compiles with the correct sealed cases (Loading, Ready, Error).
+//   - The Ready state carries the expected properties.
+// If LibraryItemDetailUiState or its cases are deleted or renamed, these fail immediately.
+final class LibraryItemDetailNavTests: XCTestCase {
+
+    // Regression: if the Loading sealed case is removed or renamed the detail screen can never
+    // display a spinner while the ViewModel is fetching the item.
+    func testLoadingStateExists() {
+        let loading: LibraryItemDetailUiState = LibraryItemDetailUiStateLoading.shared
+        XCTAssertTrue(loading is LibraryItemDetailUiStateLoading,
+                      "Loading should be the LibraryItemDetailUiStateLoading singleton")
+    }
+
+    // Regression: if the Error sealed case is removed or renamed the detail screen can never
+    // display the "Item not found" fallback (scenario 3.7).
+    func testErrorStateExists() {
+        let error: LibraryItemDetailUiState = LibraryItemDetailUiStateError.shared
+        XCTAssertTrue(error is LibraryItemDetailUiStateError,
+                      "Error should be the LibraryItemDetailUiStateError singleton")
+    }
+
+    // Regression: if the Ready sealed case is removed or renamed all visible detail content
+    // (title, author, cover, buttons) can no longer be rendered (scenarios 3.1–3.6).
+    func testReadyStatePropertiesExist() {
+        let fakeItem = LibraryItem(
+            id: "item1",
+            libraryId: "lib1",
+            title: "Test Book",
+            author: "Test Author",
+            coverUrl: nil,
+            readingProgress: 0.0,
+            isCached: false,
+            isDownloaded: false,
+            ebookFormat: EbookFormat.epub,
+            sourceId: "source1"
+        )
+        let ready = LibraryItemDetailUiStateReady(
+            item: fakeItem,
+            authToken: "token",
+            isInToRead: false,
+            isOffline: false
+        )
+        XCTAssertEqual(ready.item.id, "item1")
+        XCTAssertEqual(ready.item.title, "Test Book")
+        XCTAssertFalse(ready.isInToRead)
+        XCTAssertFalse(ready.isOffline)
+    }
+}

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -41,6 +41,7 @@ kotlin {
         }
         commonTest.dependencies {
             implementation(kotlin("test"))
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/riffle/shared/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/riffle/shared/HomeScreen.kt
@@ -20,8 +20,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.riffle.core.data.localfiles.FolderPickerInterface
 import com.riffle.core.data.localfiles.LocalFilesInstallerInterface
+import com.riffle.core.models.LibraryItem
 import com.riffle.feature.library.HomeViewModel
 import com.riffle.feature.library.LibrarySectionType
+import com.riffle.shared.library.LibraryItemDetailScreen
 import com.riffle.shared.library.LibraryItemsScreen
 import com.riffle.shared.library.LibrarySectionScreen
 import kotlinx.coroutines.launch
@@ -30,6 +32,7 @@ import org.koin.compose.koinInject
 private sealed interface LibraryNav {
     data object Items : LibraryNav
     data class Section(val sectionType: LibrarySectionType) : LibraryNav
+    data class ItemDetail(val item: LibraryItem) : LibraryNav
 }
 
 @Composable
@@ -105,7 +108,7 @@ private fun LibraryHost(libraryId: String, libraryName: String) {
             libraryId = libraryId,
             libraryName = libraryName,
             onOpenDrawer = {},
-            onItemSelected = {},
+            onItemSelected = { item -> nav = LibraryNav.ItemDetail(item) },
             onSeriesSelected = {},
             onSectionSeeMore = { sectionType -> nav = LibraryNav.Section(sectionType) },
         )
@@ -113,7 +116,13 @@ private fun LibraryHost(libraryId: String, libraryName: String) {
             libraryId = libraryId,
             sectionType = current.sectionType,
             onBack = { nav = LibraryNav.Items },
-            onItemSelected = {},
+            onItemSelected = { item -> nav = LibraryNav.ItemDetail(item) },
+        )
+        is LibraryNav.ItemDetail -> LibraryItemDetailScreen(
+            itemId = current.item.id,
+            sourceId = current.item.sourceId.ifEmpty { null },
+            onBack = { nav = LibraryNav.Items },
+            onReadNotSupported = {},
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/riffle/shared/library/LibraryItemDetailScreen.kt
+++ b/shared/src/commonMain/kotlin/com/riffle/shared/library/LibraryItemDetailScreen.kt
@@ -1,0 +1,187 @@
+package com.riffle.shared.library
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.koin.compose.koinInject
+import org.koin.core.parameter.parametersOf
+
+private val TitleStyle = TextStyle(fontWeight = FontWeight.Bold, fontSize = 22.sp)
+private val AuthorStyle = TextStyle(fontSize = 16.sp, color = Color(0xFF666666))
+private val ButtonTextStyle = TextStyle(
+    fontWeight = FontWeight.SemiBold,
+    fontSize = 16.sp,
+    color = Color.White,
+)
+
+@Composable
+fun LibraryItemDetailScreen(
+    itemId: String,
+    sourceId: String?,
+    onBack: () -> Unit,
+    onReadNotSupported: () -> Unit,
+) {
+    val vm: LibraryItemDetailViewModel = koinInject(parameters = { parametersOf(itemId, sourceId) })
+    val uiState by vm.uiState.collectAsState()
+
+    when (val state = uiState) {
+        LibraryItemDetailUiState.Loading -> LoadingContent()
+        LibraryItemDetailUiState.Error -> ErrorContent(onBack = onBack)
+        is LibraryItemDetailUiState.Ready -> ReadyContent(
+            state = state,
+            onBack = onBack,
+            onRead = onReadNotSupported,
+            onToggleToRead = { vm.toggleToRead() },
+        )
+    }
+}
+
+@Composable
+private fun LoadingContent() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        BasicText(text = "Loading…", style = TextStyle(fontSize = 16.sp, color = Color(0xFF888888)))
+    }
+}
+
+@Composable
+private fun ErrorContent(onBack: () -> Unit) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            BasicText(
+                text = "Item not found",
+                style = TextStyle(fontSize = 16.sp, color = Color(0xFF888888)),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            BasicText(
+                text = "← Back",
+                style = TextStyle(
+                    fontSize = 16.sp,
+                    color = Color(0xFF6650A4),
+                    fontWeight = FontWeight.SemiBold,
+                ),
+                modifier = Modifier.clickable(onClick = onBack),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReadyContent(
+    state: LibraryItemDetailUiState.Ready,
+    onBack: () -> Unit,
+    onRead: () -> Unit,
+    onToggleToRead: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            BasicText(
+                text = "← Back",
+                style = TextStyle(
+                    fontSize = 16.sp,
+                    color = Color(0xFF6650A4),
+                    fontWeight = FontWeight.SemiBold,
+                ),
+                modifier = Modifier.clickable(onClick = onBack),
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Box(
+            modifier = Modifier
+                .width(160.dp)
+                .aspectRatio(2f / 3f)
+                .clip(RoundedCornerShape(8.dp))
+                .align(Alignment.CenterHorizontally),
+        ) {
+            DefaultCoverPlaceholder(isAudiobook = state.item.hasAudio)
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        BasicText(
+            text = state.item.title,
+            style = TitleStyle,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        BasicText(
+            text = state.item.author,
+            style = AuthorStyle,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(48.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Color(0xFF6650A4))
+                    .clickable(onClick = onRead),
+                contentAlignment = Alignment.Center,
+            ) {
+                BasicText(text = "Read", style = ButtonTextStyle)
+            }
+
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .height(48.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(if (state.isInToRead) Color(0xFF6650A4) else Color(0xFFEAE0F8))
+                    .clickable(onClick = onToggleToRead),
+                contentAlignment = Alignment.Center,
+            ) {
+                BasicText(
+                    text = if (state.isInToRead) "In To-Read" else "Add to To-Read",
+                    style = ButtonTextStyle.copy(
+                        color = if (state.isInToRead) Color.White else Color(0xFF6650A4),
+                    ),
+                )
+            }
+        }
+
+        if (state.isOffline) {
+            Spacer(modifier = Modifier.height(12.dp))
+            BasicText(
+                text = "You are offline",
+                style = TextStyle(fontSize = 13.sp, color = Color(0xFFAA8800)),
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/riffle/shared/library/LibraryItemDetailViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/riffle/shared/library/LibraryItemDetailViewModel.kt
@@ -1,0 +1,102 @@
+package com.riffle.shared.library
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.riffle.core.data.ToReadRepository
+import com.riffle.core.domain.ConnectivityObserver
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.models.LibraryItem
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+sealed interface LibraryItemDetailUiState {
+    data object Loading : LibraryItemDetailUiState
+    data class Ready(
+        val item: LibraryItem,
+        val authToken: String,
+        val isInToRead: Boolean = false,
+        val isOffline: Boolean = false,
+    ) : LibraryItemDetailUiState
+    data object Error : LibraryItemDetailUiState
+}
+
+class LibraryItemDetailViewModel(
+    val itemId: String,
+    val sourceId: String?,
+    private val libraryObserver: LibraryObserver,
+    private val sourceRepository: SourceRepository,
+    private val tokenStorage: TokenStorage,
+    private val toReadRepository: ToReadRepository,
+    private val connectivityObserver: ConnectivityObserver,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<LibraryItemDetailUiState>(LibraryItemDetailUiState.Loading)
+    val uiState: StateFlow<LibraryItemDetailUiState> = _uiState
+
+    init {
+        viewModelScope.launch {
+            val source = sourceId?.let { id ->
+                sourceRepository.getById(id) ?: sourceRepository.getActive()
+            } ?: sourceRepository.getActive()
+            val token = source?.let { tokenStorage.getToken(it.id) } ?: ""
+            val item = sourceId
+                ?.let { libraryObserver.getItem(it, itemId) }
+                ?: libraryObserver.getItem(itemId)
+            _uiState.value = if (item != null) {
+                val isInToRead = toReadRepository.isInToRead(item.id, item.libraryId)
+                LibraryItemDetailUiState.Ready(
+                    item = item,
+                    authToken = token,
+                    isInToRead = isInToRead,
+                    isOffline = !connectivityObserver.isOnline.value,
+                )
+            } else {
+                LibraryItemDetailUiState.Error
+            }
+
+            connectivityObserver.isOnline
+                .onEach { online ->
+                    val current = _uiState.value
+                    if (current is LibraryItemDetailUiState.Ready) {
+                        _uiState.value = current.copy(isOffline = !online)
+                    }
+                }
+                .launchIn(viewModelScope)
+        }
+
+        val itemFlow = sourceId
+            ?.let { libraryObserver.observeItem(it, itemId) }
+            ?: libraryObserver.observeItem(itemId)
+        itemFlow
+            .onEach { latest ->
+                if (latest == null) return@onEach
+                val current = _uiState.value
+                if (current is LibraryItemDetailUiState.Ready && current.item != latest) {
+                    _uiState.value = current.copy(item = latest)
+                }
+            }
+            .launchIn(viewModelScope)
+    }
+
+    fun toggleToRead() {
+        val current = _uiState.value as? LibraryItemDetailUiState.Ready ?: return
+        val wasInToRead = current.isInToRead
+        _uiState.value = current.copy(isInToRead = !wasInToRead)
+        viewModelScope.launch {
+            val ok = if (wasInToRead) {
+                toReadRepository.removeFromToRead(current.item.id, current.item.libraryId)
+            } else {
+                toReadRepository.addToToRead(current.item.id, current.item.libraryId)
+            }
+            if (!ok) {
+                val now = _uiState.value as? LibraryItemDetailUiState.Ready ?: return@launch
+                _uiState.value = now.copy(isInToRead = wasInToRead)
+            }
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/com/riffle/shared/library/LibraryItemDetailViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/riffle/shared/library/LibraryItemDetailViewModelTest.kt
@@ -1,0 +1,140 @@
+package com.riffle.shared.library
+
+import com.riffle.core.data.ToReadRepository
+import com.riffle.core.domain.ConnectivityObserver
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.models.Collection
+import com.riffle.core.models.EbookFormat
+import com.riffle.core.models.Library
+import com.riffle.core.models.LibraryItem
+import com.riffle.core.models.Series
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.experimental.ExperimentalNativeApi
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+@OptIn(ExperimentalNativeApi::class)
+class LibraryItemDetailViewModelTest {
+
+    private val fakeItem = LibraryItem(
+        id = "item1",
+        libraryId = "lib1",
+        title = "Test Book",
+        author = "Test Author",
+        coverUrl = null,
+        readingProgress = 0.0f,
+        isCached = false,
+        isDownloaded = false,
+        ebookFormat = EbookFormat.Epub,
+        sourceId = "source1",
+    )
+
+    private fun makeLibraryObserver(item: LibraryItem? = fakeItem) = object : LibraryObserver {
+        override fun observeLibraries(): Flow<List<Library>> = flowOf(emptyList())
+        override fun observeLibraries(sourceId: String): Flow<List<Library>> = flowOf(emptyList())
+        override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override fun observeFinishedItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override fun observeRecentlyAddedItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override fun observeSeries(libraryId: String): Flow<List<Series>> = flowOf(emptyList())
+        override fun observeCollections(libraryId: String): Flow<List<Collection>> = flowOf(emptyList())
+        override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override fun observeContinueSeriesItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+        override suspend fun getItem(itemId: String): LibraryItem? = item
+        override fun observeItem(itemId: String): Flow<LibraryItem?> = flowOf(item)
+        override suspend fun getItem(sourceId: String, itemId: String): LibraryItem? = item
+        override fun observeItem(sourceId: String, itemId: String): Flow<LibraryItem?> = flowOf(item)
+        override suspend fun getLibrary(libraryId: String): Library? = null
+        override suspend fun getSeriesIdForItem(sourceId: String, itemId: String): String? = null
+    }
+
+    private fun makeToReadRepository(inToRead: Boolean = false) = object : ToReadRepository {
+        override fun observeToReadItemIds(libraryId: String): Flow<Set<String>> = flowOf(emptySet())
+        override suspend fun refresh(libraryId: String): Boolean = false
+        override suspend fun isInToRead(libraryItemId: String, libraryId: String): Boolean = inToRead
+        override suspend fun addToToRead(libraryItemId: String, libraryId: String): Boolean = true
+        override suspend fun removeFromToRead(libraryItemId: String, libraryId: String): Boolean = true
+    }
+
+    private fun makeConnectivityObserver(online: Boolean = true) = object : ConnectivityObserver {
+        override val isOnline: StateFlow<Boolean> = MutableStateFlow(online)
+    }
+
+    private fun makeSourceRepository() = object : SourceRepository {
+        override fun observeAll(): Flow<List<com.riffle.core.models.Source>> = flowOf(emptyList())
+        override suspend fun getActive(): com.riffle.core.models.Source? = null
+        override suspend fun commit(
+            pending: com.riffle.core.domain.PendingSource,
+            hiddenLibraryIds: Set<String>,
+        ): com.riffle.core.domain.CommitSourceResult =
+            com.riffle.core.domain.CommitSourceResult.Failure(UnsupportedOperationException())
+        override suspend fun setActive(sourceId: String) {}
+        override suspend fun remove(sourceId: String) {}
+        override suspend fun getSourceVersion(sourceId: String): String? = null
+    }
+
+    private fun makeTokenStorage() = object : TokenStorage {
+        override suspend fun saveToken(sourceId: String, token: String) {}
+        override suspend fun getToken(sourceId: String): String? = null
+        override suspend fun deleteToken(sourceId: String) {}
+    }
+
+    private fun makeViewModel(
+        item: LibraryItem? = fakeItem,
+        itemId: String = "item1",
+        sourceId: String? = "source1",
+        inToRead: Boolean = false,
+    ) = LibraryItemDetailViewModel(
+        itemId = itemId,
+        sourceId = sourceId,
+        libraryObserver = makeLibraryObserver(item),
+        sourceRepository = makeSourceRepository(),
+        tokenStorage = makeTokenStorage(),
+        toReadRepository = makeToReadRepository(inToRead),
+        connectivityObserver = makeConnectivityObserver(),
+    )
+
+    @Test
+    fun initialStateIsLoading() = runTest {
+        val vm = makeViewModel()
+        // Loading is the synchronous initial value before the coroutine runs
+        assertIs<LibraryItemDetailUiState.Loading>(vm.uiState.value)
+    }
+
+    @Test
+    fun stateBecomesReadyWhenItemFound() = runTest {
+        val vm = makeViewModel(item = fakeItem)
+        testScheduler.advanceUntilIdle()
+        assertIs<LibraryItemDetailUiState.Ready>(vm.uiState.value)
+    }
+
+    @Test
+    fun stateBecomesErrorWhenItemNotFound() = runTest {
+        val vm = makeViewModel(item = null, itemId = "missing")
+        testScheduler.advanceUntilIdle()
+        assertIs<LibraryItemDetailUiState.Error>(vm.uiState.value)
+    }
+
+    @Test
+    fun toggleToReadFlipsIsInToRead() = runTest {
+        val vm = makeViewModel(inToRead = false)
+        testScheduler.advanceUntilIdle()
+        val ready = vm.uiState.value as LibraryItemDetailUiState.Ready
+        assert(!ready.isInToRead) { "Expected isInToRead=false before toggle" }
+
+        vm.toggleToRead()
+        testScheduler.advanceUntilIdle()
+
+        val toggled = vm.uiState.value as LibraryItemDetailUiState.Ready
+        assert(toggled.isInToRead) { "Expected isInToRead=true after toggle" }
+    }
+}

--- a/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
@@ -52,6 +52,7 @@ import com.riffle.shared.library.IosNoOpLibraryItemOfflineAvailability
 import com.riffle.shared.library.IosNoOpReadaloudLinkRepository
 import com.riffle.shared.library.IosNoOpReadaloudReconciler
 import com.riffle.shared.library.IosNoOpStorytellerSyncer
+import com.riffle.shared.library.LibraryItemDetailViewModel
 import com.riffle.shared.library.LibraryItemsViewModel
 import org.koin.dsl.module
 import org.koin.core.context.startKoin as koinStartKoin
@@ -127,6 +128,17 @@ private val iosLibraryModule = module {
             sourceRepository = get(),
             repo = get(),
             tokenStorage = get(),
+        )
+    }
+    factory { params ->
+        LibraryItemDetailViewModel(
+            itemId = params.get(),
+            sourceId = params.get(),
+            libraryObserver = get(),
+            sourceRepository = get(),
+            tokenStorage = get(),
+            toReadRepository = get(),
+            connectivityObserver = get(),
         )
     }
 }


### PR DESCRIPTION
Closes #915

## Summary

- Adds a slim `LibraryItemDetailViewModel` in `shared/commonMain` (5 deps: `LibraryObserver`, `SourceRepository`, `TokenStorage`, `ToReadRepository`, `ConnectivityObserver`). Exposes `Loading`/`Ready`/`Error` sealed UiState with optimistic To-Read toggle and connectivity-driven offline banner.
- Adds `LibraryItemDetailScreen` in `shared/commonMain` using basic Compose (`BasicText`, `Box`, `Column`, `DefaultCoverPlaceholder`) — no Material3 or coil required.
- Extends `LibraryNav` sealed interface in `HomeScreen.kt` with `ItemDetail`; wires `onItemSelected` in both `LibraryItemsScreen` and `LibrarySectionScreen`.
- Registers `LibraryItemDetailViewModel` as a `factory` in `iosLibraryModule` (`shared/iosMain/Koin.kt`).
- Adds `commonTest` dependency on `kotlinx.coroutines.test` and 4 regression tests for the ViewModel (Loading → Ready, Loading → Error, toggleToRead flip).
- Adds iOS XCTest (`LibraryItemDetailNavTests`) pinning the 3 sealed-state cases; adds scenario doc `docs/testing/ios-scenarios/3-library-item-detail-nav.md` with 7 scenarios.

The Android `app/` `LibraryItemDetailViewModel` and `LibraryItemDetailScreen` are left untouched.

## Test plan
- [x] `./gradlew :shared:compileTestKotlinIosSimulatorArm64` — ViewModel test suite compiles clean on iOS
- [x] `./gradlew test jvmTest` — all 162 Android JVM tasks pass
- [ ] iOS XCTest (`LibraryItemDetailNavTests`) — runs in CI `iOS integration tests` job
- [ ] Manual: tap book tile → detail screen shows title + author + cover placeholder + Read/To-Read buttons; back returns to grid