### PR TITLE
fix(library): remove gap and stop indicator from reading progress bars

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemDetailScreen.kt
@@ -86,6 +86,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.unit.dp
 import org.koin.androidx.compose.koinViewModel
 import coil3.compose.AsyncImage
@@ -1617,6 +1618,9 @@ private fun ReadingProgressIndicator(progress: Float, listened: Boolean = false)
         LinearProgressIndicator(
             progress = { progress },
             modifier = Modifier.fillMaxWidth(),
+            strokeCap = StrokeCap.Butt,
+            gapSize = 0.dp,
+            drawStopIndicator = {},
         )
         Spacer(modifier = Modifier.height(4.dp))
         Text(

--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.material.icons.Icons
@@ -740,6 +741,9 @@ fun BookCoverTile(
                         .align(Alignment.BottomCenter)
                         .fillMaxWidth()
                         .height(3.dp),
+                    strokeCap = StrokeCap.Butt,
+                    gapSize = 0.dp,
+                    drawStopIndicator = {},
                 )
             }
             if (hasReadaloudLink) {
@@ -1382,6 +1386,9 @@ internal fun LibraryItemCard(
                     LinearProgressIndicator(
                         progress = { item.readingProgress },
                         modifier = Modifier.fillMaxWidth(),
+                        strokeCap = StrokeCap.Butt,
+                        gapSize = 0.dp,
+                        drawStopIndicator = {},
                     )
                     Text(
                         text = "${(item.readingProgress * 100).toInt()}%",


### PR DESCRIPTION
Fixes the visual gap and blue end-cap on the reading progress bars in library view.

## Changes

- `strokeCap = StrokeCap.Butt` — removes rounded ends so the filled and unfilled segments are flush
- `gapSize = 0.dp` — removes the Material3 default gap between the progress and track segments
- `drawStopIndicator = {}` — removes the small blue stop marker drawn at the right edge of progress

Applied to all three `LinearProgressIndicator` usages:
- Cover tile (bottom edge of book cover in grid view)
- List card (below author name in list view)
- Item detail screen (`ReadingProgressIndicator`)