### PR TITLE
fix(build): extend copyComposeResourcesForApk dependsOn to cover AGP 9.4.0 lintVital tasks

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -233,10 +233,13 @@ debugImplementation(libs.androidx.compose.ui.tooling)
 // into the directory registered as an asset srcDir above. AGP 9.4.0 introduced
 // generateReleaseLintVitalReportModel / lintVitalAnalyze* as tasks that also scan asset source
 // directories; without the dependsOn they fail with "implicit dependency" validation errors.
+// The same applies to the standard lint task's generateDebugLintReportModel / lintAnalyze* tasks.
 tasks.matching {
     (it.name.startsWith("merge") && it.name.endsWith("Assets")) ||
         it.name.endsWith("LintVitalReportModel") ||
-        it.name.startsWith("lintVitalAnalyze")
+        it.name.endsWith("LintReportModel") ||
+        it.name.startsWith("lintVitalAnalyze") ||
+        it.name.startsWith("lintAnalyze")
 }.configureEach {
     dependsOn(":feature:source-ui:copyComposeResourcesForApk")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -229,8 +229,14 @@ debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 }
 
-// Asset merging must wait for :feature:source-ui to assemble its Compose resources into the
-// directory registered as an asset srcDir above.
-tasks.matching { it.name.startsWith("merge") && it.name.endsWith("Assets") }.configureEach {
+// Asset merging and lint tasks must wait for :feature:source-ui to assemble its Compose resources
+// into the directory registered as an asset srcDir above. AGP 9.4.0 introduced
+// generateReleaseLintVitalReportModel / lintVitalAnalyze* as tasks that also scan asset source
+// directories; without the dependsOn they fail with "implicit dependency" validation errors.
+tasks.matching {
+    (it.name.startsWith("merge") && it.name.endsWith("Assets")) ||
+        it.name.endsWith("LintVitalReportModel") ||
+        it.name.startsWith("lintVitalAnalyze")
+}.configureEach {
     dependsOn(":feature:source-ui:copyComposeResourcesForApk")
 }

--- a/shared/src/iosMain/kotlin/com/riffle/shared/reader/IosLazyChapterFetcher.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/reader/IosLazyChapterFetcher.kt
@@ -60,11 +60,8 @@ interface IosLazyChapterFetcher {
  * Assets are cached similarly at a parallel path.
  */
 @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
-class IosLazyChapterFetcherImpl(
-    private val cap: LazyPublicationCapability,
-    private val shape: LazyPublicationShape,
-    private val itemId: String,
-) : IosLazyChapterFetcher {
+class IosLazyChapterFetcherImpl(private val cap: LazyPublicationCapability, private val shape: LazyPublicationShape, private val itemId: String,) :
+    IosLazyChapterFetcher {
 
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 


### PR DESCRIPTION
AGP 9.4.0 added `generateReleaseLintVitalReportModel` and `lintVitalAnalyze*` as tasks that scan asset source directories. Without an explicit `dependsOn`, they race with `:feature:source-ui:copyComposeResourcesForApk` and fail the release build with implicit dependency validation errors.

Extends the existing `tasks.matching` block in `app/build.gradle.kts` to cover these new task name patterns alongside the existing `merge*Assets` tasks.