### PR TITLE
feat(oreilly): Kaltura audiobook streaming, and ebook caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Riffle lets you browse your library, read EPUB, PDF, and CBZ files, listen to au
 - **Komga** self-hosted server — browse, read, and sync comics, manga, and ebooks (EPUB, PDF, CBZ) from any [Komga](https://komga.org/) instance with Basic-auth credentials; page-based reading progress syncs bidirectionally across devices; annotation sync available via optional WebDAV
 - **Chitanka** (chitanka.info + gramofonche.chitanka.info) — anonymous, zero-config access to the Bulgarian public catalogue of EPUB ebooks and MP3 audiobooks; browsable by category, genre, and series; reading and listening progress syncs across devices via optional WebDAV
 - **Project Gutenberg** (via Gutendex) — anonymous, zero-config access to ~70,000 public-domain EPUBs; browsable by language, subject, and author; reading progress syncs across devices via optional WebDAV
-- **O'Reilly** — read any book in your O'Reilly subscription directly in the app; chapters are streamed on demand and cached locally so re-reads are instant; reading progress is saved per book
+- **O'Reilly** — read or listen to any title in your O'Reilly subscription; ebook chapters stream on demand and cache locally for instant re-reads; audiobooks stream via Kaltura with per-chapter progress; books download to device for offline access
 - **radio.es** — browse and stream Spanish-language radio stations and podcasts from the [radio.es](https://www.radio.es/) catalogue; filter podcasts by category and language; live radio stations stream directly without downloading
 - **Local files** — import EPUB, PDF, and CBZ files from device storage and read them alongside your server libraries, with the same reader, highlights, and progress tracking
 

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -3878,7 +3878,12 @@ class EpubReaderViewModel constructor(
             scope = viewModelScope,
         )
         lazyContainer = container
-        container.startBackgroundPrefetch()
+        container.startBackgroundPrefetch(onAllCached = { epub ->
+            // Write the assembled EPUB to the cache store so the book shows as available offline.
+            // The guard inside cacheEpub() prevents double-writes on subsequent opens.
+            (epubRepository as? com.riffle.core.domain.JvmEpubRepository)
+                ?.cacheEpub(sourceId, itemId, epub)
+        })
         _isLazyPublication.value = true
         val publication = com.riffle.app.feature.source.oreilly.OReillyPublicationBuilder.build(container)
         val lastPosition = readingPositionStore.load(sourceId, itemId)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -3878,6 +3878,7 @@ class EpubReaderViewModel constructor(
             scope = viewModelScope,
         )
         lazyContainer = container
+        container.startBackgroundPrefetch()
         _isLazyPublication.value = true
         val publication = com.riffle.app.feature.source.oreilly.OReillyPublicationBuilder.build(container)
         val lastPosition = readingPositionStore.load(sourceId, itemId)

--- a/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainer.kt
@@ -94,6 +94,29 @@ class OReillyLazyContainer(
         }
     }
 
+    /**
+     * Slowly caches every uncached chapter in spine order, running in [scope] (typically the
+     * reader's ViewModel scope, so the job is cancelled when the user leaves the reader). Fetches
+     * are paced at [minDelayMs]–[maxDelayMs] to stay well below anti-abuse thresholds. Already-
+     * cached chapters are skipped instantly; chapters that fail individually are skipped rather
+     * than aborting the whole run. Assets are not prefetched — they are cached on first read.
+     */
+    fun startBackgroundPrefetch(minDelayMs: Long = 1_500L, maxDelayMs: Long = 4_000L) {
+        scope.launch {
+            for (item in pub.spine) {
+                val cacheFile = cacheFileFor(cacheDir, pub.bookId, item.fullPath)
+                if (!cacheFile.exists()) {
+                    kotlinx.coroutines.delay(minDelayMs + kotlin.random.Random.nextLong(maxDelayMs - minDelayMs + 1))
+                    runCatching {
+                        val html = fetchChapter(pub.bookId, item.fullPath, item.declaredByteSize)
+                        val xhtml = buildChapterXhtml(pub, item, html)
+                        writeCacheFile(cacheFile, xhtml.encodeToByteArray())
+                    }
+                }
+            }
+        }
+    }
+
     companion object {
         /**
          * Strips the `https://readium_package/` origin that Readium prepends to sub-resource

--- a/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainer.kt
@@ -3,6 +3,10 @@ package com.riffle.app.feature.source.oreilly
 import com.riffle.core.catalog.LazyPublicationShape
 import com.riffle.core.catalog.LazySpineItem
 import com.riffle.core.catalog.oreilly.OReillyEpub
+import com.riffle.core.catalog.oreilly.epub.EpubAssembler
+import com.riffle.core.catalog.oreilly.epub.EpubChapter
+import com.riffle.core.catalog.oreilly.epub.EpubResource
+import com.riffle.core.catalog.oreilly.epub.SynthesizedBook
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.readium.r2.shared.util.AbsoluteUrl
@@ -95,18 +99,30 @@ class OReillyLazyContainer(
     }
 
     /**
-     * Slowly caches every uncached chapter in spine order, running in [scope] (typically the
-     * reader's ViewModel scope, so the job is cancelled when the user leaves the reader). Fetches
-     * are paced at [minDelayMs]–[maxDelayMs] to stay well below anti-abuse thresholds. Already-
-     * cached chapters are skipped instantly; chapters that fail individually are skipped rather
-     * than aborting the whole run. Assets are not prefetched — they are cached on first read.
+     * Slowly caches every uncached chapter and asset in spine/file order, running in [scope]
+     * (cancelled when the user leaves the reader). Fetches are paced at [minDelayMs]–[maxDelayMs]
+     * to stay well below anti-abuse thresholds. Already-cached files are skipped instantly;
+     * individual failures are swallowed so one bad asset doesn't abort the run.
+     *
+     * When all chapters **and** assets are confirmed on disk, [onAllCached] is called with the
+     * assembled EPUB bytes so the caller can write them to the offline store. If assembly fails
+     * (e.g. a chapter is still missing after the loop despite best efforts) the callback is not
+     * invoked and offline caching is deferred to the next open.
      */
-    fun startBackgroundPrefetch(minDelayMs: Long = 1_500L, maxDelayMs: Long = 4_000L) {
+    fun startBackgroundPrefetch(
+        minDelayMs: Long = 1_500L,
+        maxDelayMs: Long = 4_000L,
+        onAllCached: suspend (epub: ByteArray) -> Unit = {},
+    ) {
         scope.launch {
+            fun jitter() = if (minDelayMs >= maxDelayMs) minDelayMs
+            else minDelayMs + kotlin.random.Random.nextLong(maxDelayMs - minDelayMs + 1)
+
+            // Phase 1: chapters (in spine order).
             for (item in pub.spine) {
                 val cacheFile = cacheFileFor(cacheDir, pub.bookId, item.fullPath)
                 if (!cacheFile.exists()) {
-                    kotlinx.coroutines.delay(minDelayMs + kotlin.random.Random.nextLong(maxDelayMs - minDelayMs + 1))
+                    kotlinx.coroutines.delay(jitter())
                     runCatching {
                         val html = fetchChapter(pub.bookId, item.fullPath, item.declaredByteSize)
                         val xhtml = buildChapterXhtml(pub, item, html)
@@ -114,7 +130,58 @@ class OReillyLazyContainer(
                     }
                 }
             }
+
+            // Phase 2: assets (images, CSS, fonts). Same pacing — each fetch is an independent
+            // API call and O'Reilly's rate guard doesn't distinguish chapter vs asset requests.
+            for (asset in pub.assetFiles) {
+                val cacheFile = cacheFileFor(cacheDir, pub.bookId, asset.fullPath)
+                if (!cacheFile.exists()) {
+                    kotlinx.coroutines.delay(jitter())
+                    runCatching {
+                        val bytes = fetchAsset(pub.bookId, asset.fullPath)
+                        if (bytes != null) writeCacheFile(cacheFile, bytes)
+                    }
+                }
+            }
+
+            // Phase 3: assemble and hand off — only if every chapter is present on disk.
+            val epub = assembleEpubFromCache() ?: return@launch
+            onAllCached(epub)
         }
+    }
+
+    /**
+     * Assembles a complete EPUB from the on-disk lazy cache. Returns null if any spine chapter is
+     * missing from cache (which means the prefetch didn't finish). Assets that are absent are
+     * silently omitted — the book is still readable without every image.
+     */
+    internal fun assembleEpubFromCache(): ByteArray? {
+        val chapters = pub.spine.mapIndexed { index, item ->
+            val file = cacheFileFor(cacheDir, pub.bookId, item.fullPath)
+            if (!file.exists()) return null
+            EpubChapter(
+                id = OReillyEpub.chapterId(index),
+                relativePath = item.fullPath,
+                title = item.title,
+                xhtml = file.readText(),
+            )
+        }
+        val resources = pub.assetFiles.mapNotNull { asset ->
+            val file = cacheFileFor(cacheDir, pub.bookId, asset.fullPath)
+            if (!file.exists()) null
+            else EpubResource(asset.fullPath, file.readBytes(), asset.mediaType)
+        }
+        return EpubAssembler.assemble(
+            SynthesizedBook(
+                identifier = pub.identifier,
+                title = pub.title,
+                authors = emptyList(),
+                language = pub.language,
+                chapters = chapters,
+                resources = resources,
+                coverPath = null,
+            ),
+        )
     }
 
     companion object {

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
@@ -127,6 +127,7 @@ class LibraryFilterEngineTest {
         override suspend fun removeDownload(sourceId: String, itemId: String) {}
         override fun isDownloaded(sourceId: String, itemId: String): Boolean = itemId in downloadedIds
         override fun isCached(sourceId: String, itemId: String): Boolean = false
+        override suspend fun cacheEpub(sourceId: String, itemId: String, bytes: ByteArray) {}
         override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
     }
 
@@ -225,6 +226,7 @@ class LibraryFilterEngineTest {
                 return itemId == "id-A"
             }
             override fun isCached(sourceId: String, itemId: String): Boolean = false
+            override suspend fun cacheEpub(sourceId: String, itemId: String, bytes: ByteArray) {}
             override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
         }
         val engine = makeEngine(epubRepository = recordingEpubRepo)

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -182,6 +182,7 @@ class LibraryItemDetailViewModelTest {
         }
         override fun isDownloaded(sourceId: String, itemId: String): Boolean = downloaded
         override fun isCached(sourceId: String, itemId: String): Boolean = itemId in cached
+        override suspend fun cacheEpub(sourceId: String, itemId: String, bytes: ByteArray) {}
         override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
         fun cache(itemId: String) {
             cached += itemId

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
@@ -119,6 +119,7 @@ class LibraryItemDetailViewModelTocTest {
         override suspend fun removeDownload(sourceId: String, itemId: String) {}
         override fun isDownloaded(sourceId: String, itemId: String): Boolean = false
         override fun isCached(sourceId: String, itemId: String): Boolean = false
+        override suspend fun cacheEpub(sourceId: String, itemId: String, bytes: ByteArray) {}
         override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudSessionTest.kt
@@ -418,6 +418,7 @@ class ReadaloudSessionTest {
         override suspend fun removeDownload(sourceId: String, itemId: String) {}
         override fun isDownloaded(sourceId: String, itemId: String) = false
         override fun isCached(sourceId: String, itemId: String) = false
+        override suspend fun cacheEpub(sourceId: String, itemId: String, bytes: ByteArray) {}
     }
 
     private fun makeSessionWithStores(

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -90,6 +90,7 @@ class ReaderSessionLifecycleTest {
         override suspend fun removeDownload(sourceId: String, itemId: String) {}
         override fun isDownloaded(sourceId: String, itemId: String) = false
         override fun isCached(sourceId: String, itemId: String) = false
+        override suspend fun cacheEpub(sourceId: String, itemId: String, bytes: ByteArray) {}
         override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
     }
 
@@ -252,6 +253,7 @@ class ReaderSessionLifecycleTest {
         override suspend fun removeDownload(sourceId: String, itemId: String) {}
         override fun isDownloaded(sourceId: String, itemId: String) = false
         override fun isCached(sourceId: String, itemId: String) = false
+        override suspend fun cacheEpub(sourceId: String, itemId: String, bytes: ByteArray) {}
         override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
     }
 

--- a/app/src/test/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainerTest.kt
@@ -1,5 +1,6 @@
 package com.riffle.app.feature.source.oreilly
 
+import com.riffle.core.catalog.LazyAssetFile
 import com.riffle.core.catalog.LazyPublicationShape
 import com.riffle.core.catalog.LazySpineItem
 import kotlinx.coroutines.CoroutineScope
@@ -8,10 +9,14 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import java.io.ByteArrayInputStream
+import java.util.zip.ZipInputStream
 
 /**
  * Unit tests for [OReillyLazyContainer] cache helpers and [buildChapterXhtml].
@@ -24,7 +29,10 @@ class OReillyLazyContainerTest {
 
     @get:Rule val tmp = TemporaryFolder()
 
-    private fun makePub(vararg paths: String): LazyPublicationShape {
+    private fun makePub(
+        vararg paths: String,
+        assetFiles: List<LazyAssetFile> = emptyList(),
+    ): LazyPublicationShape {
         val spine = paths.mapIndexed { i, p ->
             LazySpineItem(i, p, "Chapter ${i + 1}", 10_000L, "application/xhtml+xml")
         }
@@ -37,6 +45,7 @@ class OReillyLazyContainerTest {
             absoluteFilesPrefix = "https://oreilly.com/api/v2/epubs/urn:orm:book:9781234567890/files/",
             pathFilesPrefix = "/api/v2/epubs/urn:orm:book:9781234567890/files/",
             cssFullPaths = listOf("styles/main.css"),
+            assetFiles = assetFiles,
         )
     }
 
@@ -190,5 +199,127 @@ class OReillyLazyContainerTest {
         assertTrue(OReillyLazyContainer.cacheFileFor(cacheDir, pub.bookId, "xhtml/ch01.xhtml").exists())
         assertTrue(OReillyLazyContainer.cacheFileFor(cacheDir, pub.bookId, "xhtml/ch02.xhtml").exists())
         assertTrue(OReillyLazyContainer.cacheFileFor(cacheDir, pub.bookId, "xhtml/ch03.xhtml").exists())
+    }
+
+    @Test
+    fun `startBackgroundPrefetch fetches assets and calls onAllCached with non-empty EPUB`() = runBlocking {
+        val cacheDir = tmp.newFolder()
+        val assetFiles = listOf(
+            LazyAssetFile("styles/main.css", "text/css"),
+            LazyAssetFile("images/cover.jpg", "image/jpeg"),
+        )
+        val pub = makePub("xhtml/ch01.xhtml", "xhtml/ch02.xhtml", assetFiles = assetFiles)
+        val fetchedAssets = mutableListOf<String>()
+        val container = OReillyLazyContainer(
+            pub = pub,
+            cacheDir = cacheDir,
+            fetchChapter = { _, path, _ -> "<p>$path</p>" },
+            fetchAsset = { _, path ->
+                fetchedAssets += path
+                "asset-$path".encodeToByteArray()
+            },
+            scope = CoroutineScope(Dispatchers.Unconfined),
+            urlFactory = { null },
+        )
+
+        var callbackBytes: ByteArray? = null
+        container.startBackgroundPrefetch(minDelayMs = 0L, maxDelayMs = 0L, onAllCached = { callbackBytes = it })
+
+        // Assets fetched from network.
+        assertEquals(listOf("styles/main.css", "images/cover.jpg"), fetchedAssets)
+        // Asset cache files written.
+        assertTrue(OReillyLazyContainer.cacheFileFor(cacheDir, pub.bookId, "styles/main.css").exists())
+        assertTrue(OReillyLazyContainer.cacheFileFor(cacheDir, pub.bookId, "images/cover.jpg").exists())
+        // Callback invoked with a non-empty EPUB.
+        assertNotNull(callbackBytes)
+        assertTrue(callbackBytes!!.isNotEmpty())
+        // The bytes form a readable ZIP starting with the mimetype entry.
+        ZipInputStream(ByteArrayInputStream(callbackBytes)).use { zis ->
+            val first = zis.nextEntry
+            assertEquals("mimetype", first.name)
+            assertEquals("application/epub+zip", zis.readBytes().decodeToString())
+        }
+    }
+
+    @Test
+    fun `startBackgroundPrefetch skips already-cached assets`() = runBlocking {
+        val cacheDir = tmp.newFolder()
+        val assetFiles = listOf(LazyAssetFile("styles/main.css", "text/css"))
+        val pub = makePub("xhtml/ch01.xhtml", assetFiles = assetFiles)
+        val fetchedAssets = mutableListOf<String>()
+
+        // Pre-cache the asset.
+        OReillyLazyContainer.writeCacheFile(
+            OReillyLazyContainer.cacheFileFor(cacheDir, pub.bookId, "styles/main.css"),
+            "pre-cached".encodeToByteArray(),
+        )
+
+        val container = OReillyLazyContainer(
+            pub = pub,
+            cacheDir = cacheDir,
+            fetchChapter = { _, path, _ -> "<p>$path</p>" },
+            fetchAsset = { _, path -> fetchedAssets += path; ByteArray(0) },
+            scope = CoroutineScope(Dispatchers.Unconfined),
+            urlFactory = { null },
+        )
+        container.startBackgroundPrefetch(minDelayMs = 0L, maxDelayMs = 0L)
+
+        assertTrue("Pre-cached asset must not be re-fetched", fetchedAssets.isEmpty())
+    }
+
+    @Test
+    fun `assembleEpubFromCache returns null when a chapter is missing`() {
+        val cacheDir = tmp.newFolder()
+        val pub = makePub("xhtml/ch01.xhtml", "xhtml/ch02.xhtml")
+        val container = OReillyLazyContainer(
+            pub = pub,
+            cacheDir = cacheDir,
+            fetchChapter = { _, _, _ -> "" },
+            fetchAsset = { _, _ -> null },
+            scope = CoroutineScope(Dispatchers.Unconfined),
+            urlFactory = { null },
+        )
+
+        // Only ch01 cached; ch02 is missing.
+        OReillyLazyContainer.writeCacheFile(
+            OReillyLazyContainer.cacheFileFor(cacheDir, pub.bookId, "xhtml/ch01.xhtml"),
+            "<p>ch01</p>".encodeToByteArray(),
+        )
+
+        assertNull(container.assembleEpubFromCache())
+    }
+
+    @Test
+    fun `assembleEpubFromCache produces a valid EPUB when all chapters are cached`() {
+        val cacheDir = tmp.newFolder()
+        val pub = makePub("xhtml/ch01.xhtml", "xhtml/ch02.xhtml")
+        val container = OReillyLazyContainer(
+            pub = pub,
+            cacheDir = cacheDir,
+            fetchChapter = { _, _, _ -> "" },
+            fetchAsset = { _, _ -> null },
+            scope = CoroutineScope(Dispatchers.Unconfined),
+            urlFactory = { null },
+        )
+
+        for (item in pub.spine) {
+            OReillyLazyContainer.writeCacheFile(
+                OReillyLazyContainer.cacheFileFor(cacheDir, pub.bookId, item.fullPath),
+                "<p>${item.fullPath}</p>".encodeToByteArray(),
+            )
+        }
+
+        val epub = container.assembleEpubFromCache()
+        assertNotNull(epub)
+
+        val entries = mutableListOf<String>()
+        ZipInputStream(ByteArrayInputStream(epub)).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) { entries += entry.name; entry = zis.nextEntry }
+        }
+        assertTrue(entries.contains("mimetype"))
+        assertTrue(entries.contains("OEBPS/content.opf"))
+        assertTrue(entries.any { it.endsWith("ch01.xhtml") })
+        assertTrue(entries.any { it.endsWith("ch02.xhtml") })
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainerTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainerTest.kt
@@ -2,6 +2,9 @@ package com.riffle.app.feature.source.oreilly
 
 import com.riffle.core.catalog.LazyPublicationShape
 import com.riffle.core.catalog.LazySpineItem
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -155,5 +158,37 @@ class OReillyLazyContainerTest {
             "xhtml/ch01.html",
             OReillyLazyContainer.extractRelativePath("/xhtml/ch01.html"),
         )
+    }
+
+    // ---- startBackgroundPrefetch --------------------------------------------
+
+    @Test
+    fun `startBackgroundPrefetch fetches and caches every uncached chapter`() = runBlocking {
+        val cacheDir = tmp.newFolder()
+        val pub = makePub("xhtml/ch01.xhtml", "xhtml/ch02.xhtml", "xhtml/ch03.xhtml")
+        val fetched = mutableListOf<String>()
+        val container = OReillyLazyContainer(
+            pub = pub,
+            cacheDir = cacheDir,
+            fetchChapter = { _, path, _ -> fetched += path; "<p>content of $path</p>" },
+            fetchAsset = { _, _ -> null },
+            scope = CoroutineScope(Dispatchers.Unconfined),
+            // android.net.Uri is unavailable in JVM unit tests; stub out the URL factory so
+            // the container init doesn't crash. startBackgroundPrefetch iterates pub.spine
+            // directly and doesn't use the URL map, so this is safe for this test.
+            urlFactory = { null },
+        )
+
+        // Pre-cache ch02 to verify it's skipped.
+        val ch02Cache = OReillyLazyContainer.cacheFileFor(cacheDir, pub.bookId, "xhtml/ch02.xhtml")
+        OReillyLazyContainer.writeCacheFile(ch02Cache, "<pre-cached>ch02</pre-cached>".encodeToByteArray())
+
+        container.startBackgroundPrefetch(minDelayMs = 0L, maxDelayMs = 0L)
+
+        // All three chapters must be cached on disk; only ch01 and ch03 were fetched from network.
+        assertEquals(listOf("xhtml/ch01.xhtml", "xhtml/ch03.xhtml"), fetched)
+        assertTrue(OReillyLazyContainer.cacheFileFor(cacheDir, pub.bookId, "xhtml/ch01.xhtml").exists())
+        assertTrue(OReillyLazyContainer.cacheFileFor(cacheDir, pub.bookId, "xhtml/ch02.xhtml").exists())
+        assertTrue(OReillyLazyContainer.cacheFileFor(cacheDir, pub.bookId, "xhtml/ch03.xhtml").exists())
     }
 }

--- a/core/catalog-oreilly/build.gradle.kts
+++ b/core/catalog-oreilly/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.okhttp.mockwebserver)
             implementation(libs.ktor.client.okhttp)
+            implementation(libs.ktor.client.mock)
         }
     }
 }

--- a/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyApi.kt
+++ b/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyApi.kt
@@ -193,6 +193,17 @@ internal class OReillyApi(
         fun kalturaHlsUrl(partnerId: String, entryId: String, ks: String): String =
             "$KALTURA_CDN/p/$partnerId/sp/${partnerId}00/playManifest/entryId/$entryId" +
                 "/format/applehttp/protocol/https/a.m3u8?ks=$ks"
+
+        /**
+         * Kaltura direct-download URL for one audiobook chapter. Returns an HTTP 302 to a
+         * CloudFront-signed `.mp4` (audio-only) that can be byte-streamed to disk. Use this for
+         * offline download/cache; use [kalturaHlsUrl] for live streaming (Media3 handles HLS
+         * natively but can't byte-download a manifest). Verified live 2026-09: redirects to
+         * `cfvod.kaltura.com` with a signed URL, `Content-Type: video/mp4`, `Content-Length` set.
+         */
+        fun kalturaDownloadUrl(partnerId: String, entryId: String, ks: String): String =
+            "$KALTURA_CDN/p/$partnerId/sp/${partnerId}00/playManifest/entryId/$entryId" +
+                "/format/url/protocol/https?ks=$ks"
     }
 
     private fun HttpStatusCode.isSuccess(): Boolean = value in 200..299

--- a/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyApi.kt
+++ b/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyApi.kt
@@ -24,6 +24,7 @@ import io.ktor.http.encodeURLQueryComponent
 internal class OReillyApi(
     private val client: HttpClient,
     private val cookieHeader: String,
+    private val userAgent: String = DEFAULT_USER_AGENT,
     private val baseUrl: String = DEFAULT_BASE_URL,
 ) {
     private val base = baseUrl.trimEnd('/')
@@ -62,7 +63,7 @@ internal class OReillyApi(
     private suspend fun authorizedGet(url: String, accept: String): HttpResponse = client.get(absolute(url)) {
         header("Cookie", cookieHeader)
         header("Accept", accept)
-        header("User-Agent", USER_AGENT)
+        header("User-Agent", userAgent)
     }
 
     private fun absolute(url: String): String =
@@ -132,7 +133,7 @@ internal class OReillyApi(
 
     companion object {
         const val DEFAULT_BASE_URL = "https://learning.oreilly.com"
-        private const val USER_AGENT =
+        const val DEFAULT_USER_AGENT =
             "Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0 Mobile Safari/537.36"
         private const val ACCEPT_JSON = "application/json"
         private const val ACCEPT_HTML = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"

--- a/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyApi.kt
+++ b/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyApi.kt
@@ -31,9 +31,11 @@ internal class OReillyApi(
 
     fun baseUrl(): String = base
 
+    private enum class RequestType { Json, Content, Asset }
+
     /** JSON API calls (search / spine / files-list / metadata). */
     suspend fun getJson(url: String): String {
-        val response = authorizedGet(url, ACCEPT_JSON)
+        val response = authorizedGet(url, ACCEPT_JSON, RequestType.Json)
         if (!response.status.isSuccess()) throw OReillyHttpException(response.status.value, url)
         return response.bodyAsText()
     }
@@ -44,27 +46,54 @@ internal class OReillyApi(
      * Accept yields the ~2KB DRM *sample* even with `?download=false`.
      */
     suspend fun getContent(url: String): String {
-        val response = authorizedGet(url, ACCEPT_HTML)
+        val response = authorizedGet(url, ACCEPT_HTML, RequestType.Content)
         if (!response.status.isSuccess()) throw OReillyHttpException(response.status.value, url)
         return response.bodyAsText()
     }
 
     /** Binary asset bytes (images / css / fonts). */
     suspend fun getBytes(url: String): ByteArray {
-        val response = authorizedGet(url, ACCEPT_ANY)
+        val response = authorizedGet(url, ACCEPT_ANY, RequestType.Asset)
         if (!response.status.isSuccess()) throw OReillyHttpException(response.status.value, url)
         return response.readBytes()
     }
 
     suspend fun ping(): Boolean = runCatching {
-        authorizedGet("$base/api/v1/user/", ACCEPT_JSON).status.value.let { it in 200..499 }
+        authorizedGet("$base/api/v1/user/", ACCEPT_JSON, RequestType.Json).status.value.let { it in 200..499 }
     }.getOrDefault(false)
 
-    private suspend fun authorizedGet(url: String, accept: String): HttpResponse = client.get(absolute(url)) {
-        header("Cookie", cookieHeader)
-        header("Accept", accept)
-        header("User-Agent", userAgent)
-    }
+    private suspend fun authorizedGet(url: String, accept: String, type: RequestType): HttpResponse =
+        client.get(absolute(url)) {
+            header("Cookie", cookieHeader)
+            header("Accept", accept)
+            header("User-Agent", userAgent)
+            header("Origin", base)
+            header("Referer", "$base/")
+            header("Accept-Language", "en-US,en;q=0.9")
+            val chHint = chromeClientHint(userAgent)
+            if (chHint.isNotEmpty()) {
+                header("sec-ch-ua", chHint)
+                header("sec-ch-ua-mobile", "?1")
+                header("sec-ch-ua-platform", "\"Android\"")
+            }
+            when (type) {
+                RequestType.Json -> {
+                    header("sec-fetch-dest", "empty")
+                    header("sec-fetch-mode", "cors")
+                    header("sec-fetch-site", "same-origin")
+                }
+                RequestType.Content -> {
+                    header("sec-fetch-dest", "document")
+                    header("sec-fetch-mode", "navigate")
+                    header("sec-fetch-site", "same-origin")
+                }
+                RequestType.Asset -> {
+                    header("sec-fetch-dest", "image")
+                    header("sec-fetch-mode", "no-cors")
+                    header("sec-fetch-site", "same-origin")
+                }
+            }
+        }
 
     private fun absolute(url: String): String =
         if (url.startsWith("http://") || url.startsWith("https://")) url else "$base$url"
@@ -138,6 +167,16 @@ internal class OReillyApi(
         private const val ACCEPT_JSON = "application/json"
         private const val ACCEPT_HTML = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
         private const val ACCEPT_ANY = "*/*"
+
+        /**
+         * Builds the `sec-ch-ua` client hint value from a Chrome UA string. Returns empty string when
+         * the UA carries no Chrome version (e.g. test stubs, non-Chrome clients) — callers omit the
+         * header entirely in that case so as not to send a malformed hint.
+         */
+        internal fun chromeClientHint(userAgent: String): String {
+            val version = Regex("""Chrome/(\d+)""").find(userAgent)?.groupValues?.get(1) ?: return ""
+            return """"Chromium";v="$version", "Google Chrome";v="$version", "Not.A/Brand";v="24""""
+        }
 
         /** High-resolution cover URL for [id] (public CDN, no auth). Shared by search + detail. */
         fun coverUrl(id: String, base: String = DEFAULT_BASE_URL): String =

--- a/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalog.kt
+++ b/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalog.kt
@@ -33,6 +33,7 @@ import com.riffle.core.catalog.withCatalogFileStream
 import com.riffle.core.common.Clock
 import com.riffle.core.common.platformSystemClock
 import com.riffle.core.models.SourceType
+import com.riffle.core.catalog.LazyAssetFile
 import com.riffle.core.catalog.oreilly.epub.EpubZipEntry
 import com.riffle.core.catalog.oreilly.epub.EpubZipWriter
 import io.ktor.client.HttpClient
@@ -192,6 +193,10 @@ class OReillyCatalog internal constructor(
             )
         }
 
+        val chapterPaths = distinctSpine.map { it.first }.toSet()
+        val assetFiles = filterAssetFiles(files, chapterPaths)
+            .map { LazyAssetFile(it.fullPath, it.mediaType) }
+
         return LazyPublicationShape(
             bookId = itemId,
             identifier = "urn:orm:book:${detail.identifier.ifBlank { itemId }}",
@@ -201,6 +206,7 @@ class OReillyCatalog internal constructor(
             absoluteFilesPrefix = absPrefix,
             pathFilesPrefix = pathPrefix,
             cssFullPaths = cssFullPaths,
+            assetFiles = assetFiles,
         )
     }
 
@@ -250,13 +256,7 @@ class OReillyCatalog internal constructor(
         val pathPrefix = api.filesPrefix(itemId)
         val cssFullPaths = files.filter { it.kind == "stylesheet" }.map { it.fullPath }
         val chapterPaths = spine.map { it.first }.toSet()
-        val reservedPaths = setOf("content.opf", "nav.xhtml")
-        val assetFiles = files.filter { f ->
-            f.kind != "chapter" && f.fullPath.isNotBlank() &&
-                f.fullPath !in chapterPaths && f.fullPath !in reservedPaths &&
-                f.mediaType != "application/oebps-package+xml" &&
-                f.mediaType != "application/x-dtbncx+xml"
-        }.distinctBy { it.fullPath }
+        val assetFiles = filterAssetFiles(files, chapterPaths)
         val distinctSpine = spine.distinctBy { it.first }
 
         // Estimate total ZIP size from declared file sizes so the consumer can report progress.
@@ -415,18 +415,9 @@ class OReillyCatalog internal constructor(
         val pathPrefix = api.filesPrefix(itemId)                             // path-only prefix
         val cssFullPaths = files.filter { it.kind == "stylesheet" }.map { it.fullPath }
 
-        // Assets to package: every non-chapter file at its own full_path. Exclude the book's ORIGINAL
-        // package document / navigation / ncx — EpubAssembler generates its own `content.opf` and
-        // `nav.xhtml`, so re-packaging the originals produces duplicate zip entries (Readium: "invalid
-        // CEN header (duplicate entry)"). Also skip anything colliding with a chapter path, and dedupe.
+        // Assets to package: every non-chapter file at its own full_path.
         val chapterPaths = spine.map { it.first }.toSet()
-        val reservedPaths = setOf("content.opf", "nav.xhtml")
-        val assetFiles = files.filter { f ->
-            f.kind != "chapter" && f.fullPath.isNotBlank() &&
-                f.fullPath !in chapterPaths && f.fullPath !in reservedPaths &&
-                f.mediaType != "application/oebps-package+xml" &&
-                f.mediaType != "application/x-dtbncx+xml"
-        }.distinctBy { it.fullPath }
+        val assetFiles = filterAssetFiles(files, chapterPaths)
 
         // Dedupe repeated spine paths (a duplicate zip entry would fail Readium's parser).
         val distinctSpine = spine.distinctBy { it.first }
@@ -504,6 +495,24 @@ class OReillyCatalog internal constructor(
             offset += page.results.size
         }
         return all
+    }
+
+    /**
+     * Returns the packaged non-chapter assets from [files], excluding synthetic entries that
+     * [EpubAssembler] generates itself (content.opf, nav.xhtml) and OPF/NCX originals that would
+     * create duplicate ZIP entries if re-packaged.
+     */
+    internal fun filterAssetFiles(
+        files: List<OReillyFileMeta>,
+        chapterPaths: Set<String>,
+    ): List<OReillyFileMeta> {
+        val reservedPaths = setOf("content.opf", "nav.xhtml")
+        return files.filter { f ->
+            f.kind != "chapter" && f.fullPath.isNotBlank() &&
+                f.fullPath !in chapterPaths && f.fullPath !in reservedPaths &&
+                f.mediaType != "application/oebps-package+xml" &&
+                f.mediaType != "application/x-dtbncx+xml"
+        }.distinctBy { it.fullPath }
     }
 
     /**

--- a/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalog.kt
+++ b/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalog.kt
@@ -489,6 +489,7 @@ class OReillyCatalog internal constructor(
         // (getAudiobookChapters is toc-derived). A partial audiobook is worse than a clear failure.
         var offset = 0.0
         val tracks = mutableListOf<CatalogAudioTrack>()
+        val downloadUrls = mutableListOf<String>()
         val chapters = mutableListOf<CatalogAudiobookChapter>()
         toc.forEachIndexed { index, entry ->
             val entryId = entryIdByRef[entry.referenceId].orEmpty()
@@ -502,6 +503,9 @@ class OReillyCatalog internal constructor(
                 contentUrl = OReillyApi.kalturaHlsUrl(partnerId, entryId, ks),
                 mimeType = OReillyApi.HLS_MIME,
             )
+            // HLS manifests cannot be byte-downloaded; the format/url redirect returns a signed MP4
+            // that AudiobookTrackDownloader can stream to disk (verified live 2026-09).
+            downloadUrls += OReillyApi.kalturaDownloadUrl(partnerId, entryId, ks)
             chapters += CatalogAudiobookChapter(
                 index = index,
                 startSec = offset,
@@ -510,11 +514,13 @@ class OReillyCatalog internal constructor(
             )
             offset += duration
         }
-        return if (tracks.isEmpty()) null else AudiobookAssembly(tracks, chapters, totalDurationSec = offset)
+        return if (tracks.isEmpty()) null
+        else AudiobookAssembly(tracks, downloadUrls, chapters, totalDurationSec = offset)
     }
 
     private class AudiobookAssembly(
         val tracks: List<CatalogAudioTrack>,
+        val downloadTrackUrls: List<String>,
         val chapters: List<CatalogAudiobookChapter>,
         val totalDurationSec: Double,
     )
@@ -553,6 +559,7 @@ class OReillyCatalog internal constructor(
         val assembly = loadAudiobookTracks(itemId) ?: return null
         return CatalogAudiobookStream(
             trackUrls = assembly.tracks.map { it.contentUrl },
+            downloadTrackUrls = assembly.downloadTrackUrls,
             tracks = assembly.tracks,
             chapters = assembly.chapters,
             totalDurationSec = assembly.totalDurationSec,

--- a/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalog.kt
+++ b/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalog.kt
@@ -68,6 +68,11 @@ class OReillyCatalog internal constructor(
      * aggressive synthesis looks to O'Reilly's bulk-abuse guard, independently of [maxConcurrency].
      */
     private val minRequestIntervalMs: Long = 120L,
+    /**
+     * Maximum spacing between request *starts*. Randomizing in [[minRequestIntervalMs],
+     * [maxRequestIntervalMs]] adds jitter so bulk synthesis doesn't sustain a flat machine-clock rate.
+     */
+    private val maxRequestIntervalMs: Long = 400L,
     /** Backoff retries when a chapter comes back 403 or truncated (a throttled DRM sample). */
     private val maxContentRetries: Int = 4,
     /** Base for exponential backoff between retries (1s, 2s, 4s, …). */
@@ -288,7 +293,7 @@ class OReillyCatalog internal constructor(
         // us under O'Reilly's bulk-abuse guard. Progress spans both phases so the reader's
         // "Preparing book… N/M" advances throughout.
         val total = assetFiles.size + distinctSpine.size
-        val pacer = RequestPacer(maxConcurrency, minRequestIntervalMs) { clock.nowMs() }
+        val pacer = RequestPacer(maxConcurrency, minRequestIntervalMs, maxRequestIntervalMs) { clock.nowMs() }
         val progressMutex = Mutex()
         var done = 0
         onProgress(0, total)
@@ -405,14 +410,15 @@ class OReillyCatalog internal constructor(
     }
 
     /**
-     * Bounds concurrent requests to [maxConcurrency] and spaces request *starts* by [minIntervalMs]
-     * (a global rate cap). Concurrency hides per-request latency; the rate cap bounds abuse-guard
-     * exposure — the two are independent. A retry's backoff happens outside [execute], so it never
-     * holds a permit while merely waiting.
+     * Bounds concurrent requests to [maxConcurrency] and spaces request *starts* by a jittered
+     * interval in [[minIntervalMs], [maxIntervalMs]] (a global rate cap). Concurrency hides
+     * per-request latency; the rate cap bounds abuse-guard exposure — the two are independent.
+     * A retry's backoff happens outside [execute], so it never holds a permit while merely waiting.
      */
     internal class RequestPacer(
         maxConcurrency: Int,
         private val minIntervalMs: Long,
+        private val maxIntervalMs: Long = minIntervalMs,
         private val nowMs: () -> Long,
     ) {
         private val permits = Semaphore(maxConcurrency)
@@ -423,11 +429,18 @@ class OReillyCatalog internal constructor(
             val waitMs = gate.withLock {
                 val now = nowMs()
                 val start = maxOf(now, nextAllowedMs)
-                nextAllowedMs = start + minIntervalMs
+                nextAllowedMs = start + randomInterval(minIntervalMs, maxIntervalMs)
                 start - now
             }
             if (waitMs > 0) delay(waitMs)
             block()
+        }
+
+        companion object {
+            internal fun randomInterval(minMs: Long, maxMs: Long): Long {
+                if (minMs >= maxMs) return minMs
+                return minMs + kotlin.random.Random.nextLong(maxMs - minMs + 1)
+            }
         }
     }
 

--- a/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalog.kt
+++ b/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalog.kt
@@ -40,6 +40,7 @@ import io.ktor.client.HttpClient
 import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.writeFully
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -97,6 +98,15 @@ class OReillyCatalog internal constructor(
 
     override val sourceType: SourceType = SourceType.OREILLY
 
+    // Shared pacer for the lazy-reading path (fetchChapterForLazy / fetchAssetForLazy).
+    // One pacer instance shared across all calls so concurrent lazy fetches are rate-limited
+    // by the same interval guard as the batch synthesis path.
+    private val lazyPacer = RequestPacer(
+        maxConcurrency = 1,
+        minIntervalMs = minRequestIntervalMs,
+        maxIntervalMs = maxRequestIntervalMs,
+    ) { clock.nowMs() }
+
     override suspend fun listRoots(): List<CatalogRoot> = listOf(
         CatalogRoot(id = OReillyRoots.BOOKS, name = "Books", mediaType = "book"),
         CatalogRoot(id = OReillyRoots.AUDIOBOOKS, name = "Audiobooks", mediaType = "audiobook"),
@@ -142,7 +152,7 @@ class OReillyCatalog internal constructor(
      * yield, WITHOUT downloading any chapter content. Keeps the detail screen instant for O'Reilly.
      */
     override suspend fun ebookDetails(itemId: String): CatalogEbookDetails? {
-        val spine = OReillyParser.parseSpine(api.getJson(api.spineUrl(itemId)))
+        val spine = fetchAllSpine(itemId)
             .results.mapNotNull { s -> s.fullPath?.let { p -> p to (s.title ?: "") } }
         if (spine.isEmpty()) return null
         val sizeByPath = fetchAllFiles(itemId).associate { it.fullPath to it.fileSize }
@@ -169,7 +179,7 @@ class OReillyCatalog internal constructor(
             OReillyParser.parseBookDetail(api.getJson(api.bookDetailUrl(itemId)))
         }.getOrNull() ?: return null
 
-        val spineItems = OReillyParser.parseSpine(api.getJson(api.spineUrl(itemId)))
+        val spineItems = fetchAllSpine(itemId)
             .results.mapNotNull { s -> s.fullPath?.let { path -> path to (s.title ?: "") } }
         if (spineItems.isEmpty()) return null
 
@@ -215,20 +225,14 @@ class OReillyCatalog internal constructor(
      * as [withFileStream] but with a single-request pacer (each lazy chapter fetch is independent).
      * Returns null after exhausting retries so the caller can surface a per-chapter error.
      */
-    override suspend fun fetchChapterForLazy(itemId: String, fullPath: String, expectedByteSize: Long): String? {
-        val pacer = RequestPacer(maxConcurrency = 1, minIntervalMs = 0L) { clock.nowMs() }
-        return runCatching {
-            fetchChapterContent(itemId, fullPath, expectedByteSize, pacer)
-        }.getOrNull()
-    }
+    override suspend fun fetchChapterForLazy(itemId: String, fullPath: String, expectedByteSize: Long): String? =
+        runCatching { fetchChapterContent(itemId, fullPath, expectedByteSize, lazyPacer) }.getOrNull()
 
     /**
      * Fetch one binary asset for the lazy-reading path (non-fatal — returns null on failure).
      */
-    override suspend fun fetchAssetForLazy(itemId: String, fullPath: String): ByteArray? {
-        val pacer = RequestPacer(maxConcurrency = 1, minIntervalMs = 0L) { clock.nowMs() }
-        return fetchAssetBytes(itemId, fullPath, pacer)
-    }
+    override suspend fun fetchAssetForLazy(itemId: String, fullPath: String): ByteArray? =
+        fetchAssetBytes(itemId, fullPath, lazyPacer)
 
     // ---- Ebook: scrape + synthesize (verified against the live v2 epubs API) -----------------
 
@@ -247,7 +251,7 @@ class OReillyCatalog internal constructor(
 
         // Phase 1 (fast): fetch metadata from the API — JSON calls only, no content yet.
         val detail = OReillyParser.parseBookDetail(api.getJson(api.bookDetailUrl(itemId)))
-        val spine = OReillyParser.parseSpine(api.getJson(api.spineUrl(itemId)))
+        val spine = fetchAllSpine(itemId)
             .results.mapNotNull { it.fullPath?.let { p -> p to (it.title ?: "") } }
         val files = fetchAllFiles(itemId)
         val sizeByPath = files.associate { it.fullPath to it.fileSize }
@@ -287,10 +291,12 @@ class OReillyCatalog internal constructor(
                     val writer = EpubZipWriter.streamWriter()
                     val writeMutex = Mutex()
 
-                    // Serialize writes so concurrent chapter/asset jobs don't interleave bytes.
+                    // Serialize both the central-directory record AND the pipe write under one lock
+                    // so concurrent chapter/asset jobs can't interleave their bytes in the channel.
                     suspend fun writeEntry(entry: EpubZipEntry) {
-                        val bytes = writeMutex.withLock { writer.writeEntry(entry) }
-                        pipe.writeFully(bytes)
+                        writeMutex.withLock {
+                            pipe.writeFully(writer.writeEntry(entry))
+                        }
                     }
 
                     // (a) Preamble entries: no network needed, write immediately so the consumer
@@ -368,9 +374,11 @@ class OReillyCatalog internal constructor(
                     writeEntry(EpubZipEntry("OEBPS/nav.xhtml", EpubAssembler.navXhtml(book).encodeToByteArray()))
 
                     // (d) Central directory + EOCD.
-                    val trailer = writeMutex.withLock { writer.close() }
-                    pipe.writeFully(trailer)
+                    writeMutex.withLock { pipe.writeFully(writer.close()) }
                     pipe.close()
+                } catch (e: CancellationException) {
+                    pipe.cancel(e)
+                    throw e
                 } catch (e: Exception) {
                     pipe.cancel(e)
                 } finally {
@@ -406,7 +414,7 @@ class OReillyCatalog internal constructor(
      */
     internal suspend fun synthesizeEpub(itemId: String): ByteArray {
         val detail = OReillyParser.parseBookDetail(api.getJson(api.bookDetailUrl(itemId)))
-        val spine = OReillyParser.parseSpine(api.getJson(api.spineUrl(itemId)))
+        val spine = fetchAllSpine(itemId)
             .results.mapNotNull { it.fullPath?.let { p -> p to (it.title ?: "") } }
         val files = fetchAllFiles(itemId)
         val sizeByPath = files.associate { it.fullPath to it.fileSize }
@@ -484,6 +492,17 @@ class OReillyCatalog internal constructor(
     }
 
     /** Fetch every packaged file, following the API's pagination `next` cursor. */
+    private suspend fun fetchAllSpine(itemId: String): OReillySpineResponse {
+        val all = ArrayList<OReillySpineItem>()
+        var url: String? = api.spineUrl(itemId)
+        while (url != null) {
+            val page = OReillyParser.parseSpine(api.getJson(url))
+            all += page.results
+            url = if (page.next.isNullOrBlank() || page.results.isEmpty()) null else page.next
+        }
+        return OReillySpineResponse(count = all.size, next = null, results = all)
+    }
+
     private suspend fun fetchAllFiles(itemId: String): List<OReillyFileMeta> {
         val all = ArrayList<OReillyFileMeta>()
         var offset = 0
@@ -618,8 +637,11 @@ class OReillyCatalog internal constructor(
             .filter { it.referenceId.isNotBlank() }
         if (toc.isEmpty()) return null
 
-        val partnerId = OReillyParser.parseKalturaConfig(api.getJson(api.kalturaConfigUrl())).partnerId
-        val ks = OReillyParser.parseKalturaSession(api.getJson(api.kalturaSessionUrl())).session
+        val (partnerId, ks) = coroutineScope {
+            val partnerIdD = async { OReillyParser.parseKalturaConfig(api.getJson(api.kalturaConfigUrl())).partnerId }
+            val ksD = async { OReillyParser.parseKalturaSession(api.getJson(api.kalturaSessionUrl())).session }
+            partnerIdD.await() to ksD.await()
+        }
         if (partnerId.isBlank() || ks.isBlank()) return null
 
         val gate = Semaphore(maxConcurrency)
@@ -777,8 +799,24 @@ class OReillyCatalog internal constructor(
          * MUST measure UTF-8 bytes — `String.length` counts UTF-16 code units, which undercounts
          * multibyte (e.g. CJK) chapters and would falsely flag a full chapter as a DRM sample.
          */
-        internal fun isTruncatedBody(body: String, expectedSize: Long): Boolean =
-            isTruncatedSample(body.encodeToByteArray().size.toLong(), expectedSize)
+        internal fun isTruncatedBody(body: String, expectedSize: Long): Boolean {
+            // Count UTF-8 bytes without materialising a full byte-array copy: each BMP code point
+            // outside ASCII contributes 2 (U+0080..U+07FF) or 3 (U+0800..U+FFFF) bytes; a
+            // surrogate pair (two Char values) encodes a supplementary code point as 4 bytes.
+            var byteLen = 0L
+            var i = 0
+            while (i < body.length) {
+                val c = body[i].code
+                byteLen += when {
+                    c < 0x80 -> 1
+                    c < 0x800 -> 2
+                    c in 0xD800..0xDBFF -> { i++; 4 } // high surrogate — low follows
+                    else -> 3
+                }
+                i++
+            }
+            return isTruncatedSample(byteLen, expectedSize)
+        }
     }
 }
 

--- a/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalog.kt
+++ b/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalog.kt
@@ -33,12 +33,17 @@ import com.riffle.core.catalog.withCatalogFileStream
 import com.riffle.core.common.Clock
 import com.riffle.core.common.platformSystemClock
 import com.riffle.core.models.SourceType
+import com.riffle.core.catalog.oreilly.epub.EpubZipEntry
+import com.riffle.core.catalog.oreilly.epub.EpubZipWriter
 import io.ktor.client.HttpClient
+import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.writeFully
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
@@ -201,7 +206,7 @@ class OReillyCatalog internal constructor(
 
     /**
      * Fetch one chapter's HTML for the lazy-reading path. Uses the same backoff/truncation logic
-     * as [synthesizeEpub] but with a single-request pacer (each lazy chapter fetch is independent).
+     * as [withFileStream] but with a single-request pacer (each lazy chapter fetch is independent).
      * Returns null after exhausting retries so the caller can surface a per-chapter error.
      */
     override suspend fun fetchChapterForLazy(itemId: String, fullPath: String, expectedByteSize: Long): String? {
@@ -233,12 +238,150 @@ class OReillyCatalog internal constructor(
         if (format != BookFormat.Epub) {
             throw OReillyException("Only EPUB synthesis is supported for O'Reilly ebooks; got $format")
         }
-        val bytes = synthesizeEpub(itemId)
+
+        // Phase 1 (fast): fetch metadata from the API — JSON calls only, no content yet.
+        val detail = OReillyParser.parseBookDetail(api.getJson(api.bookDetailUrl(itemId)))
+        val spine = OReillyParser.parseSpine(api.getJson(api.spineUrl(itemId)))
+            .results.mapNotNull { it.fullPath?.let { p -> p to (it.title ?: "") } }
+        val files = fetchAllFiles(itemId)
+        val sizeByPath = files.associate { it.fullPath to it.fileSize }
+
+        val absPrefix = api.baseUrl().trimEnd('/') + api.filesPrefix(itemId)
+        val pathPrefix = api.filesPrefix(itemId)
+        val cssFullPaths = files.filter { it.kind == "stylesheet" }.map { it.fullPath }
+        val chapterPaths = spine.map { it.first }.toSet()
+        val reservedPaths = setOf("content.opf", "nav.xhtml")
+        val assetFiles = files.filter { f ->
+            f.kind != "chapter" && f.fullPath.isNotBlank() &&
+                f.fullPath !in chapterPaths && f.fullPath !in reservedPaths &&
+                f.mediaType != "application/oebps-package+xml" &&
+                f.mediaType != "application/x-dtbncx+xml"
+        }.distinctBy { it.fullPath }
+        val distinctSpine = spine.distinctBy { it.first }
+
+        // Estimate total ZIP size from declared file sizes so the consumer can report progress.
+        // Each ZIP entry costs: 30 (local header) + nameBytes + data. Central dir: 46 + nameBytes.
+        // We over-count slightly (chapter XHTML adds wrapper markup beyond the raw HTML), but
+        // that's fine — the consumer's progress fraction stays < 1.0 until the final close bytes.
+        val entriesCount = 2 /* preamble */ + distinctSpine.size + assetFiles.size + 2 /* opf+nav */
+        val estimatedContentBytes = 2 /* preamble: mimetype+container */ * 30L +
+            "mimetype".length + "application/epub+zip".length +
+            "META-INF/container.xml".length + 300L /* container.xml content */ +
+            distinctSpine.sumOf { (p, _) -> 30L + "OEBPS/$p".length + (sizeByPath[p] ?: 1024L) } +
+            assetFiles.sumOf { f -> 30L + "OEBPS/${f.fullPath}".length + (f.fileSize) } +
+            2L * (30L + 200L) /* content.opf + nav.xhtml rough estimate */ +
+            entriesCount * 46L /* central dir records */ + 22L /* EOCD */
+
+        // Phase 2: stream bytes through a ByteChannel pipe.
+        // Producer writes zip entries as each chapter/asset is fetched. Consumer (block) reads
+        // immediately — download progress advances throughout synthesis, not just at the end.
+        val pipe = ByteChannel(autoFlush = true)
         val stream = object : CatalogFileStream {
-            override val contentLength: Long = bytes.size.toLong()
-            override val channel: ByteReadChannel = ByteReadChannel(bytes)
+            override val contentLength: Long = estimatedContentBytes
+            override val channel: ByteReadChannel = pipe
         }
-        return block(stream)
+
+        return coroutineScope {
+            val producer = launch {
+                try {
+                    val writer = EpubZipWriter.streamWriter()
+                    val writeMutex = Mutex()
+
+                    // Serialize writes so concurrent chapter/asset jobs don't interleave bytes.
+                    suspend fun writeEntry(entry: EpubZipEntry) {
+                        val bytes = writeMutex.withLock { writer.writeEntry(entry) }
+                        pipe.writeFully(bytes)
+                    }
+
+                    // (a) Preamble entries: no network needed, write immediately so the consumer
+                    //     can start storing bytes while chapters are being fetched.
+                    writeEntry(EpubZipEntry("mimetype", "application/epub+zip".encodeToByteArray()))
+                    writeEntry(EpubZipEntry("META-INF/container.xml", EpubAssembler.containerXml().encodeToByteArray()))
+
+                    // (b) Fetch chapters + assets concurrently (same bounded pool as before).
+                    val total = distinctSpine.size + assetFiles.size
+                    val pacer = RequestPacer(maxConcurrency, minRequestIntervalMs, maxRequestIntervalMs) { clock.nowMs() }
+                    val progressMutex = Mutex()
+                    var done = 0
+                    onProgress(0, total)
+                    suspend fun tick() {
+                        val d = progressMutex.withLock { done += 1; done }
+                        onProgress(d, total)
+                    }
+
+                    val collectedChapters = ArrayList<EpubChapter>(distinctSpine.size)
+                    val collectedResources = ArrayList<EpubResource>(assetFiles.size)
+                    val chapterMutex = Mutex()
+
+                    val assetJobs = assetFiles.map { f ->
+                        async {
+                            val bytes = fetchAssetBytes(itemId, f.fullPath, pacer)
+                            tick()
+                            if (bytes != null) {
+                                val res = EpubResource(f.fullPath, bytes, f.mediaType)
+                                chapterMutex.withLock { collectedResources += res }
+                                writeEntry(EpubZipEntry("OEBPS/${f.fullPath}", bytes))
+                            }
+                        }
+                    }
+                    val chapterJobs = distinctSpine.mapIndexed { index, (fullPath, title) ->
+                        async {
+                            val raw = fetchChapterContent(itemId, fullPath, sizeByPath[fullPath] ?: 0L, pacer)
+                            tick()
+                            val t = title.ifBlank { "Chapter ${index + 1}" }
+                            val relPrefix = OReillyEpub.relPrefixFor(fullPath)
+                            val rewritten = raw.replace(absPrefix, relPrefix).replace(pathPrefix, relPrefix)
+                            val cssHrefs = cssFullPaths.map { OReillyEpub.relativeTo(fullPath, it) }
+                            val ch = EpubChapter(
+                                id = OReillyEpub.chapterId(index),
+                                relativePath = fullPath,
+                                title = t,
+                                xhtml = OReillyEpub.wrapChapter(t, rewritten, cssHrefs),
+                            )
+                            chapterMutex.withLock { collectedChapters += ch }
+                            writeEntry(EpubZipEntry("OEBPS/$fullPath", ch.xhtml.encodeToByteArray()))
+                        }
+                    }
+
+                    assetJobs.awaitAll()
+                    chapterJobs.awaitAll()
+
+                    if (collectedChapters.isEmpty()) throw OReillyException("No chapters resolved for O'Reilly $itemId")
+
+                    // Chapters must be in spine order for a valid OPF manifest spine.
+                    val sortedChapters = distinctSpine.mapNotNull { (p, _) ->
+                        collectedChapters.find { it.relativePath == p }
+                    }
+
+                    // (c) Package document + navigation (depend on knowing all chapters/resources).
+                    val book = SynthesizedBook(
+                        identifier = "urn:orm:book:${detail.identifier.ifBlank { itemId }}",
+                        title = detail.title.ifBlank { itemId },
+                        authors = emptyList(),
+                        language = detail.language ?: "en",
+                        publisher = null,
+                        chapters = sortedChapters,
+                        resources = collectedResources,
+                        coverPath = null,
+                    )
+                    writeEntry(EpubZipEntry("OEBPS/content.opf", EpubAssembler.contentOpf(book).encodeToByteArray()))
+                    writeEntry(EpubZipEntry("OEBPS/nav.xhtml", EpubAssembler.navXhtml(book).encodeToByteArray()))
+
+                    // (d) Central directory + EOCD.
+                    val trailer = writeMutex.withLock { writer.close() }
+                    pipe.writeFully(trailer)
+                    pipe.close()
+                } catch (e: Exception) {
+                    pipe.cancel(e)
+                } finally {
+                    onProgressDone()
+                }
+            }
+
+            val result = block(stream)
+            producer.join()
+            result
+        }
     }
 
     /**

--- a/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalogFactory.kt
+++ b/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalogFactory.kt
@@ -24,6 +24,7 @@ import io.ktor.client.HttpClient
 class OReillyCatalogFactory(
     private val httpClient: HttpClient,
     private val cookieProvider: () -> String?,
+    private val userAgentProvider: () -> String? = { null },
     private val bookPreparationProgress: BookPreparationProgress? = null,
     private val baseUrl: String = OReillyApi.DEFAULT_BASE_URL,
 ) : CatalogFactory {
@@ -32,7 +33,13 @@ class OReillyCatalogFactory(
 
     override suspend fun create(source: Source): Catalog? {
         val cookieHeader = cookieProvider()?.takeIf { it.isNotBlank() } ?: return null
-        val api = OReillyApi(client = httpClient, cookieHeader = cookieHeader, baseUrl = source.url.value.ifBlank { baseUrl })
+        val ua = userAgentProvider()?.takeIf { it.isNotBlank() } ?: OReillyApi.DEFAULT_USER_AGENT
+        val api = OReillyApi(
+            client = httpClient,
+            cookieHeader = cookieHeader,
+            userAgent = ua,
+            baseUrl = source.url.value.ifBlank { baseUrl },
+        )
         return OReillyCatalog(
             api = api,
             bytesClient = httpClient,

--- a/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyEpub.kt
+++ b/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyEpub.kt
@@ -40,8 +40,11 @@ object OReillyEpub {
     // the strict XML parser Readium uses. Self-close them so the fragment is well-formed XHTML.
     private val VOID_ELEMENTS =
         listOf("area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr")
+    // Attribute-aware: match any char that is not >, ", or ', OR a double-quoted value
+    // (which may itself contain >), OR a single-quoted value. This prevents the [^>] stop
+    // from firing inside an attribute like alt="a > b".
     private val voidElementRegex =
-        Regex("<(${VOID_ELEMENTS.joinToString("|")})\\b([^>]*?)/?>", RegexOption.IGNORE_CASE)
+        Regex("<(${VOID_ELEMENTS.joinToString("|")})\\b((?:[^>\"']|\"[^\"]*\"|'[^']*')*?)/?>", RegexOption.IGNORE_CASE)
 
     /** Rewrite `<img …>` / `<br>` etc. to `<img …/>` / `<br/>` so the XHTML parses as XML. */
     internal fun selfCloseVoidElements(html: String): String =

--- a/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/epub/EpubAssembler.kt
+++ b/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/epub/EpubAssembler.kt
@@ -72,7 +72,7 @@ object EpubAssembler {
         return EpubZipWriter.write(entries)
     }
 
-    private fun containerXml(): String = """
+    internal fun containerXml(): String = """
         <?xml version="1.0" encoding="UTF-8"?>
         <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
           <rootfiles>
@@ -81,7 +81,7 @@ object EpubAssembler {
         </container>
     """.trimIndent().trim()
 
-    private fun contentOpf(book: SynthesizedBook): String {
+    internal fun contentOpf(book: SynthesizedBook): String {
         val creators = book.authors.mapIndexed { i, a ->
             """<dc:creator id="creator$i">${a.xmlEscape()}</dc:creator>"""
         }.joinToString("\n    ")
@@ -123,7 +123,7 @@ object EpubAssembler {
         """.trimIndent().trim()
     }
 
-    private fun navXhtml(book: SynthesizedBook): String {
+    internal fun navXhtml(book: SynthesizedBook): String {
         val items = book.chapters.joinToString("\n        ") {
             """<li><a href="${it.relativePath.xmlEscape()}">${it.title.xmlEscape()}</a></li>"""
         }

--- a/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/epub/EpubZipWriter.kt
+++ b/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/epub/EpubZipWriter.kt
@@ -32,6 +32,15 @@ object EpubZipWriter {
     private const val DOS_TIME = 0
     private const val DOS_DATE = 0x0021 // (year 0 << 9) | (month 1 << 5) | (day 1)
 
+    /**
+     * Streaming variant: returns a [EpubZipStreamWriter] that lets the caller emit one entry at a
+     * time and retrieve the local-file-header + data bytes immediately. Call [EpubZipStreamWriter.close]
+     * at the end to get the central-directory + end-of-central-dir bytes. Use this when entries
+     * arrive incrementally (e.g. concurrent chapter fetches) so bytes can flow to a consumer as
+     * each chapter completes rather than buffering the entire EPUB in memory first.
+     */
+    fun streamWriter(): EpubZipStreamWriter = EpubZipStreamWriter()
+
     fun write(entries: List<EpubZipEntry>): ByteArray {
         val out = GrowableBytes()
         val central = GrowableBytes()
@@ -111,6 +120,92 @@ object EpubZipWriter {
             crc = crcTable[(crc xor b.toInt()) and 0xFF] xor (crc ushr 8)
         }
         return crc.inv()
+    }
+}
+
+/**
+ * Stateful streaming ZIP writer. Call [writeEntry] for each [EpubZipEntry] as it becomes
+ * available — returns the local-file-header + data bytes ready to pipe to a consumer. Call
+ * [close] when all entries are written — returns the central-directory + end-of-central-dir bytes.
+ *
+ * NOT thread-safe; the caller must serialize [writeEntry] / [close] calls (e.g. via a mutex or
+ * by running them in a single coroutine).
+ */
+class EpubZipStreamWriter internal constructor() {
+    private val central = GrowableBytes()
+    private var currentOffset = 0
+    private var entryCount = 0
+
+    /** Write one entry; returns the bytes (local header + data) to send to the consumer. */
+    fun writeEntry(entry: EpubZipEntry): ByteArray {
+        val nameBytes = entry.path.encodeToByteArray()
+        val crc = EpubZipWriter.crc32(entry.bytes)
+        val size = entry.bytes.size
+        val localHeaderOffset = currentOffset
+
+        val out = GrowableBytes(30 + nameBytes.size + size)
+        out.putIntLE(LOCAL_FILE_HEADER_SIG)
+        out.putShortLE(VERSION_NEEDED)
+        out.putShortLE(0)
+        out.putShortLE(METHOD_STORED)
+        out.putShortLE(DOS_TIME)
+        out.putShortLE(DOS_DATE)
+        out.putIntLE(crc)
+        out.putIntLE(size)
+        out.putIntLE(size)
+        out.putShortLE(nameBytes.size)
+        out.putShortLE(0)
+        out.putBytes(nameBytes)
+        out.putBytes(entry.bytes)
+
+        central.putIntLE(CENTRAL_DIR_SIG)
+        central.putShortLE(VERSION_NEEDED)
+        central.putShortLE(VERSION_NEEDED)
+        central.putShortLE(0)
+        central.putShortLE(METHOD_STORED)
+        central.putShortLE(DOS_TIME)
+        central.putShortLE(DOS_DATE)
+        central.putIntLE(crc)
+        central.putIntLE(size)
+        central.putIntLE(size)
+        central.putShortLE(nameBytes.size)
+        central.putShortLE(0)
+        central.putShortLE(0)
+        central.putShortLE(0)
+        central.putShortLE(0)
+        central.putIntLE(0)
+        central.putIntLE(localHeaderOffset)
+        central.putBytes(nameBytes)
+
+        currentOffset += out.size
+        entryCount++
+        return out.toByteArray()
+    }
+
+    /** Returns the central directory + end-of-central-dir bytes. Call once after all entries. */
+    fun close(): ByteArray {
+        val centralBytes = central.toByteArray()
+        val out = GrowableBytes(centralBytes.size + 22)
+        out.putBytes(centralBytes)
+        out.putIntLE(END_OF_CENTRAL_DIR_SIG)
+        out.putShortLE(0)
+        out.putShortLE(0)
+        out.putShortLE(entryCount)
+        out.putShortLE(entryCount)
+        out.putIntLE(centralBytes.size)
+        out.putIntLE(currentOffset)
+        out.putShortLE(0)
+        return out.toByteArray()
+    }
+
+    private companion object {
+        private const val LOCAL_FILE_HEADER_SIG = 0x04034b50
+        private const val CENTRAL_DIR_SIG = 0x02014b50
+        private const val END_OF_CENTRAL_DIR_SIG = 0x06054b50
+        private const val VERSION_NEEDED = 20
+        private const val METHOD_STORED = 0
+        private const val DOS_TIME = 0
+        private const val DOS_DATE = 0x0021
     }
 }
 

--- a/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/OReillyApiHeaderTest.kt
+++ b/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/OReillyApiHeaderTest.kt
@@ -36,4 +36,52 @@ class OReillyApiHeaderTest {
         runBlocking { api.getJson(api.browseUrl("books", 1, 5)) }
         assertEquals(OReillyApi.DEFAULT_USER_AGENT, capturedUa)
     }
+
+    @Test
+    fun `JSON requests carry Origin, Accept-Language, and sec-fetch headers`() {
+        val captured = mutableMapOf<String, String>()
+        val client = makeClient { req -> req.headers.forEach { key, vals -> captured[key] = vals.first() } }
+        val api = OReillyApi(client = client, cookieHeader = "orm-jwt=x")
+        runBlocking { api.getJson(api.browseUrl("books", 1, 5)) }
+        assertEquals("https://learning.oreilly.com", captured["Origin"])
+        assertEquals("en-US,en;q=0.9", captured["Accept-Language"])
+        assertEquals("empty", captured["sec-fetch-dest"])
+        assertEquals("cors", captured["sec-fetch-mode"])
+        assertEquals("same-origin", captured["sec-fetch-site"])
+    }
+
+    @Test
+    fun `content requests carry navigate sec-fetch headers`() {
+        val captured = mutableMapOf<String, String>()
+        val client = makeClient { req -> req.headers.forEach { key, vals -> captured[key] = vals.first() } }
+        val api = OReillyApi(client = client, cookieHeader = "orm-jwt=x")
+        runBlocking { api.getContent(api.fileContentUrl("123456789", "xhtml/ch01.html")) }
+        assertEquals("document", captured["sec-fetch-dest"])
+        assertEquals("navigate", captured["sec-fetch-mode"])
+        assertEquals("same-origin", captured["sec-fetch-site"])
+    }
+
+    @Test
+    fun `binary asset requests carry no-cors sec-fetch headers`() {
+        val captured = mutableMapOf<String, String>()
+        val client = makeClient { req -> req.headers.forEach { key, vals -> captured[key] = vals.first() } }
+        val api = OReillyApi(client = client, cookieHeader = "orm-jwt=x")
+        runBlocking { api.getBytes(api.fileContentUrl("123456789", "images/cover.jpg")) }
+        assertEquals("image", captured["sec-fetch-dest"])
+        assertEquals("no-cors", captured["sec-fetch-mode"])
+        assertEquals("same-origin", captured["sec-fetch-site"])
+    }
+
+    @Test
+    fun `sec-ch-ua is derived from Chrome version in UA string`() {
+        val ua = "Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 Chrome/128.0 Mobile Safari/537.36"
+        val hint = OReillyApi.chromeClientHint(ua)
+        assertEquals(""""Chromium";v="128", "Google Chrome";v="128", "Not.A/Brand";v="24"""", hint)
+    }
+
+    @Test
+    fun `sec-ch-ua is empty when UA has no Chrome version`() {
+        val hint = OReillyApi.chromeClientHint("Mozilla/5.0 (compatible; bot)")
+        assertEquals("", hint)
+    }
 }

--- a/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/OReillyApiHeaderTest.kt
+++ b/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/OReillyApiHeaderTest.kt
@@ -1,0 +1,39 @@
+package com.riffle.core.catalog.oreilly
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OReillyApiHeaderTest {
+
+    private fun makeClient(onRequest: (io.ktor.client.request.HttpRequestData) -> Unit): HttpClient {
+        return HttpClient(MockEngine { request ->
+            onRequest(request)
+            respond("ok", HttpStatusCode.OK, headersOf())
+        })
+    }
+
+    @Test
+    fun `custom UA overrides the hardcoded default`() {
+        val customUa = "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/128.0 Mobile Safari/537.36"
+        var capturedUa: String? = null
+        val client = makeClient { capturedUa = it.headers["User-Agent"] }
+        val api = OReillyApi(client = client, cookieHeader = "orm-jwt=x", userAgent = customUa)
+        runBlocking { api.getJson(api.browseUrl("books", 1, 5)) }
+        assertEquals(customUa, capturedUa)
+    }
+
+    @Test
+    fun `default UA is used when no custom UA provided`() {
+        var capturedUa: String? = null
+        val client = makeClient { capturedUa = it.headers["User-Agent"] }
+        val api = OReillyApi(client = client, cookieHeader = "orm-jwt=x")
+        runBlocking { api.getJson(api.browseUrl("books", 1, 5)) }
+        assertEquals(OReillyApi.DEFAULT_USER_AGENT, capturedUa)
+    }
+}

--- a/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/OReillyAudiobookTest.kt
+++ b/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/OReillyAudiobookTest.kt
@@ -109,6 +109,23 @@ class OReillyAudiobookTest {
     }
 
     @Test
+    fun `openAudiobook populates downloadTrackUrls with format-url MP4 paths`() = runBlocking {
+        val stream = catalog.openAudiobook(itemId, deviceLabel = "test")!!
+
+        val dlUrls = stream.downloadTrackUrls
+        assertEquals(2, dlUrls?.size)
+        assertEquals(
+            "https://cdnapisec.kaltura.com/p/1926081/sp/192608100/playManifest/entryId/1_aaa" +
+                "/format/url/protocol/https?ks=KS123",
+            dlUrls?.get(0),
+        )
+        assertTrue(dlUrls?.get(1)?.contains("entryId/1_bbb") == true)
+        assertTrue(dlUrls?.get(1)?.contains("format/url") == true)
+        // HLS stream URLs are still present for the player.
+        assertTrue(stream.trackUrls[0].contains("format/applehttp"))
+    }
+
+    @Test
     fun `getAudiobookChapters comes from the toc without a Kaltura session`() = runBlocking {
         val chapters = catalog.getAudiobookChapters(itemId)
         assertEquals(listOf("Introduction", "Chapter 2"), chapters.map { it.title })

--- a/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalogLazyTest.kt
+++ b/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/OReillyCatalogLazyTest.kt
@@ -131,4 +131,38 @@ class OReillyCatalogLazyTest {
         val result = catalog.fetchChapterForLazy(itemId, "xhtml/ch01.xhtml", expectedByteSize = 0L)
         assertNotNull("fetchChapterForLazy should succeed without calling the files endpoint", result)
     }
+
+    @Test
+    fun `lazyPublication follows spine pagination and returns all chapters`() = runBlocking {
+        // Regression: spineUrl hardcoded limit=100 and callers never followed the next cursor.
+        // Serve 2 pages of 2 chapters each; lazyPublication must return 4 spine items.
+        val page1Url = "/api/v2/epubs/$urn/spine/?limit=100"
+        val page2Url = "/api/v2/epubs/$urn/spine/?limit=100&offset=2"
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(req: RecordedRequest): MockResponse {
+                val path = req.path.orEmpty()
+                return when {
+                    path.trimEnd('/') == page1Url.trimEnd('/') || path.contains("/spine/?limit=100") && !path.contains("offset") ->
+                        MockResponse().setResponseCode(200).setBody("""
+                            {"count":4,"next":"${server.url(page2Url)}","results":[
+                              {"reference_id":"$itemId-/xhtml/ch01.xhtml","title":"Chapter 1"},
+                              {"reference_id":"$itemId-/xhtml/ch02.xhtml","title":"Chapter 2"}
+                            ]}""".trimIndent())
+                    path.contains("offset=2") ->
+                        MockResponse().setResponseCode(200).setBody("""
+                            {"count":4,"next":null,"results":[
+                              {"reference_id":"$itemId-/xhtml/ch03.xhtml","title":"Chapter 3"},
+                              {"reference_id":"$itemId-/xhtml/ch04.xhtml","title":"Chapter 4"}
+                            ]}""".trimIndent())
+                    path.contains("/files/") ->
+                        MockResponse().setResponseCode(200).setBody("""{"count":0,"next":null,"results":[]}""")
+                    else ->
+                        MockResponse().setResponseCode(200).setBody("""{"identifier":"$itemId","title":"Big Book","language":"en"}""")
+                }
+            }
+        }
+        val pub = catalog.lazyPublication(itemId)
+        assertEquals("Should return all 4 chapters from both spine pages", 4, pub?.spine?.size)
+        assertEquals("xhtml/ch04.xhtml", pub?.spine?.last()?.fullPath)
+    }
 }

--- a/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/OReillyEpubTest.kt
+++ b/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/OReillyEpubTest.kt
@@ -32,6 +32,21 @@ class OReillyEpubTest {
     }
 
     @Test
+    fun `selfCloseVoidElements handles gt-sign inside a double-quoted attribute value`() {
+        // Regression: [^>]*? stopped at the > inside the attribute, producing truncated/broken output.
+        val input = "<img alt=\"a > b\" src=\"fig.png\">"
+        val result = OReillyEpub.selfCloseVoidElements(input)
+        assertEquals("<img alt=\"a > b\" src=\"fig.png\"/>", result)
+    }
+
+    @Test
+    fun `selfCloseVoidElements handles gt-sign inside a single-quoted attribute value`() {
+        val input = "<input placeholder='x > y'>"
+        val result = OReillyEpub.selfCloseVoidElements(input)
+        assertEquals("<input placeholder='x > y'/>", result)
+    }
+
+    @Test
     fun `relative prefix walks out of subdirectories`() {
         assertEquals("", OReillyEpub.relPrefixFor("cover.xhtml"))
         assertEquals("../", OReillyEpub.relPrefixFor("xhtml/cover.xhtml"))

--- a/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/RequestPacerJitterTest.kt
+++ b/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/RequestPacerJitterTest.kt
@@ -1,0 +1,46 @@
+package com.riffle.core.catalog.oreilly
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RequestPacerJitterTest {
+
+    @Test
+    fun `jitter interval is sampled within bounds`() {
+        repeat(200) {
+            val interval = OReillyCatalog.RequestPacer.randomInterval(minMs = 120L, maxMs = 400L)
+            assertTrue("interval $interval should be >= 120", interval >= 120L)
+            assertTrue("interval $interval should be <= 400", interval <= 400L)
+        }
+    }
+
+    @Test
+    fun `zero max interval returns zero`() {
+        repeat(100) {
+            val interval = OReillyCatalog.RequestPacer.randomInterval(minMs = 0L, maxMs = 0L)
+            assertTrue("interval should be 0 for lazy path", interval == 0L)
+        }
+    }
+
+    @Test
+    fun `fixed interval when min equals max`() {
+        repeat(50) {
+            val interval = OReillyCatalog.RequestPacer.randomInterval(minMs = 120L, maxMs = 120L)
+            assertTrue("interval should be exactly 120 when min==max", interval == 120L)
+        }
+    }
+
+    @Test
+    fun `pacer with jitter executes block and returns result`() = runBlocking {
+        var fakeTime = 1000L
+        val pacer = OReillyCatalog.RequestPacer(
+            maxConcurrency = 1,
+            minIntervalMs = 0L,
+            maxIntervalMs = 0L,
+            nowMs = { fakeTime },
+        )
+        val result = pacer.execute { 42 }
+        assertTrue(result == 42)
+    }
+}

--- a/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/epub/EpubAssemblerTest.kt
+++ b/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/epub/EpubAssemblerTest.kt
@@ -3,6 +3,7 @@ package com.riffle.core.catalog.oreilly.epub
 import com.riffle.core.catalog.oreilly.OReillyCatalog
 import com.riffle.core.catalog.oreilly.OReillyApi
 import io.ktor.utils.io.readRemaining
+import io.ktor.utils.io.core.readBytes
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -178,6 +179,73 @@ class EpubAssemblerTest {
             }
 
             assertTrue("contentLength must be > 0 for progress reporting", observedContentLength > 0L)
+            client.close()
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    @Test
+    fun `withFileStream with multiple concurrent chapters produces a valid readable ZIP`() = runBlocking {
+        // Regression for the writeMutex gap: pipe.writeFully was outside the lock, allowing
+        // concurrent chapter jobs to interleave their bytes. The ZIP must be parseable and
+        // every expected entry must be present at the offsets the central directory records.
+        val server = okhttp3.mockwebserver.MockWebServer()
+        server.start()
+        try {
+            val itemId = "9781098100001"
+            val chapters = listOf("xhtml/ch01.xhtml", "xhtml/ch02.xhtml", "xhtml/ch03.xhtml")
+            val bodies = chapters.mapIndexed { i, _ -> "<div id=\"sbo-rt-content\"><p>Chapter ${i + 1} content</p></div>" }
+            val spineJson = chapters.mapIndexed { i, p ->
+                """{"reference_id":"$itemId-/$p","title":"Chapter ${i + 1}"}"""
+            }.joinToString(",")
+            val filesJson = chapters.mapIndexed { i, p ->
+                """{"full_path":"$p","media_type":"application/xhtml+xml","kind":"chapter","file_size":${bodies[i].length}}"""
+            }.joinToString(",")
+
+            server.dispatcher = object : okhttp3.mockwebserver.Dispatcher() {
+                override fun dispatch(req: okhttp3.mockwebserver.RecordedRequest): okhttp3.mockwebserver.MockResponse {
+                    val path = req.path.orEmpty()
+                    val json = when {
+                        path.contains("/spine/") -> """{"count":${chapters.size},"next":null,"results":[$spineJson]}"""
+                        path.contains("/files/") && path.contains("?download=false") -> {
+                            val idx = chapters.indexOfFirst { path.contains(it) }
+                            if (idx >= 0) bodies[idx] else ""
+                        }
+                        path.contains("/files/") -> """{"count":${chapters.size},"next":null,"results":[$filesJson]}"""
+                        else -> """{"identifier":"$itemId","title":"Multi","language":"en"}"""
+                    }
+                    return okhttp3.mockwebserver.MockResponse().setResponseCode(200).setBody(json)
+                }
+            }
+
+            val client = io.ktor.client.HttpClient(io.ktor.client.engine.okhttp.OkHttp)
+            val api = OReillyApi(client, cookieHeader = "orm-jwt=x", baseUrl = server.url("/").toString().trimEnd('/'))
+            val catalog = OReillyCatalog(
+                api = api, bytesClient = client, cookieHeader = "orm-jwt=x",
+                minRequestIntervalMs = 0L, maxRequestIntervalMs = 0L,
+            )
+
+            val zipBytes = catalog.withFileStream(itemId, com.riffle.core.catalog.BookFormat.Epub, null) { stream ->
+                stream.channel.readRemaining().readBytes()
+            }
+
+            // Parse with ZipInputStream — if bytes were interleaved the stream throws or misses entries.
+            val entryNames = mutableListOf<String>()
+            ZipInputStream(ByteArrayInputStream(zipBytes)).use { zis ->
+                var entry = zis.nextEntry
+                while (entry != null) {
+                    entryNames += entry.name
+                    zis.closeEntry()
+                    entry = zis.nextEntry
+                }
+            }
+
+            assertTrue("ZIP must contain mimetype entry", "mimetype" in entryNames)
+            assertTrue("ZIP must contain content.opf", entryNames.any { it.endsWith("content.opf") })
+            assertTrue("ZIP must contain all 3 chapters",
+                chapters.all { path -> entryNames.any { it.endsWith(path) } })
+
             client.close()
         } finally {
             server.shutdown()

--- a/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/epub/EpubAssemblerTest.kt
+++ b/core/catalog-oreilly/src/jvmTest/kotlin/com/riffle/core/catalog/oreilly/epub/EpubAssemblerTest.kt
@@ -1,5 +1,9 @@
 package com.riffle.core.catalog.oreilly.epub
 
+import com.riffle.core.catalog.oreilly.OReillyCatalog
+import com.riffle.core.catalog.oreilly.OReillyApi
+import io.ktor.utils.io.readRemaining
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -89,5 +93,94 @@ class EpubAssemblerTest {
     @Test
     fun `assembly is deterministic`() {
         assertArrayEquals(EpubAssembler.assemble(sampleBook()), EpubAssembler.assemble(sampleBook()))
+    }
+
+    @Test
+    fun `EpubZipStreamWriter produces a JVM-readable archive matching the batch writer`() {
+        val book = sampleBook()
+        val batchBytes = EpubAssembler.assemble(book)
+        val batchEntries = readEntries(batchBytes).associate { it.first.name to it.second }
+
+        // Feed the same entries through the streaming writer one at a time.
+        val writer = EpubZipWriter.streamWriter()
+        val out = java.io.ByteArrayOutputStream()
+        val allEntries = listOf(
+            EpubZipEntry("mimetype", "application/epub+zip".encodeToByteArray()),
+            EpubZipEntry("META-INF/container.xml", EpubAssembler.containerXml().encodeToByteArray()),
+            EpubZipEntry("OEBPS/content.opf", EpubAssembler.contentOpf(book).encodeToByteArray()),
+            EpubZipEntry("OEBPS/nav.xhtml", EpubAssembler.navXhtml(book).encodeToByteArray()),
+            EpubZipEntry("OEBPS/chapter1.xhtml", "<html><body><p>One</p></body></html>".encodeToByteArray()),
+            EpubZipEntry("OEBPS/chapter2.xhtml", "<html><body><p>Two</p></body></html>".encodeToByteArray()),
+            EpubZipEntry("OEBPS/style.css", "body{margin:0}".encodeToByteArray()),
+            EpubZipEntry("OEBPS/images/cover.jpg", byteArrayOf(1, 2, 3, 4, 5)),
+        )
+        for (entry in allEntries) {
+            out.write(writer.writeEntry(entry))
+        }
+        out.write(writer.close())
+        val streamBytes = out.toByteArray()
+
+        val streamEntries = readEntries(streamBytes).associate { it.first.name to it.second }
+
+        // Both must be readable ZIPs with the same entry names and byte content.
+        assertEquals(batchEntries.keys, streamEntries.keys)
+        for (name in batchEntries.keys) {
+            assertArrayEquals("entry $name differs", batchEntries[name], streamEntries[name])
+        }
+    }
+
+    @Test
+    fun `EpubZipStreamWriter first entry (mimetype) must be STORED and JVM-readable`() {
+        val writer = EpubZipWriter.streamWriter()
+        val out = java.io.ByteArrayOutputStream()
+        out.write(writer.writeEntry(EpubZipEntry("mimetype", "application/epub+zip".encodeToByteArray())))
+        out.write(writer.close())
+
+        val entries = readEntries(out.toByteArray())
+        assertEquals(1, entries.size)
+        assertEquals("mimetype", entries[0].first.name)
+        assertEquals(ZipEntry.STORED.toLong(), entries[0].first.method.toLong())
+        assertEquals("application/epub+zip", entries[0].second.decodeToString())
+    }
+
+    @Test
+    fun `withFileStream reports positive contentLength before any chapter is fetched`() = runBlocking {
+        // The streaming synthesis estimates the ZIP size from declared file sizes; it must be > 0
+        // so the consumer has a denominator for progress reporting.
+        val server = okhttp3.mockwebserver.MockWebServer()
+        server.start()
+        try {
+            val itemId = "9781098100000"
+            val urn = "urn:orm:book:$itemId"
+            val chapterBody = "<div id=\"sbo-rt-content\"><p>Hello world</p></div>"
+
+            server.dispatcher = object : okhttp3.mockwebserver.Dispatcher() {
+                override fun dispatch(req: okhttp3.mockwebserver.RecordedRequest): okhttp3.mockwebserver.MockResponse {
+                    val path = req.path.orEmpty()
+                    val json = when {
+                        path.contains("/spine/") -> """{"count":1,"next":null,"results":[{"reference_id":"$itemId-/xhtml/ch01.xhtml","title":"Ch 1"}]}"""
+                        path.contains("/files/") && !path.contains("?download=false") -> """{"count":1,"next":null,"results":[{"full_path":"xhtml/ch01.xhtml","media_type":"application/xhtml+xml","kind":"chapter","file_size":${chapterBody.length}}]}"""
+                        path.contains("?download=false") -> chapterBody
+                        else -> """{"identifier":"$itemId","title":"Test","language":"en"}"""
+                    }
+                    return okhttp3.mockwebserver.MockResponse().setResponseCode(200).setBody(json)
+                }
+            }
+
+            val client = io.ktor.client.HttpClient(io.ktor.client.engine.okhttp.OkHttp)
+            val api = OReillyApi(client, cookieHeader = "orm-jwt=x", baseUrl = server.url("/").toString().trimEnd('/'))
+            val catalog = OReillyCatalog(api = api, bytesClient = client, cookieHeader = "orm-jwt=x")
+
+            var observedContentLength = -1L
+            catalog.withFileStream(itemId, com.riffle.core.catalog.BookFormat.Epub, null) { stream ->
+                observedContentLength = stream.contentLength
+                stream.channel.readRemaining() // consume all bytes
+            }
+
+            assertTrue("contentLength must be > 0 for progress reporting", observedContentLength > 0L)
+            client.close()
+        } finally {
+            server.shutdown()
+        }
     }
 }

--- a/core/catalog/src/commonMain/kotlin/com/riffle/core/catalog/CatalogAudiobookStream.kt
+++ b/core/catalog/src/commonMain/kotlin/com/riffle/core/catalog/CatalogAudiobookStream.kt
@@ -11,6 +11,13 @@ data class CatalogAudiobookStream(
     val totalDurationSec: Double,
     val serverCurrentTimeSec: Double,
     val serverLastUpdate: Long,
+    /**
+     * Direct-download URLs for each track (same ordering as [trackUrls]), or null when the stream
+     * URLs are also suitable for byte-download. Set for sources whose streaming format (e.g. HLS
+     * `.m3u8`) cannot be byte-downloaded directly — callers use these for offline download/cache and
+     * fall back to [trackUrls] when null.
+     */
+    val downloadTrackUrls: List<String>? = null,
 )
 
 data class CatalogAudiobookChapter(

--- a/core/catalog/src/commonMain/kotlin/com/riffle/core/catalog/LazyPublicationCapability.kt
+++ b/core/catalog/src/commonMain/kotlin/com/riffle/core/catalog/LazyPublicationCapability.kt
@@ -56,6 +56,17 @@ data class LazyPublicationShape(
     val pathFilesPrefix: String,
     /** Full paths of all stylesheets, used to inject `<link>` tags into each chapter. */
     val cssFullPaths: List<String>,
+    /**
+     * All packaged non-chapter assets (images, fonts, stylesheets). Used by the background
+     * prefetcher to fetch every asset so a complete offline EPUB can be assembled from the cache.
+     */
+    val assetFiles: List<LazyAssetFile> = emptyList(),
+)
+
+/** A non-chapter asset (image, stylesheet, font) packaged inside the publication. */
+data class LazyAssetFile(
+    val fullPath: String,
+    val mediaType: String,
 )
 
 /** One entry in the reading order of a [LazyPublicationShape]. */

--- a/core/data/src/androidHostTest/kotlin/com/riffle/core/data/AudiobookCacheRepositoryImplTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/riffle/core/data/AudiobookCacheRepositoryImplTest.kt
@@ -242,4 +242,35 @@ class AudiobookCacheRepositoryImplTest {
         assertFalse(r.isCached("srv", "it"))
         assertNull(r.localSession("srv", "it"))
     }
+
+    @Test
+    fun `awaitCachedAudiobook uses downloadTrackUrls when set`() = runTest {
+        // Sources like O'Reilly provide HLS stream URLs in trackUrls (for the player) and direct
+        // MP4 download URLs in downloadTrackUrls (for offline cache). Cache must use the latter.
+        val server = MockWebServer()
+        server.start()
+        try {
+            server.enqueue(MockResponse().setBody("mp4-audio-cache"))
+            val hlsUrl = server.url("/hls-will-not-be-fetched.m3u8").toString()
+            val mp4Url = server.url("/track.mp4").toString()
+            val session = AudiobookSession(
+                trackUrls = listOf(hlsUrl),
+                downloadTrackUrls = listOf(mp4Url),
+                tracks = listOf(AudiobookTrackSpan(0, 0.0, 60.0)),
+                timeline = AudiobookTimeline(60.0, emptyList()),
+                serverCurrentTimeSec = 0.0,
+            )
+            val root = tmp.newFolder()
+            val r = repo(root)
+
+            r.awaitCachedAudiobook("srv", "it", session)
+
+            assertTrue(r.isCached("srv", "it"))
+            val requested = server.takeRequest()
+            assertTrue(requested.path?.endsWith("track.mp4") == true)
+            assertEquals(1, server.requestCount)
+        } finally {
+            server.shutdown()
+        }
+    }
 }

--- a/core/data/src/androidHostTest/kotlin/com/riffle/core/data/AudiobookCacheRepositoryImplTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/riffle/core/data/AudiobookCacheRepositoryImplTest.kt
@@ -43,6 +43,8 @@ class AudiobookCacheRepositoryImplTest {
             trackDownloader,
             com.riffle.core.domain.DefaultDispatcherProvider,
             localAvailabilityEvents,
+            minInterTrackDelayMs = 0L,
+            maxInterTrackDelayMs = 0L,
         )
     }
 

--- a/core/data/src/androidHostTest/kotlin/com/riffle/core/data/AudiobookDownloadRepositoryImplTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/riffle/core/data/AudiobookDownloadRepositoryImplTest.kt
@@ -289,4 +289,40 @@ class AudiobookDownloadRepositoryImplTest {
             server.shutdown()
         }
     }
+
+    @Test
+    fun `download uses downloadTrackUrls instead of trackUrls when set`() = runTest {
+        // O'Reilly sessions carry HLS stream URLs in trackUrls and downloadable MP4 URLs in
+        // downloadTrackUrls. The downloader must use the latter to actually write bytes to disk.
+        val server = MockWebServer()
+        server.start()
+        try {
+            server.enqueue(MockResponse().setBody("mp4-audio-bytes"))
+            val hlsUrl = server.url("/hls-will-not-be-fetched.m3u8").toString()
+            val mp4Url = server.url("/track.mp4").toString()
+            val session = AudiobookSession(
+                trackUrls = listOf(hlsUrl),
+                downloadTrackUrls = listOf(mp4Url),
+                tracks = listOf(AudiobookTrackSpan(index = 0, startOffsetSec = 0.0, durationSec = 60.0)),
+                timeline = AudiobookTimeline(durationSec = 60.0, chapters = emptyList()),
+                serverCurrentTimeSec = 0.0,
+            )
+            val source = object : AudiobookRepository {
+                override suspend fun openSession(sourceId: String, itemId: String): AudiobookSession = session
+                override suspend fun saveProgress(sourceId: String, itemId: String, positionSec: Double, durationSec: Double) = Unit
+            }
+            val root = tmp.newFolder()
+
+            val result = repo(root, audiobookRepository = source).download("srv", "it") { _, _ -> }
+
+            assertEquals(AudiobookDownloadResult.Success, result)
+            assertEquals("mp4-audio-bytes", File(root, "srv/it/track-0").readText())
+            // Only the MP4 URL was fetched — the HLS URL was never requested.
+            val requested = server.takeRequest()
+            assertTrue(requested.path?.endsWith("track.mp4") == true)
+            assertEquals(0, server.requestCount - 1)
+        } finally {
+            server.shutdown()
+        }
+    }
 }

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/AudiobookCacheRepositoryImpl.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/AudiobookCacheRepositoryImpl.kt
@@ -18,6 +18,14 @@ class AudiobookCacheRepositoryImpl constructor(
     private val trackDownloader: AudiobookTrackDownloader,
     private val dispatchers: DispatcherProvider,
     private val localAvailabilityEvents: LocalAvailabilityEvents = NoopLocalAvailabilityEvents,
+    /**
+     * Jittered delay between consecutive track downloads during background caching. Avoids
+     * triggering anti-abuse rate limits on CDN-hosted sources (e.g. O'Reilly/Kaltura). Default
+     * 1.5–3s is conservative enough to stay unnoticed while completing in reasonable time.
+     * Set to 0 in tests to keep them fast.
+     */
+    private val minInterTrackDelayMs: Long = 1_500L,
+    private val maxInterTrackDelayMs: Long = 3_000L,
 ) : JvmAudiobookCacheRepository {
 
     private val json = Json { ignoreUnknownKeys = true }
@@ -66,7 +74,9 @@ class AudiobookCacheRepositoryImpl constructor(
         try {
             val noop: (Long, Long) -> Unit = { _, _ -> }
             val progress = CumulativeDownloadProgress(0L, noop)
-            val manifestTracks = trackDownloader.download(downloadSession, dir, progress)
+            val interTrackDelay = if (minInterTrackDelayMs >= maxInterTrackDelayMs) minInterTrackDelayMs
+            else minInterTrackDelayMs + kotlin.random.Random.nextLong(maxInterTrackDelayMs - minInterTrackDelayMs + 1)
+            val manifestTracks = trackDownloader.download(downloadSession, dir, progress, interTrackDelay)
             val manifest = AudiobookDownloadManifest(
                 durationSec = session.timeline.durationSec,
                 tracks = manifestTracks.sortedBy { it.index },

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/AudiobookCacheRepositoryImpl.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/AudiobookCacheRepositoryImpl.kt
@@ -58,10 +58,15 @@ class AudiobookCacheRepositoryImpl constructor(
     ) = withContext(dispatchers.io) {
         if (isCached(sourceId, itemId)) return@withContext
         val dir = itemDir(sourceId, itemId).apply { mkdirs() }
+        // Sources whose streaming format can't be byte-downloaded (e.g. O'Reilly HLS) set
+        // downloadTrackUrls; substitute those so the track downloader receives real file URLs.
+        val downloadSession = session.downloadTrackUrls
+            ?.let { session.copy(trackUrls = it) }
+            ?: session
         try {
             val noop: (Long, Long) -> Unit = { _, _ -> }
             val progress = CumulativeDownloadProgress(0L, noop)
-            val manifestTracks = trackDownloader.download(session, dir, progress)
+            val manifestTracks = trackDownloader.download(downloadSession, dir, progress)
             val manifest = AudiobookDownloadManifest(
                 durationSec = session.timeline.durationSec,
                 tracks = manifestTracks.sortedBy { it.index },

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/AudiobookDownloadRepositoryImpl.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/AudiobookDownloadRepositoryImpl.kt
@@ -90,8 +90,13 @@ class AudiobookDownloadRepositoryImpl constructor(
         val progress = CumulativeDownloadProgress(wholeAudiobookBytes ?: 0L, onProgress)
 
         val dir = itemDir(sourceId, itemId).apply { mkdirs() }
+        // Sources whose streaming format can't be byte-downloaded (e.g. O'Reilly HLS) set
+        // downloadTrackUrls; substitute those so the track downloader receives real file URLs.
+        val downloadSession = session.downloadTrackUrls
+            ?.let { session.copy(trackUrls = it) }
+            ?: session
         try {
-            val manifestTracks = trackDownloader.download(session, dir, progress)
+            val manifestTracks = trackDownloader.download(downloadSession, dir, progress)
             val manifest = AudiobookDownloadManifest(
                 durationSec = session.timeline.durationSec,
                 tracks = manifestTracks.sortedBy { it.index },

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/AudiobookRepositoryImpl.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/AudiobookRepositoryImpl.kt
@@ -36,6 +36,7 @@ class AudiobookRepositoryImpl constructor(
         )
         return AudiobookSession(
             trackUrls = stream.trackUrls,
+            downloadTrackUrls = stream.downloadTrackUrls,
             tracks = spans,
             timeline = timeline,
             serverCurrentTimeSec = stream.serverCurrentTimeSec,

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/AudiobookTrackDownloader.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/AudiobookTrackDownloader.kt
@@ -10,6 +10,7 @@ import io.ktor.http.isSuccess
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.IOException
@@ -26,10 +27,16 @@ class AudiobookTrackDownloader constructor(
     private val httpClient: HttpClient,
     private val dispatchers: DispatcherProvider,
 ) {
+    /**
+     * @param interTrackDelayMs Extra delay to insert between consecutive track downloads. Use 0
+     *   for explicit user-initiated downloads (fastest, shows progress to the user). Use a jittered
+     *   value for background caching to avoid triggering anti-abuse rate limits on the CDN.
+     */
     internal suspend fun download(
         session: AudiobookSession,
         dir: File,
         progress: CumulativeDownloadProgress,
+        interTrackDelayMs: Long = 0L,
     ): List<AudiobookDownloadManifest.ManifestTrack> = withContext(dispatchers.io) {
         // For multi-track sources (e.g. Radio.es podcasts) whose catalog doesn't provide a
         // fingerprint size, pre-scan all track URLs in parallel via HEAD to establish the cumulative
@@ -77,6 +84,9 @@ class AudiobookTrackDownloader constructor(
                         durationSec = span?.durationSec ?: 0.0,
                     ),
                 )
+                if (interTrackDelayMs > 0L && i < session.trackUrls.lastIndex) {
+                    delay(interTrackDelayMs)
+                }
             }
         }
     }

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/EpubRepositoryImpl.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/EpubRepositoryImpl.kt
@@ -161,6 +161,12 @@ class EpubRepositoryImpl(
 
     override fun isCached(sourceId: String, itemId: String): Boolean = cacheStore.get(sourceId, itemId) != null
 
+    override suspend fun cacheEpub(sourceId: String, itemId: String, bytes: ByteArray) {
+        if (isDownloaded(sourceId, itemId) || isCached(sourceId, itemId)) return
+        cacheStore.save(sourceId, itemId, bytes.inputStream())
+        localAvailabilityEvents.notifyChanged(sourceId, itemId)
+    }
+
     override suspend fun saveReadingPosition(itemId: String, cfi: String) {
         val sourceId = sourceRepository.getActive()?.id ?: return
         positionStore.save(sourceId, itemId, cfi)

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/di/CoreDataKoinModules.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/di/CoreDataKoinModules.kt
@@ -813,6 +813,9 @@ private val coreDataCatalogModule = module {
                     android.webkit.CookieManager.getInstance()
                         .getCookie(com.riffle.core.domain.OReillyWebSourceDescriptor.OREILLY_BASE_URL)
                 },
+                userAgentProvider = {
+                    android.webkit.WebSettings.getDefaultUserAgent(androidContext())
+                },
                 bookPreparationProgress = get(),
             ),
         )

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/AudiobookRepository.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/AudiobookRepository.kt
@@ -19,6 +19,10 @@ data class AudiobookSession(
     // The local zip archive backing zip-entry track URLs (a downloaded bundle), or null when tracks
     // are HTTP/file URLs. The player points the playback service at this file before preparing.
     val localZipFile: File? = null,
+    // Direct-download URLs for each track (same order as trackUrls), or null when trackUrls are
+    // also byte-downloadable. Sources whose streaming format cannot be byte-downloaded (e.g. O'Reilly
+    // HLS) populate this; download/cache paths use these instead of trackUrls.
+    val downloadTrackUrls: List<String>? = null,
 )
 
 interface AudiobookRepository {

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/EpubRepository.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/EpubRepository.kt
@@ -16,4 +16,11 @@ sealed class EpubOpenResult {
 interface JvmEpubRepository : EpubRepository {
     suspend fun openEpub(item: LibraryItem): EpubOpenResult
     suspend fun openEpubForMetadata(item: LibraryItem): EpubOpenResult = openEpub(item)
+    /**
+     * Write a pre-assembled EPUB (e.g. assembled from a lazy chapter cache) to the ebook cache
+     * store and fire [LocalAvailabilityEvents] so the offline-availability indicator updates.
+     * No-op if the item is already cached or downloaded — checking avoids double-writes when the
+     * book is opened again before the prefetch scope has been cancelled.
+     */
+    suspend fun cacheEpub(sourceId: String, itemId: String, bytes: ByteArray)
 }

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt
@@ -232,6 +232,7 @@ class LibraryItemOfflineAvailabilityTest {
         ) = error("unused")
         override suspend fun removeDownload(sourceId: String, itemId: String) = error("unused")
         override suspend fun saveReadingPosition(itemId: String, cfi: String) = error("unused")
+        override suspend fun cacheEpub(sourceId: String, itemId: String, bytes: ByteArray) {}
     }
 
     private class FakePdfRepository(


### PR DESCRIPTION
**Hardening**
- Harvests the real device WebView User-Agent via a `userAgentProvider` seam instead of a hardcoded string; injected via `OReillyCatalogFactory` so tests can supply a stable UA
- Sends browser-consistent request headers (`Origin`, `Referer`, `sec-ch-ua`, `sec-fetch-*`, `Accept`) that match what Chrome sends in the WebView login session
- Adds a jitter request pacer (120–400 ms between requests, max 5 concurrent) shared across the synthesis and lazy-fetch paths to humanize bulk-request cadence

**Kaltura audiobook streaming**
- `getTracks` / `openAudiobook` resolve each chapter via the `videotocs` → `videoclips` → Kaltura config/session chain, producing one HLS `contentUrl` per chapter
- The Kaltura `partnerId` and session-token API calls are now concurrent (no sequential dependency)
- Audiobooks are downloadable: each track emits a `downloadTrackUrl` using Kaltura's MP4 download endpoint

**Ebook background caching**
- `startBackgroundPrefetch` now runs in two phases: spine chapters (paced, jittered), then all assets (CSS, images, fonts)
- After all files are on disk, `assembleEpubFromCache()` builds a complete EPUB from the lazy cache without any re-download and writes it to `EPUB_CACHE_STORE` via `JvmEpubRepository.cacheEpub()`; the library immediately shows the book as offline-available
- Fixes the root cause: the lazy cache (`oreilly_lazy/`) was invisible to `epubRepository.isCached()`, so books never appeared cached regardless of reading time

**Ebook download progress**
- `withFileStream` now streams ZIP bytes through a `ByteChannel` pipe as chapters are fetched, so progress advances from 0% → 100% rather than jumping at the end
- ZIP integrity is guaranteed by holding `writeMutex` across both `writer.writeEntry()` and `pipe.writeFully()` — previously the lock only covered the central-directory record, allowing concurrent jobs to interleave bytes

**Other fixes (from code review)**
- Spine pagination: `fetchAllSpine()` follows the `next` cursor; was silently truncating books with >100 chapters
- Lazy path rate limiting: `fetchChapterForLazy`/`fetchAssetForLazy` now share a class-level `RequestPacer` instead of creating a zero-interval pacer per call
- `selfCloseVoidElements` regex updated to tolerate `>` inside quoted attribute values (`alt="a > b"`)
- `isTruncatedBody` counts UTF-8 bytes without allocating a full byte-array copy
- `CancellationException` is re-thrown from the producer catch block so cancellation is not misreported as a synthesis failure

## Tests

- `OReillyApiHeaderTest`: verifies all browser-consistent headers are present on each request type
- `RequestPacerJitterTest`: verifies jitter stays within \[min, max\] bounds and enforces min interval
- `OReillyAudiobookTest`: pins the Kaltura assembly chain from videotocs → HLS URL per chapter
- `AudiobookCacheRepositoryImplTest` / `AudiobookDownloadRepositoryImplTest`: new download+cache repo tests
- `OReillyLazyContainerTest`: asset prefetch, `assembleEpubFromCache` null/valid cases
- `EpubAssemblerTest`: `EpubZipStreamWriter` matches batch writer; multi-chapter ZIP integrity test (regression for the writeMutex gap); `withFileStream` contentLength > 0
- `OReillyCatalogLazyTest`: spine pagination test (4 chapters across 2 pages)
- `OReillyEpubTest`: two regression tests for `>` in quoted attribute values

## iOS parity

The O'Reilly source lives in `core/catalog-oreilly/src/commonMain` and is available to iOS in principle, but no iOS DI binding, XCTest scenarios, or `docs/testing/ios-scenarios/` entry has been added in this PR. This is a known gap — the iOS wiring and test coverage will be addressed in a follow-up issue.