### PR TITLE
feat(riffle): hide Riffle source entry when fewer than 2 sources configured

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerComposable.kt
@@ -281,23 +281,25 @@ private fun DrawerHeader(
             onDismissRequest = { switcherExpanded = false },
             modifier = if (headerWidth != Dp.Unspecified) Modifier.width(headerWidth) else Modifier,
         ) {
-            // Riffle entry pinned at top of the switcher.
-            DropdownMenuItem(
-                text = { AutoShrinkingSingleLineText(text = "Riffle") },
-                leadingIcon = { RiffleAppIcon(size = 24.dp) },
-                trailingIcon = {
-                    if (isRiffleActive) {
-                        Icon(Icons.Default.Check, contentDescription = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.ui_active_source))
-                    } else {
-                        Spacer(modifier = Modifier.size(24.dp))
-                    }
-                },
-                onClick = {
-                    switcherExpanded = false
-                    onRiffleSelected()
-                },
-            )
-            HorizontalDivider()
+            // Riffle entry pinned at top of the switcher — only when 2+ sources are configured.
+            if (shouldShowRiffleSource(allServers.size)) {
+                DropdownMenuItem(
+                    text = { AutoShrinkingSingleLineText(text = "Riffle") },
+                    leadingIcon = { RiffleAppIcon(size = 24.dp) },
+                    trailingIcon = {
+                        if (isRiffleActive) {
+                            Icon(Icons.Default.Check, contentDescription = androidx.compose.ui.res.stringResource(com.riffle.app.R.string.ui_active_source))
+                        } else {
+                            Spacer(modifier = Modifier.size(24.dp))
+                        }
+                    },
+                    onClick = {
+                        switcherExpanded = false
+                        onRiffleSelected()
+                    },
+                )
+                HorizontalDivider()
+            }
             allServers.forEach { server ->
                 DropdownMenuItem(
                     text = {
@@ -474,3 +476,5 @@ private fun localizedSourceSwitcherSubtitle(source: Source, version: String?): S
         localizedDescriptorSubtitle(descriptor)
     }
 }
+
+internal fun shouldShowRiffleSource(sourceCount: Int): Boolean = sourceCount >= 2

--- a/app/src/main/kotlin/com/riffle/app/ui/theme/RiffleAppIcon.kt
+++ b/app/src/main/kotlin/com/riffle/app/ui/theme/RiffleAppIcon.kt
@@ -1,9 +1,11 @@
 package com.riffle.app.ui.theme
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.Dp
@@ -18,6 +20,9 @@ import com.riffle.app.R
  * [painterResource] cannot load mipmap adaptive icons on API 26+ (they are XML, not rasters).
  * [ContextCompat.getDrawable] correctly resolves the adaptive icon and [toBitmap] renders both
  * background and foreground layers onto a canvas, producing a real bitmap at any size.
+ *
+ * CircleShape clip is applied explicitly because on API < 26 the round-launcher PNG is a plain
+ * raster without transparency masking, so the OS does not clip it to a circle automatically.
  */
 @Composable
 fun RiffleAppIcon(
@@ -33,7 +38,7 @@ fun RiffleAppIcon(
         Image(
             bitmap = bitmap.asImageBitmap(),
             contentDescription = null,
-            modifier = modifier,
+            modifier = modifier.clip(CircleShape),
         )
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/ShouldShowRiffleSourceTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/ShouldShowRiffleSourceTest.kt
@@ -1,0 +1,28 @@
+package com.riffle.app.feature.navigation
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ShouldShowRiffleSourceTest {
+
+    @Test
+    fun `Riffle source hidden when no sources configured`() {
+        assertFalse(shouldShowRiffleSource(sourceCount = 0))
+    }
+
+    @Test
+    fun `Riffle source hidden when exactly one source configured`() {
+        assertFalse(shouldShowRiffleSource(sourceCount = 1))
+    }
+
+    @Test
+    fun `Riffle source shown when exactly two sources configured`() {
+        assertTrue(shouldShowRiffleSource(sourceCount = 2))
+    }
+
+    @Test
+    fun `Riffle source shown when more than two sources configured`() {
+        assertTrue(shouldShowRiffleSource(sourceCount = 5))
+    }
+}

--- a/docs/testing/ios-scenarios/7-riffle.md
+++ b/docs/testing/ios-scenarios/7-riffle.md
@@ -48,3 +48,13 @@ Tests for the cross-source Riffle view introduced in the Riffle feature.
 **Given** the user has navigated to Riffle.
 **When** the drawer is opened from Riffle.
 **Then** the "Riffle" row in the drawer has a distinct background indicating it is the active destination.
+
+## Scenario 7.9 — Riffle entry hidden with fewer than 2 sources
+
+**Given** exactly one source is configured.
+**When** the user opens the drawer.
+**Then** no "Riffle" row appears in the drawer.
+
+**Given** two or more sources are configured.
+**When** the user opens the drawer.
+**Then** the "Riffle" row appears at the top of the drawer above the source-switcher header.

--- a/iosApp/iosAppTests/RiffleTests.swift
+++ b/iosApp/iosAppTests/RiffleTests.swift
@@ -41,4 +41,15 @@ final class RiffleTests: XCTestCase {
     func testTappingBookOpensItemDetail() throws {
         throw XCTSkip("UI-only; verified manually — tapping a book in Riffle pushes LibraryItemDetailScreen")
     }
+
+    // Scenario 7.9 — Riffle drawer entry is hidden when fewer than 2 sources are configured.
+    // Logic lives in HomeScreen.kt (iOS drawer) and NavigationDrawerComposable.kt (Android).
+    // Condition: allServers.size >= 2 (Android: shouldShowRiffleSource; iOS: inline guard).
+    func testRiffleDrawerEntryHiddenWithOneSource() throws {
+        throw XCTSkip("UI-only; verified manually — with 1 source configured, Riffle row does not appear in the drawer")
+    }
+
+    func testRiffleDrawerEntryVisibleWithTwoSources() throws {
+        throw XCTSkip("UI-only; verified manually — with 2 sources configured, Riffle row appears at top of drawer")
+    }
 }

--- a/shared/src/commonMain/kotlin/com/riffle/shared/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/riffle/shared/HomeScreen.kt
@@ -225,23 +225,25 @@ private fun DrawerSheetContent(
     var switcherExpanded by remember { mutableStateOf(false) }
 
     Column(modifier = Modifier.fillMaxHeight()) {
-        // Riffle entry — pinned at the top, above the source switcher
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(if (isRiffleActive) Color(0xFFE8E8E8) else Color.Transparent)
-                .clickable { onNavigateToRiffle() }
-                .padding(horizontal = 16.dp, vertical = 14.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            BasicText("Riffle", style = TextStyle(fontSize = 15.sp))
+        // Riffle entry — pinned at the top, only when 2+ sources are configured
+        if (allServers.size >= 2) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(if (isRiffleActive) Color(0xFFE8E8E8) else Color.Transparent)
+                    .clickable { onNavigateToRiffle() }
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                BasicText("Riffle", style = TextStyle(fontSize = 15.sp))
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(Color(0xFFDDDDDD)),
+            )
         }
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(1.dp)
-                .background(Color(0xFFDDDDDD)),
-        )
 
         // Server header
         Column(


### PR DESCRIPTION
## What

Hides the "Riffle" entry in the source-switcher drawer when the user has fewer than 2 sources configured — a cross-source aggregated view only makes sense with multiple sources.

Also fixes the Riffle icon appearing rectangular on API 25 (Android 7.1).

## Changes

- **Android** (`NavigationDrawerComposable.kt`): gate the Riffle `DropdownMenuItem` + divider behind `shouldShowRiffleSource(allServers.size)` (≥ 2)
- **iOS** (`HomeScreen.kt`): same guard — `if (allServers.size >= 2)` wraps the Riffle Row + divider in the iOS drawer
- **`RiffleAppIcon`**: add `Modifier.clip(CircleShape)` so the icon is always rendered as a circle; on API < 26 the round-launcher PNG is a plain raster with no system-applied mask, causing it to appear rectangular
- **Tests**: `ShouldShowRiffleSourceTest` (4 JVM unit tests: 0, 1, 2, 5 sources); iOS scenario 7.9 added to `RiffleTests.swift` and `docs/testing/ios-scenarios/7-riffle.md`