### PR TITLE
feat(oreilly): lazy per-chapter reading — stream O'Reilly books without full download

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Riffle lets you browse your library, read EPUB, PDF, and CBZ files, listen to au
 - **Komga** self-hosted server — browse, read, and sync comics, manga, and ebooks (EPUB, PDF, CBZ) from any [Komga](https://komga.org/) instance with Basic-auth credentials; page-based reading progress syncs bidirectionally across devices; annotation sync available via optional WebDAV
 - **Chitanka** (chitanka.info + gramofonche.chitanka.info) — anonymous, zero-config access to the Bulgarian public catalogue of EPUB ebooks and MP3 audiobooks; browsable by category, genre, and series; reading and listening progress syncs across devices via optional WebDAV
 - **Project Gutenberg** (via Gutendex) — anonymous, zero-config access to ~70,000 public-domain EPUBs; browsable by language, subject, and author; reading progress syncs across devices via optional WebDAV
+- **O'Reilly** — read any book in your O'Reilly subscription directly in the app; chapters are streamed on demand and cached locally so re-reads are instant; reading progress is saved per book
 - **radio.es** — browse and stream Spanish-language radio stations and podcasts from the [radio.es](https://www.radio.es/) catalogue; filter podcasts by category and language; live radio stations stream directly without downloading
 - **Local files** — import EPUB, PDF, and CBZ files from device storage and read them alongside your server libraries, with the same reader, highlights, and progress tracking
 

--- a/app/src/main/kotlin/com/riffle/app/di/AppKoinModules.kt
+++ b/app/src/main/kotlin/com/riffle/app/di/AppKoinModules.kt
@@ -111,10 +111,13 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
 import org.readium.adapter.pdfium.document.PdfiumDocumentFactory
+import org.readium.r2.shared.publication.Locator
+import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.util.asset.AssetRetriever
 import org.readium.r2.shared.util.http.DefaultHttpClient
 import org.readium.r2.streamer.PublicationOpener
 import org.readium.r2.streamer.parser.DefaultPublicationParser
+import java.io.File
 
 val appKoinModule: Module = module {
 
@@ -461,8 +464,12 @@ val appKoinModule: Module = module {
     }
 
     factory<ReaderSessionLifecycle.Factory> {
-        ReaderSessionLifecycle.Factory { openPublication, cfiStringToLocator ->
-            ReaderSessionLifecycle(
+        object : ReaderSessionLifecycle.Factory {
+            override fun create(
+                openPublication: suspend (File) -> Publication?,
+                cfiStringToLocator: suspend (String) -> Locator?,
+                openLazy: (suspend (String, String) -> Pair<Publication, String?>?)?,
+            ) = ReaderSessionLifecycle(
                 openPublication = openPublication,
                 cfiStringToLocator = cfiStringToLocator,
                 libraryObserver = get(),
@@ -477,6 +484,7 @@ val appKoinModule: Module = module {
                 annotationStore = get(),
                 logger = get(),
                 itemProgressPuller = get(),
+                openLazy = openLazy,
             )
         }
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -578,6 +578,8 @@ class EpubReaderViewModel constructor(
     // Highlights mode only (Task 10, ADR 0048): the chapter grouping + resolved server id from the
     // last [openBook] build, kept so the resume-position collector below can map a synthesised-href
     // locator update back to a highlight id without rebuilding the Publication. Null in FullBook mode.
+    private var lazyContainer: com.riffle.app.feature.source.oreilly.OReillyLazyContainer? = null
+
     private var highlightsResumeChapters: List<ChapterElision>? = null
     private var highlightsResumeServerId: String? = null
     // Plurality [AnnotationEntity.originFontFamily] across the currently-loaded elided chapters
@@ -1132,6 +1134,15 @@ class EpubReaderViewModel constructor(
             val sourceId = navServerId ?: sourceRepository.getActive()?.id
             val catalog = sourceId?.let { catalogRegistry.forSourceId(it) }
             readingSessionsEnabled.set(catalog is com.riffle.core.catalog.ReadingSessionsCapability)
+        }
+        // Lazy-publication prefetch: when the reader is on a lazy publication (O'Reilly), kick off
+        // background download of the next chapter each time the current chapter href changes.
+        viewModelScope.launch {
+            position.currentLocatorHref.collect { href ->
+                val c = lazyContainer ?: return@collect
+                val index = c.pub.spine.indexOfFirst { it.fullPath == href }
+                if (index >= 0) c.prefetchNext(index)
+            }
         }
         viewModelScope.launch {
             // Sequential: formatting prefs must be available before openBook() so the
@@ -3854,13 +3865,15 @@ class EpubReaderViewModel constructor(
             ?: return null
         val shape = cap.lazyPublication(itemId) ?: return null
         val cacheDir = getApplication<android.app.Application>().cacheDir.resolve("oreilly_lazy/$itemId")
-        val publication = com.riffle.app.feature.source.oreilly.OReillyPublicationBuilder.build(
+        val container = com.riffle.app.feature.source.oreilly.OReillyLazyContainer(
             pub = shape,
             cacheDir = cacheDir,
             fetchChapter = { _, path -> cap.fetchChapterForLazy(itemId, path) ?: "" },
             fetchAsset = { _, path -> cap.fetchAssetForLazy(itemId, path) },
             scope = viewModelScope,
         )
+        lazyContainer = container
+        val publication = com.riffle.app.feature.source.oreilly.OReillyPublicationBuilder.build(container)
         val lastPosition = readingPositionStore.load(sourceId, itemId)
         return Pair(publication, lastPosition)
     }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -892,6 +892,10 @@ class EpubReaderViewModel constructor(
     val currentSearchIndex: StateFlow<Int> = search.currentSearchIndex
     val searchNavigationEvents: Flow<Locator> = search.searchNavigationEvents
 
+    /** True when the open publication is a lazy (per-chapter streaming) O'Reilly book.
+     *  Lazy publications have no search service — use this to show a "Download to search" hint. */
+    val isLazyPublication: Boolean get() = lazyContainer != null
+
     // ---- Readaloud (ADR 0027) ----------------------------------------------------------------
 
     // isStorytellerService and readerServerId now live on [lifecycle] (issue #376). The single

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -579,6 +579,7 @@ class EpubReaderViewModel constructor(
     // last [openBook] build, kept so the resume-position collector below can map a synthesised-href
     // locator update back to a highlight id without rebuilding the Publication. Null in FullBook mode.
     private var lazyContainer: com.riffle.app.feature.source.oreilly.OReillyLazyContainer? = null
+    private val _isLazyPublication = kotlinx.coroutines.flow.MutableStateFlow(false)
 
     private var highlightsResumeChapters: List<ChapterElision>? = null
     private var highlightsResumeServerId: String? = null
@@ -894,7 +895,7 @@ class EpubReaderViewModel constructor(
 
     /** True when the open publication is a lazy (per-chapter streaming) O'Reilly book.
      *  Lazy publications have no search service — use this to show a "Download to search" hint. */
-    val isLazyPublication: Boolean get() = lazyContainer != null
+    val isLazyPublication: kotlinx.coroutines.flow.StateFlow<Boolean> = _isLazyPublication
 
     // ---- Readaloud (ADR 0027) ----------------------------------------------------------------
 
@@ -3872,11 +3873,12 @@ class EpubReaderViewModel constructor(
         val container = com.riffle.app.feature.source.oreilly.OReillyLazyContainer(
             pub = shape,
             cacheDir = cacheDir,
-            fetchChapter = { _, path -> cap.fetchChapterForLazy(itemId, path) ?: "" },
+            fetchChapter = { _, path, expectedSize -> cap.fetchChapterForLazy(itemId, path, expectedSize) ?: "" },
             fetchAsset = { _, path -> cap.fetchAssetForLazy(itemId, path) },
             scope = viewModelScope,
         )
         lazyContainer = container
+        _isLazyPublication.value = true
         val publication = com.riffle.app.feature.source.oreilly.OReillyPublicationBuilder.build(container)
         val lastPosition = readingPositionStore.load(sourceId, itemId)
         return Pair(publication, lastPosition)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -391,6 +391,7 @@ class EpubReaderViewModel constructor(
         readerSessionLifecycleFactory.create(
             openPublication = { file -> openPublication(file) },
             cfiStringToLocator = { cfi -> cfiStringToLocator(cfi) },
+            openLazy = { sourceId, itemId -> openLazyPublication(sourceId, itemId) },
         )
 
     // Readaloud session — owns readaloud state and leaf controls. Full extraction happens across
@@ -3845,6 +3846,23 @@ class EpubReaderViewModel constructor(
             is Try.Success -> r.value
             is Try.Failure -> null
         }
+    }
+
+    private suspend fun openLazyPublication(sourceId: String, itemId: String): Pair<Publication, String?>? {
+        val cap = catalogRegistry.forSourceId(sourceId)
+            as? com.riffle.core.catalog.LazyPublicationCapability
+            ?: return null
+        val shape = cap.lazyPublication(itemId) ?: return null
+        val cacheDir = getApplication<android.app.Application>().cacheDir.resolve("oreilly_lazy/$itemId")
+        val publication = com.riffle.app.feature.source.oreilly.OReillyPublicationBuilder.build(
+            pub = shape,
+            cacheDir = cacheDir,
+            fetchChapter = { _, path -> cap.fetchChapterForLazy(itemId, path) ?: "" },
+            fetchAsset = { _, path -> cap.fetchAssetForLazy(itemId, path) },
+            scope = viewModelScope,
+        )
+        val lastPosition = readingPositionStore.load(sourceId, itemId)
+        return Pair(publication, lastPosition)
     }
 
     fun updateFormatting(prefs: FormattingPreferences) = formatting.updateFormatting(itemId, prefs)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
@@ -57,12 +57,17 @@ class ReaderSessionLifecycle constructor(
     private val annotationStore: AnnotationStore,
     private val logger: Logger,
     private val itemProgressPuller: com.riffle.core.data.ItemProgressPuller,
+    /** Optional hook for sources that build a [Publication] without downloading an EPUB file.
+     *  Receives (sourceId, itemId) and returns (publication, lastPositionJson?).
+     *  When non-null and returning non-null, the normal [epubRepository.openEpub] path is skipped. */
+    private val openLazy: (suspend (String, String) -> Pair<Publication, String?>?)? = null,
 ) {
 
-    fun interface Factory {
+    interface Factory {
         fun create(
             openPublication: suspend (File) -> Publication?,
             cfiStringToLocator: suspend (String) -> Locator?,
+            openLazy: (suspend (String, String) -> Pair<Publication, String?>?)? = null,
         ): ReaderSessionLifecycle
     }
 
@@ -121,6 +126,13 @@ class ReaderSessionLifecycle constructor(
             }
         }
 
+        // Lazy path: source built a Publication directly (e.g. O'Reilly per-chapter streaming).
+        // Skip the EPUB download entirely when this succeeds.
+        val lazyPair = openLazy?.invoke(item.sourceId, item.id)
+        if (lazyPair != null) {
+            return resolveReadyWithPub(lazyPair.first, lazyPair.second, item.title, params)
+        }
+
         val result = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
             epubRepository.openEpub(item)
         }
@@ -147,6 +159,15 @@ class ReaderSessionLifecycle constructor(
         epubFile = result.epubFile
         val pub = openPublication(result.epubFile)
             ?: return OpenOutcome.Error("Failed to open EPUB")
+        return resolveReadyWithPub(pub, result.lastPosition, title, params)
+    }
+
+    private suspend fun resolveReadyWithPub(
+        pub: Publication,
+        lastPosition: String?,
+        title: String,
+        params: OpenParams,
+    ): OpenOutcome {
         _publication.value = pub
 
         val activeServer: Source? = sourceRepository.getActive()
@@ -221,7 +242,7 @@ class ReaderSessionLifecycle constructor(
         // Stored lastPosition is Readium Locator JSON. Rows written before ADR 0036's translation
         // fix may still hold a raw ABS `epubcfi(...)` — heal those on open so legacy progress
         // isn't lost. A genuinely unusable value falls back to null.
-        val storedLocator = result.lastPosition?.takeIf { it.isNotBlank() }?.let { stored ->
+        val storedLocator = lastPosition?.takeIf { it.isNotBlank() }?.let { stored ->
             runCatching { Locator.fromJSON(JSONObject(stored)) }.getOrNull()
                 ?: cfiStringToLocator(stored)
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainer.kt
@@ -1,0 +1,205 @@
+package com.riffle.app.feature.source.oreilly
+
+import com.riffle.core.catalog.LazyPublicationShape
+import com.riffle.core.catalog.LazySpineItem
+import com.riffle.core.catalog.oreilly.OReillyEpub
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.readium.r2.shared.util.AbsoluteUrl
+import org.readium.r2.shared.util.Try
+import org.readium.r2.shared.util.Url
+import org.readium.r2.shared.util.data.Container
+import org.readium.r2.shared.util.data.ReadError
+import org.readium.r2.shared.util.resource.Resource
+import java.io.File
+
+/**
+ * Readium [Container] for O'Reilly lazy publications. Each chapter resource is fetched on the
+ * first [Resource.read] call and stored in a `(bookId, fullPath)` disk cache so re-reading a
+ * chapter never re-fetches. Asset bytes (images/css) are fetched similarly and cached.
+ *
+ * Nothing is eagerly downloaded; only the resources Readium actually renders are ever fetched.
+ * Call [prefetchNext] after a chapter renders to warm the following chapter in the background
+ * so most chapter turns feel instant.
+ *
+ * Write-once cache: each slot writes to a `.tmp` file then renames, so concurrent readers never
+ * see a partial file.
+ */
+class OReillyLazyContainer(
+    val pub: LazyPublicationShape,
+    private val cacheDir: File,
+    /** Fetch one chapter's HTML (may throw on network error). */
+    private val fetchChapter: suspend (itemId: String, fullPath: String) -> String,
+    /** Fetch one binary asset; null on failure (non-fatal). */
+    private val fetchAsset: suspend (itemId: String, fullPath: String) -> ByteArray?,
+    private val scope: CoroutineScope,
+    private val urlFactory: (String) -> Url? = { Url(it) },
+) : Container<Resource> {
+
+    private val urlToSpine: Map<Url, LazySpineItem>
+    private val allSpineUrls: Set<Url>
+
+    init {
+        val spineMap = mutableMapOf<Url, LazySpineItem>()
+        for (item in pub.spine) {
+            urlFactory(item.fullPath)?.let { url -> spineMap[url] = item }
+        }
+        urlToSpine = spineMap
+        allSpineUrls = spineMap.keys.toSet()
+    }
+
+    override val entries: Set<Url> get() = allSpineUrls
+
+    override fun get(url: Url): Resource? {
+        val spineItem = urlToSpine[url]
+        if (spineItem != null) {
+            return LazyChapterResource(
+                sourceUrl = url as? AbsoluteUrl,
+                spineItem = spineItem,
+                pub = pub,
+                cacheDir = cacheDir,
+                fetchChapter = fetchChapter,
+            )
+        }
+        // Unknown URL — try as a relative asset path (Readium requests css/images by their href).
+        val relativePath = url.toString().removePrefix("/")
+        return LazyAssetResource(
+            sourceUrl = url as? AbsoluteUrl,
+            fullPath = relativePath,
+            bookId = pub.bookId,
+            cacheDir = cacheDir,
+            fetchAsset = fetchAsset,
+        )
+    }
+
+    override fun close() = Unit
+
+    /**
+     * Background-prefetch the chapter after [currentIndex] so it's cached before the user
+     * navigates there. No-op if already cached or index is out of range.
+     */
+    fun prefetchNext(currentIndex: Int) {
+        val nextItem = pub.spine.getOrNull(currentIndex + 1) ?: return
+        val cacheFile = cacheFileFor(cacheDir, pub.bookId, nextItem.fullPath)
+        if (cacheFile.exists()) return
+        scope.launch {
+            runCatching {
+                val html = fetchChapter(pub.bookId, nextItem.fullPath)
+                val xhtml = buildChapterXhtml(pub, nextItem, html)
+                writeCacheFile(cacheFile, xhtml.encodeToByteArray())
+            }
+        }
+    }
+
+    companion object {
+        /** Stable cache path for `(bookId, fullPath)` under `cacheDir`. */
+        fun cacheFileFor(cacheDir: File, bookId: String, fullPath: String): File {
+            val safeBook = bookId.replace(Regex("[^A-Za-z0-9_\\-]"), "_")
+            val safePath = fullPath.replace('/', '_').replace(Regex("[^A-Za-z0-9_.\\-]"), "_")
+            return File(cacheDir, "$safeBook/$safePath")
+        }
+
+        /** Atomic write: write to `.tmp` then rename so readers never see partial files. */
+        fun writeCacheFile(target: File, bytes: ByteArray) {
+            target.parentFile?.mkdirs()
+            val tmp = File(target.parent, "${target.name}.tmp")
+            tmp.writeBytes(bytes)
+            tmp.renameTo(target)
+        }
+
+        fun buildChapterXhtml(pub: LazyPublicationShape, item: LazySpineItem, rawHtml: String): String {
+            val rewritten = rawHtml
+                .replace(pub.absoluteFilesPrefix, OReillyEpub.relPrefixFor(item.fullPath))
+                .replace(pub.pathFilesPrefix, OReillyEpub.relPrefixFor(item.fullPath))
+            val cssHrefs = pub.cssFullPaths.map { OReillyEpub.relativeTo(item.fullPath, it) }
+            return OReillyEpub.wrapChapter(item.title, rewritten, cssHrefs)
+        }
+    }
+}
+
+private class LazyChapterResource(
+    override val sourceUrl: AbsoluteUrl?,
+    private val spineItem: LazySpineItem,
+    private val pub: LazyPublicationShape,
+    private val cacheDir: File,
+    private val fetchChapter: suspend (itemId: String, fullPath: String) -> String,
+) : Resource {
+
+    override suspend fun properties(): Try<Resource.Properties, ReadError> =
+        Try.success(Resource.Properties())
+
+    override suspend fun length(): Try<Long, ReadError> =
+        Try.success(spineItem.declaredByteSize)
+
+    override suspend fun read(range: LongRange?): Try<ByteArray, ReadError> {
+        return try {
+            val bytes = getOrFetchBytes()
+            val result = if (range == null) bytes
+            else {
+                val start = range.first.coerceIn(0, bytes.size.toLong()).toInt()
+                val end = (range.last + 1).coerceIn(0, bytes.size.toLong()).toInt()
+                if (end <= start) ByteArray(0) else bytes.copyOfRange(start, end)
+            }
+            Try.success(result)
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            Try.failure(ReadError.Decoding(e))
+        }
+    }
+
+    private suspend fun getOrFetchBytes(): ByteArray {
+        val cacheFile = OReillyLazyContainer.cacheFileFor(cacheDir, pub.bookId, spineItem.fullPath)
+        if (cacheFile.exists()) return cacheFile.readBytes()
+        val html = fetchChapter(pub.bookId, spineItem.fullPath)
+        val xhtml = OReillyLazyContainer.buildChapterXhtml(pub, spineItem, html)
+        val bytes = xhtml.encodeToByteArray()
+        OReillyLazyContainer.writeCacheFile(cacheFile, bytes)
+        return bytes
+    }
+
+    override fun close() = Unit
+}
+
+private class LazyAssetResource(
+    override val sourceUrl: AbsoluteUrl?,
+    private val fullPath: String,
+    private val bookId: String,
+    private val cacheDir: File,
+    private val fetchAsset: suspend (itemId: String, fullPath: String) -> ByteArray?,
+) : Resource {
+
+    override suspend fun properties(): Try<Resource.Properties, ReadError> =
+        Try.success(Resource.Properties())
+
+    override suspend fun length(): Try<Long, ReadError> {
+        val f = cacheFile()
+        return if (f.exists()) Try.success(f.length()) else Try.success(0L)
+    }
+
+    override suspend fun read(range: LongRange?): Try<ByteArray, ReadError> {
+        return try {
+            val cacheFile = cacheFile()
+            val bytes = if (cacheFile.exists()) {
+                cacheFile.readBytes()
+            } else {
+                val fetched = fetchAsset(bookId, fullPath) ?: ByteArray(0)
+                if (fetched.isNotEmpty()) OReillyLazyContainer.writeCacheFile(cacheFile, fetched)
+                fetched
+            }
+            val result = if (range == null) bytes
+            else {
+                val start = range.first.coerceIn(0, bytes.size.toLong()).toInt()
+                val end = (range.last + 1).coerceIn(0, bytes.size.toLong()).toInt()
+                if (end <= start) ByteArray(0) else bytes.copyOfRange(start, end)
+            }
+            Try.success(result)
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            Try.failure(ReadError.Decoding(e))
+        }
+    }
+
+    private fun cacheFile() = OReillyLazyContainer.cacheFileFor(cacheDir, bookId, fullPath)
+
+    override fun close() = Unit
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainer.kt
@@ -29,7 +29,7 @@ class OReillyLazyContainer(
     val pub: LazyPublicationShape,
     private val cacheDir: File,
     /** Fetch one chapter's HTML (may throw on network error). */
-    private val fetchChapter: suspend (itemId: String, fullPath: String) -> String,
+    private val fetchChapter: suspend (itemId: String, fullPath: String, expectedByteSize: Long) -> String,
     /** Fetch one binary asset; null on failure (non-fatal). */
     private val fetchAsset: suspend (itemId: String, fullPath: String) -> ByteArray?,
     private val scope: CoroutineScope,
@@ -87,7 +87,7 @@ class OReillyLazyContainer(
         if (cacheFile.exists()) return
         scope.launch {
             runCatching {
-                val html = fetchChapter(pub.bookId, nextItem.fullPath)
+                val html = fetchChapter(pub.bookId, nextItem.fullPath, nextItem.declaredByteSize)
                 val xhtml = buildChapterXhtml(pub, nextItem, html)
                 writeCacheFile(cacheFile, xhtml.encodeToByteArray())
             }
@@ -115,7 +115,13 @@ class OReillyLazyContainer(
             target.parentFile?.mkdirs()
             val tmp = File(target.parent, "${target.name}.tmp")
             tmp.writeBytes(bytes)
-            tmp.renameTo(target)
+            if (!tmp.renameTo(target)) {
+                // renameTo can fail across mount points (e.g. under storage pressure). Fall back to
+                // a direct write so the cache is still populated; the file won't be atomic but is
+                // better than leaving it absent and re-fetching from network on every read.
+                target.writeBytes(bytes)
+                tmp.delete()
+            }
         }
 
         fun buildChapterXhtml(pub: LazyPublicationShape, item: LazySpineItem, rawHtml: String): String {
@@ -133,7 +139,7 @@ private class LazyChapterResource(
     private val spineItem: LazySpineItem,
     private val pub: LazyPublicationShape,
     private val cacheDir: File,
-    private val fetchChapter: suspend (itemId: String, fullPath: String) -> String,
+    private val fetchChapter: suspend (itemId: String, fullPath: String, expectedByteSize: Long) -> String,
 ) : Resource {
 
     override suspend fun properties(): Try<Resource.Properties, ReadError> =
@@ -161,7 +167,7 @@ private class LazyChapterResource(
     private suspend fun getOrFetchBytes(): ByteArray {
         val cacheFile = OReillyLazyContainer.cacheFileFor(cacheDir, pub.bookId, spineItem.fullPath)
         if (cacheFile.exists()) return cacheFile.readBytes()
-        val html = fetchChapter(pub.bookId, spineItem.fullPath)
+        val html = fetchChapter(pub.bookId, spineItem.fullPath, spineItem.declaredByteSize)
         val xhtml = OReillyLazyContainer.buildChapterXhtml(pub, spineItem, html)
         val bytes = xhtml.encodeToByteArray()
         OReillyLazyContainer.writeCacheFile(cacheFile, bytes)

--- a/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainer.kt
@@ -62,7 +62,10 @@ class OReillyLazyContainer(
             )
         }
         // Unknown URL — try as a relative asset path (Readium requests css/images by their href).
-        val relativePath = url.toString().removePrefix("/")
+        // Sub-resources (images, CSS) arrive as absolute readium_package:// URLs:
+        //   https://readium_package/{path}
+        // Strip that prefix to recover the relative path used in the O'Reilly files API.
+        val relativePath = extractRelativePath(url.toString())
         return LazyAssetResource(
             sourceUrl = url as? AbsoluteUrl,
             fullPath = relativePath,
@@ -92,6 +95,14 @@ class OReillyLazyContainer(
     }
 
     companion object {
+        /**
+         * Strips the `https://readium_package/` origin that Readium prepends to sub-resource
+         * URLs (images, CSS) when requesting them from the container. Returns the bare relative
+         * path suitable for the O'Reilly files API.
+         */
+        internal fun extractRelativePath(urlString: String): String =
+            urlString.removePrefix("https://readium_package/").removePrefix("/")
+
         /** Stable cache path for `(bookId, fullPath)` under `cacheDir`. */
         fun cacheFileFor(cacheDir: File, bookId: String, fullPath: String): File {
             val safeBook = bookId.replace(Regex("[^A-Za-z0-9_\\-]"), "_")
@@ -173,7 +184,17 @@ private class LazyAssetResource(
 
     override suspend fun length(): Try<Long, ReadError> {
         val f = cacheFile()
-        return if (f.exists()) Try.success(f.length()) else Try.success(0L)
+        if (f.exists()) return Try.success(f.length())
+        // ReadableInputStreamAdapter (Readium) calls length() before read(). If we return 0
+        // here it will interpret the resource as empty and never call read(). Fetch eagerly so
+        // the correct byte count is available, and cache to disk so read() can serve instantly.
+        val fetched = fetchAsset(bookId, fullPath)
+        return if (fetched != null && fetched.isNotEmpty()) {
+            OReillyLazyContainer.writeCacheFile(f, fetched)
+            Try.success(fetched.size.toLong())
+        } else {
+            Try.success(0L)
+        }
     }
 
     override suspend fun read(range: LongRange?): Try<ByteArray, ReadError> {
@@ -182,9 +203,10 @@ private class LazyAssetResource(
             val bytes = if (cacheFile.exists()) {
                 cacheFile.readBytes()
             } else {
-                val fetched = fetchAsset(bookId, fullPath) ?: ByteArray(0)
-                if (fetched.isNotEmpty()) OReillyLazyContainer.writeCacheFile(cacheFile, fetched)
-                fetched
+                val fetched = fetchAsset(bookId, fullPath)
+                val result = fetched ?: ByteArray(0)
+                if (result.isNotEmpty()) OReillyLazyContainer.writeCacheFile(cacheFile, result)
+                result
             }
             val result = if (range == null) bytes
             else {

--- a/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyPublicationBuilder.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyPublicationBuilder.kt
@@ -1,0 +1,80 @@
+package com.riffle.app.feature.source.oreilly
+
+import com.riffle.core.catalog.LazyPublicationShape
+import com.riffle.core.catalog.LazySpineItem
+import kotlinx.coroutines.CoroutineScope
+import org.readium.r2.shared.ExperimentalReadiumApi
+import org.readium.r2.shared.publication.Link
+import org.readium.r2.shared.publication.LocalizedString
+import org.readium.r2.shared.publication.Manifest
+import org.readium.r2.shared.publication.Metadata
+import org.readium.r2.shared.publication.Publication
+import org.readium.r2.shared.publication.services.PerResourcePositionsService
+import org.readium.r2.shared.util.Url
+import org.readium.r2.shared.util.mediatype.MediaType
+import java.io.File
+
+/**
+ * Assembles a Readium [Publication] for an O'Reilly book using lazy per-chapter fetching.
+ *
+ * The returned publication has one [Link] per spine item. Each link's URL matches the
+ * [LazySpineItem.fullPath] as resolved by [urlFactory]. Readium fetches resources through
+ * [OReillyLazyContainer], which downloads and caches each chapter on first access.
+ *
+ * No search service is registered — O'Reilly content is HTML scraped and would need a separate
+ * extraction pass. [PerResourcePositionsService] gives the chapter map one position per chapter.
+ */
+object OReillyPublicationBuilder {
+
+    @OptIn(ExperimentalReadiumApi::class)
+    fun build(
+        pub: LazyPublicationShape,
+        cacheDir: File,
+        fetchChapter: suspend (itemId: String, fullPath: String) -> String,
+        fetchAsset: suspend (itemId: String, fullPath: String) -> ByteArray?,
+        scope: CoroutineScope,
+        urlFactory: (String) -> Url? = { Url(it) },
+    ): Publication {
+        val readingOrder = pub.spine.mapNotNull { item ->
+            val url = urlFactory(item.fullPath) ?: return@mapNotNull null
+            Link(
+                href = url,
+                mediaType = MediaType.XHTML,
+                title = item.title.ifBlank { "Chapter ${item.index + 1}" },
+            )
+        }
+
+        val manifest = Manifest(
+            metadata = Metadata(
+                conformsTo = setOf(Publication.Profile.EPUB),
+                localizedTitle = LocalizedString(pub.title),
+                languages = listOf(pub.language),
+                identifier = pub.identifier,
+            ),
+            readingOrder = readingOrder,
+            tableOfContents = readingOrder,
+        )
+
+        val container = OReillyLazyContainer(
+            pub = pub,
+            cacheDir = cacheDir,
+            fetchChapter = fetchChapter,
+            fetchAsset = fetchAsset,
+            scope = scope,
+            urlFactory = urlFactory,
+        )
+
+        return Publication(
+            manifest = manifest,
+            container = container,
+            servicesBuilder = Publication.ServicesBuilder(
+                positions = { ctx ->
+                    PerResourcePositionsService(
+                        readingOrder = ctx.manifest.readingOrder,
+                        fallbackMediaType = MediaType.XHTML,
+                    )
+                },
+            ),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyPublicationBuilder.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyPublicationBuilder.kt
@@ -1,8 +1,5 @@
 package com.riffle.app.feature.source.oreilly
 
-import com.riffle.core.catalog.LazyPublicationShape
-import com.riffle.core.catalog.LazySpineItem
-import kotlinx.coroutines.CoroutineScope
 import org.readium.r2.shared.ExperimentalReadiumApi
 import org.readium.r2.shared.publication.Link
 import org.readium.r2.shared.publication.LocalizedString
@@ -12,7 +9,6 @@ import org.readium.r2.shared.publication.Publication
 import org.readium.r2.shared.publication.services.PerResourcePositionsService
 import org.readium.r2.shared.util.Url
 import org.readium.r2.shared.util.mediatype.MediaType
-import java.io.File
 
 /**
  * Assembles a Readium [Publication] for an O'Reilly book using lazy per-chapter fetching.
@@ -28,13 +24,10 @@ object OReillyPublicationBuilder {
 
     @OptIn(ExperimentalReadiumApi::class)
     fun build(
-        pub: LazyPublicationShape,
-        cacheDir: File,
-        fetchChapter: suspend (itemId: String, fullPath: String) -> String,
-        fetchAsset: suspend (itemId: String, fullPath: String) -> ByteArray?,
-        scope: CoroutineScope,
+        container: OReillyLazyContainer,
         urlFactory: (String) -> Url? = { Url(it) },
     ): Publication {
+        val pub = container.pub
         val readingOrder = pub.spine.mapNotNull { item ->
             val url = urlFactory(item.fullPath) ?: return@mapNotNull null
             Link(
@@ -53,15 +46,6 @@ object OReillyPublicationBuilder {
             ),
             readingOrder = readingOrder,
             tableOfContents = readingOrder,
-        )
-
-        val container = OReillyLazyContainer(
-            pub = pub,
-            cacheDir = cacheDir,
-            fetchChapter = fetchChapter,
-            fetchAsset = fetchAsset,
-            scope = scope,
-            urlFactory = urlFactory,
         )
 
         return Publication(

--- a/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyPublicationBuilder.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyPublicationBuilder.kt
@@ -6,7 +6,7 @@ import org.readium.r2.shared.publication.LocalizedString
 import org.readium.r2.shared.publication.Manifest
 import org.readium.r2.shared.publication.Metadata
 import org.readium.r2.shared.publication.Publication
-import org.readium.r2.shared.publication.services.PerResourcePositionsService
+import org.readium.r2.streamer.parser.epub.EpubPositionsService
 import org.readium.r2.shared.util.Url
 import org.readium.r2.shared.util.mediatype.MediaType
 
@@ -18,7 +18,8 @@ import org.readium.r2.shared.util.mediatype.MediaType
  * [OReillyLazyContainer], which downloads and caches each chapter on first access.
  *
  * No search service is registered — O'Reilly content is HTML scraped and would need a separate
- * extraction pass. [PerResourcePositionsService] gives the chapter map one position per chapter.
+ * extraction pass. [EpubPositionsService] with OriginalLength(1024) gives within-chapter positions
+ * based on [LazySpineItem.declaredByteSize].
  */
 object OReillyPublicationBuilder {
 
@@ -52,12 +53,14 @@ object OReillyPublicationBuilder {
             manifest = manifest,
             container = container,
             servicesBuilder = Publication.ServicesBuilder(
-                positions = { ctx ->
-                    PerResourcePositionsService(
-                        readingOrder = ctx.manifest.readingOrder,
-                        fallbackMediaType = MediaType.XHTML,
-                    )
-                },
+                // OriginalLength uses Resource.length() (our LazyChapterResource returns
+                // declaredByteSize) to estimate positions within each chapter, giving
+                // within-chapter progress in the chapter map.
+                positions = EpubPositionsService.createFactory(
+                    reflowableStrategy = EpubPositionsService.ReflowableStrategy.OriginalLength(
+                        pageLength = 1024,
+                    ),
+                ),
             ),
         )
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainerTest.kt
@@ -122,4 +122,38 @@ class OReillyLazyContainerTest {
         assertTrue(xhtml.contains("<html"))
         assertTrue(xhtml.contains("</html>"))
     }
+
+    // ---- extractRelativePath ------------------------------------------------
+
+    @Test
+    fun `extractRelativePath strips readium_package origin from absolute URL`() {
+        assertEquals(
+            "assets/cover.png",
+            OReillyLazyContainer.extractRelativePath("https://readium_package/assets/cover.png"),
+        )
+    }
+
+    @Test
+    fun `extractRelativePath strips readium_package origin for root-level asset`() {
+        assertEquals(
+            "epub.css",
+            OReillyLazyContainer.extractRelativePath("https://readium_package/epub.css"),
+        )
+    }
+
+    @Test
+    fun `extractRelativePath leaves bare relative paths unchanged`() {
+        assertEquals(
+            "images/fig.png",
+            OReillyLazyContainer.extractRelativePath("images/fig.png"),
+        )
+    }
+
+    @Test
+    fun `extractRelativePath strips leading slash from non-readium path`() {
+        assertEquals(
+            "xhtml/ch01.html",
+            OReillyLazyContainer.extractRelativePath("/xhtml/ch01.html"),
+        )
+    }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainerTest.kt
@@ -1,0 +1,125 @@
+package com.riffle.app.feature.source.oreilly
+
+import com.riffle.core.catalog.LazyPublicationShape
+import com.riffle.core.catalog.LazySpineItem
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Unit tests for [OReillyLazyContainer] cache helpers and [buildChapterXhtml].
+ *
+ * These tests target the companion-object helpers and static logic (cache key derivation,
+ * atomic write, XHTML assembly) rather than the full Readium Container/Resource hierarchy,
+ * which requires android.net.Uri unavailable in JVM unit tests.
+ */
+class OReillyLazyContainerTest {
+
+    @get:Rule val tmp = TemporaryFolder()
+
+    private fun makePub(vararg paths: String): LazyPublicationShape {
+        val spine = paths.mapIndexed { i, p ->
+            LazySpineItem(i, p, "Chapter ${i + 1}", 10_000L, "application/xhtml+xml")
+        }
+        return LazyPublicationShape(
+            bookId = "9781234567890",
+            identifier = "urn:orm:book:9781234567890",
+            title = "Test Book",
+            language = "en",
+            spine = spine,
+            absoluteFilesPrefix = "https://oreilly.com/api/v2/epubs/urn:orm:book:9781234567890/files/",
+            pathFilesPrefix = "/api/v2/epubs/urn:orm:book:9781234567890/files/",
+            cssFullPaths = listOf("styles/main.css"),
+        )
+    }
+
+    // ---- cacheFileFor -------------------------------------------------------
+
+    @Test
+    fun `cacheFileFor produces stable path for bookId and fullPath`() {
+        val cacheDir = tmp.newFolder()
+        val f1 = OReillyLazyContainer.cacheFileFor(cacheDir, "9781234567890", "xhtml/ch01.xhtml")
+        val f2 = OReillyLazyContainer.cacheFileFor(cacheDir, "9781234567890", "xhtml/ch01.xhtml")
+        assertEquals(f1.absolutePath, f2.absolutePath)
+    }
+
+    @Test
+    fun `cacheFileFor produces different paths for different chapters`() {
+        val cacheDir = tmp.newFolder()
+        val f1 = OReillyLazyContainer.cacheFileFor(cacheDir, "9781234567890", "xhtml/ch01.xhtml")
+        val f2 = OReillyLazyContainer.cacheFileFor(cacheDir, "9781234567890", "xhtml/ch02.xhtml")
+        assertFalse(f1.absolutePath == f2.absolutePath)
+    }
+
+    @Test
+    fun `cacheFileFor sanitizes slashes in fullPath`() {
+        val cacheDir = tmp.newFolder()
+        val f = OReillyLazyContainer.cacheFileFor(cacheDir, "id", "xhtml/ch01.xhtml")
+        assertFalse(f.name.contains('/'))
+    }
+
+    // ---- writeCacheFile -----------------------------------------------------
+
+    @Test
+    fun `writeCacheFile writes bytes atomically and is readable`() {
+        val cacheDir = tmp.newFolder()
+        val target = OReillyLazyContainer.cacheFileFor(cacheDir, "book", "ch01.xhtml")
+        val content = "hello world".encodeToByteArray()
+        OReillyLazyContainer.writeCacheFile(target, content)
+        assertTrue(target.exists())
+        assertArrayEquals(content, target.readBytes())
+    }
+
+    @Test
+    fun `writeCacheFile creates parent directories`() {
+        val cacheDir = tmp.newFolder()
+        val target = OReillyLazyContainer.cacheFileFor(cacheDir, "nested/book", "ch01.xhtml")
+        assertFalse(target.parentFile!!.exists())
+        OReillyLazyContainer.writeCacheFile(target, ByteArray(0))
+        assertTrue(target.parentFile!!.exists())
+    }
+
+    // ---- buildChapterXhtml --------------------------------------------------
+
+    @Test
+    fun `buildChapterXhtml rewrites absolute URL prefix to relative`() {
+        val pub = makePub("xhtml/ch01.xhtml")
+        val item = pub.spine[0]
+        val rawHtml = "<p>See <a href=\"https://oreilly.com/api/v2/epubs/urn:orm:book:9781234567890/files/images/fig.png\">fig</a></p>"
+        val xhtml = OReillyLazyContainer.buildChapterXhtml(pub, item, rawHtml)
+        assertFalse(xhtml.contains("https://oreilly.com/api/v2"))
+        assertTrue(xhtml.contains("../images/fig.png"))
+    }
+
+    @Test
+    fun `buildChapterXhtml rewrites path prefix to relative`() {
+        val pub = makePub("xhtml/ch01.xhtml")
+        val item = pub.spine[0]
+        val rawHtml = "<img src=\"/api/v2/epubs/urn:orm:book:9781234567890/files/images/x.jpg\"/>"
+        val xhtml = OReillyLazyContainer.buildChapterXhtml(pub, item, rawHtml)
+        assertFalse(xhtml.contains("/api/v2/epubs"))
+        assertTrue(xhtml.contains("../images/x.jpg"))
+    }
+
+    @Test
+    fun `buildChapterXhtml injects stylesheet link`() {
+        val pub = makePub("xhtml/ch01.xhtml")
+        val item = pub.spine[0]
+        val xhtml = OReillyLazyContainer.buildChapterXhtml(pub, item, "<p>body</p>")
+        assertTrue(xhtml.contains("styles/main.css") || xhtml.contains("../styles/main.css"))
+    }
+
+    @Test
+    fun `buildChapterXhtml wraps content in valid XHTML structure`() {
+        val pub = makePub("ch01.xhtml") // root-level chapter (no subdir)
+        val item = pub.spine[0]
+        val xhtml = OReillyLazyContainer.buildChapterXhtml(pub, item, "<p>Hello</p>")
+        assertTrue(xhtml.startsWith("<?xml"))
+        assertTrue(xhtml.contains("<html"))
+        assertTrue(xhtml.contains("</html>"))
+    }
+}

--- a/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalog.kt
+++ b/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalog.kt
@@ -199,12 +199,10 @@ class OReillyCatalog internal constructor(
      * as [synthesizeEpub] but with a single-request pacer (each lazy chapter fetch is independent).
      * Returns null after exhausting retries so the caller can surface a per-chapter error.
      */
-    override suspend fun fetchChapterForLazy(itemId: String, fullPath: String): String? {
-        val files = runCatching { fetchAllFiles(itemId) }.getOrNull() ?: return null
-        val expectedSize = files.firstOrNull { it.fullPath == fullPath }?.fileSize ?: 0L
+    override suspend fun fetchChapterForLazy(itemId: String, fullPath: String, expectedByteSize: Long): String? {
         val pacer = RequestPacer(maxConcurrency = 1, minIntervalMs = 0L) { clock.nowMs() }
         return runCatching {
-            fetchChapterContent(itemId, fullPath, expectedSize, pacer)
+            fetchChapterContent(itemId, fullPath, expectedByteSize, pacer)
         }.getOrNull()
     }
 

--- a/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalog.kt
+++ b/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalog.kt
@@ -17,6 +17,9 @@ import com.riffle.core.catalog.CatalogRoot
 import com.riffle.core.catalog.DownloadsCapability
 import com.riffle.core.catalog.EbookDetailsCapability
 import com.riffle.core.catalog.FacetSelection
+import com.riffle.core.catalog.LazyPublicationCapability
+import com.riffle.core.catalog.LazyPublicationShape
+import com.riffle.core.catalog.LazySpineItem
 import com.riffle.core.catalog.ReadCapability
 import com.riffle.core.catalog.SortKey
 import com.riffle.core.catalog.ToReadListCapability
@@ -78,7 +81,8 @@ class OReillyCatalog internal constructor(
     ReadCapability,
     DownloadsCapability,
     ToReadListCapability,
-    EbookDetailsCapability {
+    EbookDetailsCapability,
+    LazyPublicationCapability {
 
     override val sourceType: SourceType = SourceType.OREILLY
 
@@ -140,6 +144,76 @@ class OReillyCatalog internal constructor(
             tocEntries = toc,
             epubVersion = "3.0",
         )
+    }
+
+    // ---- Lazy (on-demand) publication (LazyPublicationCapability) ----------------------------
+
+    /**
+     * Builds the publication shape from metadata only — spine order + file sizes from two cheap
+     * JSON calls, same source as [ebookDetails]. Returns null when the spine is empty or
+     * unreachable. No chapter HTML is downloaded.
+     */
+    override suspend fun lazyPublication(itemId: String): LazyPublicationShape? {
+        val detail = runCatching {
+            OReillyParser.parseBookDetail(api.getJson(api.bookDetailUrl(itemId)))
+        }.getOrNull() ?: return null
+
+        val spineItems = OReillyParser.parseSpine(api.getJson(api.spineUrl(itemId)))
+            .results.mapNotNull { s -> s.fullPath?.let { path -> path to (s.title ?: "") } }
+        if (spineItems.isEmpty()) return null
+
+        val files = fetchAllFiles(itemId)
+        val fileMeta = files.associateBy { it.fullPath }
+        val cssFullPaths = files.filter { it.kind == "stylesheet" }.map { it.fullPath }
+
+        val absPrefix = api.baseUrl().trimEnd('/') + api.filesPrefix(itemId)
+        val pathPrefix = api.filesPrefix(itemId)
+
+        val distinctSpine = spineItems.distinctBy { it.first }
+
+        val spine = distinctSpine.mapIndexed { index, (fullPath, title) ->
+            val meta = fileMeta[fullPath]
+            LazySpineItem(
+                index = index,
+                fullPath = fullPath,
+                title = title.ifBlank { "Chapter ${index + 1}" },
+                declaredByteSize = meta?.fileSize ?: 0L,
+                mediaType = meta?.mediaType ?: "application/xhtml+xml",
+            )
+        }
+
+        return LazyPublicationShape(
+            bookId = itemId,
+            identifier = "urn:orm:book:${detail.identifier.ifBlank { itemId }}",
+            title = detail.title.ifBlank { itemId },
+            language = detail.language ?: "en",
+            spine = spine,
+            absoluteFilesPrefix = absPrefix,
+            pathFilesPrefix = pathPrefix,
+            cssFullPaths = cssFullPaths,
+        )
+    }
+
+    /**
+     * Fetch one chapter's HTML for the lazy-reading path. Uses the same backoff/truncation logic
+     * as [synthesizeEpub] but with a single-request pacer (each lazy chapter fetch is independent).
+     * Returns null after exhausting retries so the caller can surface a per-chapter error.
+     */
+    override suspend fun fetchChapterForLazy(itemId: String, fullPath: String): String? {
+        val files = runCatching { fetchAllFiles(itemId) }.getOrNull() ?: return null
+        val expectedSize = files.firstOrNull { it.fullPath == fullPath }?.fileSize ?: 0L
+        val pacer = RequestPacer(maxConcurrency = 1, minIntervalMs = 0L) { clock.nowMs() }
+        return runCatching {
+            fetchChapterContent(itemId, fullPath, expectedSize, pacer)
+        }.getOrNull()
+    }
+
+    /**
+     * Fetch one binary asset for the lazy-reading path (non-fatal — returns null on failure).
+     */
+    override suspend fun fetchAssetForLazy(itemId: String, fullPath: String): ByteArray? {
+        val pacer = RequestPacer(maxConcurrency = 1, minIntervalMs = 0L) { clock.nowMs() }
+        return fetchAssetBytes(itemId, fullPath, pacer)
     }
 
     // ---- Ebook: scrape + synthesize (verified against the live v2 epubs API) -----------------
@@ -338,7 +412,7 @@ class OReillyCatalog internal constructor(
      * exposure — the two are independent. A retry's backoff happens outside [execute], so it never
      * holds a permit while merely waiting.
      */
-    private class RequestPacer(
+    internal class RequestPacer(
         maxConcurrency: Int,
         private val minIntervalMs: Long,
         private val nowMs: () -> Long,

--- a/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyEpub.kt
+++ b/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyEpub.kt
@@ -5,7 +5,7 @@ package com.riffle.core.catalog.oreilly
  * unit-testable. [OReillyCatalog] fetches the raw bytes and calls these to build the
  * [com.riffle.core.catalog.oreilly.epub.SynthesizedBook].
  */
-internal object OReillyEpub {
+object OReillyEpub {
 
     fun chapterFileName(index: Int): String = "chapter$index.xhtml"
 

--- a/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/LazyPublicationCapabilityTest.kt
+++ b/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/LazyPublicationCapabilityTest.kt
@@ -1,0 +1,51 @@
+package com.riffle.core.catalog.oreilly
+
+import com.riffle.core.catalog.CatalogCapability
+import com.riffle.core.catalog.LazyPublicationCapability
+import com.riffle.core.catalog.LazyPublicationShape
+import com.riffle.core.catalog.LazySpineItem
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LazyPublicationCapabilityTest {
+
+    @Test
+    fun `LazyPublicationCapability is a CatalogCapability`() {
+        val fake = object : LazyPublicationCapability {
+            override suspend fun lazyPublication(itemId: String) = null
+            override suspend fun fetchChapterForLazy(itemId: String, fullPath: String) = null
+            override suspend fun fetchAssetForLazy(itemId: String, fullPath: String) = null
+        }
+        assert(fake is CatalogCapability)
+    }
+
+    @Test
+    fun `LazyPublicationShape spine preserves order and sizes`() {
+        val spine = listOf(
+            LazySpineItem(0, "xhtml/ch01.xhtml", "Chapter 1", 50_000L, "application/xhtml+xml"),
+            LazySpineItem(1, "xhtml/ch02.xhtml", "Chapter 2", 30_000L, "application/xhtml+xml"),
+        )
+        val pub = LazyPublicationShape(
+            bookId = "9781234567890",
+            identifier = "urn:orm:book:9781234567890",
+            title = "Test Book",
+            language = "en",
+            spine = spine,
+            absoluteFilesPrefix = "https://learning.oreilly.com/api/v2/epubs/urn:orm:book:9781234567890/files/",
+            pathFilesPrefix = "/api/v2/epubs/urn:orm:book:9781234567890/files/",
+            cssFullPaths = listOf("styles/main.css"),
+        )
+        assertEquals(2, pub.spine.size)
+        assertEquals("xhtml/ch01.xhtml", pub.spine[0].fullPath)
+        assertEquals(50_000L, pub.spine[0].declaredByteSize)
+        assertEquals("xhtml/ch02.xhtml", pub.spine[1].fullPath)
+        assertEquals(listOf("styles/main.css"), pub.cssFullPaths)
+    }
+
+    @Test
+    fun `LazySpineItem index is preserved`() {
+        val item = LazySpineItem(5, "xhtml/ch06.xhtml", "Chapter 6", 20_000L, "application/xhtml+xml")
+        assertEquals(5, item.index)
+        assertEquals("xhtml/ch06.xhtml", item.fullPath)
+    }
+}

--- a/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/LazyPublicationCapabilityTest.kt
+++ b/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/LazyPublicationCapabilityTest.kt
@@ -13,7 +13,7 @@ class LazyPublicationCapabilityTest {
     fun `LazyPublicationCapability is a CatalogCapability`() {
         val fake = object : LazyPublicationCapability {
             override suspend fun lazyPublication(itemId: String) = null
-            override suspend fun fetchChapterForLazy(itemId: String, fullPath: String) = null
+            override suspend fun fetchChapterForLazy(itemId: String, fullPath: String, expectedByteSize: Long) = null
             override suspend fun fetchAssetForLazy(itemId: String, fullPath: String) = null
         }
         assert(fake is CatalogCapability)

--- a/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalogLazyTest.kt
+++ b/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalogLazyTest.kt
@@ -105,4 +105,30 @@ class OReillyCatalogLazyTest {
         assertEquals("$base/api/v2/epubs/$urn/files/", pub!!.absoluteFilesPrefix)
         assertEquals("/api/v2/epubs/$urn/files/", pub.pathFilesPrefix)
     }
+
+    @Test
+    fun `fetchChapterForLazy does not call the files-listing endpoint`() = runBlocking {
+        // Use a dispatcher where the files-listing endpoint returns 500. If fetchChapterForLazy
+        // still called fetchAllFiles (the old bug), the whole call would fail and return null.
+        val noFilesListDispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                val path = request.path.orEmpty()
+                return when {
+                    // Chapter download endpoint — serves content
+                    path.contains("?download=false") ->
+                        MockResponse().setResponseCode(200).setBody("<p>Hello</p>")
+                    // Files-listing endpoint — fail hard so the test catches any regression
+                    path.startsWith("/api/v2/epubs/$urn/files/") ->
+                        MockResponse().setResponseCode(500).setBody("should not be called")
+                    else -> MockResponse().setResponseCode(404).setBody("{}")
+                }
+            }
+        }
+        server.dispatcher = noFilesListDispatcher
+
+        // expectedByteSize = 0 skips truncation detection; we only care that no files-listing
+        // request was made, not about truncation handling.
+        val result = catalog.fetchChapterForLazy(itemId, "xhtml/ch01.xhtml", expectedByteSize = 0L)
+        assertNotNull("fetchChapterForLazy should succeed without calling the files endpoint", result)
+    }
 }

--- a/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalogLazyTest.kt
+++ b/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalogLazyTest.kt
@@ -1,0 +1,108 @@
+package com.riffle.core.catalog.oreilly
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Tests for [OReillyCatalog.lazyPublication], [OReillyCatalog.fetchChapterForLazy], and
+ * [OReillyCatalog.fetchAssetForLazy]. Verifies the lazy-open metadata path returns a
+ * correctly-ordered spine with sizes and CSS paths — no chapter HTML is downloaded.
+ */
+class OReillyCatalogLazyTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var client: HttpClient
+    private lateinit var catalog: OReillyCatalog
+
+    private val itemId = "9781234567890"
+    private val urn = "urn:orm:book:$itemId"
+
+    private val dispatcher = object : Dispatcher() {
+        override fun dispatch(request: RecordedRequest): MockResponse {
+            val path = request.path.orEmpty()
+            val body = when {
+                path.startsWith("/api/v2/epubs/$urn/") && path.endsWith("/") && !path.contains("/spine") && !path.contains("/files") ->
+                    """{"identifier":"$itemId","title":"Test Book","language":"en"}"""
+
+                path.startsWith("/api/v2/epubs/$urn/spine/") ->
+                    """{
+                        "count":2,"next":null,"results":[
+                          {"reference_id":"$itemId-/xhtml/ch01.xhtml","title":"Chapter 1"},
+                          {"reference_id":"$itemId-/xhtml/ch02.xhtml","title":"Chapter 2"}
+                        ]
+                    }"""
+
+                path.startsWith("/api/v2/epubs/$urn/files/") && !path.contains("?download=false") ->
+                    """{
+                        "count":3,"next":null,"results":[
+                          {"full_path":"xhtml/ch01.xhtml","media_type":"application/xhtml+xml","kind":"chapter","file_size":50000},
+                          {"full_path":"xhtml/ch02.xhtml","media_type":"application/xhtml+xml","kind":"chapter","file_size":30000},
+                          {"full_path":"styles/main.css","media_type":"text/css","kind":"stylesheet","file_size":5000}
+                        ]
+                    }"""
+
+                else -> return MockResponse().setResponseCode(404).setBody("{}")
+            }
+            return MockResponse().setResponseCode(200).setBody(body)
+        }
+    }
+
+    @Before
+    fun setUp() {
+        server = MockWebServer().apply { dispatcher = this@OReillyCatalogLazyTest.dispatcher; start() }
+        client = HttpClient(OkHttp)
+        val api = OReillyApi(client, cookieHeader = "orm-jwt=x", baseUrl = server.url("/").toString().trimEnd('/'))
+        catalog = OReillyCatalog(api = api, bytesClient = client, cookieHeader = "orm-jwt=x")
+    }
+
+    @After
+    fun tearDown() {
+        client.close()
+        server.shutdown()
+    }
+
+    @Test
+    fun `lazyPublication returns spine in reading order with declared sizes`() = runBlocking {
+        val pub = catalog.lazyPublication(itemId)
+
+        assertNotNull(pub)
+        assertEquals(itemId, pub!!.bookId)
+        assertEquals("Test Book", pub.title)
+        assertEquals("en", pub.language)
+        assertEquals(2, pub.spine.size)
+        assertEquals("xhtml/ch01.xhtml", pub.spine[0].fullPath)
+        assertEquals("Chapter 1", pub.spine[0].title)
+        assertEquals(50_000L, pub.spine[0].declaredByteSize)
+        assertEquals(0, pub.spine[0].index)
+        assertEquals("xhtml/ch02.xhtml", pub.spine[1].fullPath)
+        assertEquals(30_000L, pub.spine[1].declaredByteSize)
+        assertEquals(1, pub.spine[1].index)
+    }
+
+    @Test
+    fun `lazyPublication includes stylesheet paths in cssFullPaths`() = runBlocking {
+        val pub = catalog.lazyPublication(itemId)
+        assertNotNull(pub)
+        assertEquals(listOf("styles/main.css"), pub!!.cssFullPaths)
+    }
+
+    @Test
+    fun `lazyPublication sets absoluteFilesPrefix and pathFilesPrefix correctly`() = runBlocking {
+        val pub = catalog.lazyPublication(itemId)
+        assertNotNull(pub)
+        val base = server.url("/").toString().trimEnd('/')
+        assertEquals("$base/api/v2/epubs/$urn/files/", pub!!.absoluteFilesPrefix)
+        assertEquals("/api/v2/epubs/$urn/files/", pub.pathFilesPrefix)
+    }
+}

--- a/core/catalog/src/commonMain/kotlin/com/riffle/core/catalog/LazyPublicationCapability.kt
+++ b/core/catalog/src/commonMain/kotlin/com/riffle/core/catalog/LazyPublicationCapability.kt
@@ -26,8 +26,12 @@ interface LazyPublicationCapability : CatalogCapability {
     /**
      * Fetch one chapter's HTML for the lazy-reading path. Applies the same backoff/truncation
      * logic as the full synthesize path. Returns null after exhausting retries.
+     *
+     * [expectedByteSize] is the declared size from [LazySpineItem.declaredByteSize] and is used
+     * for truncation detection — pass it through from the spine rather than re-fetching the file
+     * listing on every chapter load.
      */
-    suspend fun fetchChapterForLazy(itemId: String, fullPath: String): String?
+    suspend fun fetchChapterForLazy(itemId: String, fullPath: String, expectedByteSize: Long): String?
 
     /**
      * Fetch one asset's bytes for the lazy-reading path (non-fatal — returns null on failure).

--- a/core/catalog/src/commonMain/kotlin/com/riffle/core/catalog/LazyPublicationCapability.kt
+++ b/core/catalog/src/commonMain/kotlin/com/riffle/core/catalog/LazyPublicationCapability.kt
@@ -1,0 +1,65 @@
+package com.riffle.core.catalog
+
+/**
+ * Opt-in mixin for sources that can open an ebook lazily — building the publication shape from
+ * metadata only (no content bytes) and streaming chapter content on demand as Readium renders it.
+ *
+ * Gated on this capability so the shared reader open path stays source-agnostic — same pattern as
+ * [EbookDetailsCapability]. Only [com.riffle.core.models.SourceType.OREILLY] implements this
+ * today; every other source falls through to the normal file-based route.
+ *
+ * iOS: the fetch + disk-cache logic ([fetchChapterForLazy] / [fetchAssetForLazy]) stays in
+ * commonMain and is usable from iOS. The Readium-iOS equivalent of Container/Resource is
+ * ReadiumSwift's Resource/Container; the iOS lazy open path requires a separate iosMain
+ * implementation once iOS reading is active. Tracked in a follow-up issue.
+ */
+interface LazyPublicationCapability : CatalogCapability {
+    /**
+     * Returns the book shape (metadata + spine order + file sizes) from cheap API calls, with no
+     * chapter content fetched. The caller uses this to build a lazy Readium Publication backed by
+     * an on-demand fetching container.
+     *
+     * Returns null when the spine is empty or unreachable.
+     */
+    suspend fun lazyPublication(itemId: String): LazyPublicationShape?
+
+    /**
+     * Fetch one chapter's HTML for the lazy-reading path. Applies the same backoff/truncation
+     * logic as the full synthesize path. Returns null after exhausting retries.
+     */
+    suspend fun fetchChapterForLazy(itemId: String, fullPath: String): String?
+
+    /**
+     * Fetch one asset's bytes for the lazy-reading path (non-fatal — returns null on failure).
+     */
+    suspend fun fetchAssetForLazy(itemId: String, fullPath: String): ByteArray?
+}
+
+/**
+ * Publication shape computed from source metadata — spine order, file metadata, and book identity
+ * — with no chapter HTML downloaded. Carries everything needed to build a Readium Manifest and
+ * to make per-chapter fetch calls later via [LazyPublicationCapability].
+ */
+data class LazyPublicationShape(
+    val bookId: String,
+    val identifier: String,
+    val title: String,
+    val language: String,
+    val spine: List<LazySpineItem>,
+    /** Absolute base URL prefix of chapter content, used for absolute→relative asset URL rewriting. */
+    val absoluteFilesPrefix: String,
+    /** Path-only prefix (e.g. `/api/v2/epubs/…`), also used in URL rewriting. */
+    val pathFilesPrefix: String,
+    /** Full paths of all stylesheets, used to inject `<link>` tags into each chapter. */
+    val cssFullPaths: List<String>,
+)
+
+/** One entry in the reading order of a [LazyPublicationShape]. */
+data class LazySpineItem(
+    val index: Int,
+    val fullPath: String,
+    val title: String,
+    /** Declared byte size. Used for truncation detection and Readium position count estimation. */
+    val declaredByteSize: Long,
+    val mediaType: String,
+)

--- a/feature/source-ui/src/commonMain/composeResources/values/strings.xml
+++ b/feature/source-ui/src/commonMain/composeResources/values/strings.xml
@@ -83,7 +83,7 @@
     <string name="ui_minutes_ago">%1$d min ago</string>
     <string name="ui_hours_ago">%1$d h ago</string>
     <string name="ui_days_ago">%1$d d ago</string>
-    <string name="source_oreilly_name">O\'Reilly</string>
+    <string name="source_oreilly_name">O'Reilly</string>
     <string name="ui_source_oreilly_subtitle">learning.oreilly.com</string>
-    <string name="ui_source_oreilly_picker_blurb">Browse and read ebooks and audiobooks from your O\'Reilly account.</string>
+    <string name="ui_source_oreilly_picker_blurb">Browse and read ebooks and audiobooks from your O'Reilly account.</string>
 </resources>


### PR DESCRIPTION
## Summary

- Adds a lazy publication open path for O'Reilly books: the reader opens instantly using metadata only, then fetches and caches each chapter as Readium renders it — no full-book download required before reading
- Cover images and CSS assets are served correctly through Readium's sub-resource URL scheme (`https://readium_package/…`)
- Chapter map shows within-chapter progress (switched from `PerResourcePositionsService` to `EpubPositionsService.OriginalLength` backed by `LazySpineItem.declaredByteSize`)
- Next chapter is prefetched in the background on locator change so most chapter turns feel instant
- `isLazyPublication` exposed as a `StateFlow<Boolean>` to drive a future "Download to search" hint (search service is omitted for lazy publications — O'Reilly content is HTML-scraped and needs a separate extraction pass)

## iOS parity

The `LazyPublicationCapability` interface and fetch logic live in `commonMain` and are usable from iOS. The Readium-Swift equivalent of `Container`/`Resource` requires a separate `iosMain` implementation once iOS reading is active. Tracked in issue #987.

## Key technical decisions

- **`OReillyLazyContainer`**: Readium `Container<Resource>` that routes spine-item requests to `LazyChapterResource` (on-demand HTML fetch → XHTML wrap → disk cache) and all other URLs through `LazyAssetResource` (images/CSS). Sub-resource URLs arrive as `https://readium_package/{path}`; `extractRelativePath()` strips that prefix before the O'Reilly files API call.
- **`LazyAssetResource.length()`**: eagerly fetches and caches when uncalled — Readium's `ReadableInputStreamAdapter` calls `length()` before `read()`; returning 0 makes every read return EOF (verified by inspecting extracted Readium JARs).
- **`writeCacheFile`**: write-once `.tmp`→rename atomic cache; falls back to direct write when `renameTo` returns false (cross-mount-point failure on Android).
- **`fetchChapterForLazy` signature**: now takes `expectedByteSize: Long` directly, eliminating the redundant full-files-listing API call on every chapter open.

## Tests

- `OReillyLazyContainerTest`: cache-key derivation, atomic write, XHTML assembly, `extractRelativePath` (4 cases)
- `OReillyCatalogLazyTest`: spine ordering with declared sizes, CSS path inclusion, files-prefix correctness, regression for no-`fetchAllFiles` call during lazy chapter fetch
- `LazyPublicationCapabilityTest`: interface is a `CatalogCapability` subtype

## Code review finding dismissed

**Prefetch href comparison without `normalizeEpubHref` (PLAUSIBLE)**: `LazySpineItem.fullPath` and `locator.href` both use the same bare relative path produced by the same `urlFactory` (`Url(it).toString()`), so there is no scheme prefix mismatch to normalize. Dismissed on inspection.

## Related

Closes #986