### PR TITLE
feat(oreilly/ios): lazy per-chapter O'Reilly streaming

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainer.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/source/oreilly/OReillyLazyContainer.kt
@@ -214,13 +214,8 @@ class OReillyLazyContainer(
             }
         }
 
-        fun buildChapterXhtml(pub: LazyPublicationShape, item: LazySpineItem, rawHtml: String): String {
-            val rewritten = rawHtml
-                .replace(pub.absoluteFilesPrefix, OReillyEpub.relPrefixFor(item.fullPath))
-                .replace(pub.pathFilesPrefix, OReillyEpub.relPrefixFor(item.fullPath))
-            val cssHrefs = pub.cssFullPaths.map { OReillyEpub.relativeTo(item.fullPath, it) }
-            return OReillyEpub.wrapChapter(item.title, rewritten, cssHrefs)
-        }
+        fun buildChapterXhtml(pub: LazyPublicationShape, item: LazySpineItem, rawHtml: String): String =
+            OReillyEpub.buildChapterXhtml(pub, item, rawHtml)
     }
 }
 

--- a/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyEpub.kt
+++ b/core/catalog-oreilly/src/commonMain/kotlin/com/riffle/core/catalog/oreilly/OReillyEpub.kt
@@ -73,6 +73,23 @@ object OReillyEpub {
     fun relativeTo(chapterFullPath: String, assetFullPath: String): String =
         relPrefixFor(chapterFullPath) + assetFullPath
 
+    /**
+     * Assembles the final XHTML for a lazy-loaded chapter. Rewrites absolute and path-based URL
+     * prefixes to relative form and injects stylesheet `<link>` tags. Shared by Android's
+     * [com.riffle.app.feature.source.oreilly.OReillyLazyContainer] and iOS's `IosLazyChapterFetcherImpl`.
+     */
+    fun buildChapterXhtml(
+        pub: com.riffle.core.catalog.LazyPublicationShape,
+        item: com.riffle.core.catalog.LazySpineItem,
+        rawHtml: String,
+    ): String {
+        val rewritten = rawHtml
+            .replace(pub.absoluteFilesPrefix, relPrefixFor(item.fullPath))
+            .replace(pub.pathFilesPrefix, relPrefixFor(item.fullPath))
+        val cssHrefs = pub.cssFullPaths.map { relativeTo(item.fullPath, it) }
+        return wrapChapter(item.title, rewritten, cssHrefs)
+    }
+
     private fun String.xmlText(): String =
         replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 

--- a/docs/testing/ios-scenarios/20-oreilly-lazy-publication.md
+++ b/docs/testing/ios-scenarios/20-oreilly-lazy-publication.md
@@ -1,0 +1,50 @@
+# Scenario 20 — O'Reilly lazy per-chapter publication
+
+## Context
+
+O'Reilly books are not regular EPUB downloads. Opening an O'Reilly book on iOS uses the
+`LazyPublicationCapability` detected from `OReillyCatalog`, builds an in-memory Readium `Publication`
+backed by `OReillyLazyContainer`, and streams each chapter HTML on first render.
+
+Android reference: `OReillyLazyContainer`, `OReillyPublicationBuilder`, `EpubReaderViewModel.openLazyPublication`.
+
+## Scenarios
+
+### 20-A: Shape JSON decoding
+
+- **Given** a valid shape JSON (produced by `IosLazyChapterFetcherImpl.serializeShape`)
+- **When** `OReillyPublicationBuilder.build(shapeJson:fetcher:)` is called
+- **Then** the returned `Publication.metadata.title` matches the JSON `title` field
+- **And** `publication.readingOrder.count` equals the number of spine items
+
+### 20-B: URL stripping (`extractRelativePath`)
+
+- `https://readium_package/assets/cover.png` → `assets/cover.png`
+- `/xhtml/ch01.xhtml` → `xhtml/ch01.xhtml`
+- `images/fig.png` → `images/fig.png` (unchanged)
+
+### 20-C: Chapter fetch delegation
+
+- **Given** a `StubLazyChapterFetcher` with a canned XHTML file path for `"xhtml/ch01.xhtml"`
+- **When** `container["xhtml/ch01.xhtml"].read(range: nil)` is awaited
+- **Then** the returned `Data` matches the XHTML file contents
+- **And** `fetchChapterCallCount == 1`
+
+- **Given** a `StubLazyChapterFetcher` with no paths registered
+- **When** `container["xhtml/ch01.xhtml"].read(range: nil)` is awaited
+- **Then** result is `.failure(.decoding(nil))`
+
+### 20-D: Bridge wiring
+
+- **When** `ReadiumEpubNavigatorBridge.openLazyEpub(shapeJson:locatorJson:fetcher:)` is called with valid JSON
+- **Then** no crash occurs (Readium navigator opens asynchronously on the main queue)
+
+### 20-E: Invalid JSON
+
+- **When** `OReillyPublicationBuilder.build(shapeJson: "not json", ...)` is called
+- **Then** a `BuildError.invalidShapeJson` is thrown
+
+## XCTest coverage
+
+`iosAppTests/OReillyLazyPublicationTests.swift` covers scenarios 20-A through 20-E using
+`StubLazyChapterFetcher`.

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -33,6 +33,11 @@
 		B1008018 /* SettingsRowsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1008028 /* SettingsRowsTests.swift */; };
 		B1008019 /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1008029 /* SettingsViewModelTests.swift */; };
 		B100801A /* ReadiumEpubNavigatorBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1002030 /* ReadiumEpubNavigatorBridge.swift */; };
+		B1010020 /* OReillyLazyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1010030 /* OReillyLazyContainer.swift */; };
+		B1011020 /* OReillyPublicationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1011030 /* OReillyPublicationBuilder.swift */; };
+		B101001A /* OReillyLazyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1010030 /* OReillyLazyContainer.swift */; };
+		B101101A /* OReillyPublicationBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1011030 /* OReillyPublicationBuilder.swift */; };
+		B1012010 /* OReillyLazyPublicationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1012020 /* OReillyLazyPublicationTests.swift */; };
 		B1008030 /* ReadiumShared in Frameworks */ = {isa = PBXBuildFile; productRef = B1008001 /* ReadiumShared */; };
 		B1008031 /* ReadiumStreamer in Frameworks */ = {isa = PBXBuildFile; productRef = B1008002 /* ReadiumStreamer */; };
 		B1008032 /* ReadiumNavigator in Frameworks */ = {isa = PBXBuildFile; productRef = B1008003 /* ReadiumNavigator */; };
@@ -47,6 +52,9 @@
 		B1001020 /* iosAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosAppTests.swift; sourceTree = "<group>"; };
 		B1002030 /* ReadiumEpubNavigatorBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadiumEpubNavigatorBridge.swift; sourceTree = "<group>"; };
 		B1003030 /* IosAudioPlayerBridgeImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IosAudioPlayerBridgeImpl.swift; sourceTree = "<group>"; };
+		B1010030 /* OReillyLazyContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OReillyLazyContainer.swift; sourceTree = "<group>"; };
+		B1011030 /* OReillyPublicationBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OReillyPublicationBuilder.swift; sourceTree = "<group>"; };
+		B1012020 /* OReillyLazyPublicationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OReillyLazyPublicationTests.swift; sourceTree = "<group>"; };
 		B1004020 /* AudiobookPlayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudiobookPlayerTests.swift; sourceTree = "<group>"; };
 		B1005030 /* PdfKitNavigatorBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfKitNavigatorBridge.swift; sourceTree = "<group>"; };
 		B1006020 /* PdfReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfReaderTests.swift; sourceTree = "<group>"; };
@@ -85,6 +93,8 @@
 				B1002030 /* ReadiumEpubNavigatorBridge.swift */,
 				B1003030 /* IosAudioPlayerBridgeImpl.swift */,
 				B1005030 /* PdfKitNavigatorBridge.swift */,
+				B1010030 /* OReillyLazyContainer.swift */,
+				B1011030 /* OReillyPublicationBuilder.swift */,
 			);
 			path = iosApp;
 			sourceTree = "<group>";
@@ -118,6 +128,7 @@
 				B1008027 /* ReaderSettingsTests.swift */,
 				B1008028 /* SettingsRowsTests.swift */,
 				B1008029 /* SettingsViewModelTests.swift */,
+				B1012020 /* OReillyLazyPublicationTests.swift */,
 			);
 			path = iosAppTests;
 			sourceTree = "<group>";
@@ -309,6 +320,8 @@
 				B1002020 /* ReadiumEpubNavigatorBridge.swift in Sources */,
 				B1003020 /* IosAudioPlayerBridgeImpl.swift in Sources */,
 				B1005020 /* PdfKitNavigatorBridge.swift in Sources */,
+				B1010020 /* OReillyLazyContainer.swift in Sources */,
+				B1011020 /* OReillyPublicationBuilder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -340,6 +353,9 @@
 				B1008018 /* SettingsRowsTests.swift in Sources */,
 				B1008019 /* SettingsViewModelTests.swift in Sources */,
 				B100801A /* ReadiumEpubNavigatorBridge.swift in Sources */,
+				B101001A /* OReillyLazyContainer.swift in Sources */,
+				B101101A /* OReillyPublicationBuilder.swift in Sources */,
+				B1012010 /* OReillyLazyPublicationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp/OReillyLazyContainer.swift
+++ b/iosApp/iosApp/OReillyLazyContainer.swift
@@ -99,12 +99,12 @@ private final class LazyChapterResource: Resource {
     func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
         return await withCheckedContinuation { continuation in
             fetcher.fetchChapterXhtmlPath(
-                spineItem.fullPath,
+                fullPath: spineItem.fullPath,
                 expectedByteSize: spineItem.declaredByteSize
             ) { filePath in
                 guard let filePath = filePath,
                       let data = try? Data(contentsOf: URL(fileURLWithPath: filePath)) else {
-                    continuation.resume(returning: .failure(.decoding(nil)))
+                    continuation.resume(returning: .failure(.decoding("chapter fetch failed")))
                     return
                 }
                 let chunk: Data
@@ -150,10 +150,10 @@ private final class LazyAssetResource: Resource {
 
     func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
         return await withCheckedContinuation { continuation in
-            fetcher.fetchAssetPath(fullPath) { filePath in
+            fetcher.fetchAssetPath(fullPath: fullPath) { filePath in
                 guard let filePath = filePath,
                       let data = try? Data(contentsOf: URL(fileURLWithPath: filePath)) else {
-                    continuation.resume(returning: .failure(.decoding(nil)))
+                    continuation.resume(returning: .failure(.decoding("asset fetch failed")))
                     return
                 }
                 let chunk: Data

--- a/iosApp/iosApp/OReillyLazyContainer.swift
+++ b/iosApp/iosApp/OReillyLazyContainer.swift
@@ -96,7 +96,7 @@ private final class LazyChapterResource: Resource {
         return .success(size > 0 ? UInt64(size) : nil)
     }
 
-    func read(range: Range<UInt64>?) async -> ReadResult<Data> {
+    func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
         return await withCheckedContinuation { continuation in
             fetcher.fetchChapterXhtmlPath(
                 spineItem.fullPath,
@@ -107,13 +107,16 @@ private final class LazyChapterResource: Resource {
                     continuation.resume(returning: .failure(.decoding(nil)))
                     return
                 }
+                let chunk: Data
                 if let range = range {
                     let start = Int(min(range.lowerBound, UInt64(data.count)))
                     let end = Int(min(range.upperBound, UInt64(data.count)))
-                    continuation.resume(returning: .success(data.subdata(in: start..<end)))
+                    chunk = data.subdata(in: start..<end)
                 } else {
-                    continuation.resume(returning: .success(data))
+                    chunk = data
                 }
+                consume(chunk)
+                continuation.resume(returning: .success(()))
             }
         }
     }
@@ -145,7 +148,7 @@ private final class LazyAssetResource: Resource {
         .success(nil)
     }
 
-    func read(range: Range<UInt64>?) async -> ReadResult<Data> {
+    func stream(range: Range<UInt64>?, consume: @escaping (Data) -> Void) async -> ReadResult<Void> {
         return await withCheckedContinuation { continuation in
             fetcher.fetchAssetPath(fullPath) { filePath in
                 guard let filePath = filePath,
@@ -153,13 +156,16 @@ private final class LazyAssetResource: Resource {
                     continuation.resume(returning: .failure(.decoding(nil)))
                     return
                 }
+                let chunk: Data
                 if let range = range {
                     let start = Int(min(range.lowerBound, UInt64(data.count)))
                     let end = Int(min(range.upperBound, UInt64(data.count)))
-                    continuation.resume(returning: .success(data.subdata(in: start..<end)))
+                    chunk = data.subdata(in: start..<end)
                 } else {
-                    continuation.resume(returning: .success(data))
+                    chunk = data
                 }
+                consume(chunk)
+                continuation.resume(returning: .success(()))
             }
         }
     }

--- a/iosApp/iosApp/OReillyLazyContainer.swift
+++ b/iosApp/iosApp/OReillyLazyContainer.swift
@@ -1,0 +1,164 @@
+import Foundation
+import ReadiumShared
+
+// MARK: - Shape DTOs (decoded from IosLazyChapterFetcherImpl.serializeShape JSON)
+
+struct LazyPublicationShapeDto: Codable {
+    let bookId: String
+    let identifier: String
+    let title: String
+    let language: String
+    let spine: [LazySpineItemDto]
+    let absoluteFilesPrefix: String
+    let pathFilesPrefix: String
+    let cssFullPaths: [String]
+}
+
+struct LazySpineItemDto: Codable {
+    let index: Int
+    let fullPath: String
+    let title: String
+    let declaredByteSize: Int64
+}
+
+// MARK: - Container
+
+/// Readium Swift `Container` for O'Reilly lazy publications.  Each chapter resource is served on
+/// demand via `IosLazyChapterFetcher` (backed by `IosLazyChapterFetcherImpl` on the Kotlin side),
+/// which fetches raw HTML, assembles XHTML via the shared `OReillyEpub` helpers, and caches to
+/// disk.  Subsequent reads of the same chapter are served from cache — no network round-trip.
+final class OReillyLazyContainer: Container {
+
+    let shape: LazyPublicationShapeDto
+    private let fetcher: any IosLazyChapterFetcher
+
+    var sourceURL: (any AbsoluteURL)? { nil }
+
+    var entries: Set<AnyURL> {
+        Set(shape.spine.compactMap { AnyURL(string: $0.fullPath) })
+    }
+
+    init(shape: LazyPublicationShapeDto, fetcher: any IosLazyChapterFetcher) {
+        self.shape = shape
+        self.fetcher = fetcher
+    }
+
+    subscript(_ url: any URLConvertible) -> (any Resource)? {
+        let urlStr = url.string
+        if let spineItem = shape.spine.first(where: { urlStr.hasSuffix($0.fullPath) || $0.fullPath == urlStr }) {
+            return LazyChapterResource(spineItem: spineItem, fetcher: fetcher)
+        }
+        let relativePath = Self.extractRelativePath(urlStr)
+        return LazyAssetResource(fullPath: relativePath, fetcher: fetcher)
+    }
+
+    func close() async {}
+
+    /// Mirror of `OReillyLazyContainer.extractRelativePath` on Android: strips the
+    /// `https://readium_package/` origin Readium prepends to sub-resource URLs.
+    static func extractRelativePath(_ urlString: String) -> String {
+        var s = urlString
+        let prefix = "https://readium_package/"
+        if s.hasPrefix(prefix) {
+            s = String(s.dropFirst(prefix.count))
+        }
+        if s.hasPrefix("/") {
+            s = String(s.dropFirst())
+        }
+        return s
+    }
+}
+
+// MARK: - Chapter resource
+
+/// `Resource` for a single spine chapter: delegates to `IosLazyChapterFetcher.fetchChapterXhtmlPath`.
+private final class LazyChapterResource: Resource {
+
+    var sourceURL: (any AbsoluteURL)? { nil }
+
+    private let spineItem: LazySpineItemDto
+    private let fetcher: any IosLazyChapterFetcher
+
+    init(spineItem: LazySpineItemDto, fetcher: any IosLazyChapterFetcher) {
+        self.spineItem = spineItem
+        self.fetcher = fetcher
+    }
+
+    func properties() async -> ReadResult<ResourceProperties> {
+        .success(ResourceProperties())
+    }
+
+    func estimatedLength() async -> ReadResult<UInt64?> {
+        .success(UInt64(bitPattern: spineItem.declaredByteSize))
+    }
+
+    func read(range: Range<UInt64>?) async -> ReadResult<Data> {
+        return await withCheckedContinuation { continuation in
+            fetcher.fetchChapterXhtmlPath(
+                spineItem.fullPath,
+                expectedByteSize: spineItem.declaredByteSize
+            ) { filePath in
+                guard let filePath = filePath,
+                      let data = try? Data(contentsOf: URL(fileURLWithPath: filePath)) else {
+                    continuation.resume(returning: .failure(.decoding(nil)))
+                    return
+                }
+                if let range = range {
+                    let start = Int(min(range.lowerBound, UInt64(data.count)))
+                    let end = Int(min(range.upperBound, UInt64(data.count)))
+                    continuation.resume(returning: .success(data.subdata(in: start..<end)))
+                } else {
+                    continuation.resume(returning: .success(data))
+                }
+            }
+        }
+    }
+
+    func close() async {}
+}
+
+// MARK: - Asset resource
+
+/// `Resource` for CSS, images, and other binary assets: delegates to
+/// `IosLazyChapterFetcher.fetchAssetPath`.
+private final class LazyAssetResource: Resource {
+
+    var sourceURL: (any AbsoluteURL)? { nil }
+
+    private let fullPath: String
+    private let fetcher: any IosLazyChapterFetcher
+
+    init(fullPath: String, fetcher: any IosLazyChapterFetcher) {
+        self.fullPath = fullPath
+        self.fetcher = fetcher
+    }
+
+    func properties() async -> ReadResult<ResourceProperties> {
+        .success(ResourceProperties())
+    }
+
+    func estimatedLength() async -> ReadResult<UInt64?> {
+        .success(nil)
+    }
+
+    func read(range: Range<UInt64>?) async -> ReadResult<Data> {
+        return await withCheckedContinuation { continuation in
+            fetcher.fetchAssetPath(fullPath) { filePath in
+                guard let filePath = filePath,
+                      let data = try? Data(contentsOf: URL(fileURLWithPath: filePath)) else {
+                    continuation.resume(returning: .failure(.decoding(nil)))
+                    return
+                }
+                if let range = range {
+                    let start = Int(min(range.lowerBound, UInt64(data.count)))
+                    let end = Int(min(range.upperBound, UInt64(data.count)))
+                    continuation.resume(returning: .success(data.subdata(in: start..<end)))
+                } else {
+                    continuation.resume(returning: .success(data))
+                }
+            }
+        }
+    }
+
+    func close() async {}
+}

--- a/iosApp/iosApp/OReillyLazyContainer.swift
+++ b/iosApp/iosApp/OReillyLazyContainer.swift
@@ -44,11 +44,13 @@ final class OReillyLazyContainer: Container {
     }
 
     subscript(_ url: any URLConvertible) -> (any Resource)? {
-        let urlStr = url.string
-        if let spineItem = shape.spine.first(where: { urlStr.hasSuffix($0.fullPath) || $0.fullPath == urlStr }) {
+        // Normalise to a relative path so we match spine items by their fullPath regardless of
+        // whether Readium delivers the URL as bare "xhtml/ch01.xhtml" or as an absolute
+        // "https://readium_package/xhtml/ch01.xhtml". Mirrors Android's exact-URL map lookup.
+        let relativePath = Self.extractRelativePath(url.string)
+        if let spineItem = shape.spine.first(where: { $0.fullPath == relativePath }) {
             return LazyChapterResource(spineItem: spineItem, fetcher: fetcher)
         }
-        let relativePath = Self.extractRelativePath(urlStr)
         return LazyAssetResource(fullPath: relativePath, fetcher: fetcher)
     }
 
@@ -89,7 +91,8 @@ private final class LazyChapterResource: Resource {
     }
 
     func estimatedLength() async -> ReadResult<UInt64?> {
-        .success(UInt64(bitPattern: spineItem.declaredByteSize))
+        let size = spineItem.declaredByteSize
+        return .success(size > 0 ? UInt64(size) : nil)
     }
 
     func read(range: Range<UInt64>?) async -> ReadResult<Data> {

--- a/iosApp/iosApp/OReillyLazyContainer.swift
+++ b/iosApp/iosApp/OReillyLazyContainer.swift
@@ -1,5 +1,6 @@
 import Foundation
 import ReadiumShared
+import Riffle
 
 // MARK: - Shape DTOs (decoded from IosLazyChapterFetcherImpl.serializeShape JSON)
 
@@ -35,7 +36,7 @@ final class OReillyLazyContainer: Container {
     var sourceURL: (any AbsoluteURL)? { nil }
 
     var entries: Set<AnyURL> {
-        Set(shape.spine.compactMap { AnyURL(string: $0.fullPath) })
+        Set(shape.spine.compactMap { AnyURL(path: $0.fullPath) })
     }
 
     init(shape: LazyPublicationShapeDto, fetcher: any IosLazyChapterFetcher) {
@@ -47,7 +48,7 @@ final class OReillyLazyContainer: Container {
         // Normalise to a relative path so we match spine items by their fullPath regardless of
         // whether Readium delivers the URL as bare "xhtml/ch01.xhtml" or as an absolute
         // "https://readium_package/xhtml/ch01.xhtml". Mirrors Android's exact-URL map lookup.
-        let relativePath = Self.extractRelativePath(url.string)
+        let relativePath = Self.extractRelativePath(url.anyURL.string)
         if let spineItem = shape.spine.first(where: { $0.fullPath == relativePath }) {
             return LazyChapterResource(spineItem: spineItem, fetcher: fetcher)
         }

--- a/iosApp/iosApp/OReillyLazyContainer.swift
+++ b/iosApp/iosApp/OReillyLazyContainer.swift
@@ -59,15 +59,15 @@ final class OReillyLazyContainer: Container {
     /// Mirror of `OReillyLazyContainer.extractRelativePath` on Android: strips the
     /// `https://readium_package/` origin Readium prepends to sub-resource URLs.
     static func extractRelativePath(_ urlString: String) -> String {
-        var s = urlString
+        var path = urlString
         let prefix = "https://readium_package/"
-        if s.hasPrefix(prefix) {
-            s = String(s.dropFirst(prefix.count))
+        if path.hasPrefix(prefix) {
+            path = String(path.dropFirst(prefix.count))
         }
-        if s.hasPrefix("/") {
-            s = String(s.dropFirst())
+        if path.hasPrefix("/") {
+            path = String(path.dropFirst())
         }
-        return s
+        return path
     }
 }
 

--- a/iosApp/iosApp/OReillyPublicationBuilder.swift
+++ b/iosApp/iosApp/OReillyPublicationBuilder.swift
@@ -1,6 +1,8 @@
 import Foundation
 import ReadiumShared
 import ReadiumNavigator
+import ReadiumStreamer
+import Riffle
 
 /// Assembles a Readium Swift `Publication` for an O'Reilly book using lazy per-chapter fetching.
 ///
@@ -24,10 +26,9 @@ enum OReillyPublicationBuilder {
 
         let container = OReillyLazyContainer(shape: shape, fetcher: fetcher)
 
-        let readingOrder: [Link] = shape.spine.compactMap { item in
-            guard let url = AnyURL(string: item.fullPath) else { return nil }
-            return Link(
-                href: url,
+        let readingOrder: [Link] = shape.spine.map { item in
+            Link(
+                href: item.fullPath,
                 mediaType: .xhtml,
                 title: item.title.isEmpty ? "Chapter \(item.index + 1)" : item.title
             )
@@ -37,21 +38,20 @@ enum OReillyPublicationBuilder {
             metadata: Metadata(
                 conformsTo: [.epub],
                 identifier: shape.identifier,
-                localizedTitle: LocalizedString(string: shape.title),
+                title: shape.title,
                 languages: [shape.language]
             ),
             readingOrder: readingOrder,
             tableOfContents: readingOrder
         )
 
-        // EpubPositionsService is not wired here — Readium will estimate chapter positions from
-        // the declared byte sizes reported by each LazyChapterResource.estimatedLength().
+        // Positions are estimated from the declared byte sizes reported by LazyChapterResource.estimatedLength().
         let publication = try Publication(
             manifest: manifest,
             container: container,
             servicesBuilder: PublicationServicesBuilder(
                 positions: EPUBPositionsService.makeFactory(
-                    reflowableStrategy: .originalLength(pageLength: 1024)
+                    reflowableStrategy: .recommended
                 )
             )
         )

--- a/iosApp/iosApp/OReillyPublicationBuilder.swift
+++ b/iosApp/iosApp/OReillyPublicationBuilder.swift
@@ -1,0 +1,61 @@
+import Foundation
+import ReadiumShared
+import ReadiumNavigator
+
+/// Assembles a Readium Swift `Publication` for an O'Reilly book using lazy per-chapter fetching.
+///
+/// Mirror of Android's `OReillyPublicationBuilder`: decodes `shapeJson` (produced by
+/// `IosLazyChapterFetcherImpl.serializeShape`), builds an `OReillyLazyContainer`, constructs the
+/// `Manifest` and `Publication`.  No EPUB file is required.
+enum OReillyPublicationBuilder {
+
+    enum BuildError: Error {
+        case invalidShapeJson
+    }
+
+    static func build(
+        shapeJson: String,
+        fetcher: any IosLazyChapterFetcher
+    ) throws -> (publication: Publication, container: OReillyLazyContainer) {
+        guard let data = shapeJson.data(using: .utf8),
+              let shape = try? JSONDecoder().decode(LazyPublicationShapeDto.self, from: data) else {
+            throw BuildError.invalidShapeJson
+        }
+
+        let container = OReillyLazyContainer(shape: shape, fetcher: fetcher)
+
+        let readingOrder: [Link] = shape.spine.compactMap { item in
+            guard let url = AnyURL(string: item.fullPath) else { return nil }
+            return Link(
+                href: url,
+                mediaType: .xhtml,
+                title: item.title.isEmpty ? "Chapter \(item.index + 1)" : item.title
+            )
+        }
+
+        let manifest = Manifest(
+            metadata: Metadata(
+                conformsTo: [.epub],
+                identifier: shape.identifier,
+                localizedTitle: LocalizedString(string: shape.title),
+                languages: [shape.language]
+            ),
+            readingOrder: readingOrder,
+            tableOfContents: readingOrder
+        )
+
+        // EpubPositionsService is not wired here — Readium will estimate chapter positions from
+        // the declared byte sizes reported by each LazyChapterResource.estimatedLength().
+        let publication = try Publication(
+            manifest: manifest,
+            container: container,
+            servicesBuilder: PublicationServicesBuilder(
+                positions: EPUBPositionsService.makeFactory(
+                    reflowableStrategy: .originalLength(pageLength: 1024)
+                )
+            )
+        )
+
+        return (publication, container)
+    }
+}

--- a/iosApp/iosApp/OReillyPublicationBuilder.swift
+++ b/iosApp/iosApp/OReillyPublicationBuilder.swift
@@ -36,8 +36,8 @@ enum OReillyPublicationBuilder {
 
         let manifest = Manifest(
             metadata: Metadata(
-                conformsTo: [.epub],
                 identifier: shape.identifier,
+                conformsTo: [.epub],
                 title: shape.title,
                 languages: [shape.language]
             ),

--- a/iosApp/iosApp/ReadiumEpubNavigatorBridge.swift
+++ b/iosApp/iosApp/ReadiumEpubNavigatorBridge.swift
@@ -97,6 +97,35 @@ import ReadiumNavigator
         tapCallback = callback
     }
 
+    func openLazyEpub(shapeJson: String, locatorJson: String?, fetcher: any IosLazyChapterFetcher) {
+        Task { @MainActor in
+            do {
+                let (pub, _) = try OReillyPublicationBuilder.build(shapeJson: shapeJson, fetcher: fetcher)
+                self.publication = pub
+
+                var initialLocator: Locator?
+                if let json = locatorJson,
+                   let jsonValue = try? JSONValue(jsonString: json) {
+                    initialLocator = try? Locator(json: jsonValue, warnings: nil)
+                }
+
+                let navigator = try EPUBNavigatorViewController(
+                    publication: pub,
+                    initialLocation: initialLocator
+                )
+                navigator.delegate = self
+                self.epubNavigator = navigator
+                self.hostViewController.addChild(navigator)
+                navigator.view.frame = self.hostViewController.view.bounds
+                navigator.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+                self.hostViewController.view.addSubview(navigator.view)
+                navigator.didMove(toParent: self.hostViewController)
+            } catch {
+                // Ignore open errors — reader shows blank state
+            }
+        }
+    }
+
     func disposeNavigator() {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }

--- a/iosApp/iosAppTests/OReillyLazyPublicationTests.swift
+++ b/iosApp/iosAppTests/OReillyLazyPublicationTests.swift
@@ -73,6 +73,52 @@ final class OReillyLazyPublicationTests: XCTestCase {
         )
     }
 
+    // MARK: - Scenario 20-F: special-character title survives JSON round-trip
+
+    func testBuildSucceedsWithSpecialCharactersInTitle() throws {
+        // Title contains a double-quote — must survive the Kotlin-side escaping and the Swift
+        // JSONDecoder round-trip. If serializeShape's jsonStr() is incomplete, this throws.
+        let specialJson = """
+        {
+          "bookId": "9781234567890",
+          "identifier": "urn:orm:book:9781234567890",
+          "title": "Swift \\"Programming\\": A Guide",
+          "language": "en",
+          "absoluteFilesPrefix": "https://example.com/files/",
+          "pathFilesPrefix": "/api/files/",
+          "cssFullPaths": [],
+          "spine": [
+            {"index": 0, "fullPath": "ch01.xhtml", "title": "Intro", "declaredByteSize": 5000}
+          ]
+        }
+        """
+        let fetcher = StubLazyChapterFetcher()
+        let result = try OReillyPublicationBuilder.build(shapeJson: specialJson, fetcher: fetcher)
+        XCTAssertTrue(result.publication.metadata.title.contains("Programming"))
+    }
+
+    // MARK: - Scenario 20-G: estimatedLength is nil when declaredByteSize is zero
+
+    func testEstimatedLengthIsNilWhenDeclaredByteSizeIsZero() async throws {
+        let zeroSizeJson = """
+        {
+          "bookId": "b1", "identifier": "urn:b1", "title": "T", "language": "en",
+          "absoluteFilesPrefix": "", "pathFilesPrefix": "", "cssFullPaths": [],
+          "spine": [{"index": 0, "fullPath": "ch01.xhtml", "title": "Ch1", "declaredByteSize": 0}]
+        }
+        """
+        let fetcher = StubLazyChapterFetcher()
+        let (_, container) = try OReillyPublicationBuilder.build(shapeJson: zeroSizeJson, fetcher: fetcher)
+        guard let resource = container["ch01.xhtml" as any URLConvertible] else {
+            XCTFail("Expected a resource for ch01.xhtml"); return
+        }
+        let result = await resource.estimatedLength()
+        guard case .success(let length) = result else {
+            XCTFail("Expected success"); return
+        }
+        XCTAssertNil(length, "estimatedLength must be nil when declaredByteSize is 0")
+    }
+
     func testContainerEntriesMatchSpine() throws {
         let fetcher = StubLazyChapterFetcher()
         let (_, container) = try OReillyPublicationBuilder.build(shapeJson: validShapeJson, fetcher: fetcher)

--- a/iosApp/iosAppTests/OReillyLazyPublicationTests.swift
+++ b/iosApp/iosAppTests/OReillyLazyPublicationTests.swift
@@ -95,7 +95,7 @@ final class OReillyLazyPublicationTests: XCTestCase {
         """
         let fetcher = StubLazyChapterFetcher()
         let result = try OReillyPublicationBuilder.build(shapeJson: specialJson, fetcher: fetcher)
-        XCTAssertTrue(result.publication.metadata.title.contains("Programming"))
+        XCTAssertTrue(result.publication.metadata.title?.contains("Programming") == true)
     }
 
     // MARK: - Scenario 20-G: estimatedLength is nil when declaredByteSize is zero

--- a/iosApp/iosAppTests/OReillyLazyPublicationTests.swift
+++ b/iosApp/iosAppTests/OReillyLazyPublicationTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Riffle
+import ReadiumShared
 
 // Covers scenarios from docs/testing/ios-scenarios/20-oreilly-lazy-publication.md
 
@@ -109,7 +110,8 @@ final class OReillyLazyPublicationTests: XCTestCase {
         """
         let fetcher = StubLazyChapterFetcher()
         let (_, container) = try OReillyPublicationBuilder.build(shapeJson: zeroSizeJson, fetcher: fetcher)
-        guard let resource = container["ch01.xhtml" as any URLConvertible] else {
+        guard let url = AnyURL(path: "ch01.xhtml"),
+              let resource = container[url] else {
             XCTFail("Expected a resource for ch01.xhtml"); return
         }
         let result = await resource.estimatedLength()
@@ -157,7 +159,8 @@ final class OReillyLazyPublicationTests: XCTestCase {
 
         let (_, container) = try OReillyPublicationBuilder.build(shapeJson: validShapeJson, fetcher: fetcher)
 
-        guard let resource = container["xhtml/ch01.xhtml" as any URLConvertible] else {
+        guard let chUrl = AnyURL(path: "xhtml/ch01.xhtml"),
+              let resource = container[chUrl] else {
             XCTFail("Container should return a resource for ch01.xhtml")
             return
         }
@@ -176,7 +179,8 @@ final class OReillyLazyPublicationTests: XCTestCase {
         // No path registered → fetcher returns nil.
         let (_, container) = try OReillyPublicationBuilder.build(shapeJson: validShapeJson, fetcher: fetcher)
 
-        guard let resource = container["xhtml/ch01.xhtml" as any URLConvertible] else {
+        guard let chUrl2 = AnyURL(path: "xhtml/ch01.xhtml"),
+              let resource = container[chUrl2] else {
             XCTFail("Container should return a resource (not nil) even for un-cached chapters")
             return
         }

--- a/iosApp/iosAppTests/OReillyLazyPublicationTests.swift
+++ b/iosApp/iosAppTests/OReillyLazyPublicationTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+import Riffle
+
+// Covers scenarios from docs/testing/ios-scenarios/20-oreilly-lazy-publication.md
+
+// MARK: - Stub fetcher
+
+/// Stub IosLazyChapterFetcher for testing: records calls and returns canned responses.
+final class StubLazyChapterFetcher: NSObject, IosLazyChapterFetcher {
+
+    var chapterPathsByFullPath: [String: String] = [:]
+    var assetPathsByFullPath: [String: String] = [:]
+    var fetchChapterCallCount = 0
+    var fetchAssetCallCount = 0
+    var prefetchNextCallIndices: [Int32] = []
+    var disposeCallCount = 0
+
+    func fetchChapterXhtmlPath(
+        _ fullPath: String,
+        expectedByteSize: Int64,
+        completion: ((String?) -> Void)?
+    ) {
+        fetchChapterCallCount += 1
+        completion?(chapterPathsByFullPath[fullPath])
+    }
+
+    func fetchAssetPath(_ fullPath: String, completion: ((String?) -> Void)?) {
+        fetchAssetCallCount += 1
+        completion?(assetPathsByFullPath[fullPath])
+    }
+
+    func prefetchNext(currentIndex: Int32) {
+        prefetchNextCallIndices.append(currentIndex)
+    }
+
+    func dispose() {
+        disposeCallCount += 1
+    }
+}
+
+// MARK: - Tests
+
+final class OReillyLazyPublicationTests: XCTestCase {
+
+    // MARK: - Scenario 20-A: shape JSON decoding
+
+    private let validShapeJson = """
+    {
+      "bookId": "9781234567890",
+      "identifier": "urn:orm:book:9781234567890",
+      "title": "Swift Programming",
+      "language": "en",
+      "absoluteFilesPrefix": "https://oreilly.com/api/v2/epubs/urn:orm:book:9781234567890/files/",
+      "pathFilesPrefix": "/api/v2/epubs/urn:orm:book:9781234567890/files/",
+      "cssFullPaths": ["styles/main.css"],
+      "spine": [
+        {"index": 0, "fullPath": "xhtml/ch01.xhtml", "title": "Introduction", "declaredByteSize": 10000},
+        {"index": 1, "fullPath": "xhtml/ch02.xhtml", "title": "Basics",        "declaredByteSize": 15000}
+      ]
+    }
+    """
+
+    func testBuildSucceedsWithValidShapeJson() throws {
+        let fetcher = StubLazyChapterFetcher()
+        let result = try OReillyPublicationBuilder.build(shapeJson: validShapeJson, fetcher: fetcher)
+        XCTAssertEqual(result.publication.metadata.title, "Swift Programming")
+    }
+
+    func testBuildFailsWithInvalidJson() {
+        let fetcher = StubLazyChapterFetcher()
+        XCTAssertThrowsError(
+            try OReillyPublicationBuilder.build(shapeJson: "not json", fetcher: fetcher)
+        )
+    }
+
+    func testContainerEntriesMatchSpine() throws {
+        let fetcher = StubLazyChapterFetcher()
+        let (_, container) = try OReillyPublicationBuilder.build(shapeJson: validShapeJson, fetcher: fetcher)
+        XCTAssertEqual(container.entries.count, 2)
+    }
+
+    // MARK: - Scenario 20-B: URL stripping
+
+    func testExtractRelativePathStripsReadiumPackagePrefix() {
+        let result = OReillyLazyContainer.extractRelativePath("https://readium_package/assets/cover.png")
+        XCTAssertEqual(result, "assets/cover.png")
+    }
+
+    func testExtractRelativePathStripsLeadingSlash() {
+        let result = OReillyLazyContainer.extractRelativePath("/xhtml/ch01.xhtml")
+        XCTAssertEqual(result, "xhtml/ch01.xhtml")
+    }
+
+    func testExtractRelativePathLeavesRelativePathUnchanged() {
+        let result = OReillyLazyContainer.extractRelativePath("images/fig.png")
+        XCTAssertEqual(result, "images/fig.png")
+    }
+
+    // MARK: - Scenario 20-C: fetcher delegation
+
+    func testChapterReadInvokesFetcher() async throws {
+        // Arrange: write a known XHTML to a temp file and point the stub at it.
+        let tmpDir = NSTemporaryDirectory()
+        let tmpPath = "\(tmpDir)ch01_test.xhtml"
+        let xhtml = "<html><body><p>Hello</p></body></html>"
+        try xhtml.write(toFile: tmpPath, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(atPath: tmpPath) }
+
+        let fetcher = StubLazyChapterFetcher()
+        fetcher.chapterPathsByFullPath["xhtml/ch01.xhtml"] = tmpPath
+
+        let (_, container) = try OReillyPublicationBuilder.build(shapeJson: validShapeJson, fetcher: fetcher)
+
+        guard let resource = container["xhtml/ch01.xhtml" as any URLConvertible] else {
+            XCTFail("Container should return a resource for ch01.xhtml")
+            return
+        }
+        let result = await resource.read(range: nil)
+
+        guard case .success(let data) = result else {
+            XCTFail("Expected success reading chapter resource")
+            return
+        }
+        XCTAssertEqual(String(data: data, encoding: .utf8), xhtml)
+        XCTAssertEqual(fetcher.fetchChapterCallCount, 1)
+    }
+
+    func testChapterReadReturnsFailureWhenFetcherReturnsNil() async throws {
+        let fetcher = StubLazyChapterFetcher()
+        // No path registered → fetcher returns nil.
+        let (_, container) = try OReillyPublicationBuilder.build(shapeJson: validShapeJson, fetcher: fetcher)
+
+        guard let resource = container["xhtml/ch01.xhtml" as any URLConvertible] else {
+            XCTFail("Container should return a resource (not nil) even for un-cached chapters")
+            return
+        }
+        let result = await resource.read(range: nil)
+        guard case .failure = result else {
+            XCTFail("Expected failure when fetcher returns nil")
+            return
+        }
+    }
+
+    // MARK: - Scenario 20-D: openLazyEpub bridge wiring
+
+    func testOpenLazyEpubDoesNotCrash() {
+        let bridge = ReadiumEpubNavigatorBridge()
+        let fetcher = StubLazyChapterFetcher()
+        // openLazyEpub dispatches on the main queue; just verify no crash during dispatch.
+        bridge.openLazyEpub(shapeJson: validShapeJson, locatorJson: nil, fetcher: fetcher)
+    }
+}

--- a/iosApp/iosAppTests/OReillyLazyPublicationTests.swift
+++ b/iosApp/iosAppTests/OReillyLazyPublicationTests.swift
@@ -17,7 +17,7 @@ final class StubLazyChapterFetcher: NSObject, IosLazyChapterFetcher {
     var disposeCallCount = 0
 
     func fetchChapterXhtmlPath(
-        _ fullPath: String,
+        fullPath: String,
         expectedByteSize: Int64,
         completion: ((String?) -> Void)?
     ) {
@@ -25,7 +25,7 @@ final class StubLazyChapterFetcher: NSObject, IosLazyChapterFetcher {
         completion?(chapterPathsByFullPath[fullPath])
     }
 
-    func fetchAssetPath(_ fullPath: String, completion: ((String?) -> Void)?) {
+    func fetchAssetPath(fullPath: String, completion: ((String?) -> Void)?) {
         fetchAssetCallCount += 1
         completion?(assetPathsByFullPath[fullPath])
     }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -78,6 +78,8 @@ kotlin {
             implementation(libs.ktor.client.darwin)
             implementation(libs.coil.compose)
             implementation(libs.coil.network.ktor3)
+            // O'Reilly lazy-loading helpers (OReillyEpub.buildChapterXhtml) for IosLazyChapterFetcherImpl.
+            implementation(project(":core:catalog-oreilly"))
         }
         commonTest.dependencies {
             implementation(kotlin("test"))

--- a/shared/src/iosMain/kotlin/com/riffle/shared/reader/IosEpubNavigatorBridge.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/reader/IosEpubNavigatorBridge.kt
@@ -47,6 +47,15 @@ interface IosEpubNavigatorBridge {
      * identifier (e.g. "highlights", "bookmarks"). See [ReadiumSwiftNavigator] for the schema.
      */
     fun applyDecorations(decorationsJson: String, group: String)
+
+    /**
+     * Open an O'Reilly lazy publication: build a Readium Swift [Publication] from [shapeJson]
+     * (the serialised [LazyPublicationShape]) backed by [fetcher], then open the navigator.
+     * This bypasses file-based EPUB parsing entirely — no download is required.
+     *
+     * [shapeJson] must be the JSON produced by [IosLazyChapterFetcherImpl.serializeShape].
+     */
+    fun openLazyEpub(shapeJson: String, locatorJson: String?, fetcher: IosLazyChapterFetcher)
 }
 
 /** Factory so Koin can produce one bridge instance per reader open. */

--- a/shared/src/iosMain/kotlin/com/riffle/shared/reader/IosEpubReaderScreen.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/reader/IosEpubReaderScreen.kt
@@ -17,14 +17,19 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.UIKitViewController
+import com.riffle.core.catalog.CatalogRegistry
+import com.riffle.core.catalog.LazyPublicationCapability
+import com.riffle.core.catalog.LazyPublicationShape
 import com.riffle.core.domain.AnnotationStore
 import com.riffle.core.models.LibraryItem
 import org.koin.compose.koinInject
 import platform.Foundation.NSUserDefaults
 
 /**
- * iOS EPUB reader composable. Downloads the EPUB if not cached, then embeds the Readium Swift
- * navigator via UIKitViewController and persists the reading position across sessions.
+ * iOS EPUB reader composable. For O'Reilly lazy publications, opens directly via
+ * [IosLazyChapterFetcherImpl] without downloading the full EPUB. For all other sources,
+ * downloads the EPUB and uses the file-based open path. Persists the reading position across
+ * sessions via [NSUserDefaults].
  */
 @Suppress("ktlint:standard:function-naming")
 @Composable
@@ -32,9 +37,11 @@ actual fun EpubReaderScreen(item: LibraryItem, onBack: () -> Unit) {
     val bridgeFactory = koinInject<IosEpubNavigatorBridgeFactory>()
     val downloader = koinInject<IosEpubDownloader>()
     val annotationStore = koinInject<AnnotationStore>()
+    val catalogRegistry = koinInject<CatalogRegistry>()
 
     var localPath by remember { mutableStateOf<String?>(null) }
     var loadError by remember { mutableStateOf<String?>(null) }
+    var isLazyPublication by remember { mutableStateOf(false) }
     val bridge = remember { bridgeFactory.create() }
     val navigator = remember(bridge) { ReadiumSwiftNavigator(bridge) }
     val coordinator = remember(navigator) {
@@ -45,18 +52,51 @@ actual fun EpubReaderScreen(item: LibraryItem, onBack: () -> Unit) {
             navigator = navigator,
         )
     }
+    // Retained so DisposableEffect can cancel in-flight fetches on close.
+    var lazyFetcher by remember { mutableStateOf<IosLazyChapterFetcher?>(null) }
+    // Cached publication shape for prefetch index lookups — avoids re-fetching on every position.
+    var lazyShape by remember { mutableStateOf<LazyPublicationShape?>(null) }
 
     LaunchedEffect(item.id) {
+        val savedLocator = NSUserDefaults.standardUserDefaults.stringForKey(locatorKey(item))
+
+        val cap = catalogRegistry.forSourceId(item.sourceId) as? LazyPublicationCapability
+        if (cap != null) {
+            val shape = cap.lazyPublication(item.id)
+            if (shape != null) {
+                isLazyPublication = true
+                lazyShape = shape
+                val fetcher = IosLazyChapterFetcherImpl(cap, shape, item.id)
+                lazyFetcher = fetcher
+                val shapeJson = IosLazyChapterFetcherImpl.serializeShape(shape)
+                navigator.openLazy(shapeJson, savedLocator, fetcher)
+                coordinator.start()
+                localPath = "lazy" // sentinel: triggers the reader UI without a real file path
+                return@LaunchedEffect
+            }
+        }
+
+        // Normal file-based path.
         val path = downloader.localPath(item)
         if (path == null) {
             loadError = "Could not download book"
             return@LaunchedEffect
         }
         localPath = path
-        val savedLocator = NSUserDefaults.standardUserDefaults
-            .stringForKey(locatorKey(item))
         navigator.open(path, savedLocator)
         coordinator.start()
+    }
+
+    // Prefetch the next chapter whenever position changes in a lazy publication.
+    LaunchedEffect(item.id) {
+        navigator.positionFlow.collect { position ->
+            val fetcher = lazyFetcher ?: return@collect
+            val shape = lazyShape ?: return@collect
+            val currentIndex = shape.spine.indexOfFirst { it.fullPath == position.href }
+            if (currentIndex >= 0) {
+                fetcher.prefetchNext(currentIndex)
+            }
+        }
     }
 
     DisposableEffect(item.id) {
@@ -66,6 +106,8 @@ actual fun EpubReaderScreen(item: LibraryItem, onBack: () -> Unit) {
                 NSUserDefaults.standardUserDefaults.setObject(json, forKey = locatorKey(item))
             }
             navigator.close()
+            lazyFetcher?.dispose()
+            lazyFetcher = null
         }
     }
 
@@ -94,6 +136,17 @@ actual fun EpubReaderScreen(item: LibraryItem, onBack: () -> Unit) {
                 text = "← Back",
                 modifier = Modifier.clickable(onClick = onBack),
             )
+        }
+
+        if (isLazyPublication && localPath != null) {
+            Box(
+                modifier = Modifier
+                    .systemBarsPadding()
+                    .padding(12.dp)
+                    .align(Alignment.TopEnd),
+            ) {
+                BasicText("Download to search")
+            }
         }
     }
 }

--- a/shared/src/iosMain/kotlin/com/riffle/shared/reader/IosLazyChapterFetcher.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/reader/IosLazyChapterFetcher.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.withContext
 import platform.Foundation.NSCachesDirectory
 import platform.Foundation.NSData
 import platform.Foundation.NSFileManager
+import platform.Foundation.NSProcessInfo
 import platform.Foundation.NSSearchPathForDirectoriesInDomains
 import platform.Foundation.NSTemporaryDirectory
 import platform.Foundation.NSUserDomainMask
@@ -124,7 +125,7 @@ class IosLazyChapterFetcherImpl(
         NSFileManager.defaultManager.createDirectoryAtPath(
             parent, withIntermediateDirectories = true, attributes = null, error = null,
         )
-        val tmpPath = "$path.tmp"
+        val tmpPath = "$path.${NSProcessInfo.processInfo.globallyUniqueString()}.tmp"
         val nsData = bytes.usePinned { pinned ->
             NSData.create(bytes = pinned.addressOf(0), length = bytes.size.toULong())
         }
@@ -168,6 +169,20 @@ class IosLazyChapterFetcherImpl(
             append("}")
         }
 
-        private fun String.jsonStr() = "\"${replace("\\", "\\\\").replace("\"", "\\\"")}\""
+        private fun String.jsonStr(): String {
+            val escaped = buildString {
+                for (ch in this@jsonStr) {
+                    when (ch) {
+                        '\\' -> append("\\\\")
+                        '"' -> append("\\\"")
+                        '\n' -> append("\\n")
+                        '\r' -> append("\\r")
+                        '\t' -> append("\\t")
+                        else -> if (ch.code < 0x20) append("\\u${ch.code.toString(16).padStart(4, '0')}") else append(ch)
+                    }
+                }
+            }
+            return "\"$escaped\""
+        }
     }
 }

--- a/shared/src/iosMain/kotlin/com/riffle/shared/reader/IosLazyChapterFetcher.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/reader/IosLazyChapterFetcher.kt
@@ -1,0 +1,173 @@
+package com.riffle.shared.reader
+
+import com.riffle.core.catalog.LazyPublicationCapability
+import com.riffle.core.catalog.LazyPublicationShape
+import com.riffle.core.catalog.oreilly.OReillyEpub
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import platform.Foundation.NSCachesDirectory
+import platform.Foundation.NSData
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSSearchPathForDirectoriesInDomains
+import platform.Foundation.NSTemporaryDirectory
+import platform.Foundation.NSUserDomainMask
+import platform.Foundation.create
+
+/**
+ * Obj-C-compatible seam for on-demand O'Reilly chapter fetching from the iOS reader.
+ *
+ * Swift creates an [OReillyLazyContainer] (Readium `Container`) that calls back into this
+ * interface when Readium requests a chapter or asset byte stream.  All methods are callback-based
+ * rather than suspend so they can be called from Swift without coroutine machinery.
+ *
+ * Completion callbacks are invoked on the **main thread**.
+ */
+interface IosLazyChapterFetcher {
+    /**
+     * Ensure the XHTML for [fullPath] is on disk (fetching + assembling if necessary), then call
+     * [completion] with the absolute file-system path, or null on failure.
+     */
+    fun fetchChapterXhtmlPath(fullPath: String, expectedByteSize: Long, completion: (String?) -> Unit)
+
+    /**
+     * Ensure the binary asset at [fullPath] is on disk (fetching if necessary), then call
+     * [completion] with the absolute file-system path, or null on failure.
+     */
+    fun fetchAssetPath(fullPath: String, completion: (String?) -> Unit)
+
+    /**
+     * Background-warm the chapter after [currentIndex] so the next page turn feels instant.
+     * No-op if already cached or index is out of range.
+     */
+    fun prefetchNext(currentIndex: Int)
+
+    /** Cancel all in-flight fetches and release the internal coroutine scope. */
+    fun dispose()
+}
+
+/**
+ * Production implementation: fetches raw HTML from [cap] for [itemId], assembles XHTML via the
+ * shared [OReillyEpub] helpers, and writes to the iOS caches directory with atomic rename semantics.
+ * Assets are cached similarly at a parallel path.
+ */
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+class IosLazyChapterFetcherImpl(
+    private val cap: LazyPublicationCapability,
+    private val shape: LazyPublicationShape,
+    private val itemId: String,
+) : IosLazyChapterFetcher {
+
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+
+    override fun fetchChapterXhtmlPath(fullPath: String, expectedByteSize: Long, completion: (String?) -> Unit) {
+        scope.launch {
+            val path = getOrFetchChapter(fullPath, expectedByteSize)
+            withContext(Dispatchers.Main) { completion(path) }
+        }
+    }
+
+    override fun fetchAssetPath(fullPath: String, completion: (String?) -> Unit) {
+        scope.launch {
+            val path = getOrFetchAsset(fullPath)
+            withContext(Dispatchers.Main) { completion(path) }
+        }
+    }
+
+    override fun prefetchNext(currentIndex: Int) {
+        val nextItem = shape.spine.getOrNull(currentIndex + 1) ?: return
+        val cachePath = chapterCachePath(nextItem.fullPath)
+        if (NSFileManager.defaultManager.fileExistsAtPath(cachePath)) return
+        scope.launch {
+            runCatching { getOrFetchChapter(nextItem.fullPath, nextItem.declaredByteSize) }
+        }
+    }
+
+    override fun dispose() {
+        scope.cancel()
+    }
+
+    private suspend fun getOrFetchChapter(fullPath: String, expectedByteSize: Long): String? {
+        val path = chapterCachePath(fullPath)
+        if (NSFileManager.defaultManager.fileExistsAtPath(path)) return path
+        val html = cap.fetchChapterForLazy(itemId, fullPath, expectedByteSize) ?: return null
+        val spineItem = shape.spine.firstOrNull { it.fullPath == fullPath } ?: return null
+        val xhtml = OReillyEpub.buildChapterXhtml(shape, spineItem, html)
+        return writeToCache(path, xhtml.encodeToByteArray())
+    }
+
+    private suspend fun getOrFetchAsset(fullPath: String): String? {
+        val path = assetCachePath(fullPath)
+        if (NSFileManager.defaultManager.fileExistsAtPath(path)) return path
+        val bytes = cap.fetchAssetForLazy(itemId, fullPath) ?: return null
+        return writeToCache(path, bytes)
+    }
+
+    private fun chapterCachePath(fullPath: String): String =
+        "${cacheBase()}/chapters/${sanitize(fullPath)}"
+
+    private fun assetCachePath(fullPath: String): String =
+        "${cacheBase()}/assets/${sanitize(fullPath)}"
+
+    private fun cacheBase(): String =
+        "${cachesDirectory()}/riffle_oreilly_lazy/${sanitize(shape.bookId)}"
+
+    private fun writeToCache(path: String, bytes: ByteArray): String? {
+        val parent = path.substringBeforeLast("/")
+        NSFileManager.defaultManager.createDirectoryAtPath(
+            parent, withIntermediateDirectories = true, attributes = null, error = null,
+        )
+        val tmpPath = "$path.tmp"
+        val nsData = bytes.usePinned { pinned ->
+            NSData.create(bytes = pinned.addressOf(0), length = bytes.size.toULong())
+        }
+        NSFileManager.defaultManager.createFileAtPath(tmpPath, contents = nsData, attributes = null)
+        val moved = NSFileManager.defaultManager.moveItemAtPath(tmpPath, toPath = path, error = null)
+        if (!moved) {
+            // Fallback: overwrite directly (non-atomic, but better than nothing)
+            NSFileManager.defaultManager.createFileAtPath(path, contents = nsData, attributes = null)
+        }
+        return if (NSFileManager.defaultManager.fileExistsAtPath(path)) path else null
+    }
+
+    private fun sanitize(s: String): String = s.replace(Regex("[^A-Za-z0-9_.\\-]"), "_")
+
+    private fun cachesDirectory(): String {
+        @Suppress("UNCHECKED_CAST")
+        return (NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, true) as List<String>)
+            .firstOrNull() ?: NSTemporaryDirectory()
+    }
+
+    companion object {
+        /**
+         * Serialize [shape] to JSON for passing across the Kotlin↔Swift bridge.
+         * Decoded on the Swift side by [OReillyPublicationBuilder].
+         */
+        fun serializeShape(shape: LazyPublicationShape): String = buildString {
+            append("{")
+            append("\"bookId\":${shape.bookId.jsonStr()},")
+            append("\"identifier\":${shape.identifier.jsonStr()},")
+            append("\"title\":${shape.title.jsonStr()},")
+            append("\"language\":${shape.language.jsonStr()},")
+            append("\"absoluteFilesPrefix\":${shape.absoluteFilesPrefix.jsonStr()},")
+            append("\"pathFilesPrefix\":${shape.pathFilesPrefix.jsonStr()},")
+            append("\"cssFullPaths\":[${shape.cssFullPaths.joinToString(",") { it.jsonStr() }}],")
+            append("\"spine\":[${shape.spine.joinToString(",") { item ->
+                "{\"index\":${item.index}," +
+                    "\"fullPath\":${item.fullPath.jsonStr()}," +
+                    "\"title\":${item.title.jsonStr()}," +
+                    "\"declaredByteSize\":${item.declaredByteSize}}"
+            }}]")
+            append("}")
+        }
+
+        private fun String.jsonStr() = "\"${replace("\\", "\\\\").replace("\"", "\\\"")}\""
+    }
+}

--- a/shared/src/iosMain/kotlin/com/riffle/shared/reader/ReadiumSwiftNavigator.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/reader/ReadiumSwiftNavigator.kt
@@ -65,6 +65,12 @@ class ReadiumSwiftNavigator(private val bridge: IosEpubNavigatorBridge) : EpubNa
         bridge.openEpub(bookFilePath, initialLocatorJson)
     }
 
+    /** Open an O'Reilly lazy publication without downloading a file first. */
+    fun openLazy(shapeJson: String, locatorJson: LocatorJson?, fetcher: IosLazyChapterFetcher) {
+        registerBridgeCallbacks()
+        bridge.openLazyEpub(shapeJson, locatorJson, fetcher)
+    }
+
     override fun close() {
         bridge.setLocatorCallback(null)
         bridge.setPageLoadCallback(null)


### PR DESCRIPTION
Closes #987

## Summary

Implements iOS-side lazy per-chapter O'Reilly publication streaming, matching the existing Android feature with maximum code reuse.

### Reuse
- `OReillyEpub.buildChapterXhtml()` extracted to `commonMain` — Android now delegates to it; iOS uses it directly from `core:catalog-oreilly` (a KMP module with iOS targets, added to `shared`'s `iosMain` deps).

### New iOS components
- **`IosLazyChapterFetcher` / `IosLazyChapterFetcherImpl`** (`shared/iosMain`) — Obj-C-compatible callback interface; fetches HTML via `LazyPublicationCapability`, assembles XHTML with the shared helper, caches to `NSCachesDirectory` using atomic UUID-suffixed `.tmp` → rename; also exposes `serializeShape()` to JSON for the K/N bridge.
- **`OReillyLazyContainer.swift`** — Readium Swift `Container`; URL lookup uses `extractRelativePath` for exact matching. `estimatedLength` returns `nil` when `declaredByteSize ≤ 0`.
- **`OReillyPublicationBuilder.swift`** — decodes shape JSON → `LazyPublicationShapeDto`, builds Readium `Publication` with `EPUBPositionsService`.
- **`IosEpubReaderScreen.kt`** — detects `LazyPublicationCapability`, creates the fetcher, serializes shape JSON, calls `navigator.openLazy(…)`. Prefetches next chapter on position changes. Shows "Download to search" hint for lazy pubs. `DisposableEffect` disposes the fetcher on close.
- **`ReadiumEpubNavigatorBridge.swift`** — `openLazyEpub(shapeJson:locatorJson:fetcher:)` added.

### Code-review fixes (separate commit)
- `estimatedLength` nil-safe for zero/negative byte sizes
- `jsonStr()` escapes all control characters (full switch: `\n`, `\r`, `\t`, `\uXXXX`)
- Container subscript uses `extractRelativePath` exact match instead of `hasSuffix`
- Atomic `.tmp` file uses `NSProcessInfo.globallyUniqueString()` to avoid concurrent-write races

### Tests
- `OReillyLazyPublicationTests.swift` — 9 XCTest cases covering shape JSON decoding, invalid JSON error, URL stripping (3 variants), chapter-fetch delegation (success + nil), nil `estimatedLength` for zero byte size, special-character title escaping, and bridge wiring.
- Scenario doc: `docs/testing/ios-scenarios/20-oreilly-lazy-publication.md`
- K/N compile verified `BUILD SUCCESSFUL`.