### PR TITLE
fix(downloads): fix cache settings option spacing — RadioButton internal padding was causing visual inconsistency

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/downloads/DownloadsScreen.kt
@@ -5,7 +5,6 @@ import com.riffle.feature.downloads.LocalItemUi
 import com.riffle.feature.downloads.LocalMediaType
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -206,9 +205,10 @@ private fun CacheSettingsDialog(
         onDismissRequest = onDismiss,
         title = { Text(androidx.compose.ui.res.stringResource(com.riffle.app.R.string.ui_cache_settings)) },
         text = {
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Column {
                 Text(
                     text = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.ui_cached_book_audiobook_comic_and_readaloud_files_can_be_removed_after_they_have_n),
+                    modifier = Modifier.padding(bottom = 4.dp),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )


### PR DESCRIPTION
## What

`CacheSettingsDialog` showed inconsistent vertical spacing between the cache option rows on small screens.

The previous fix (#822) removed `Row padding(vertical=4.dp)` so `Arrangement.spacedBy(4.dp)` would be the sole spacing source. That fixed layout-box gaps, but didn't account for Material3's `RadioButton` having a built-in ~14dp internal top/bottom padding (from the 48dp `minimumInteractiveComponentSize` touch target). The effective visual gaps were:

- **Description → first option**: 4dp (spacedBy) + 14dp (RadioButton internal top) ≈ 18dp
- **Option → option**: 14dp (bottom) + 4dp (spacedBy) + 14dp (top) ≈ 32dp

Those are not equal, which is what the user sees as inconsistency.

## Fix

Drop `Arrangement.spacedBy` from the Column entirely and add `Modifier.padding(bottom = 4.dp)` to the description text only. The RadioButton rows now flow with no extra inter-row gap — each RadioButton's own internal padding provides natural, uniform visual separation between consecutive options.