### PR TITLE
feat(ios): wire SeriesDetailScreen and CollectionDetailScreen (#916)

### DIFF
--- a/docs/testing/ios-scenarios/4-series-collection-detail.md
+++ b/docs/testing/ios-scenarios/4-series-collection-detail.md
@@ -1,0 +1,47 @@
+# iOS Scenario: Series and Collection Detail (Issue #916)
+
+Covers `SeriesDetailScreen` and `CollectionDetailScreen` rendered via `HomeScreen` on iOS.
+
+## Preconditions
+- App is configured with an Audiobookshelf source that has at least one library with series or collections.
+- App launches to `HomeScreen`.
+
+## Scenarios
+
+### 4.1 — Tapping a series tile navigates to series detail
+**Steps:**
+1. Launch the app with a configured ABS source.
+2. Wait for the library home to load.
+3. Scroll to the "Series" section.
+4. Tap a series tile.
+
+**Expected:**
+- A series detail screen appears showing the series name in the top bar.
+- A grid of book covers for that series is visible (or "No books in this series" if empty).
+
+### 4.2 — Back from series detail returns to library home
+**Steps:**
+1. Navigate into a series detail screen (see 4.1).
+2. Tap the back arrow ("←").
+
+**Expected:**
+- The library home screen reappears with the section grid.
+
+### 4.3 — Tapping a collection tile navigates to collection detail
+**Steps:**
+1. Launch the app with a configured ABS source.
+2. Wait for the library home to load.
+3. Scroll to the "Collections" section.
+4. Tap a collection tile.
+
+**Expected:**
+- A collection detail screen appears showing the collection name in the top bar.
+- A grid of book covers for that collection is visible (or "No books in this collection" if empty).
+
+### 4.4 — Back from collection detail returns to library home
+**Steps:**
+1. Navigate into a collection detail screen (see 4.3).
+2. Tap the back arrow ("←").
+
+**Expected:**
+- The library home screen reappears with the section grid.

--- a/feature/library/src/commonMain/kotlin/com/riffle/feature/library/CollectionDetailViewModel.kt
+++ b/feature/library/src/commonMain/kotlin/com/riffle/feature/library/CollectionDetailViewModel.kt
@@ -1,0 +1,100 @@
+package com.riffle.feature.library
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.riffle.core.domain.ConnectivityObserver
+import com.riffle.core.domain.DispatcherProvider
+import com.riffle.core.domain.LibraryItemOfflineAvailability
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.LibraryRefreshResult
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.domain.usecase.RefreshCollections
+import com.riffle.core.models.LibraryItem
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class CollectionDetailViewModel constructor(
+    val collectionId: String,
+    private val libraryId: String,
+    private val libraryObserver: LibraryObserver,
+    private val refreshCollectionsUseCase: RefreshCollections,
+    private val sourceRepository: SourceRepository,
+    private val tokenStorage: TokenStorage,
+    private val offlineAvailability: LibraryItemOfflineAvailability,
+    private val connectivityObserver: ConnectivityObserver,
+    private val dispatchers: DispatcherProvider,
+) : ViewModel() {
+
+    private val _refreshFailed = MutableStateFlow(false)
+
+    val isOffline: StateFlow<Boolean> = combine(
+        connectivityObserver.isOnline,
+        _refreshFailed,
+    ) { online, refreshFailed ->
+        !online || refreshFailed
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    private val allItems: StateFlow<List<LibraryItem>> = libraryObserver.observeCollectionItems(collectionId)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val items: StateFlow<List<LibraryItem>> = combine(allItems, isOffline) { items, offline ->
+        if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
+    }
+        .flowOn(dispatchers.default)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    var authToken: String by mutableStateOf("")
+        private set
+
+    init {
+        viewModelScope.launch {
+            val source = sourceRepository.getActive()
+            if (source != null) {
+                authToken = tokenStorage.getToken(source.id) ?: ""
+            }
+            refresh()
+        }
+        viewModelScope.launch {
+            connectivityObserver.isOnline
+                .drop(1)
+                .filter { it }
+                .collect { refresh() }
+        }
+        viewModelScope.launch {
+            combine(_refreshFailed, connectivityObserver.isOnline) { failed, online -> failed && online }
+                .collectLatest { shouldPoll ->
+                    if (shouldPoll) {
+                        while (true) {
+                            delay(FAILED_REFRESH_RETRY_INTERVAL_MS)
+                            runRefresh()
+                        }
+                    }
+                }
+        }
+    }
+
+    fun refresh() {
+        viewModelScope.launch { runRefresh() }
+    }
+
+    private suspend fun runRefresh() {
+        _refreshFailed.value = refreshCollectionsUseCase(libraryId) is LibraryRefreshResult.NetworkError
+    }
+
+    private companion object {
+        const val FAILED_REFRESH_RETRY_INTERVAL_MS = 10_000L
+    }
+}

--- a/feature/library/src/commonMain/kotlin/com/riffle/feature/library/SeriesDetailViewModel.kt
+++ b/feature/library/src/commonMain/kotlin/com/riffle/feature/library/SeriesDetailViewModel.kt
@@ -1,0 +1,95 @@
+package com.riffle.feature.library
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.riffle.core.domain.ConnectivityObserver
+import com.riffle.core.domain.LibraryItemOfflineAvailability
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.LibraryRefreshResult
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.domain.usecase.RefreshSeries
+import com.riffle.core.models.LibraryItem
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class SeriesDetailViewModel constructor(
+    val seriesId: String,
+    private val libraryId: String,
+    private val libraryObserver: LibraryObserver,
+    private val refreshSeriesUseCase: RefreshSeries,
+    private val sourceRepository: SourceRepository,
+    private val tokenStorage: TokenStorage,
+    private val offlineAvailability: LibraryItemOfflineAvailability,
+    private val connectivityObserver: ConnectivityObserver,
+) : ViewModel() {
+
+    private val allItems: StateFlow<List<LibraryItem>> = libraryObserver.observeSeriesItems(seriesId)
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    private val _refreshFailed = MutableStateFlow(false)
+
+    val isOffline: StateFlow<Boolean> = combine(
+        connectivityObserver.isOnline,
+        _refreshFailed,
+    ) { online, refreshFailed ->
+        !online || refreshFailed
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    val items: StateFlow<List<LibraryItem>> = combine(allItems, isOffline) { items, offline ->
+        if (offline) items.filter { offlineAvailability.isAvailableOffline(it) } else items
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    var authToken: String by mutableStateOf("")
+        private set
+
+    init {
+        viewModelScope.launch {
+            val source = sourceRepository.getActive()
+            if (source != null) {
+                authToken = tokenStorage.getToken(source.id) ?: ""
+            }
+            refresh()
+        }
+        viewModelScope.launch {
+            connectivityObserver.isOnline
+                .drop(1)
+                .filter { it }
+                .collect { refresh() }
+        }
+        viewModelScope.launch {
+            combine(_refreshFailed, connectivityObserver.isOnline) { failed, online -> failed && online }
+                .collectLatest { shouldPoll ->
+                    if (shouldPoll) {
+                        while (true) {
+                            delay(FAILED_REFRESH_RETRY_INTERVAL_MS)
+                            runRefresh()
+                        }
+                    }
+                }
+        }
+    }
+
+    fun refresh() {
+        viewModelScope.launch { runRefresh() }
+    }
+
+    private suspend fun runRefresh() {
+        _refreshFailed.value = refreshSeriesUseCase(libraryId) is LibraryRefreshResult.NetworkError
+    }
+
+    private companion object {
+        const val FAILED_REFRESH_RETRY_INTERVAL_MS = 10_000L
+    }
+}

--- a/feature/library/src/commonTest/kotlin/com/riffle/feature/library/CollectionDetailViewModelTest.kt
+++ b/feature/library/src/commonTest/kotlin/com/riffle/feature/library/CollectionDetailViewModelTest.kt
@@ -1,0 +1,147 @@
+package com.riffle.feature.library
+
+import com.riffle.core.domain.ConnectivityObserver
+import com.riffle.core.domain.DispatcherProvider
+import com.riffle.core.domain.LibraryItemOfflineAvailability
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.LibraryRefreshResult
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.domain.usecase.RefreshCollections
+import com.riffle.core.models.Collection
+import com.riffle.core.models.EbookFormat
+import com.riffle.core.models.Library
+import com.riffle.core.models.LibraryItem
+import com.riffle.core.models.Series
+import com.riffle.core.models.Source
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CollectionDetailViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val onlineState = MutableStateFlow(true)
+
+    @BeforeTest fun setUp() { Dispatchers.setMain(dispatcher) }
+    @AfterTest fun tearDown() { Dispatchers.resetMain() }
+
+    private fun stubRefresher() = object : com.riffle.core.domain.LibraryRefresher {
+        override suspend fun refreshLibraries(): LibraryRefreshResult = LibraryRefreshResult.Success
+        override suspend fun refreshLibraryItems(libraryId: String): LibraryRefreshResult = LibraryRefreshResult.Success
+        override suspend fun refreshSeries(libraryId: String): LibraryRefreshResult = LibraryRefreshResult.Success
+        override suspend fun refreshCollections(libraryId: String): LibraryRefreshResult = LibraryRefreshResult.Success
+        override suspend fun refreshItemProgress(sourceId: String, itemId: String): LibraryRefreshResult = LibraryRefreshResult.Success
+    }
+
+    private fun item(id: String, cached: Boolean = false) = LibraryItem(
+        id = id,
+        libraryId = "lib1",
+        title = "Title $id",
+        author = "",
+        coverUrl = null,
+        readingProgress = 0f,
+        isCached = cached,
+        isDownloaded = false,
+        ebookFormat = EbookFormat.Epub,
+    )
+
+    private fun makeVm(
+        collectionItems: List<LibraryItem> = emptyList(),
+        offlineItems: Set<String> = emptySet(),
+    ) = CollectionDetailViewModel(
+        collectionId = "col1",
+        libraryId = "lib1",
+        libraryObserver = object : LibraryObserver {
+            override fun observeLibraries(): Flow<List<Library>> = flowOf(emptyList())
+            override fun observeLibraries(sourceId: String): Flow<List<Library>> = flowOf(emptyList())
+            override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+            override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+            override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+            override fun observeFinishedItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+            override fun observeRecentlyAddedItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+            override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+            override fun observeSeries(libraryId: String): Flow<List<Series>> = flowOf(emptyList())
+            override fun observeCollections(libraryId: String): Flow<List<Collection>> = flowOf(emptyList())
+            override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+            override fun observeContinueSeriesItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+            override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = flowOf(collectionItems)
+            override fun observeItem(itemId: String): Flow<LibraryItem?> = flowOf(null)
+            override suspend fun getItem(itemId: String): LibraryItem? = null
+            override suspend fun getItem(sourceId: String, itemId: String): LibraryItem? = null
+            override suspend fun getSeriesIdForItem(sourceId: String, itemId: String): String? = null
+            override suspend fun getLibrary(libraryId: String): Library? = null
+        },
+        refreshCollectionsUseCase = object : RefreshCollections(stubRefresher()) {},
+        sourceRepository = object : SourceRepository {
+            override fun observeAll(): Flow<List<Source>> = flowOf(emptyList())
+            override suspend fun getActive(): Source? = null
+            override suspend fun commit(pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>): com.riffle.core.domain.CommitSourceResult = throw NotImplementedError()
+            override suspend fun setActive(sourceId: String) = Unit
+            override suspend fun remove(sourceId: String) = Unit
+            override suspend fun getSourceVersion(sourceId: String): String? = null
+        },
+        tokenStorage = object : TokenStorage {
+            override suspend fun getToken(sourceId: String): String? = null
+            override suspend fun saveToken(sourceId: String, token: String) = Unit
+            override suspend fun deleteToken(sourceId: String) = Unit
+        },
+        offlineAvailability = object : LibraryItemOfflineAvailability {
+            override fun isAvailableOffline(item: LibraryItem): Boolean = item.id in offlineItems
+        },
+        connectivityObserver = object : ConnectivityObserver {
+            override val isOnline: StateFlow<Boolean> get() = onlineState
+        },
+        dispatchers = object : DispatcherProvider {
+            override val main: CoroutineDispatcher get() = dispatcher
+            override val mainImmediate: CoroutineDispatcher get() = dispatcher
+            override val io: CoroutineDispatcher get() = dispatcher
+            override val default: CoroutineDispatcher get() = dispatcher
+        },
+    )
+
+    @Test
+    fun itemsEmittedFromObserveCollectionItems() = runTest {
+        val items = listOf(item("a"), item("b"))
+        val vm = makeVm(collectionItems = items)
+        assertEquals(items, vm.items.first())
+    }
+
+    @Test
+    fun isOfflineFalseWhenOnlineAndRefreshSucceeds() = runTest {
+        val vm = makeVm()
+        assertFalse(vm.isOffline.first())
+    }
+
+    @Test
+    fun isOfflineTrueWhenConnectionLost() = runTest {
+        onlineState.value = false
+        val vm = makeVm()
+        assertTrue(vm.isOffline.first())
+    }
+
+    @Test
+    fun offlineFiltersToOnlyAvailableItems() = runTest {
+        onlineState.value = false
+        val items = listOf(item("a", cached = true), item("b"))
+        val vm = makeVm(collectionItems = items, offlineItems = setOf("a"))
+        assertEquals(listOf(item("a", cached = true)), vm.items.first())
+    }
+
+}

--- a/feature/library/src/commonTest/kotlin/com/riffle/feature/library/SeriesDetailViewModelTest.kt
+++ b/feature/library/src/commonTest/kotlin/com/riffle/feature/library/SeriesDetailViewModelTest.kt
@@ -1,0 +1,139 @@
+package com.riffle.feature.library
+
+import com.riffle.core.domain.ConnectivityObserver
+import com.riffle.core.domain.LibraryItemOfflineAvailability
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.domain.LibraryRefreshResult
+import com.riffle.core.domain.SourceRepository
+import com.riffle.core.domain.TokenStorage
+import com.riffle.core.domain.usecase.RefreshSeries
+import com.riffle.core.models.Collection
+import com.riffle.core.models.EbookFormat
+import com.riffle.core.models.Library
+import com.riffle.core.models.LibraryItem
+import com.riffle.core.models.Series
+import com.riffle.core.models.Source
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SeriesDetailViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val onlineState = MutableStateFlow(true)
+
+    @BeforeTest fun setUp() { Dispatchers.setMain(dispatcher) }
+    @AfterTest fun tearDown() { Dispatchers.resetMain() }
+
+    private fun stubRefresher() = object : com.riffle.core.domain.LibraryRefresher {
+        override suspend fun refreshLibraries(): LibraryRefreshResult = LibraryRefreshResult.Success
+        override suspend fun refreshLibraryItems(libraryId: String): LibraryRefreshResult = LibraryRefreshResult.Success
+        override suspend fun refreshSeries(libraryId: String): LibraryRefreshResult = LibraryRefreshResult.Success
+        override suspend fun refreshCollections(libraryId: String): LibraryRefreshResult = LibraryRefreshResult.Success
+        override suspend fun refreshItemProgress(sourceId: String, itemId: String): LibraryRefreshResult = LibraryRefreshResult.Success
+    }
+
+    private fun item(id: String, cached: Boolean = false) = LibraryItem(
+        id = id,
+        libraryId = "lib1",
+        title = "Title $id",
+        author = "",
+        coverUrl = null,
+        readingProgress = 0f,
+        isCached = cached,
+        isDownloaded = false,
+        ebookFormat = EbookFormat.Epub,
+    )
+
+    private fun makeVm(
+        seriesItems: List<LibraryItem> = emptyList(),
+        offlineItems: Set<String> = emptySet(),
+    ) = SeriesDetailViewModel(
+        seriesId = "series1",
+        libraryId = "lib1",
+        libraryObserver = object : LibraryObserver {
+            override fun observeLibraries(): Flow<List<Library>> = flowOf(emptyList())
+            override fun observeLibraries(sourceId: String): Flow<List<Library>> = flowOf(emptyList())
+            override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+            override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+            override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+            override fun observeFinishedItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+            override fun observeRecentlyAddedItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+            override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+            override fun observeSeries(libraryId: String): Flow<List<Series>> = flowOf(emptyList())
+            override fun observeCollections(libraryId: String): Flow<List<Collection>> = flowOf(emptyList())
+            override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = flowOf(seriesItems)
+            override fun observeContinueSeriesItems(libraryId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+            override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = flowOf(emptyList())
+            override fun observeItem(itemId: String): Flow<LibraryItem?> = flowOf(null)
+            override suspend fun getItem(itemId: String): LibraryItem? = null
+            override suspend fun getItem(sourceId: String, itemId: String): LibraryItem? = null
+            override suspend fun getSeriesIdForItem(sourceId: String, itemId: String): String? = null
+            override suspend fun getLibrary(libraryId: String): Library? = null
+        },
+        refreshSeriesUseCase = object : RefreshSeries(stubRefresher()) {},
+        sourceRepository = object : SourceRepository {
+            override fun observeAll(): Flow<List<Source>> = flowOf(emptyList())
+            override suspend fun getActive(): Source? = null
+            override suspend fun commit(pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>): com.riffle.core.domain.CommitSourceResult = throw NotImplementedError()
+            override suspend fun setActive(sourceId: String) = Unit
+            override suspend fun remove(sourceId: String) = Unit
+            override suspend fun getSourceVersion(sourceId: String): String? = null
+        },
+        tokenStorage = object : TokenStorage {
+            override suspend fun getToken(sourceId: String): String? = null
+            override suspend fun saveToken(sourceId: String, token: String) = Unit
+            override suspend fun deleteToken(sourceId: String) = Unit
+        },
+        offlineAvailability = object : LibraryItemOfflineAvailability {
+            override fun isAvailableOffline(item: LibraryItem): Boolean = item.id in offlineItems
+        },
+        connectivityObserver = object : ConnectivityObserver {
+            override val isOnline: StateFlow<Boolean> get() = onlineState
+        },
+    )
+
+    @Test
+    fun itemsEmittedFromObserveSeriesItems() = runTest {
+        val items = listOf(item("a"), item("b"))
+        val vm = makeVm(seriesItems = items)
+        assertEquals(items, vm.items.first())
+    }
+
+    @Test
+    fun isOfflineFalseWhenOnlineAndRefreshSucceeds() = runTest {
+        val vm = makeVm()
+        assertFalse(vm.isOffline.first())
+    }
+
+    @Test
+    fun isOfflineTrueWhenConnectionLost() = runTest {
+        onlineState.value = false
+        val vm = makeVm()
+        assertTrue(vm.isOffline.first())
+    }
+
+    @Test
+    fun offlineFiltersToOnlyAvailableItems() = runTest {
+        onlineState.value = false
+        val items = listOf(item("a", cached = true), item("b"))
+        val vm = makeVm(seriesItems = items, offlineItems = setOf("a"))
+        assertEquals(listOf(item("a", cached = true)), vm.items.first())
+    }
+
+}

--- a/iosApp/iosAppTests/iosAppTests.swift
+++ b/iosApp/iosAppTests/iosAppTests.swift
@@ -77,4 +77,89 @@ final class IosAppTests: XCTestCase {
         let backOnHome = sectionLabels.contains { app.staticTexts[$0].waitForExistence(timeout: 5) }
         XCTAssertTrue(backOnHome, "Navigating back should return to the library home screen")
     }
+
+    // MARK: - Scenario 4: Series and Collection Detail (issue #916)
+
+    /// 4.1 + 4.2 — Tapping a series tile navigates to series detail; back returns to library.
+    func testSeriesTileNavigatesToDetailAndBackReturns() throws {
+        if app.staticTexts["Add a source to get started"].waitForExistence(timeout: 5) {
+            throw XCTSkip("No source configured — series detail test requires a connected server")
+        }
+        if app.staticTexts["No libraries found"].waitForExistence(timeout: 3) {
+            throw XCTSkip("No libraries found — series detail test requires a server with libraries")
+        }
+
+        // Wait for library to load
+        _ = app.activityIndicators.firstMatch.waitForNonExistence(timeout: 15)
+
+        let seriesHeader = app.staticTexts["Series"]
+        guard seriesHeader.waitForExistence(timeout: 5) else {
+            throw XCTSkip("No Series section visible — library may have no series")
+        }
+
+        // Tap the first series tile (any button in the row below "Series" header)
+        let seriesTile = app.buttons.matching(NSPredicate(format: "NOT label IN %@",
+            ["Series", "Collections", "All Books", "In Progress", "Recently Added", "Finished", "Continue Series", "See all"]
+        )).firstMatch
+        guard seriesTile.waitForExistence(timeout: 5) else {
+            throw XCTSkip("No tappable series tile found")
+        }
+        seriesTile.tap()
+
+        // Series detail screen should show a back arrow
+        let backArrow = app.staticTexts["←"].firstMatch
+        XCTAssertTrue(
+            backArrow.waitForExistence(timeout: 5),
+            "Series detail screen should show a back arrow"
+        )
+
+        // Tap back
+        backArrow.tap()
+
+        // Library home should reappear
+        let anySection = ["In Progress", "Recently Added", "Finished", "Continue Series", "All Books", "Series"].contains {
+            app.staticTexts[$0].waitForExistence(timeout: 5)
+        }
+        XCTAssertTrue(anySection, "Navigating back from series detail should return to library home")
+    }
+
+    /// 4.3 + 4.4 — Tapping a collection tile navigates to collection detail; back returns to library.
+    func testCollectionTileNavigatesToDetailAndBackReturns() throws {
+        if app.staticTexts["Add a source to get started"].waitForExistence(timeout: 5) {
+            throw XCTSkip("No source configured — collection detail test requires a connected server")
+        }
+        if app.staticTexts["No libraries found"].waitForExistence(timeout: 3) {
+            throw XCTSkip("No libraries found — collection detail test requires a server with libraries")
+        }
+
+        _ = app.activityIndicators.firstMatch.waitForNonExistence(timeout: 15)
+
+        let collectionsHeader = app.staticTexts["Collections"]
+        guard collectionsHeader.waitForExistence(timeout: 5) else {
+            throw XCTSkip("No Collections section visible — library may have no collections")
+        }
+
+        // Scroll to Collections section and tap the first tile
+        collectionsHeader.swipeUp()
+        let collectionTile = app.buttons.matching(NSPredicate(format: "NOT label IN %@",
+            ["Series", "Collections", "All Books", "In Progress", "Recently Added", "Finished", "Continue Series", "See all"]
+        )).firstMatch
+        guard collectionTile.waitForExistence(timeout: 5) else {
+            throw XCTSkip("No tappable collection tile found")
+        }
+        collectionTile.tap()
+
+        let backArrow = app.staticTexts["←"].firstMatch
+        XCTAssertTrue(
+            backArrow.waitForExistence(timeout: 5),
+            "Collection detail screen should show a back arrow"
+        )
+
+        backArrow.tap()
+
+        let anySection = ["In Progress", "Recently Added", "Finished", "Continue Series", "All Books", "Collections"].contains {
+            app.staticTexts[$0].waitForExistence(timeout: 5)
+        }
+        XCTAssertTrue(anySection, "Navigating back from collection detail should return to library home")
+    }
 }

--- a/shared/src/commonMain/kotlin/com/riffle/shared/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/riffle/shared/HomeScreen.kt
@@ -23,9 +23,11 @@ import com.riffle.core.data.localfiles.LocalFilesInstallerInterface
 import com.riffle.core.models.LibraryItem
 import com.riffle.feature.library.HomeViewModel
 import com.riffle.feature.library.LibrarySectionType
+import com.riffle.shared.library.CollectionDetailScreen
 import com.riffle.shared.library.LibraryItemDetailScreen
 import com.riffle.shared.library.LibraryItemsScreen
 import com.riffle.shared.library.LibrarySectionScreen
+import com.riffle.shared.library.SeriesDetailScreen
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 
@@ -33,6 +35,8 @@ private sealed interface LibraryNav {
     data object Items : LibraryNav
     data class Section(val sectionType: LibrarySectionType) : LibraryNav
     data class ItemDetail(val item: LibraryItem) : LibraryNav
+    data class SeriesDetail(val seriesId: String, val seriesLibraryId: String, val seriesName: String) : LibraryNav
+    data class CollectionDetail(val collectionId: String, val collectionLibraryId: String, val collectionName: String) : LibraryNav
 }
 
 @Composable
@@ -109,7 +113,20 @@ private fun LibraryHost(libraryId: String, libraryName: String) {
             libraryName = libraryName,
             onOpenDrawer = {},
             onItemSelected = { item -> nav = LibraryNav.ItemDetail(item) },
-            onSeriesSelected = {},
+            onSeriesSelected = { series ->
+                nav = LibraryNav.SeriesDetail(
+                    seriesId = series.id,
+                    seriesLibraryId = series.libraryId,
+                    seriesName = series.name,
+                )
+            },
+            onCollectionSelected = { collection ->
+                nav = LibraryNav.CollectionDetail(
+                    collectionId = collection.id,
+                    collectionLibraryId = collection.libraryId,
+                    collectionName = collection.name,
+                )
+            },
             onSectionSeeMore = { sectionType -> nav = LibraryNav.Section(sectionType) },
         )
         is LibraryNav.Section -> LibrarySectionScreen(
@@ -123,6 +140,20 @@ private fun LibraryHost(libraryId: String, libraryName: String) {
             sourceId = current.item.sourceId.ifEmpty { null },
             onBack = { nav = LibraryNav.Items },
             onReadNotSupported = {},
+        )
+        is LibraryNav.SeriesDetail -> SeriesDetailScreen(
+            seriesId = current.seriesId,
+            libraryId = current.seriesLibraryId,
+            seriesName = current.seriesName,
+            onItemSelected = {},
+            onNavigateBack = { nav = LibraryNav.Items },
+        )
+        is LibraryNav.CollectionDetail -> CollectionDetailScreen(
+            collectionId = current.collectionId,
+            libraryId = current.collectionLibraryId,
+            collectionName = current.collectionName,
+            onItemSelected = {},
+            onNavigateBack = { nav = LibraryNav.Items },
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/riffle/shared/library/CollectionDetailScreen.kt
+++ b/shared/src/commonMain/kotlin/com/riffle/shared/library/CollectionDetailScreen.kt
@@ -1,0 +1,92 @@
+package com.riffle.shared.library
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.riffle.core.models.LibraryItem
+import com.riffle.feature.library.CollectionDetailViewModel
+import org.koin.compose.koinInject
+import org.koin.core.parameter.parametersOf
+
+@Composable
+fun CollectionDetailScreen(
+    collectionId: String,
+    libraryId: String,
+    collectionName: String,
+    onItemSelected: (LibraryItem) -> Unit,
+    onNavigateBack: () -> Unit,
+    viewModel: CollectionDetailViewModel = koinInject { parametersOf(collectionId, libraryId) },
+) {
+    val items by viewModel.items.collectAsState()
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        if (items.isEmpty()) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                BasicText("No books in this collection")
+            }
+        } else {
+            LazyVerticalGrid(
+                columns = GridCells.Adaptive(120.dp),
+                contentPadding = PaddingValues(
+                    start = 16.dp,
+                    end = 16.dp,
+                    top = 60.dp,
+                    bottom = 16.dp,
+                ),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                items(items, key = { it.id }) { item ->
+                    BookCoverTile(
+                        item = item,
+                        modifier = Modifier.aspectRatio(2f / 3f),
+                        onClick = { onItemSelected(item) },
+                    )
+                }
+            }
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color.White)
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .align(Alignment.TopStart),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            BasicText(
+                text = "←",
+                modifier = Modifier
+                    .padding(end = 12.dp)
+                    .clickable(onClick = onNavigateBack),
+                style = TextStyle(fontSize = 20.sp),
+            )
+            BasicText(
+                text = collectionName,
+                style = TextStyle(fontWeight = FontWeight.SemiBold, fontSize = 16.sp),
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/com/riffle/shared/library/LibraryItemsScreen.kt
+++ b/shared/src/commonMain/kotlin/com/riffle/shared/library/LibraryItemsScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.riffle.core.models.Collection
 import com.riffle.core.models.LibraryItem
 import com.riffle.core.models.Series
 import com.riffle.feature.library.LibrarySectionType
@@ -52,6 +53,7 @@ fun LibraryItemsScreen(
     onOpenDrawer: () -> Unit,
     onItemSelected: (LibraryItem) -> Unit,
     onSeriesSelected: (Series) -> Unit,
+    onCollectionSelected: (com.riffle.core.models.Collection) -> Unit,
     onSectionSeeMore: (LibrarySectionType) -> Unit,
     viewModel: LibraryItemsViewModel = koinInject { parametersOf(libraryId) },
 ) {
@@ -116,6 +118,24 @@ fun LibraryItemsScreen(
                     HorizontalBookRow(
                         items = projection.finished.take(10),
                         onItemClick = onItemSelected,
+                    )
+                }
+            }
+            if (projection.series.isNotEmpty()) {
+                item { SectionHeader("Series", onSeeAll = null) }
+                item {
+                    SeriesRow(
+                        series = projection.series.take(10),
+                        onSeriesClick = onSeriesSelected,
+                    )
+                }
+            }
+            if (projection.collections.isNotEmpty()) {
+                item { SectionHeader("Collections", onSeeAll = null) }
+                item {
+                    CollectionRow(
+                        collections = projection.collections.take(10),
+                        onCollectionClick = onCollectionSelected,
                     )
                 }
             }
@@ -229,6 +249,100 @@ fun BookCoverTile(
         DefaultCoverPlaceholder(
             isAudiobook = item.isListenable && !item.isReadable,
             modifier = Modifier.fillMaxSize(),
+        )
+    }
+}
+
+@Composable
+private fun SeriesRow(
+    series: List<Series>,
+    onSeriesClick: (Series) -> Unit,
+) {
+    LazyRow(
+        contentPadding = PaddingValues(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.height(SECTION_ROW_HEIGHT.dp),
+    ) {
+        items(series, key = { it.id }) { s ->
+            SeriesTile(
+                series = s,
+                modifier = Modifier.width(SECTION_CELL_WIDTH.dp),
+                onClick = { onSeriesClick(s) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SeriesTile(
+    series: Series,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+) {
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(6.dp))
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.BottomStart,
+    ) {
+        DefaultCoverPlaceholder(
+            isAudiobook = false,
+            modifier = Modifier.fillMaxSize(),
+        )
+        BasicText(
+            text = series.name,
+            modifier = Modifier
+                .padding(4.dp)
+                .background(Color.Black.copy(alpha = 0.5f))
+                .padding(4.dp),
+            style = TextStyle(color = Color.White, fontSize = 11.sp),
+        )
+    }
+}
+
+@Composable
+private fun CollectionRow(
+    collections: List<Collection>,
+    onCollectionClick: (Collection) -> Unit,
+) {
+    LazyRow(
+        contentPadding = PaddingValues(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.height(SECTION_ROW_HEIGHT.dp),
+    ) {
+        items(collections, key = { it.id }) { col ->
+            CollectionTile(
+                collection = col,
+                modifier = Modifier.width(SECTION_CELL_WIDTH.dp),
+                onClick = { onCollectionClick(col) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun CollectionTile(
+    collection: Collection,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+) {
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(6.dp))
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.BottomStart,
+    ) {
+        DefaultCoverPlaceholder(
+            isAudiobook = false,
+            modifier = Modifier.fillMaxSize(),
+        )
+        BasicText(
+            text = collection.name,
+            modifier = Modifier
+                .padding(4.dp)
+                .background(Color.Black.copy(alpha = 0.5f))
+                .padding(4.dp),
+            style = TextStyle(color = Color.White, fontSize = 11.sp),
         )
     }
 }

--- a/shared/src/commonMain/kotlin/com/riffle/shared/library/SeriesDetailScreen.kt
+++ b/shared/src/commonMain/kotlin/com/riffle/shared/library/SeriesDetailScreen.kt
@@ -1,0 +1,92 @@
+package com.riffle.shared.library
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.riffle.core.models.LibraryItem
+import com.riffle.feature.library.SeriesDetailViewModel
+import org.koin.compose.koinInject
+import org.koin.core.parameter.parametersOf
+
+@Composable
+fun SeriesDetailScreen(
+    seriesId: String,
+    libraryId: String,
+    seriesName: String,
+    onItemSelected: (LibraryItem) -> Unit,
+    onNavigateBack: () -> Unit,
+    viewModel: SeriesDetailViewModel = koinInject { parametersOf(seriesId, libraryId) },
+) {
+    val items by viewModel.items.collectAsState()
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        if (items.isEmpty()) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                BasicText("No books in this series")
+            }
+        } else {
+            LazyVerticalGrid(
+                columns = GridCells.Adaptive(120.dp),
+                contentPadding = PaddingValues(
+                    start = 16.dp,
+                    end = 16.dp,
+                    top = 60.dp,
+                    bottom = 16.dp,
+                ),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                items(items, key = { it.id }) { item ->
+                    BookCoverTile(
+                        item = item,
+                        modifier = Modifier.aspectRatio(2f / 3f),
+                        onClick = { onItemSelected(item) },
+                    )
+                }
+            }
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color.White)
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .align(Alignment.TopStart),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            BasicText(
+                text = "←",
+                modifier = Modifier
+                    .padding(end = 12.dp)
+                    .clickable(onClick = onNavigateBack),
+                style = TextStyle(fontSize = 20.sp),
+            )
+            BasicText(
+                text = seriesName,
+                style = TextStyle(fontWeight = FontWeight.SemiBold, fontSize = 16.sp),
+            )
+        }
+    }
+}

--- a/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
@@ -39,8 +39,10 @@ import com.riffle.core.network.AbsLibraryApi
 import com.riffle.core.network.KomgaLibraryApi
 import com.riffle.core.network.KomgaLibraryApiClient
 import com.riffle.core.network.createDefaultHttpClient
+import com.riffle.feature.library.CollectionDetailViewModel
 import com.riffle.feature.library.HomeViewModel
 import com.riffle.feature.library.LibrarySectionViewModel
+import com.riffle.feature.library.SeriesDetailViewModel
 import com.riffle.shared.library.AnnotationsListViewModel
 import com.riffle.shared.library.IosNoOpAnnotationStore
 import com.riffle.shared.library.IosNoOpAnnotationsLibraryRepository
@@ -139,6 +141,31 @@ private val iosLibraryModule = module {
             tokenStorage = get(),
             toReadRepository = get(),
             connectivityObserver = get(),
+        )
+    }
+    factory { params ->
+        SeriesDetailViewModel(
+            seriesId = params.get(),
+            libraryId = params.get(),
+            libraryObserver = get(),
+            refreshSeriesUseCase = get(),
+            sourceRepository = get(),
+            tokenStorage = get(),
+            offlineAvailability = get(),
+            connectivityObserver = get(),
+        )
+    }
+    factory { params ->
+        CollectionDetailViewModel(
+            collectionId = params.get(),
+            libraryId = params.get(),
+            libraryObserver = get(),
+            refreshCollectionsUseCase = get(),
+            sourceRepository = get(),
+            tokenStorage = get(),
+            offlineAvailability = get(),
+            connectivityObserver = get(),
+            dispatchers = get(),
         )
     }
 }


### PR DESCRIPTION
Closes #916

## What changed

- **`SeriesDetailViewModel`** and **`CollectionDetailViewModel`** moved to `feature:library/commonMain` — no `SavedStateHandle`, direct constructor parameters (same pattern as `LibrarySectionViewModel`)
- **`SeriesDetailScreen`** and **`CollectionDetailScreen`** added to `shared/commonMain` — KMP-compatible, using `BasicText` + `LazyVerticalGrid` (same style as `LibrarySectionScreen`)
- **`LibraryItemsScreen`** (shared): added `onCollectionSelected` parameter and Series/Collection tile rows so users can tap into them
- **`HomeScreen.kt`**: extended `LibraryNav` sealed interface with `SeriesDetail` and `CollectionDetail` states; wired `onSeriesSelected` and `onCollectionSelected` callbacks
- **iOS Koin module**: registered `SeriesDetailViewModel` and `CollectionDetailViewModel` factories
- **iOS XCTest scenarios 4.1–4.4**: tap series/collection tile → detail screen appears; back returns to library home

## Tests

- `SeriesDetailViewModelTest`: items loading, online/offline state, offline filtering
- `CollectionDetailViewModelTest`: same coverage for collections
- iOS XCTest scenarios in `iosAppTests.swift` (4.1–4.4); skip automatically when no server is configured

## Depends on
- #909 ✅ merged