### PR TITLE
fix(i18n): use chapter terminology for sections count in Bulgarian and Spanish

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -311,7 +311,7 @@
     <string name="ui_sleeping_in">Заспиване след %1$s</string>
     <string name="ui_sleeping_at_end_of_chapter">Заспиване в края на главата</string>
     <string name="ui_minutes_short">%1$d мин</string>
-    <string name="ui_sections_count">%1$d раздел(а)</string>
+    <string name="ui_sections_count">%1$d глави</string>
     <string name="ui_chapters_count">%1$d глави</string>
     <string name="ui_progress_listened">%1$d%% изслушано</string>
     <string name="ui_progress_read">%1$d%% прочетено</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -311,7 +311,7 @@
     <string name="ui_sleeping_in">Se detendrá en %1$s</string>
     <string name="ui_sleeping_at_end_of_chapter">Se detendrá al final del capítulo</string>
     <string name="ui_minutes_short">%1$d min</string>
-    <string name="ui_sections_count">%1$d secciones</string>
+    <string name="ui_sections_count">%1$d capítulos</string>
     <string name="ui_chapters_count">%1$d capítulos</string>
     <string name="ui_progress_listened">%1$d%% escuchado</string>
     <string name="ui_progress_read">%1$d%% leído</string>


### PR DESCRIPTION
## Summary

- Bulgarian `ui_sections_count` was displaying "раздел(а)" (sections) — changed to "глави" (chapters), matching `ui_chapters_count` and the rest of the Bulgarian chapter terminology.
- Spanish `ui_sections_count` was displaying "secciones" (sections) — changed to "capítulos" (chapters), matching `ui_chapters_count`.

Both locales now consistently use chapter terminology in the book details screen's TOC section count.