### PR TITLE
fix(ci): pre-build XCFramework before iOS integration tests

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -78,6 +78,9 @@ jobs:
             derived-data-${{ runner.os }}-${{ hashFiles('iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-
             derived-data-${{ runner.os }}-
 
+      - name: Assemble Riffle XCFramework
+        run: ./gradlew assembleRiffleDebugXCFramework
+
       - name: Select and pre-boot simulator
         run: |
           UDID=$(xcrun simctl list devices available -j | python3 -c "


### PR DESCRIPTION
## Root cause

The `iOS integration tests` job was cancelled on its first CI run (merged via #985) — not because the tests failed, but because the job hit its 30-minute timeout before tests even had a chance to complete.

**Why it was slow:** `xcodebuild test` invokes Gradle via the Xcode project's Run Script phase (a subprocess). When Gradle runs this way, it doesn't get the same build cache environment that `setup-gradle` configured for the job, so the entire Kotlin/Native framework compiles from scratch. That cold compilation took ~25 min, leaving only ~1 min before the timeout — all tests that ran in that window passed.

**Evidence:** The `iOS build` job, which runs `./gradlew assembleRiffleDebugXCFramework` as an explicit step *before* `xcodebuild build`, finishes in ~14 min total. That job builds more code (the full app) but is still twice as fast, because Gradle runs with the full build cache in the explicit step and xcodebuild's Gradle invocation finds outputs already cached.

## Fix

Add an explicit `./gradlew assembleRiffleDebugXCFramework` step to the `integration-tests` job, before `xcodebuild test`, matching the pattern used by the `build` job. When xcodebuild subsequently invokes Gradle via its Run Script, Gradle finds the framework already built in the local build cache and skips recompilation — shrinking the xcodebuild phase from ~25 min to a few minutes. The 30-minute timeout stays unchanged.