### PR TITLE
fix(websource): show ABS progress for Gramofonche items in browse grid

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/source/websource/OwnedItemMatcher.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/websource/OwnedItemMatcher.kt
@@ -4,7 +4,7 @@ import com.riffle.core.catalog.CatalogItem
 import com.riffle.core.models.LibraryItem
 import java.text.Normalizer
 
-private const val SEP = "|||"
+internal const val NORM_KEY_SEP = "|||"
 
 /**
  * Pre-built index of a user's server-source library items for the "Unowned" catalog filter.
@@ -45,7 +45,7 @@ internal class OwnedItemIndex(
         val normAuthor = normalizeTitle(item.author)
 
         // 2. Exact combined key
-        if (normAuthor.isNotEmpty() && "$normTitle$SEP$normAuthor" in exactKeys) return true
+        if (normAuthor.isNotEmpty() && "$normTitle$NORM_KEY_SEP$normAuthor" in exactKeys) return true
 
         // 3. Title-only key
         if (normTitle in exactKeys) return true
@@ -83,6 +83,35 @@ internal class OwnedItemIndex(
     }
 }
 
+/**
+ * Maps normalized title+author keys to the highest [LibraryItem.readingProgress] seen for that
+ * key across all server-source items. Only includes items where progress > 0.
+ *
+ * Used by [UnboundedBrowseViewModel] to surface played/in-progress state for catalog items that
+ * have been uploaded to a server source (e.g. ABS) by the user — even when the item was never
+ * played through Riffle on the web-source side.
+ *
+ * Keys stored per item:
+ *   - `"$normTitle$NORM_KEY_SEP$normAuthor"` — combined key (when author is non-empty)
+ *   - `"$normTitle"` — title-only key (always stored as fallback)
+ */
+internal fun buildProgressByNormKey(items: List<LibraryItem>): Map<String, Float> {
+    val result = mutableMapOf<String, Float>()
+    for (item in items) {
+        val progress = item.readingProgress
+        if (progress <= 0f) continue
+        val normTitle = normalizeTitle(item.title)
+        if (normTitle.isEmpty()) continue
+        val normAuthor = normalizeTitle(item.author)
+        // Title-only key — always stored so items with no author field in ABS still match.
+        result.merge(normTitle, progress, ::maxOf)
+        if (normAuthor.isNotEmpty()) {
+            result.merge("$normTitle$NORM_KEY_SEP$normAuthor", progress, ::maxOf)
+        }
+    }
+    return result
+}
+
 internal fun buildOwnedItemIndex(items: List<LibraryItem>): OwnedItemIndex {
     val isbns = mutableSetOf<String>()
     val exactKeys = mutableSetOf<String>()
@@ -106,7 +135,7 @@ internal fun buildOwnedItemIndex(items: List<LibraryItem>): OwnedItemIndex {
                 if (baseNorm.isNotEmpty()) titlesWithMeta.add(baseNorm)
             }
         } else {
-            exactKeys.add("$normTitle$SEP$normAuthor")
+            exactKeys.add("$normTitle$NORM_KEY_SEP$normAuthor")
         }
         scanList.add(OwnedItemIndex.AbsEntry(normTitle, normAuthor))
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/websource/UnboundedBrowseViewModel.kt
@@ -187,18 +187,63 @@ abstract class UnboundedBrowseViewModel(
             .map { books -> books.associate { it.id to it.readingProgress } }
             .stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
 
+    // Progress from server-source items (e.g. ABS), keyed by normalised title+author. Used as a
+    // fallback when the Chitanka item has no local progress — covers items the user uploaded to ABS
+    // via the in-app import or an external script and then listened to entirely on the server side.
+    // Loaded eagerly (not gated on _unownedFilterActive) because the progress indicator must appear
+    // regardless of whether the Unowned filter is on. buildProgressByNormKey() is much lighter than
+    // buildOwnedItemIndex() — it only filters items with progress > 0 — so the main-thread cost is
+    // acceptable even for large ABS libraries.
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val serverSourceProgressByNormKey: StateFlow<Map<String, Float>> =
+        sourceRepository.observeAll()
+            .map { sources -> sources.filter { !it.type.isWebSource }.map { it.id } }
+            .flatMapLatest { serverSourceIds ->
+                if (serverSourceIds.isEmpty()) flowOf(emptyMap())
+                else {
+                    val perSourceFlows = serverSourceIds.map { sourceId ->
+                        libraryObserver.observeAllItemsForSource(sourceId)
+                    }
+                    combine(perSourceFlows) { arrays -> buildProgressByNormKey(arrays.flatMap { it }) }
+                }
+            }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
+
+    // Merged progress lookup — local Chitanka progress by item id (primary source, highest
+    // fidelity), falling back to server-source progress keyed by normalised title+author. Combining
+    // both into one StateFlow keeps the filteredItems combine at 5 parameters (the typed overload
+    // limit for kotlinx.coroutines combine).
+    private data class ProgressLookup(
+        val byItemId: Map<String, Float>,
+        val byNormKey: Map<String, Float>,
+    ) {
+        fun progressFor(item: CatalogItem): Float? {
+            val local = byItemId[item.id]
+            if (local != null) return local
+            if (byNormKey.isEmpty()) return null
+            val normTitle = normalizeTitle(item.title)
+            val normAuthor = normalizeTitle(item.author)
+            return byNormKey["$normTitle$NORM_KEY_SEP$normAuthor"] ?: byNormKey[normTitle]
+        }
+    }
+
+    private val progressLookup: StateFlow<ProgressLookup> =
+        combine(localReadingProgressByItemId, serverSourceProgressByNormKey) { local, server ->
+            ProgressLookup(local, server)
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, ProgressLookup(emptyMap(), emptyMap()))
+
     val filteredItems: StateFlow<List<CatalogItem>> =
         combine(
             _items,
-            localReadingProgressByItemId,
+            progressLookup,
             _notStartedFilterActive,
             ownedItemIndex,
             _unownedFilterActive,
-        ) { catalog, progressById, notStartedActive, index, unownedActive ->
+        ) { catalog, progress, notStartedActive, index, unownedActive ->
             catalog
                 .map { item ->
-                    val localProgress = progressById[item.id]
-                    if (localProgress == null) item else item.copy(readingProgress = localProgress)
+                    val p = progress.progressFor(item)
+                    if (p != null) item.copy(readingProgress = p) else item
                 }
                 .filter { item -> !notStartedActive || (item.readingProgress ?: 0f) <= 0f }
                 .filter { item -> !unownedActive || !index.isOwned(item) }

--- a/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseViewModelTest.kt
@@ -720,31 +720,114 @@ class ChitankaBrowseViewModelTest {
     }
 
     @Test
-    fun `owned item index does not query Room until unowned filter is activated`() = runTest(dispatcher) {
-        // Regression: ownedItemIndex used SharingStarted.Eagerly without gating on the filter,
-        // so observeAllItemsForSource() was called on every VM creation regardless of whether
-        // the user had the Unowned filter on. For a large ABS library this ran buildOwnedItemIndex()
-        // on the main thread every time a source or library switch recreated the VM, causing
-        // UI freezes. The index must only be built when the filter is actually active.
-        var queryFired = false
-        val spyObserver = object : LibraryObserver by FakeLibraryObserver() {
-            override fun observeAllItemsForSource(sourceId: String): Flow<List<LibraryItem>> {
-                queryFired = true
-                return flowOf(emptyList())
+    fun `server source items are queried on startup to populate progress for browse items`() =
+        runTest(dispatcher) {
+            // serverSourceProgressByNormKey fires observeAllItemsForSource eagerly so that browse
+            // items uploaded to ABS can show their played/in-progress state without requiring the
+            // Unowned filter to be active. The buildOwnedItemIndex() path (which caused the original
+            // UI-freeze regression) remains gated on _unownedFilterActive — see the test below.
+            var queryFired = false
+            val spyObserver = object : LibraryObserver by FakeLibraryObserver() {
+                override fun observeAllItemsForSource(sourceId: String): Flow<List<LibraryItem>> {
+                    queryFired = true
+                    return flowOf(emptyList())
+                }
             }
+            val vm = makeVm(
+                sourceRepo = fakeSourceRepo(active = chitankaSource, allSources = listOf(chitankaSource, absSource)),
+                libraryObserver = spyObserver,
+            )
+            advanceUntilIdle()
+
+            assertTrue("serverSourceProgressByNormKey must query Room on startup for progress", queryFired)
         }
+
+    @Test
+    fun `owned item index does not hide items until unowned filter is activated`() = runTest(dispatcher) {
+        // buildOwnedItemIndex() is still gated on _unownedFilterActive. Even though server source
+        // items are loaded eagerly for progress tracking, the ownership exclusion only takes effect
+        // once the user toggles the Unowned filter.
+        val serverItem = serverLibraryItem(title = "Dune", author = "Frank Herbert")
+        val serverItems = MutableStateFlow(listOf(serverItem))
+
+        val catalog = mockk<Catalog>(relaxed = true)
+        coEvery { catalog.browse(rootId = any(), page = 0, pageSize = any(), facet = any()) } returns
+            listOf(item("cat-1").copy(title = "Dune", author = "Frank Herbert"), item("cat-2"))
+
         val vm = makeVm(
+            catalog = catalog,
             sourceRepo = fakeSourceRepo(active = chitankaSource, allSources = listOf(chitankaSource, absSource)),
-            libraryObserver = spyObserver,
+            libraryObserver = FakeLibraryObserver(serverSourceItemsFlow = serverItems),
         )
         advanceUntilIdle()
 
-        assertFalse("ownedItemIndex must not query Room while the unowned filter is off", queryFired)
+        // Both items visible before filter is activated — the loaded server items don't trigger hiding
+        assertEquals(2, vm.filteredItems.value.size)
+        assertFalse(vm.unownedFilterActive.value)
 
         vm.toggleUnownedFilter()
         advanceUntilIdle()
 
-        assertTrue("ownedItemIndex must query Room once the filter is activated", queryFired)
+        // After filter: owned item hidden because buildOwnedItemIndex() ran
+        assertTrue(vm.unownedFilterActive.value)
+        assertEquals(listOf("cat-2"), vm.filteredItems.value.map { it.id })
+    }
+
+    @Test
+    fun `catalog items uploaded to ABS show played progress from server source`() = runTest(dispatcher) {
+        // Root cause of "Gramofonche uploaded item is not marked as played": localReadingProgressByItemId
+        // only queries Chitanka source items (scoped by activeServerId). When a user uploads a
+        // Gramofonche item to ABS and listens there, the ABS item's readingProgress is never
+        // reflected in the Chitanka browse grid. serverSourceProgressByNormKey fixes this by
+        // looking up server-source progress by normalized title+author as a fallback.
+        val serverItem = serverLibraryItem(title = "Приказки", author = "Народни приказки")
+            .copy(readingProgress = 1.0f)
+        val serverItems = MutableStateFlow(listOf(serverItem))
+
+        val catalog = mockk<Catalog>(relaxed = true)
+        coEvery { catalog.browse(rootId = any(), page = 0, pageSize = any(), facet = any()) } returns
+            listOf(
+                item("prikazki/1-slug").copy(title = "Приказки", author = "Народни приказки"),
+                item("prikazki/2-other"),
+            )
+
+        val vm = makeVm(
+            rootId = ChitankaCatalog.ROOT_AUDIOBOOKS,
+            catalog = catalog,
+            sourceRepo = fakeSourceRepo(active = chitankaSource, allSources = listOf(chitankaSource, absSource)),
+            libraryObserver = FakeLibraryObserver(serverSourceItemsFlow = serverItems),
+        )
+        advanceUntilIdle()
+
+        val byId = vm.filteredItems.value.associateBy { it.id }
+        assertEquals(1.0f, byId.getValue("prikazki/1-slug").readingProgress)
+        assertEquals(null, byId.getValue("prikazki/2-other").readingProgress)
+    }
+
+    @Test
+    fun `local Chitanka progress takes precedence over server source progress`() = runTest(dispatcher) {
+        // If the same item has local progress in the Chitanka source (e.g., user played it in
+        // Riffle before uploading) AND server-source progress, the local value wins.
+        val itemId = "prikazki/3-test"
+        val roomItems = MutableStateFlow(listOf(libraryItem(itemId, progress = 0.7f)
+            .copy(libraryId = ChitankaCatalog.ROOT_AUDIOBOOKS)))
+
+        val serverItem = serverLibraryItem(title = itemId, author = "A").copy(readingProgress = 1.0f)
+        val serverItems = MutableStateFlow(listOf(serverItem))
+
+        val catalog = mockk<Catalog>(relaxed = true)
+        coEvery { catalog.browse(rootId = any(), page = 0, pageSize = any(), facet = any()) } returns
+            listOf(item(itemId))
+
+        val vm = makeVm(
+            rootId = ChitankaCatalog.ROOT_AUDIOBOOKS,
+            catalog = catalog,
+            sourceRepo = fakeSourceRepo(active = chitankaSource, allSources = listOf(chitankaSource, absSource)),
+            libraryObserver = FakeLibraryObserver(allBooksFlow = roomItems, serverSourceItemsFlow = serverItems),
+        )
+        advanceUntilIdle()
+
+        assertEquals(0.7f, vm.filteredItems.value.first().readingProgress)
     }
 
     // ---- filter helpers ----------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Root cause**: `localReadingProgressByItemId` in `UnboundedBrowseViewModel` is scoped to the Chitanka source only (`observeAllBooks(rootId)` → `scopedItemFlow` → `activeServerId`). When a user uploads a Gramofonche audiobook to ABS (via the in-app import or the external `chitanka-to-audiobookshelf` script) and listens there, the ABS item's `readingProgress` is never reflected in the browse grid.
- **Fix**: add `serverSourceProgressByNormKey` — a `StateFlow` that eagerly queries all non-web-source library items and indexes them by normalised title+author via `buildProgressByNormKey()` (same normalisation as `OwnedItemIndex` strategies 2+3). A new `ProgressLookup` data class merges local + server progress; `filteredItems` uses it so local Chitanka progress always wins and server progress is the fallback.
- The fix applies to both `ChitankaBrowseViewModel` (Chitanka books + Gramofonche audiobooks) and `GutenbergBrowseViewModel` since both extend `UnboundedBrowseViewModel`.
- Partial progress (e.g. 60% listened) is also reflected — not just the finished (100%) state.

## Tests added

- `catalog items uploaded to ABS show played progress from server source` — regression test for the bug
- `local Chitanka progress takes precedence over server source progress` — guards against local progress being overwritten by the server fallback
- `server source items are queried on startup to populate progress for browse items` — pins the new eager-load behaviour
- `owned item index does not hide items until unowned filter is activated` — replaces the old "query fires" test with a behaviour-level assertion: items are not hidden before the Unowned filter is toggled (ownership index remains gated)

## Notes

- `buildProgressByNormKey()` is much lighter than `buildOwnedItemIndex()` (filter-and-map vs. building several data structures), so loading it eagerly without gating on a filter is acceptable even for large ABS libraries.
- `NORM_KEY_SEP` was promoted from `private const val SEP` to `internal` so `ProgressLookup` can use the same key format without duplicating the literal.

## Code review dismissals

All five findings from the automated review were in files outside this diff (`AndroidEpubNavigator.kt`, `LibraryItemDetailViewModel.kt`, `EpubReaderViewModel.kt`, `LibraryLocalizationResourceTest.kt`) — pre-existing issues unrelated to this change.