### PR TITLE
fix(chitanka): deduplicate search results emitted from both book-section and text-section

### DIFF
--- a/core/catalog-chitanka/src/jvmMain/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraper.kt
+++ b/core/catalog-chitanka/src/jvmMain/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraper.kt
@@ -59,9 +59,14 @@ internal object ChitankaScraper {
         val doc: Document = Jsoup.parse(html)
         val items = mutableListOf<ChitankaBookSummary>()
         val slugCoverMap = mutableMapOf<String, String>()
+        // Keyed by slug; entries added to items only if section 2 has no matching text result.
+        // Avoids duplicates on search pages where Chitanka returns /book/ covers and /text/ entries
+        // for the same book simultaneously — the /text/ entries carry authors and are canonical.
+        val bookItemsBySlug = mutableMapOf<String, ChitankaBookSummary>()
 
-        // 1) "Книги" section: article.book-media inside div.booklist. Add books directly and
-        // build a slug→cover map used to enrich sibling text results.
+        // 1) "Книги" section: article.book-media inside div.booklist. Build a slug→cover map to
+        // enrich sibling text results, and stash each entry by slug. Do NOT add to items yet —
+        // when a matching text result exists in section 2 it is canonical (it carries authors).
         doc.select("div.booklist article.book-media").forEach { el ->
             val bookLink = el.selectFirst("a.booklink") ?: return@forEach
             val href = bookLink.attr("href")
@@ -71,7 +76,7 @@ internal object ChitankaScraper {
             val coverUrl = if (!imgSrc.isNullOrEmpty() && !isChitankaDefaultCover(imgSrc)) toAbsolute(imgSrc) else null
             val slug = href.replace(Regex("^/book/\\d+-"), "")
             if (title.isNotEmpty() && href.isNotEmpty()) {
-                items += ChitankaBookSummary(
+                bookItemsBySlug[slug] = ChitankaBookSummary(
                     site = ChitankaSite.CHITANKA,
                     url = url,
                     title = title,
@@ -84,6 +89,7 @@ internal object ChitankaScraper {
         }
 
         // 2) Text results: <li class="title …"> inside ul.superlist.fa-ul.
+        val coveredSlugs = mutableSetOf<String>()
         doc.select("ul.superlist.fa-ul li.title").forEach { el ->
             val titleEl = el.selectFirst("a.textlink") ?: return@forEach
             val title = titleEl.text().trim()
@@ -106,7 +112,14 @@ internal object ChitankaScraper {
                     coverUrl = coverUrl,
                     format = "epub",
                 )
+                coveredSlugs += textSlug
             }
+        }
+
+        // Any book-section entry with no matching text result still needs to be surfaced
+        // (e.g. browse/category pages where only section 1 matches).
+        bookItemsBySlug.forEach { (slug, summary) ->
+            if (slug !in coveredSlugs) items += summary
         }
 
         // 3) Fallback for genre/category pages: article.book-media at top level with no superlist.

--- a/core/catalog-chitanka/src/jvmTest/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraperTest.kt
+++ b/core/catalog-chitanka/src/jvmTest/kotlin/com/riffle/core/catalog/chitanka/ChitankaScraperTest.kt
@@ -142,6 +142,41 @@ class ChitankaScraperTest {
     }
 
     @Test
+    fun `search results page deduplicates book-section and text-section entries for the same slug`() {
+        // Chitanka search pages have two sections for the same book: a /book/ cover card (no
+        // authors) and a /text/ entry (with authors). Before this fix, parseSearchResults added
+        // both, so the same book appeared twice — one entry missing the author. The text-section
+        // entry is canonical; the book-section entry is only used for cover enrichment.
+        val html = fixture("chitanka-search.html")
+        val res = ChitankaScraper.parseSearchResults(html)
+
+        assertEquals(
+            "expected exactly 3 items (one per book), not 6 — duplicates must be suppressed",
+            3,
+            res.items.size,
+        )
+        // All surviving entries must be the /text/ variants (with authors, not the /book/ entries).
+        assertTrue(
+            "all items should have /text/ URLs, not /book/",
+            res.items.all { it.url.contains("/text/") },
+        )
+        // Authors must be present — the book-section entries (authors = emptyList()) must have
+        // been suppressed in favour of the text-section entries.
+        assertTrue(
+            "all items must carry at least one author",
+            res.items.all { it.authors.isNotEmpty() },
+        )
+        // Cover from section 1 must be forwarded to the text entry via slugCoverMap.
+        val abuHasan = res.items.find { it.url.contains("abu-hasan") }
+        assertNotNull("abu-hasan must be in results", abuHasan)
+        assertNotNull("abu-hasan text entry must inherit the cover from the book-section card", abuHasan!!.coverUrl)
+        // Default-cover books should yield null (the sentinel is still filtered).
+        val noCover = res.items.find { it.url.contains("kniga-bez-korica") }
+        assertNotNull("kniga-bez-korica must be in results", noCover)
+        assertNull("default-cover book must yield null coverUrl", noCover!!.coverUrl)
+    }
+
+    @Test
     fun `empty html yields empty listing and null next page`() {
         val res = ChitankaScraper.parseSearchResults("<html><body></body></html>")
         assertTrue(res.items.isEmpty())

--- a/core/catalog-chitanka/src/jvmTest/resources/chitanka-search.html
+++ b/core/catalog-chitanka/src/jvmTest/resources/chitanka-search.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="bg">
+<head><meta charset="UTF-8"><title>Търсене</title></head>
+<body>
+<!-- Section 1: "Книги" cover cards — /book/ URLs, no author text -->
+<div class="booklist">
+  <article class="book-media">
+    <a class="booklink" href="/book/44723-abu-hasan">
+      <img itemprop="image" src="https://chitanka.info/img/44723.120.jpg" alt="Абу Хасан">
+      <span itemprop="name">Абу Хасан</span>
+    </a>
+  </article>
+  <article class="book-media">
+    <a class="booklink" href="/book/1234-vtora-kniga">
+      <img itemprop="image" src="https://chitanka.info/img/1234.120.jpg" alt="Втора книга">
+      <span itemprop="name">Втора книга</span>
+    </a>
+  </article>
+  <!-- Book with default cover — should yield null coverUrl -->
+  <article class="book-media">
+    <a class="booklink" href="/book/9999-kniga-bez-korica">
+      <img itemprop="image" src="https://chitanka.info/thumb/book-cover/00/0.120.png" alt="">
+      <span itemprop="name">Книга без корица</span>
+    </a>
+  </article>
+</div>
+
+<!-- Section 2: Text results — /text/ URLs, with authors -->
+<ul class="superlist fa-ul">
+  <li class="title">
+    <a class="textlink" href="/text/44723-abu-hasan">Абу Хасан</a>
+    <dl class="dl-horizontal">
+      <dt>Автор:</dt>
+      <dd class="tauthor"><a itemprop="name">Народна творба</a></dd>
+    </dl>
+  </li>
+  <li class="title">
+    <a class="textlink" href="/text/1234-vtora-kniga">Втора книга</a>
+    <dl class="dl-horizontal">
+      <dt>Автор:</dt>
+      <dd class="tauthor"><a itemprop="name">Тестов Автор</a></dd>
+    </dl>
+  </li>
+  <li class="title">
+    <a class="textlink" href="/text/9999-kniga-bez-korica">Книга без корица</a>
+    <dl class="dl-horizontal">
+      <dt>Автор:</dt>
+      <dd class="tauthor"><a itemprop="name">Трети Писател</a></dd>
+    </dl>
+  </li>
+</ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Chitanka search pages return two HTML sections for the same book: a `/book/` cover card (no authors) and a `/text/` entry (with authors). `parseSearchResults` was adding both to the item list, producing duplicate entries — one without an author, one with the same authors. Both resolved to the same detail page (`resolveItem` promotes `/book/` → `/text/`), making them appear identical when tapped but creating separate library rows when opened.
- Fix: stash section-1 (book cover) entries by slug instead of immediately adding them to items. After section-2 (text results) runs, only add section-1 entries whose slug was not covered — preserving correct behaviour for category/browse pages where section-2 is absent.
- Other web sources (Gutenberg, RadioES) use JSON APIs and are not affected. `catalog-chitanka` is JVM-only (`jvmMain`), so no iOS parity is required.

## Test plan

- [ ] New regression test `search results page deduplicates book-section and text-section entries for the same slug` in `ChitankaScraperTest` — asserts exactly 3 items (not 6) for a fixture with 3 books in both sections, all with `/text/` URLs and non-empty authors, cover enrichment preserved.
- [ ] Existing category listing tests still pass (section-1-only pages unaffected by the change).
- [ ] `./gradlew :core:catalog-chitanka:jvmTest` — all tests green locally.