### PR TITLE
fix(navigation): clear active source on Riffle entry to fix first-tap source switch

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModel.kt
@@ -170,6 +170,14 @@ class NavigationDrawerViewModel constructor(
     }
 
     fun setRiffleActive() {
-        viewModelScope.launch { lastOpenedLibraryStore.setRiffleActive() }
+        viewModelScope.launch {
+            // Clear the active source so that switching back to any source (including the one
+            // that was active before entering Riffle) is always a state change. Without this,
+            // setActiveServer(X) on the previously-active source produces no new emission from the
+            // activeServer StateFlow (setActiveAtomic is transactional — Room fires one notification,
+            // net result is unchanged), so the LaunchedEffect in MainScreen never navigates away.
+            sourceRepository.clearActive()
+            lastOpenedLibraryStore.setRiffleActive()
+        }
     }
 }

--- a/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/navigation/NavigationDrawerViewModelTest.kt
@@ -74,6 +74,9 @@ class NavigationDrawerViewModelTest {
         override suspend fun setActive(sourceId: String) {
             serversFlow.update { list -> list.map { it.copy(isActive = it.id == sourceId) } }
         }
+        override suspend fun clearActive() {
+            serversFlow.update { list -> list.map { it.copy(isActive = false) } }
+        }
         override suspend fun remove(sourceId: String) {
             serversFlow.update { list -> list.filter { it.id != sourceId } }
         }
@@ -506,6 +509,25 @@ class NavigationDrawerViewModelTest {
 
         val wasRiffle = riffleActiveFlow.first()
         assertEquals(true, wasRiffle)
+    }
+
+    // Regression: switching from Riffle back to the source that was active BEFORE Riffle was
+    // entered must change activeServer (null → source), so MainScreen's LaunchedEffect fires and
+    // navigates away from the Riffle screen. Without clearActive() in setRiffleActive(), the
+    // previously-active source stays active in the DB; setActiveAtomic is transactional and Room
+    // emits one notification with the net-unchanged value, so the StateFlow never changes and the
+    // LaunchedEffect is never triggered — first tap to switch away from Riffle silently no-ops.
+    @Test
+    fun `setRiffleActive clears the active source so re-selecting it later triggers a state change`() = runTest(testDispatcher) {
+        serversFlow.value = listOf(server("srv-1", active = true))
+        val vm = makeVm()
+        backgroundScope.launch { vm.activeServer.collect {} }
+        testScheduler.advanceUntilIdle()
+
+        vm.setRiffleActive()
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(null, vm.activeServer.value)
     }
 
     // Regression: switching the active source while Riffle is showing must clear the

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/SourceRepositoryImpl.kt
@@ -63,6 +63,10 @@ class SourceRepositoryImpl constructor(
         dao.setActiveAtomic(sourceId)
     }
 
+    override suspend fun clearActive() {
+        dao.clearActiveFlag()
+    }
+
     override suspend fun remove(sourceId: String) {
         // Keep Room cleanup atomic. Some user databases have accumulated rows in source-scoped
         // caches and cross-source readaloud tables; deleting the source row through one graph

--- a/core/data/src/iosMain/kotlin/com/riffle/core/data/IosSourceRepositoryImpl.kt
+++ b/core/data/src/iosMain/kotlin/com/riffle/core/data/IosSourceRepositoryImpl.kt
@@ -63,6 +63,10 @@ class IosSourceRepositoryImpl(private val dao: SourceDao, private val libraryDao
         dao.setActiveAtomic(sourceId)
     }
 
+    override suspend fun clearActive() {
+        dao.clearActiveFlag()
+    }
+
     override suspend fun remove(sourceId: String) {
         dao.deleteSourceGraph(sourceId)
         tokenStorage.deleteToken(sourceId)

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/SourceRepository.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/SourceRepository.kt
@@ -33,6 +33,8 @@ interface SourceRepository {
         hiddenLibraryIds: Set<String>,
     ): CommitSourceResult
     suspend fun setActive(sourceId: String)
+    /** Deactivate all sources, leaving none active (e.g. when entering Riffle mode). */
+    suspend fun clearActive() {}
     suspend fun remove(sourceId: String)
     suspend fun getSourceVersion(sourceId: String): String?
 

--- a/docs/testing/ios-scenarios/7-riffle.md
+++ b/docs/testing/ios-scenarios/7-riffle.md
@@ -49,14 +49,6 @@ Tests for the cross-source Riffle view introduced in the Riffle feature.
 **When** the drawer is opened from Riffle.
 **Then** the "Riffle" row in the drawer has a distinct background indicating it is the active destination.
 
-## Scenario 7.10 — Switching from Riffle back to the previously-active source navigates away on first tap
-
-**Given** source A is the active source and the user has navigated to the Riffle screen.
-**When** the user opens the drawer and taps source A (the same source that was active before entering Riffle).
-**Then** the drawer closes and the user is taken to source A's library on the **first** tap, not the second.
-
-*Regression: entering Riffle must deactivate the underlying source so that re-selecting the same source is always a state change that triggers navigation away from Riffle.*
-
 ## Scenario 7.9 — Riffle entry hidden with fewer than 2 sources
 
 **Given** exactly one source is configured.
@@ -66,3 +58,11 @@ Tests for the cross-source Riffle view introduced in the Riffle feature.
 **Given** two or more sources are configured.
 **When** the user opens the drawer.
 **Then** the "Riffle" row appears at the top of the drawer above the source-switcher header.
+
+## Scenario 7.10 — Switching from Riffle back to the previously-active source navigates away on first tap
+
+**Given** source A is the active source and the user has navigated to the Riffle screen.
+**When** the user opens the drawer and taps source A (the same source that was active before entering Riffle).
+**Then** the drawer closes and the user is taken to source A's library on the **first** tap, not the second.
+
+*Regression: entering Riffle must deactivate the underlying source so that re-selecting the same source is always a state change that triggers navigation away from Riffle.*

--- a/docs/testing/ios-scenarios/7-riffle.md
+++ b/docs/testing/ios-scenarios/7-riffle.md
@@ -49,6 +49,14 @@ Tests for the cross-source Riffle view introduced in the Riffle feature.
 **When** the drawer is opened from Riffle.
 **Then** the "Riffle" row in the drawer has a distinct background indicating it is the active destination.
 
+## Scenario 7.10 — Switching from Riffle back to the previously-active source navigates away on first tap
+
+**Given** source A is the active source and the user has navigated to the Riffle screen.
+**When** the user opens the drawer and taps source A (the same source that was active before entering Riffle).
+**Then** the drawer closes and the user is taken to source A's library on the **first** tap, not the second.
+
+*Regression: entering Riffle must deactivate the underlying source so that re-selecting the same source is always a state change that triggers navigation away from Riffle.*
+
 ## Scenario 7.9 — Riffle entry hidden with fewer than 2 sources
 
 **Given** exactly one source is configured.

--- a/iosApp/iosAppTests/RiffleTests.swift
+++ b/iosApp/iosAppTests/RiffleTests.swift
@@ -42,6 +42,13 @@ final class RiffleTests: XCTestCase {
         throw XCTSkip("UI-only; verified manually — tapping a book in Riffle pushes LibraryItemDetailScreen")
     }
 
+    // Scenario 7.10 — Switching from Riffle back to the previously-active source navigates on first tap.
+    // The fix is in IosSourceRepositoryImpl.clearActive() called by setRiffleActive() in the shared
+    // NavigationDrawerViewModel (commonMain). iOS exercises the same ViewModel path.
+    func testSwitchingFromRiffleToSameSourceNavigatesOnFirstTap() throws {
+        throw XCTSkip("UI-only; verified manually — tap Riffle, open drawer, tap the source that was active before: library opens on the FIRST tap, not the second")
+    }
+
     // Scenario 7.9 — Riffle drawer entry is hidden when fewer than 2 sources are configured.
     // Logic lives in HomeScreen.kt (iOS drawer) and NavigationDrawerComposable.kt (Android).
     // Condition: allServers.size >= 2 (Android: shouldShowRiffleSource; iOS: inline guard).

--- a/shared/src/commonMain/kotlin/com/riffle/shared/DrawerViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/riffle/shared/DrawerViewModel.kt
@@ -72,7 +72,17 @@ class DrawerViewModel(
     }
 
     fun setActiveServer(sourceId: String) {
-        viewModelScope.launch { sourceRepository.setActive(sourceId) }
+        viewModelScope.launch {
+            lastOpenedLibraryStore.clearRiffleActive()
+            sourceRepository.setActive(sourceId)
+        }
+    }
+
+    fun setRiffleActive() {
+        viewModelScope.launch {
+            sourceRepository.clearActive()
+            lastOpenedLibraryStore.setRiffleActive()
+        }
     }
 
     init {

--- a/shared/src/commonMain/kotlin/com/riffle/shared/HomeScreen.kt
+++ b/shared/src/commonMain/kotlin/com/riffle/shared/HomeScreen.kt
@@ -178,10 +178,12 @@ fun HomeScreen() {
                     isRiffleActive = appSection == AppSection.Riffle,
                     onNavigateToRiffle = {
                         drawerOpen = false
+                        drawerViewModel.setRiffleActive()
                         appSection = AppSection.Riffle
                     },
                     onServerSelected = { source ->
                         drawerOpen = false
+                        appSection = AppSection.Library
                         drawerViewModel.setActiveServer(source.id)
                         refreshKey++
                     },

--- a/shared/src/commonTest/kotlin/com/riffle/shared/DrawerViewModelTest.kt
+++ b/shared/src/commonTest/kotlin/com/riffle/shared/DrawerViewModelTest.kt
@@ -51,7 +51,12 @@ private fun fakeSourceRepository(sources: List<Source> = listOf(absSource)): Sou
         override suspend fun getActive(): Source? = flow.value.firstOrNull { it.isActive }
         override suspend fun commit(pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>) =
             error("not used")
-        override suspend fun setActive(sourceId: String) {}
+        override suspend fun setActive(sourceId: String) {
+            flow.value = flow.value.map { it.copy(isActive = it.id == sourceId) }
+        }
+        override suspend fun clearActive() {
+            flow.value = flow.value.map { it.copy(isActive = false) }
+        }
         override suspend fun remove(sourceId: String) {}
         override suspend fun getSourceVersion(sourceId: String): String? = null
     }
@@ -90,9 +95,17 @@ private fun fakeVisibilityStore(hidden: Set<String> = emptySet()): LibraryVisibi
         override suspend fun showLibrary(sourceId: String, libraryId: String) {}
     }
 
-private fun fakeLastOpenedStore(): LastOpenedLibraryStore = object : LastOpenedLibraryStore {
+private fun fakeLastOpenedStore(): LastOpenedLibraryStore = trackingLastOpenedStore()
+
+private fun trackingLastOpenedStore(): TrackingLastOpenedStore = TrackingLastOpenedStore()
+
+private class TrackingLastOpenedStore : LastOpenedLibraryStore {
+    val riffleActiveFlow = MutableStateFlow(false)
     override fun lastOpenedLibrary(sourceId: String): Flow<String?> = flowOf(null)
-    override suspend fun setLastOpenedLibrary(sourceId: String, libraryId: String) {}
+    override suspend fun setLastOpenedLibrary(sourceId: String, libraryId: String) { riffleActiveFlow.value = false }
+    override fun wasRiffleLastActive(): Flow<Boolean> = riffleActiveFlow
+    override suspend fun setRiffleActive() { riffleActiveFlow.value = true }
+    override suspend fun clearRiffleActive() { riffleActiveFlow.value = false }
 }
 
 class DrawerViewModelTest {
@@ -145,6 +158,41 @@ class DrawerViewModelTest {
         )
         val visible = vm.visibleLibraries.value
         assertEquals(listOf("B"), visible.map { it.id })
+    }
+
+    // Regression: setRiffleActive must clear the active source so that switching back to the
+    // previously-active source always changes activeServer (null → source) and triggers navigation.
+    @Test
+    fun setRiffleActiveClearsActiveSource() = runTest {
+        val store = trackingLastOpenedStore()
+        val vm = DrawerViewModel(
+            sourceRepository = fakeSourceRepository(listOf(absSource)),
+            libraryObserver = fakeLibraryObserver(),
+            visibilityStore = fakeVisibilityStore(),
+            lastOpenedLibraryStore = store,
+        )
+
+        vm.setRiffleActive()
+        testScheduler.advanceUntilIdle()
+
+        assertNull(vm.activeServer.value)
+    }
+
+    // Regression: setRiffleActive must persist the "riffle last active" flag for cold-start routing.
+    @Test
+    fun setRiffleActiveSetsRiffleFlag() = runTest {
+        val store = trackingLastOpenedStore()
+        val vm = DrawerViewModel(
+            sourceRepository = fakeSourceRepository(),
+            libraryObserver = fakeLibraryObserver(),
+            visibilityStore = fakeVisibilityStore(),
+            lastOpenedLibraryStore = store,
+        )
+
+        vm.setRiffleActive()
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(true, store.riffleActiveFlow.value)
     }
 
     @Test


### PR DESCRIPTION
## Root cause

When entering Riffle mode the previously-active source stayed marked `isActive=1` in the database. Selecting the **same** source again called `setActiveAtomic` (a `@Transaction`), so Room fired one notification with the net-unchanged value. The `StateFlow<Source?>` deduplicated it and the `LaunchedEffect` in `MainScreen` never navigated away. Only tapping a *different* source on the second tap produced a genuine state change.

## Fix

Call `sourceRepository.clearActive()` inside `setRiffleActive()` on both Android (`NavigationDrawerViewModel`) and iOS (`DrawerViewModel`). This sets `activeServer` → `null` on Riffle entry, so any subsequent `setActiveServer(X)` is always a `null → X` transition that reliably triggers navigation.

iOS `HomeScreen.kt` also lacked `appSection = AppSection.Library` in `onServerSelected`, so switching from Riffle left the Riffle screen visible even after the library loaded. Fixed inline.

## Changes

- `SourceRepository`: added `clearActive()` (deactivates all sources in DB)
- `SourceRepositoryImpl` / `IosSourceRepositoryImpl`: implement `clearActive()` via `dao.clearActiveFlag()`
- `NavigationDrawerViewModel.setRiffleActive()`: calls `clearActive()` before setting the Riffle flag
- `DrawerViewModel` (iOS shared): same — `setRiffleActive()` clears active source; `setActiveServer()` calls `clearRiffleActive()`
- `HomeScreen.kt` (iOS): `onNavigateToRiffle` calls `setRiffleActive()`; `onServerSelected` resets `appSection = Library`

## Tests

- `NavigationDrawerViewModelTest`: regression — `setRiffleActive clears the active source so re-selecting it later triggers a state change`
- `DrawerViewModelTest`: regression — `setRiffleActiveClearsActiveSource` and `setRiffleActiveSetsRiffleFlag`
- iOS scenario 7.10 added in `docs/testing/ios-scenarios/7-riffle.md` and `iosApp/iosAppTests/RiffleTests.swift`

## Review notes

- Finding: `onItemSelected = {}` no-ops in `SeriesDetailScreen`/`CollectionDetailScreen` — pre-existing, not in this diff, dismissed.
- Finding: `refreshKey++` races with async DB write — pre-existing behavior, dismissed.
- Finding: `setRiffleActive` non-atomic (two sequential suspend calls) — the crash window is two DB calls with no user interaction; recovery path (routes to AddSource) is safe, dismissed.
- Finding: `clearActive()` as default no-op risks silent regression in test doubles — both real implementations already override it; 15+ test fakes would need updating for a theoretical safety improvement, dismissed.
- Finding: scenario 7.10 out of order in docs — fixed in second commit.