### PR TITLE
feat(library): show source icon in top bar for all source types

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/library/LibraryItemsScreen.kt
@@ -136,6 +136,8 @@ import com.riffle.core.models.Collection
 import com.riffle.core.models.HighlightColor
 import com.riffle.core.models.LibraryItem
 import com.riffle.core.models.Series
+import com.riffle.core.models.Source
+import com.riffle.app.ui.source.SourceIcon
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlin.math.floor
 import kotlin.math.max
@@ -205,6 +207,7 @@ fun LibraryItemsScreen(
     val tabVisibility by viewModel.tabVisibility.collectAsState()
     val playlists by viewModel.playlists.collectAsState()
     val coversAreSquare by viewModel.coversAreSquare.collectAsState()
+    val activeSource by viewModel.activeSource.collectAsState()
     // Positional scoping (no custom `key`) — this composable's saved state is keyed by its call
     // site, so the previous "library_selected_tab_v2" keyed value from older builds cannot be
     // resurrected here (different key namespace), resetting everyone to Home on first launch
@@ -300,6 +303,7 @@ fun LibraryItemsScreen(
                 searchQuery = searchQuery,
                 onSearchQueryChange = viewModel::onSearchQueryChange,
                 onOpenDrawer = onOpenDrawer,
+                source = activeSource,
             )
         },
         bottomBar = {
@@ -1160,6 +1164,7 @@ internal fun LibrarySearchHeader(
     searchQuery: String,
     onSearchQueryChange: (String) -> Unit,
     onOpenDrawer: () -> Unit,
+    source: Source? = null,
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
     // Claim initial focus on an invisible focusable element so the BasicTextField below never
@@ -1210,6 +1215,13 @@ internal fun LibrarySearchHeader(
                 },
             ) {
                 Icon(Icons.Default.Menu, contentDescription = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.ui_open_menu))
+            }
+            if (source != null) {
+                SourceIcon(
+                    source = source,
+                    size = 24.dp,
+                    modifier = Modifier.padding(end = 8.dp),
+                )
             }
             Text(
                 text = libraryName.uppercase(),

--- a/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/chitanka/ChitankaBrowseScreen.kt
@@ -3,6 +3,7 @@ package com.riffle.app.feature.source.chitanka
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -18,7 +19,9 @@ import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
+import com.riffle.app.ui.source.SourceTypeIcon
 import com.riffle.app.ui.theme.RiffleIcons
+import com.riffle.core.models.SourceType
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
@@ -123,8 +126,11 @@ fun ChitankaBrowseScreen(
             TopAppBar(
                 title = { Text(libraryName) },
                 navigationIcon = {
-                    IconButton(onClick = onOpenDrawer) {
-                        Icon(Icons.Default.Menu, contentDescription = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.ui_open_drawer))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        IconButton(onClick = onOpenDrawer) {
+                            Icon(Icons.Default.Menu, contentDescription = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.ui_open_drawer))
+                        }
+                        SourceTypeIcon(type = SourceType.CHITANKA, size = 24.dp, modifier = Modifier.padding(end = 4.dp))
                     }
                 },
                 actions = {

--- a/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/gutenberg/GutenbergBrowseScreen.kt
@@ -3,6 +3,7 @@ package com.riffle.app.feature.source.gutenberg
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -19,7 +20,9 @@ import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
+import com.riffle.app.ui.source.SourceTypeIcon
 import com.riffle.app.ui.theme.RiffleIcons
+import com.riffle.core.models.SourceType
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -106,8 +109,11 @@ fun GutenbergBrowseScreen(
             TopAppBar(
                 title = { Text(libraryName) },
                 navigationIcon = {
-                    IconButton(onClick = onOpenDrawer) {
-                        Icon(Icons.Default.Menu, contentDescription = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.ui_open_drawer))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        IconButton(onClick = onOpenDrawer) {
+                            Icon(Icons.Default.Menu, contentDescription = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.ui_open_drawer))
+                        }
+                        SourceTypeIcon(type = SourceType.GUTENBERG, size = 24.dp, modifier = Modifier.padding(end = 4.dp))
                     }
                 },
                 actions = {

--- a/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyBrowseScreen.kt
@@ -1,6 +1,7 @@
 package com.riffle.app.feature.source.oreilly
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -12,6 +13,8 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Menu
+import com.riffle.app.ui.source.SourceTypeIcon
+import com.riffle.core.models.SourceType
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -88,8 +91,11 @@ fun OReillyBrowseScreen(
             TopAppBar(
                 title = { Text(libraryName) },
                 navigationIcon = {
-                    IconButton(onClick = onOpenDrawer) {
-                        Icon(Icons.Default.Menu, contentDescription = stringResource(R.string.ui_open_drawer))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        IconButton(onClick = onOpenDrawer) {
+                            Icon(Icons.Default.Menu, contentDescription = stringResource(R.string.ui_open_drawer))
+                        }
+                        SourceTypeIcon(type = SourceType.OREILLY, size = 24.dp, modifier = Modifier.padding(end = 4.dp))
                     }
                 },
                 actions = {

--- a/app/src/main/kotlin/com/riffle/app/feature/source/radioes/RadioEsBrowseScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/radioes/RadioEsBrowseScreen.kt
@@ -2,6 +2,7 @@ package com.riffle.app.feature.source.radioes
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -18,6 +19,8 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.GridView
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Menu
+import com.riffle.app.ui.source.SourceTypeIcon
+import com.riffle.core.models.SourceType
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -97,8 +100,11 @@ fun RadioEsBrowseScreen(
             TopAppBar(
                 title = { Text(libraryName) },
                 navigationIcon = {
-                    IconButton(onClick = onOpenDrawer) {
-                        Icon(Icons.Default.Menu, contentDescription = stringResource(R.string.ui_open_drawer))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        IconButton(onClick = onOpenDrawer) {
+                            Icon(Icons.Default.Menu, contentDescription = stringResource(R.string.ui_open_drawer))
+                        }
+                        SourceTypeIcon(type = SourceType.RADIO_ES, size = 24.dp, modifier = Modifier.padding(end = 4.dp))
                     }
                 },
                 actions = {

--- a/feature/library/src/commonMain/kotlin/com/riffle/feature/library/LibraryItemsViewModel.kt
+++ b/feature/library/src/commonMain/kotlin/com/riffle/feature/library/LibraryItemsViewModel.kt
@@ -29,6 +29,7 @@ import com.riffle.core.models.Collection
 import com.riffle.core.models.LibraryItem
 import com.riffle.core.models.ScreenDimensionBucket
 import com.riffle.core.models.Series
+import com.riffle.core.models.Source
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -78,6 +79,17 @@ class LibraryItemsViewModel constructor(
 
     private val _activeSourceId = MutableStateFlow<String?>(null)
     private val _screenDimensionBucket = MutableStateFlow<ScreenDimensionBucket?>(null)
+
+    val activeSource: StateFlow<Source?> = sourceRepository.observeAll()
+        .flatMapLatest { sources ->
+            if (sources.isEmpty()) return@flatMapLatest flowOf(null)
+            combine(sources.map { source ->
+                libraryObserver.observeLibraries(source.id).map { libs ->
+                    source.takeIf { libs.any { it.id == libraryId } }
+                }
+            }) { results -> results.firstNotNullOfOrNull { it } }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
     /** User's persisted pinch-to-zoom multiplier for the cover grids (1.0 = defaults). */
     val coverGridScale: StateFlow<Float> = combine(_activeSourceId, _screenDimensionBucket) { sourceId, bucket ->

--- a/feature/library/src/commonTest/kotlin/com/riffle/feature/library/LibraryItemsViewModelTest.kt
+++ b/feature/library/src/commonTest/kotlin/com/riffle/feature/library/LibraryItemsViewModelTest.kt
@@ -314,6 +314,69 @@ class LibraryItemsViewModelTest {
         "id-$title", "lib-1", title, author, coverUrl, 0f, false, false, EbookFormat.Epub,
     )
 
+    // --- activeSource resolution ---
+
+    @Test
+    fun `activeSource resolves to the source whose library list contains the current libraryId`() = runTest {
+        val localLibraryId = "local:folder:uuid-1"
+        val absSource = Source(
+            id = "src-abs",
+            url = SourceUrl.parse("https://abs.example.com")!!,
+            isActive = true,
+            insecureConnectionAllowed = false,
+            username = "",
+            type = com.riffle.core.models.SourceType.ABS,
+        )
+        val localSource = Source(
+            id = "src-local",
+            url = SourceUrl.parse("https://local.example.com")!!,
+            isActive = false,
+            insecureConnectionAllowed = false,
+            username = "",
+            type = com.riffle.core.models.SourceType.LOCAL_FILES,
+        )
+        val sourceRepo = object : SourceRepository {
+            override fun observeAll(): Flow<List<Source>> = MutableStateFlow(listOf(absSource, localSource))
+            override suspend fun getActive(): Source? = absSource
+            override suspend fun commit(pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>) =
+                throw UnsupportedOperationException()
+            override suspend fun setActive(sourceId: String) {}
+            override suspend fun remove(sourceId: String) {}
+            override suspend fun getSourceVersion(sourceId: String): String? = null
+        }
+        val libraryObserver = object : LibraryObserver {
+            override fun observeLibraries(): Flow<List<Library>> = MutableStateFlow(emptyList())
+            override fun observeLibraries(sourceId: String): Flow<List<Library>> = MutableStateFlow(
+                if (sourceId == "src-local") listOf(Library(localLibraryId, "Local", "ebook", false))
+                else emptyList()
+            )
+            override fun observeLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
+            override fun observeUngroupedLibraryItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
+            override fun observeInProgressItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
+            override fun observeFinishedItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
+            override fun observeRecentlyAddedItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
+            override fun observeContinueSeriesItems(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
+            override fun observeAllBooks(libraryId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
+            override fun observeSeries(libraryId: String): Flow<List<Series>> = MutableStateFlow(emptyList())
+            override fun observeCollections(libraryId: String): Flow<List<Collection>> = MutableStateFlow(emptyList())
+            override fun observeSeriesItems(seriesId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
+            override fun observeCollectionItems(collectionId: String): Flow<List<LibraryItem>> = MutableStateFlow(emptyList())
+            override suspend fun getItem(itemId: String): LibraryItem? = null
+            override fun observeItem(itemId: String): Flow<LibraryItem?> = MutableStateFlow(null)
+            override suspend fun getItem(sourceId: String, itemId: String): LibraryItem? = null
+            override suspend fun getLibrary(libraryId: String): Library? = null
+            override suspend fun getSeriesIdForItem(sourceId: String, itemId: String): String? = null
+        }
+        val vm = makeViewModel(
+            libraryId = localLibraryId,
+            sourceRepository = sourceRepo,
+            libraryRepository = libraryObserver,
+        )
+        backgroundScope.launch { vm.activeSource.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(localSource, vm.activeSource.value)
+    }
+
     // --- empty query passthrough ---
 
     @Test


### PR DESCRIPTION
## What

Show a small source favicon/icon between the hamburger menu and library name in the top bar, for every source type — not just ABS/Komga.

## How

**`LibraryItemsScreen` / `LibraryItemsViewModel` (ABS, Komga, LOCAL_FILES):**

Replaced the previous `getActive()`-based `activeSource` (which only worked for `isActive=1` server sources) with a flow that fans out `observeLibraries(source.id)` across all sources and finds whichever source's library list contains the current `libraryId`. This works for LOCAL_FILES, whose `isActive` flag is never set.

The `SourceIcon` composable is rendered between the hamburger and the library name text in `LibrarySearchHeader`.

**Catalog browse screens (CHITANKA, GUTENBERG, RADIO_ES, OREILLY):**

Each catalog screen is a dedicated `@Composable` with its own `TopAppBar`. The `navigationIcon` slot is now a `Row` containing the hamburger `IconButton` followed by a `SourceTypeIcon` for the hardcoded source type — no VM change needed since the source type is statically known.

## Test

`LibraryItemsViewModelTest`: added `activeSource resolves to the source whose library list contains the current libraryId` — asserts that when the current `libraryId` belongs to a LOCAL_FILES source (not the `isActive=true` ABS source), `activeSource` emits the LOCAL_FILES source. This assertion would revert to null/ABS if `getActive()` were ever re-introduced.