### PR TITLE
fix(reader): skip stale server-resume nav when user has already touched in continuous mode

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousNavigationView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousNavigationView.kt
@@ -9,7 +9,7 @@ import com.riffle.core.domain.FormattingPreferences
  * actually needs.
  */
 internal interface ContinuousNavigationView {
-    fun navigateTo(href: String, progression: Float, alignToTop: Boolean = false)
+    fun navigateTo(href: String, progression: Float, alignToTop: Boolean = false, skipIfUserAlreadyInteracted: Boolean = false)
 
     /**
      * Annotation-precise navigate: when [focusAnnotationId] is non-null the landing anchors on

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousReaderView.kt
@@ -496,8 +496,8 @@ internal class ContinuousReaderView @JvmOverloads constructor(
 
     override fun updatePreferences(prefs: FormattingPreferences) = controller.updatePreferences(prefs)
 
-    override fun navigateTo(href: String, progression: Float, alignToTop: Boolean) =
-        controller.navigateTo(href, progression, alignToTop)
+    override fun navigateTo(href: String, progression: Float, alignToTop: Boolean, skipIfUserAlreadyInteracted: Boolean) =
+        controller.navigateTo(href, progression, alignToTop, skipIfUserAlreadyInteracted)
 
     override fun navigateTo(href: String, progression: Float, alignToTop: Boolean, focusAnnotationId: String?) =
         controller.navigateTo(href, progression, alignToTop, focusAnnotationId)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -679,8 +679,8 @@ internal class ContinuousWindowController(
         webViews.forEach { wv -> wv.reinjectAndRemeasure(styleJs) }
     }
 
-    override fun navigateTo(href: String, progression: Float, alignToTop: Boolean) {
-        navigateTo(href, progression, alignToTop, focusAnnotationId = null)
+    override fun navigateTo(href: String, progression: Float, alignToTop: Boolean, skipIfUserAlreadyInteracted: Boolean) {
+        navigateTo(href, progression, alignToTop, skipIfUserAlreadyInteracted = skipIfUserAlreadyInteracted, focusAnnotationId = null)
     }
 
     override fun isTargetInWindow(href: String): Boolean =
@@ -704,6 +704,10 @@ internal class ContinuousWindowController(
      * open-time `focusAnnotationId` path in [openWindowAt].
      */
     override fun navigateTo(href: String, progression: Float, alignToTop: Boolean, focusAnnotationId: String?) {
+        navigateTo(href, progression, alignToTop, skipIfUserAlreadyInteracted = false, focusAnnotationId = focusAnnotationId)
+    }
+
+    private fun navigateTo(href: String, progression: Float, alignToTop: Boolean, skipIfUserAlreadyInteracted: Boolean, focusAnnotationId: String?) {
         backwardNavigationIntent = false
         backwardShiftConsumedForTouchGesture = false
         // Programmatic navigation overrides any gesture-scoped scroll floor: a leftover
@@ -729,6 +733,11 @@ internal class ContinuousWindowController(
             // WebView measure storms (observed 1.8 s on an emulator). If the user has touched
             // the reader in the meantime, they've superseded the navigation — landing anyway
             // yanks the viewport back to a stale target from under their scroll.
+            //
+            // For server-resume refires (skipIfUserAlreadyInteracted=true): if the user already
+            // touched before this navigateTo was called, skip entirely — do NOT reset the flag,
+            // which would allow a stale channel item to snap the viewport back.
+            if (skipIfUserAlreadyInteracted && inWindowNavSupersededByTouch) return
             inWindowNavSupersededByTouch = false
             port.post {
                 if (inWindowNavSupersededByTouch) return@post

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/ContinuousWindowController.kt
@@ -708,6 +708,18 @@ internal class ContinuousWindowController(
     }
 
     private fun navigateTo(href: String, progression: Float, alignToTop: Boolean, skipIfUserAlreadyInteracted: Boolean, focusAnnotationId: String?) {
+        val target = href.substringBefore('#')
+        val fragment = href.substringAfter('#', "")
+        val targetIndex = ContinuousPositionTracker.chapterIndexForHref(
+            allChapters.map { it.link.href.toString() }, href,
+        )
+        if (targetIndex < 0) return
+        val inWindow = targetIndex in topIndex until (topIndex + webViews.size)
+        // Server-resume refires (skipIfUserAlreadyInteracted=true): if the user already touched
+        // before this navigateTo was called, skip entirely — before any state mutation — so no
+        // gesture floor, boundary detent, or inWindowNavSupersededByTouch flag is disturbed.
+        // Applies to both in-window (snap-back) and cross-window (full WebView teardown) paths.
+        if (skipIfUserAlreadyInteracted && inWindowNavSupersededByTouch) return
         backwardNavigationIntent = false
         backwardShiftConsumedForTouchGesture = false
         // Programmatic navigation overrides any gesture-scoped scroll floor: a leftover
@@ -721,23 +733,11 @@ internal class ContinuousWindowController(
         backwardFlingFloorY = 0
         gestureStartFlingFloorY = 0
         boundaryDetentArmed = false
-        val target = href.substringBefore('#')
-        val fragment = href.substringAfter('#', "")
-        val targetIndex = ContinuousPositionTracker.chapterIndexForHref(
-            allChapters.map { it.link.href.toString() }, href,
-        )
-        if (targetIndex < 0) return
-        val inWindow = targetIndex in topIndex until (topIndex + webViews.size)
         if (inWindow) {
             // The posted landing can execute SECONDS later when the main thread is busy with
             // WebView measure storms (observed 1.8 s on an emulator). If the user has touched
             // the reader in the meantime, they've superseded the navigation — landing anyway
             // yanks the viewport back to a stale target from under their scroll.
-            //
-            // For server-resume refires (skipIfUserAlreadyInteracted=true): if the user already
-            // touched before this navigateTo was called, skip entirely — do NOT reset the flag,
-            // which would allow a stale channel item to snap the viewport back.
-            if (skipIfUserAlreadyInteracted && inWindowNavSupersededByTouch) return
             inWindowNavSupersededByTouch = false
             port.post {
                 if (inWindowNavSupersededByTouch) return@post

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -2166,7 +2166,7 @@ private fun EpubNavigatorView(
             if (!isContinuous) snapshotFlow { fragmentRef.value }.filterNotNull().first()
             readerPresenter.navigateTo(
                 NavigationTarget.ToLocatorJson(locator.toJSON().toString()),
-                NavigationOptions(landAtStartWhenNoTarget = false),
+                NavigationOptions(landAtStartWhenNoTarget = false, skipIfUserAlreadyInteracted = true),
             )
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenter.kt
@@ -126,7 +126,7 @@ internal class ContinuousPresenter : ReaderPresenter {
                     ?.optString(0)
                     ?.takeIf { it.isNotEmpty() }
                 val fullHref = if (anchor != null) "$href#$anchor" else href
-                view.navigateTo(fullHref, progression, alignToTop = options.alignToTop)
+                view.navigateTo(fullHref, progression, alignToTop = options.alignToTop, skipIfUserAlreadyInteracted = options.skipIfUserAlreadyInteracted)
             }
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenter.kt
@@ -111,6 +111,7 @@ internal class ContinuousPresenter : ReaderPresenter {
                 href = target.href,
                 progression = target.progression,
                 alignToTop = options.alignToTop,
+                skipIfUserAlreadyInteracted = options.skipIfUserAlreadyInteracted,
             )
             is NavigationTarget.ToLocatorJson -> {
                 // Reader-side Locator JSON is `{href, locations: {progression, fragments[]}}` —

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReaderPresenter.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/presenter/ReaderPresenter.kt
@@ -281,6 +281,15 @@ internal data class NavigationOptions(
     val alignToTop: Boolean = false,
     /** Annotation id whose already-resolved decoration Range should anchor a Readium jump. */
     val focusAnnotationId: String? = null,
+    /**
+     * Continuous-only. When `true`, an in-window landing scroll is skipped if the user has already
+     * touched the reader surface (i.e. [ContinuousWindowController.inWindowNavSupersededByTouch]
+     * is set). Pass `true` for server-resume refires so a stale channel item arriving after
+     * [com.riffle.app.feature.reader.session.ResumeRestorer.onUserInteracted] does not snap the
+     * viewport back to the saved position while the user is actively scrolling.
+     * Default `false` so TOC, bookmark, and annotation jumps are never suppressed.
+     */
+    val skipIfUserAlreadyInteracted: Boolean = false,
 )
 
 internal sealed class NavigationTarget {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenterTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/presenter/ContinuousPresenterTest.kt
@@ -25,12 +25,12 @@ import org.junit.Test
 class ContinuousPresenterTest {
 
     private class FakeView : ContinuousNavigationView {
-        data class NavCall(val href: String, val progression: Float, val alignToTop: Boolean)
+        data class NavCall(val href: String, val progression: Float, val alignToTop: Boolean, val skipIfUserAlreadyInteracted: Boolean = false)
         val navCalls: MutableList<NavCall> = mutableListOf()
         val pageCalls: MutableList<Boolean> = mutableListOf()
         val domPatches: MutableList<HighlightsDomPatch> = mutableListOf()
-        override fun navigateTo(href: String, progression: Float, alignToTop: Boolean) {
-            navCalls += NavCall(href, progression, alignToTop)
+        override fun navigateTo(href: String, progression: Float, alignToTop: Boolean, skipIfUserAlreadyInteracted: Boolean) {
+            navCalls += NavCall(href, progression, alignToTop, skipIfUserAlreadyInteracted)
         }
         override fun scrollByPage(forward: Boolean) {
             pageCalls += forward
@@ -283,6 +283,57 @@ class ContinuousPresenterTest {
         // No exception, no observable effect when the view isn't bound yet — mirrors the
         // navigate/scrollByPage safety contract elsewhere on the presenter.
         presenter.applyHighlightDomPatch(HighlightsDomPatch.Remove("ann-1"))
+    }
+
+    // ---- skipIfUserAlreadyInteracted regression guard ------------------------------------
+    //
+    // Root cause: serverLocatorEvents collector calls navigateTo AFTER onUserInteracted() fires
+    // ACTION_DOWN (setting inWindowNavSupersededByTouch=true). The old code reset the guard
+    // unconditionally in navigateTo, allowing a stale resume-restore channel item to scroll
+    // the viewport back to the saved position while the user was actively scrolling.
+    // The fix: skipIfUserAlreadyInteracted=true is threaded from NavigationOptions all the way
+    // to ContinuousWindowController, which skips the nav (without resetting the guard) when
+    // the user has already touched.
+
+    @Test
+    fun `navigateTo ToLocatorJson passes skipIfUserAlreadyInteracted=false by default`() = runTest {
+        val presenter = ContinuousPresenter()
+        val view = FakeView()
+        presenter.attach(view)
+
+        presenter.navigateTo(
+            NavigationTarget.ToLocatorJson("""{"href":"ch01.xhtml","locations":{"progression":0.5}}"""),
+            NavigationOptions(landAtStartWhenNoTarget = false),
+        )
+
+        assertEquals(1, view.navCalls.size)
+        assertEquals(false, view.navCalls[0].skipIfUserAlreadyInteracted)
+    }
+
+    @Test
+    fun `navigateTo ToLocatorJson threads skipIfUserAlreadyInteracted=true to the view`() = runTest {
+        // Regression for the "just-opened book backward scroll snaps back" bug:
+        // serverLocatorEvents collector passes skipIfUserAlreadyInteracted=true so that a stale
+        // resume-restore channel item, consumed after the user has touched the reader, does NOT
+        // reset inWindowNavSupersededByTouch and snap the viewport back.
+        val presenter = ContinuousPresenter()
+        val view = FakeView()
+        presenter.attach(view)
+
+        presenter.navigateTo(
+            NavigationTarget.ToLocatorJson("""{"href":"ch01.xhtml","locations":{"progression":0.5}}"""),
+            NavigationOptions(landAtStartWhenNoTarget = false, skipIfUserAlreadyInteracted = true),
+        )
+
+        assertEquals(1, view.navCalls.size)
+        // The flag must reach the view unchanged so ContinuousWindowController can honour it.
+        assertEquals(true, view.navCalls[0].skipIfUserAlreadyInteracted)
+    }
+
+    @Test
+    fun `NavigationOptions skipIfUserAlreadyInteracted defaults to false`() {
+        // TOC taps, bookmark jumps, annotation nav: must NOT be suppressed by a prior touch.
+        assertEquals(false, NavigationOptions().skipIfUserAlreadyInteracted)
     }
 
     @Test


### PR DESCRIPTION
## What

When opening a book in continuous mode, `armReturnRestore` fires the saved position into the `serverLocatorEvents` conflated channel. This channel item can stay pending until the coroutine collector runs — which may be *after* the user has already touched the reader (ACTION_DOWN → `inWindowNavSupersededByTouch = true`). The old `navigateTo` unconditionally reset `inWindowNavSupersededByTouch = false` and then wiped gesture-protection state (`backwardFlingFloorY`, `gestureStartFlingFloorY`, `boundaryDetentArmed`) before posting the smooth scroll back to the saved position. The result: the user's scroll was interrupted and the viewport snapped back — for up to ~2s while the retry budget (5 refires) was consumed.

The same race was causing `ContinuousChapterBoundaryHarnessTest.boundaryDetentArmedAfterBackwardPrepend` to flake: a backward swipe set `boundaryDetentArmed = true`, then the stale resume nav cleared it before the assertion.

## How

Added `skipIfUserAlreadyInteracted: Boolean = false` to `NavigationOptions` and threaded it through:

- `EpubReaderScreen` `serverLocatorEvents` collector → passes `true`
- `ContinuousPresenter.navigateTo` (both `ToLocatorJson` and `ToProgression` branches)
- `ContinuousNavigationView` interface
- `ContinuousReaderView` → `ContinuousWindowController`

In `ContinuousWindowController`, a new private `navigateToInternal` checks the flag **before any state mutation** (before gesture-floor resets, before the in-window/cross-window split). A stale server-resume refire is a complete no-op when the user has already touched — no flags disturbed, no scroll posted, no WebViews torn down.

TOC/bookmark/annotation navigations keep `skipIfUserAlreadyInteracted = false` (the default) and are unaffected.

## Tests

Three new behavioral assertions in `ContinuousPresenterTest`:
- `skipIfUserAlreadyInteracted = false` by default (guards against silent drift)
- `skipIfUserAlreadyInteracted = true` is threaded verbatim to the view (the assertion that would flip red if the fix were reverted)
- `NavigationOptions.skipIfUserAlreadyInteracted` defaults to `false`

The harness test flakiness in `ContinuousChapterBoundaryHarnessTest.boundaryDetentArmedAfterBackwardPrepend` is resolved by the same production fix (no test changes needed — the test logic was sound; the production race was the non-determinism source).

## iOS parity

iOS has no continuous reader mode or `ResumeRestorer` infrastructure — the iOS reader uses Readium directly for all navigation and has no equivalent server-resume retry loop. There is no iOS code path where this race can occur, and no iOS fix or XCTest is needed.