### PR TITLE
fix(build): cover standard lint tasks in AGP 9.4.0 asset dependsOn

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -233,10 +233,13 @@ debugImplementation(libs.androidx.compose.ui.tooling)
 // into the directory registered as an asset srcDir above. AGP 9.4.0 introduced
 // generateReleaseLintVitalReportModel / lintVitalAnalyze* as tasks that also scan asset source
 // directories; without the dependsOn they fail with "implicit dependency" validation errors.
+// The same applies to the standard lint task's generateDebugLintReportModel / lintAnalyze* tasks.
 tasks.matching {
     (it.name.startsWith("merge") && it.name.endsWith("Assets")) ||
         it.name.endsWith("LintVitalReportModel") ||
-        it.name.startsWith("lintVitalAnalyze")
+        it.name.endsWith("LintReportModel") ||
+        it.name.startsWith("lintVitalAnalyze") ||
+        it.name.startsWith("lintAnalyze")
 }.configureEach {
     dependsOn(":feature:source-ui:copyComposeResourcesForApk")
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -229,8 +229,14 @@ debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 }
 
-// Asset merging must wait for :feature:source-ui to assemble its Compose resources into the
-// directory registered as an asset srcDir above.
-tasks.matching { it.name.startsWith("merge") && it.name.endsWith("Assets") }.configureEach {
+// Asset merging and lint tasks must wait for :feature:source-ui to assemble its Compose resources
+// into the directory registered as an asset srcDir above. AGP 9.4.0 introduced
+// generateReleaseLintVitalReportModel / lintVitalAnalyze* as tasks that also scan asset source
+// directories; without the dependsOn they fail with "implicit dependency" validation errors.
+tasks.matching {
+    (it.name.startsWith("merge") && it.name.endsWith("Assets")) ||
+        it.name.endsWith("LintVitalReportModel") ||
+        it.name.startsWith("lintVitalAnalyze")
+}.configureEach {
     dependsOn(":feature:source-ui:copyComposeResourcesForApk")
 }

--- a/shared/src/iosMain/kotlin/com/riffle/shared/reader/IosLazyChapterFetcher.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/reader/IosLazyChapterFetcher.kt
@@ -60,11 +60,8 @@ interface IosLazyChapterFetcher {
  * Assets are cached similarly at a parallel path.
  */
 @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
-class IosLazyChapterFetcherImpl(
-    private val cap: LazyPublicationCapability,
-    private val shape: LazyPublicationShape,
-    private val itemId: String,
-) : IosLazyChapterFetcher {
+class IosLazyChapterFetcherImpl(private val cap: LazyPublicationCapability, private val shape: LazyPublicationShape, private val itemId: String,) :
+    IosLazyChapterFetcher {
 
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 


### PR DESCRIPTION
## Summary

- Extends the `tasks.matching` block in `app/build.gradle.kts` to also cover `lintAnalyze*` and `*LintReportModel` tasks, in addition to the `lintVital*` variants already covered.
- AGP 9.4.0 scans asset source directories for both the standard `lint` task and the `lintVital` task. The previous fix only covered `lintVital`, so `./gradlew lint` (used in CI's Android lint job) still hit implicit-dependency validation errors.

## Test plan

- [ ] CI Android lint job passes (`./gradlew lint riffleChecks`)
- [ ] CI build job passes (`./gradlew assembleDebug`)