### PR TITLE
fix(reader): open non-active-source books correctly and restore their reading progress

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/di/KoinViewModelModules.kt
+++ b/app/src/main/kotlin/com/riffle/app/di/KoinViewModelModules.kt
@@ -609,6 +609,7 @@ private val readerViewModelModule = module {
         val handle = get<androidx.lifecycle.SavedStateHandle>()
         CbzReaderViewModel(
             itemId = checkNotNull(handle.get<String>("itemId")) { "CbzReaderViewModel requires an itemId nav argument" },
+            sourceId = handle.get<String>("sourceId"),
             libraryObserver = get(),
             cbzRepository = get(),
             readingSessionRepository = get(),

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -535,7 +535,8 @@ class EpubReaderViewModel constructor(
 
     private val positionSaveCoordinator = PositionSaveCoordinator<String>(
         savePosition = { cfi ->
-            epubRepository.saveReadingPosition(itemId, cfi)
+            val sid = navServerId ?: sourceRepository.getActive()?.id
+            if (sid != null) epubRepository.saveReadingPosition(sid, itemId, cfi)
             // Matched book: reading is also listening — persist the translated audiobook position
             // locally so the durable sweep pushes the audio record too, without reopening (ADR 0036).
             readaloud.mirrorReadingToAudiobook(cfi)
@@ -1409,11 +1410,18 @@ class EpubReaderViewModel constructor(
                 openAtCfi = openAtCfi,
                 openAnnotationId = openAnnotationId,
                 startTocHref = startTocHref,
+                sourceId = navServerId,
             ),
         )
         when (outcome) {
-            is com.riffle.app.feature.reader.session.ReaderSessionLifecycle.OpenOutcome.Error ->
-                _state.value = ReaderState.Error(outcome.message)
+            is com.riffle.app.feature.reader.session.ReaderSessionLifecycle.OpenOutcome.Error -> {
+                val displayMessage = if (outcome.message == "Book not found") {
+                    getApplication<android.app.Application>().getString(com.riffle.app.R.string.reader_book_not_found)
+                } else {
+                    outcome.message
+                }
+                _state.value = ReaderState.Error(displayMessage)
+            }
             is com.riffle.app.feature.reader.session.ReaderSessionLifecycle.OpenOutcome.Ready ->
                 onOpenReady(outcome)
         }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
@@ -82,6 +82,7 @@ class PdfReaderViewModel constructor(
     }
 
     private val itemId: String = checkNotNull(savedStateHandle["itemId"])
+    private val navSourceId: String? = savedStateHandle.get<String>("sourceId")
 
     private val _state = MutableStateFlow<ReaderState>(ReaderState.Loading)
     val state: StateFlow<ReaderState> = _state
@@ -149,7 +150,10 @@ class PdfReaderViewModel constructor(
     )
 
     private val positionSaveCoordinator = PositionSaveCoordinator<String>(
-        savePosition = { cfi -> pdfRepository.saveReadingPosition(itemId, cfi) },
+        savePosition = { cfi ->
+            val sid = navSourceId ?: sourceRepository.getActive()?.id
+            if (sid != null) pdfRepository.saveReadingPosition(sid, itemId, cfi)
+        },
         updateProgress = { progress -> updateReadingProgressUseCase(itemId, progress) },
     )
 
@@ -271,9 +275,10 @@ class PdfReaderViewModel constructor(
     }
 
     private suspend fun openBook() {
-        val item = libraryObserver.getItem(itemId)
+        val item = navSourceId?.let { libraryObserver.getItem(it, itemId) }
+            ?: libraryObserver.getItem(itemId)
         if (item == null) {
-            _state.value = ReaderState.Error("Book not found")
+            _state.value = ReaderState.Error(getApplication<android.app.Application>().getString(com.riffle.app.R.string.reader_book_not_found))
             return
         }
         when (val result = pdfRepository.openPdf(item)) {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/cbz/CbzReaderScreen.kt
@@ -120,7 +120,7 @@ fun CbzReaderScreen(
     val immersiveState = rememberImmersiveModeState()
 
     LaunchedEffect(state) {
-        if (state is CbzReaderState.Error) immersiveState.show()
+        if (state is CbzReaderState.Error || state is CbzReaderState.BookNotFound) immersiveState.show()
     }
 
     DisposableEffect(viewModel) {
@@ -150,6 +150,12 @@ fun CbzReaderScreen(
         when (val s = state) {
             CbzReaderState.Loading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator()
+            }
+            CbzReaderState.BookNotFound -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(
+                    androidx.compose.ui.res.stringResource(com.riffle.app.R.string.reader_book_not_found),
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
             }
             is CbzReaderState.Error -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 Text(s.message, color = MaterialTheme.colorScheme.onSurface)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReadaloudSession.kt
@@ -430,7 +430,7 @@ class ReadaloudSession constructor(
         val sentenceJson = com.riffle.app.feature.reader.readaloudLocatorJson(
             fragmentRef, quoteBuilder.sentenceQuotes.value[sid]
         ).toString()
-        epubRepository.saveReadingPosition(itemId, sentenceJson)
+        epubRepository.saveReadingPosition(sourceId, itemId, sentenceJson)
         val readerSync = readerSyncProvider()
         val audiobookFollow = audiobookFollowProvider()
         val audioItemId = readerSync?.audioItemId ?: audiobookFollow?.audioItemId ?: return

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
@@ -98,7 +98,8 @@ class ReaderSessionLifecycle constructor(
         // ~300ms of pre-visible stall on cold open. resolveReady returns to caller context
         // implicitly on return.
         val item = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
-            libraryObserver.getItem(params.itemId)
+            params.sourceId?.let { libraryObserver.getItem(it, params.itemId) }
+                ?: libraryObserver.getItem(params.itemId)
         } ?: return OpenOutcome.Error("Book not found")
 
         // Refresh this book's server position BEFORE loading the initial locator so the reader
@@ -340,6 +341,7 @@ class ReaderSessionLifecycle constructor(
         val openAtCfi: String?,
         val startTocHref: String?,
         val openAnnotationId: String? = null,
+        val sourceId: String? = null,
     )
 
     sealed interface OpenOutcome {

--- a/app/src/main/kotlin/com/riffle/app/navigation/LibraryNavGraph.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/LibraryNavGraph.kt
@@ -262,7 +262,12 @@ internal fun NavGraphBuilder.libraryNavGraph(
             onReadItemAtHref = { item, href ->
                 val encodedId = URLEncoder.encode(item.id, "UTF-8")
                 val encodedHref = URLEncoder.encode(href, "UTF-8")
-                navController.navigate("epub_reader/$encodedId?startTocHref=$encodedHref")
+                val sourceParam = if (item.sourceId.isNotBlank()) {
+                    "&sourceId=${URLEncoder.encode(item.sourceId, "UTF-8")}"
+                } else {
+                    ""
+                }
+                navController.navigate("epub_reader/$encodedId?startTocHref=$encodedHref$sourceParam")
             },
             onListenItemAtSec = { item, startSec ->
                 val encodedId = URLEncoder.encode(item.id, "UTF-8")

--- a/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/MainScreen.kt
@@ -76,8 +76,8 @@ internal const val LIBRARY_ITEM_DETAIL = "library_item_detail/{itemId}?sourceId=
 internal const val PLAYLIST_DETAIL = "playlist_detail/{libraryId}/{playlistId}/{playlistName}"
 internal const val EPUB_READER =
     "epub_reader/{itemId}?startReadaloudAtSec={startReadaloudAtSec}&openAtCfi={openAtCfi}&openAnnotationId={openAnnotationId}&startTocHref={startTocHref}&source={source}&sourceId={sourceId}"
-internal const val PDF_READER = "pdf_reader/{itemId}"
-internal const val CBZ_READER = "cbz_reader/{itemId}"
+internal const val PDF_READER = "pdf_reader/{itemId}?sourceId={sourceId}"
+internal const val CBZ_READER = "cbz_reader/{itemId}?sourceId={sourceId}"
 internal const val ANNOTATION_SEARCH = "annotation_search/{libraryId}?query={query}"
 internal const val AUDIOBOOK_PLAYER = "audiobook_player/{itemId}?startAtSec={startAtSec}&playlistId={playlistId}&libraryId={libraryId}"
 

--- a/app/src/main/kotlin/com/riffle/app/navigation/ReaderNavGraph.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/ReaderNavGraph.kt
@@ -112,6 +112,11 @@ internal fun NavGraphBuilder.readerNavGraph(
         route = PDF_READER,
         arguments = listOf(
             navArgument("itemId") { type = NavType.StringType },
+            navArgument("sourceId") {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = null
+            },
         )
     ) { backStackEntry ->
         PdfReaderScreen(onNavigateBack = { navController.popBackStackIfTop(backStackEntry) })
@@ -121,6 +126,11 @@ internal fun NavGraphBuilder.readerNavGraph(
         route = CBZ_READER,
         arguments = listOf(
             navArgument("itemId") { type = NavType.StringType },
+            navArgument("sourceId") {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = null
+            },
         )
     ) { backStackEntry ->
         CbzReaderScreen(onNavigateBack = { navController.popBackStackIfTop(backStackEntry) })

--- a/app/src/main/kotlin/com/riffle/app/navigation/ReaderRouter.kt
+++ b/app/src/main/kotlin/com/riffle/app/navigation/ReaderRouter.kt
@@ -6,10 +6,15 @@ import java.net.URLEncoder
 
 fun readerRouteFor(item: LibraryItem): String? {
     val encodedId = URLEncoder.encode(item.id, "UTF-8")
+    val sourceParam = if (item.sourceId.isNotBlank()) {
+        "?sourceId=${URLEncoder.encode(item.sourceId, "UTF-8")}"
+    } else {
+        ""
+    }
     return when (item.ebookFormat) {
-        EbookFormat.Epub -> "epub_reader/$encodedId"
-        EbookFormat.Pdf -> "pdf_reader/$encodedId"
-        EbookFormat.Cbz -> "cbz_reader/$encodedId"
+        EbookFormat.Epub -> "epub_reader/$encodedId$sourceParam"
+        EbookFormat.Pdf -> "pdf_reader/$encodedId$sourceParam"
+        EbookFormat.Cbz -> "cbz_reader/$encodedId$sourceParam"
         EbookFormat.Unsupported -> null
     }
 }

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="export_pdf_error">Не можа да се генерира PDF</string>
+    <string name="reader_book_not_found">Книгата не е намерена</string>
     <string name="ui_active">Активен</string>
     <string name="ui_active_source">Активен източник</string>
     <string name="ui_add_a_note">Добавяне на бележка…</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="export_pdf_error">No se pudo generar el PDF</string>
+    <string name="reader_book_not_found">Libro no encontrado</string>
     <string name="ui_active">Activo</string>
     <string name="ui_active_source">Fuente activa</string>
     <string name="ui_add_a_note">Añade una nota…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="app_name" translatable="false">Riffle</string>
     <string name="export_pdf_error">Couldn\'t generate PDF</string>
+    <string name="reader_book_not_found">Book not found</string>
     <string name="source_audiobookshelf_name" translatable="false">Audiobookshelf</string>
     <string name="source_chitanka_name" translatable="false">Chitanka</string>
     <string name="source_komga_name" translatable="false">Komga</string>

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryFilterEngineTest.kt
@@ -128,7 +128,7 @@ class LibraryFilterEngineTest {
         override fun isDownloaded(sourceId: String, itemId: String): Boolean = itemId in downloadedIds
         override fun isCached(sourceId: String, itemId: String): Boolean = false
         override suspend fun cacheEpub(sourceId: String, itemId: String, bytes: ByteArray) {}
-        override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
+        override suspend fun saveReadingPosition(sourceId: String, itemId: String, cfi: String) {}
     }
 
     private fun fakePdfRepo(): PdfRepository = object : JvmPdfRepository {
@@ -137,7 +137,7 @@ class LibraryFilterEngineTest {
         override suspend fun removeDownload(sourceId: String, itemId: String) {}
         override fun isDownloaded(sourceId: String, itemId: String): Boolean = false
         override fun isCached(sourceId: String, itemId: String): Boolean = false
-        override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {}
+        override suspend fun saveReadingPosition(sourceId: String, itemId: String, locatorJson: String) {}
     }
 
     private fun fakeAudiobookDownloadRepo(): AudiobookDownloadRepository = object : JvmAudiobookDownloadRepository {
@@ -227,7 +227,7 @@ class LibraryFilterEngineTest {
             }
             override fun isCached(sourceId: String, itemId: String): Boolean = false
             override suspend fun cacheEpub(sourceId: String, itemId: String, bytes: ByteArray) {}
-            override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
+            override suspend fun saveReadingPosition(sourceId: String, itemId: String, cfi: String) {}
         }
         val engine = makeEngine(epubRepository = recordingEpubRepo)
         isOfflineFlow.value = true

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTest.kt
@@ -183,7 +183,7 @@ class LibraryItemDetailViewModelTest {
         override fun isDownloaded(sourceId: String, itemId: String): Boolean = downloaded
         override fun isCached(sourceId: String, itemId: String): Boolean = itemId in cached
         override suspend fun cacheEpub(sourceId: String, itemId: String, bytes: ByteArray) {}
-        override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
+        override suspend fun saveReadingPosition(sourceId: String, itemId: String, cfi: String) {}
         fun cache(itemId: String) {
             cached += itemId
         }
@@ -212,7 +212,7 @@ class LibraryItemDetailViewModelTest {
         }
         override fun isDownloaded(sourceId: String, itemId: String): Boolean = downloaded
         override fun isCached(sourceId: String, itemId: String): Boolean = itemId in cached
-        override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {}
+        override suspend fun saveReadingPosition(sourceId: String, itemId: String, locatorJson: String) {}
     }
 
     private class FakeAudiobookDownloadRepository(

--- a/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/LibraryItemDetailViewModelTocTest.kt
@@ -120,7 +120,7 @@ class LibraryItemDetailViewModelTocTest {
         override fun isDownloaded(sourceId: String, itemId: String): Boolean = false
         override fun isCached(sourceId: String, itemId: String): Boolean = false
         override suspend fun cacheEpub(sourceId: String, itemId: String, bytes: ByteArray) {}
-        override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
+        override suspend fun saveReadingPosition(sourceId: String, itemId: String, cfi: String) {}
     }
 
     private class FakePdfRepo : JvmPdfRepository {
@@ -129,7 +129,7 @@ class LibraryItemDetailViewModelTocTest {
         override suspend fun removeDownload(sourceId: String, itemId: String) {}
         override fun isDownloaded(sourceId: String, itemId: String): Boolean = false
         override fun isCached(sourceId: String, itemId: String): Boolean = false
-        override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {}
+        override suspend fun saveReadingPosition(sourceId: String, itemId: String, locatorJson: String) {}
     }
 
     private val noOpSessionRepo = object : ReadingSessionRepository {

--- a/app/src/test/kotlin/com/riffle/app/feature/library/NoopCbzRepository.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/library/NoopCbzRepository.kt
@@ -15,7 +15,7 @@ internal class NoopCbzRepository(
         onProgress: (downloaded: Long, total: Long) -> Unit,
     ) = error("unused in test")
     override suspend fun removeDownload(sourceId: String, itemId: String) = error("unused in test")
-    override suspend fun saveReadingPosition(itemId: String, locatorJson: String) = error("unused in test")
+    override suspend fun saveReadingPosition(sourceId: String, itemId: String, locatorJson: String) = error("unused in test")
     override suspend fun supportsStreaming(sourceId: String): Boolean = false
     override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int, maxWidth: Int?): ByteArray = error("unused in test")
     override suspend fun awaitCachedSource(item: com.riffle.core.models.LibraryItem): com.riffle.core.domain.CbzLocalSource? = null

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReadaloudSessionTest.kt
@@ -407,9 +407,9 @@ class ReadaloudSessionTest {
      * Fake [EpubRepository] that records [saveReadingPosition] calls.
      */
     private class FakeEpubRepository : JvmEpubRepository {
-        val savedPositions = mutableListOf<Pair<String, String>>()
-        override suspend fun saveReadingPosition(itemId: String, cfi: String) {
-            savedPositions.add(itemId to cfi)
+        val savedPositions = mutableListOf<Triple<String, String, String>>()
+        override suspend fun saveReadingPosition(sourceId: String, itemId: String, cfi: String) {
+            savedPositions.add(Triple(sourceId, itemId, cfi))
         }
         override suspend fun openEpub(item: com.riffle.core.models.LibraryItem) =
             error("not needed in test")
@@ -534,7 +534,8 @@ class ReadaloudSessionTest {
 
             // 1) Sentence-precise ebook position must be persisted
             assertEquals("epubRepository.saveReadingPosition called once", 1, fakeEpubRepo.savedPositions.size)
-            assertEquals("correct itemId", "ebook-789", fakeEpubRepo.savedPositions.first().first)
+            assertEquals("correct sourceId", "srv2", fakeEpubRepo.savedPositions.first().first)
+            assertEquals("correct itemId", "ebook-789", fakeEpubRepo.savedPositions.first().second)
 
             // 2) Audio mirror must be written
             assertEquals("audioSyncStore.mirror called once", 1, fakeAudioSyncStore.mirrorCalls.size)

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -91,7 +91,7 @@ class ReaderSessionLifecycleTest {
         override fun isDownloaded(sourceId: String, itemId: String) = false
         override fun isCached(sourceId: String, itemId: String) = false
         override suspend fun cacheEpub(sourceId: String, itemId: String, bytes: ByteArray) {}
-        override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
+        override suspend fun saveReadingPosition(sourceId: String, itemId: String, cfi: String) {}
     }
 
     private class FakeServerRepository(private val active: Source?) : SourceRepository {
@@ -254,7 +254,7 @@ class ReaderSessionLifecycleTest {
         override fun isDownloaded(sourceId: String, itemId: String) = false
         override fun isCached(sourceId: String, itemId: String) = false
         override suspend fun cacheEpub(sourceId: String, itemId: String, bytes: ByteArray) {}
-        override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
+        override suspend fun saveReadingPosition(sourceId: String, itemId: String, cfi: String) {}
     }
 
     private fun makeLifecycle(
@@ -302,11 +302,13 @@ class ReaderSessionLifecycleTest {
         openAtCfi: String? = null,
         openAnnotationId: String? = null,
         startTocHref: String? = null,
+        sourceId: String? = null,
     ) = ReaderSessionLifecycle.OpenParams(
         itemId = itemId,
         openAtCfi = openAtCfi,
         openAnnotationId = openAnnotationId,
         startTocHref = startTocHref,
+        sourceId = sourceId,
     )
 
     // ── Tests ────────────────────────────────────────────────────────────────────────────
@@ -389,6 +391,22 @@ class ReaderSessionLifecycleTest {
         assertTrue(outcome is ReaderSessionLifecycle.OpenOutcome.Error)
         assertEquals("Book not found", (outcome as ReaderSessionLifecycle.OpenOutcome.Error).message)
         assertNull(lifecycle.publication.value)
+    }
+
+    @Test
+    fun `open succeeds when sourceId in params resolves item not in active source`() = runTest {
+        // Regression: items from non-active sources (e.g. Chitanka downloaded books) must be
+        // found via getItem(sourceId, itemId), not just getItem(itemId) which checks active server.
+        val nonActiveSourceId = "src-chitanka"
+        val chitankaItem = ebookItem.copy(sourceId = nonActiveSourceId)
+        val (lifecycle, _) = makeLifecycle(
+            libraryObserver = FakeLibraryObserver(
+                items = mapOf((nonActiveSourceId to "item-1") to chitankaItem),
+                activeItems = emptyMap(), // item NOT in active (ABS) server
+            ),
+        )
+        val outcome = lifecycle.open(params(sourceId = nonActiveSourceId))
+        assertTrue("Expected Ready, got $outcome", outcome is ReaderSessionLifecycle.OpenOutcome.Ready)
     }
 
     @Test

--- a/core/data/src/androidHostTest/kotlin/com/riffle/core/data/EpubPositionIntegrationTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/riffle/core/data/EpubPositionIntegrationTest.kt
@@ -109,7 +109,7 @@ class EpubPositionIntegrationTest {
 
         // First session: open book then save position
         repo1.openEpub(item())
-        repo1.saveReadingPosition("item-1", "epubcfi(/6/4[chap01]!/4/2[body01]/1:0)")
+        repo1.saveReadingPosition("source-1", "item-1", "epubcfi(/6/4[chap01]!/4/2[body01]/1:0)")
 
         // Simulate restart: new repository instance backed by the same persistent DAO
         val repo2 = buildRepo()
@@ -138,13 +138,68 @@ class EpubPositionIntegrationTest {
         source.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes)))
         val repo1 = buildRepo()
         repo1.openEpub(item())
-        repo1.saveReadingPosition("item-1", "epubcfi(/6/2!/4/1:10)")
-        repo1.saveReadingPosition("item-1", "epubcfi(/6/8!/4/1:99)")
+        repo1.saveReadingPosition("source-1", "item-1", "epubcfi(/6/2!/4/1:10)")
+        repo1.saveReadingPosition("source-1", "item-1", "epubcfi(/6/8!/4/1:99)")
 
         val repo2 = buildRepo()
         val result = repo2.openEpub(item()) as EpubOpenResult.Success
 
         assertEquals("epubcfi(/6/8!/4/1:99)", result.lastPosition)
+    }
+
+    @Test
+    fun `position is restored when the item belongs to a non-active source`() = runTest {
+        source.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(epubBytes)))
+
+        // Repo whose "active" source is source-1 — the book's own source.
+        val repo1 = buildRepo()
+        repo1.openEpub(item())
+        repo1.saveReadingPosition("source-1", "item-1", "epubcfi(/6/6!/4/1:42)")
+
+        // Simulate the Riffle source scenario: build a repo where "active" is source-2 but the
+        // book's sourceId is still source-1. Before the fix, openEpub loaded position keyed by
+        // activeSource.id ("source-2") and returned null, making the reader start from the
+        // beginning. After the fix, it loads by item.sourceId ("source-1") and finds the position.
+        val differentActiveSourceRepo = object : SourceRepository {
+            val activeSource2 = Source(
+                id = "source-2",
+                url = SourceUrl.parse(source.url("/").toString().trimEnd('/'))!!,
+                isActive = true,
+                insecureConnectionAllowed = false,
+                username = "",
+            )
+            val source1 = Source(
+                id = "source-1",
+                url = SourceUrl.parse(source.url("/").toString().trimEnd('/'))!!,
+                isActive = false,
+                insecureConnectionAllowed = false,
+                username = "",
+            )
+            override fun observeAll(): Flow<List<Source>> = flowOf(listOf(activeSource2, source1))
+            override suspend fun getActive(): Source = activeSource2
+            override suspend fun getById(sourceId: String): Source? =
+                if (sourceId == "source-1") source1 else if (sourceId == "source-2") activeSource2 else null
+            override suspend fun commit(pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>) =
+                throw UnsupportedOperationException()
+            override suspend fun setActive(sourceId: String) = Unit
+            override suspend fun remove(sourceId: String) = Unit
+            override suspend fun getSourceVersion(sourceId: String): String? = null
+        }
+        val repo2 = EpubRepositoryImpl(
+            catalogRegistry = TestCatalogRegistry(differentActiveSourceRepo, mapOf("source-1" to "test-token", "source-2" to "test-token")),
+            cacheStore = cacheStore,
+            downloadsStore = LocalStoreImpl(tmp.newFolder("downloads-cross-source"), ".epub", com.riffle.core.domain.DefaultDispatcherProvider),
+            positionStore = ReadingPositionStoreImpl(sharedPositionDao, com.riffle.core.domain.TestClock(System.currentTimeMillis())),
+            sourceRepository = differentActiveSourceRepo,
+        )
+
+        val result = repo2.openEpub(item()) as EpubOpenResult.Success
+
+        assertEquals(
+            "position keyed by item.sourceId must be restored regardless of active source",
+            "epubcfi(/6/6!/4/1:42)",
+            result.lastPosition,
+        )
     }
 
     private class InMemoryReadingPositionDao : ReadingPositionDao {

--- a/core/data/src/androidHostTest/kotlin/com/riffle/core/data/comic/NetworkComicPageSourceTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/riffle/core/data/comic/NetworkComicPageSourceTest.kt
@@ -30,7 +30,7 @@ class NetworkComicPageSourceTest {
         override suspend fun removeDownload(sourceId: String, itemId: String) {}
         override fun isDownloaded(sourceId: String, itemId: String): Boolean = false
         override fun isCached(sourceId: String, itemId: String): Boolean = false
-        override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {}
+        override suspend fun saveReadingPosition(sourceId: String, itemId: String, locatorJson: String) {}
         override suspend fun supportsStreaming(sourceId: String): Boolean = true
         override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int, maxWidth: Int?): ByteArray {
             requestedSourceId = sourceId

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/CbzRepositoryImpl.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/CbzRepositoryImpl.kt
@@ -45,7 +45,7 @@ class CbzRepositoryImpl(
         val local = resolveLocalFile(item.sourceId, item.id)
         if (local != null) {
             if (local.tier == LocalFileTier.Cache) contentCacheAccessStore.markAccessed(contentCacheKey(item))
-            val lastPosition = loadLastPosition(item.id)
+            val lastPosition = loadLastPosition(item.sourceId, item.id)
             return openLocal(local.file, lastPosition)
         }
         val catalog = catalogRegistry.forSourceId(item.sourceId)
@@ -60,7 +60,7 @@ class CbzRepositoryImpl(
             if (pageCount <= 0) return CbzOpenResult.NetworkError(
                 IllegalStateException("Server returned zero page count for ${item.id}")
             )
-            val lastPosition = loadLastPosition(item.id)
+            val lastPosition = loadLastPosition(item.sourceId, item.id)
             return CbzOpenResult.Streaming(
                 imageSource = NetworkComicPageSource(
                     sourceId = item.sourceId, itemId = item.id, count = pageCount,
@@ -81,14 +81,14 @@ class CbzRepositoryImpl(
             )
             contentCacheAccessStore.markAccessed(contentCacheKey(item))
             localAvailabilityEvents.notifyChanged(item.sourceId, item.id)
-            openLocal(cbzFile, loadLastPosition(item.id))
+            openLocal(cbzFile, loadLastPosition(item.sourceId, item.id))
         } catch (t: Throwable) {
             CbzOpenResult.NetworkError(t)
         }
     }
 
-    private suspend fun loadLastPosition(itemId: String): String? =
-        sourceRepository.getActive()?.let { positionStore.load(it.id, itemId) }
+    private suspend fun loadLastPosition(sourceId: String, itemId: String): String? =
+        positionStore.load(sourceId, itemId)
 
     /** Opens [file] as a local archive on the IO dispatcher, reading its ComicInfo bookmarks. */
     private suspend fun openLocal(file: File, lastPosition: String?): CbzOpenResult =
@@ -145,8 +145,7 @@ class CbzRepositoryImpl(
 
     override fun isCached(sourceId: String, itemId: String): Boolean = cacheStore.get(sourceId, itemId) != null
 
-    override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {
-        val sourceId = sourceRepository.getActive()?.id ?: return
+    override suspend fun saveReadingPosition(sourceId: String, itemId: String, locatorJson: String) {
         positionStore.save(sourceId, itemId, locatorJson)
     }
 

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/EpubRepositoryImpl.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/EpubRepositoryImpl.kt
@@ -78,11 +78,7 @@ class EpubRepositoryImpl(
                     }
             }
         }
-        // Position load intentionally stays keyed by activeSource.id — [saveReadingPosition] also
-        // uses it, so this pair stays consistent within a session. Round-trip across a user-switch
-        // is a separate concern tracked apart from this fix.
-        val activeSource = sourceRepository.getActive()
-        val lastPosition = activeSource?.let { positionStore.load(it.id, item.id) }
+        val lastPosition = positionStore.load(item.sourceId, item.id)
         return EpubOpenResult.Success(epubFile = epubFile, lastPosition = lastPosition)
     }
 
@@ -167,8 +163,7 @@ class EpubRepositoryImpl(
         localAvailabilityEvents.notifyChanged(sourceId, itemId)
     }
 
-    override suspend fun saveReadingPosition(itemId: String, cfi: String) {
-        val sourceId = sourceRepository.getActive()?.id ?: return
+    override suspend fun saveReadingPosition(sourceId: String, itemId: String, cfi: String) {
         positionStore.save(sourceId, itemId, cfi)
     }
 

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/PdfRepositoryImpl.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/PdfRepositoryImpl.kt
@@ -53,8 +53,7 @@ class PdfRepositoryImpl(
                 return PdfOpenResult.NetworkError(t)
             }
         }
-        val activeSource = sourceRepository.getActive()
-        val lastPosition = activeSource?.let { positionStore.load(it.id, item.id) }
+        val lastPosition = positionStore.load(item.sourceId, item.id)
         return PdfOpenResult.Success(pdfFile = pdfFile, lastPosition = lastPosition)
     }
 
@@ -120,8 +119,7 @@ class PdfRepositoryImpl(
 
     override fun isCached(sourceId: String, itemId: String): Boolean = cacheStore.get(sourceId, itemId) != null
 
-    override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {
-        val sourceId = sourceRepository.getActive()?.id ?: return
+    override suspend fun saveReadingPosition(sourceId: String, itemId: String, locatorJson: String) {
         positionStore.save(sourceId, itemId, locatorJson)
     }
 

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/CbzRepository.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/CbzRepository.kt
@@ -54,7 +54,7 @@ interface CbzRepository {
     suspend fun removeDownload(sourceId: String, itemId: String)
     fun isDownloaded(sourceId: String, itemId: String): Boolean
     fun isCached(sourceId: String, itemId: String): Boolean
-    suspend fun saveReadingPosition(itemId: String, locatorJson: String)
+    suspend fun saveReadingPosition(sourceId: String, itemId: String, locatorJson: String)
     /** True when the catalog for [sourceId] implements per-page streaming. */
     suspend fun supportsStreaming(sourceId: String): Boolean
     /**

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/EpubRepository.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/EpubRepository.kt
@@ -16,7 +16,7 @@ interface EpubRepository {
     suspend fun removeDownload(sourceId: String, itemId: String)
     fun isDownloaded(sourceId: String, itemId: String): Boolean
     fun isCached(sourceId: String, itemId: String): Boolean
-    suspend fun saveReadingPosition(itemId: String, cfi: String)
+    suspend fun saveReadingPosition(sourceId: String, itemId: String, cfi: String)
     suspend fun loadLastPosition(sourceId: String, itemId: String): String? = null
     suspend fun loadLastPositionHref(sourceId: String, itemId: String): String? = null
 }

--- a/core/domain/src/commonMain/kotlin/com/riffle/core/domain/PdfRepository.kt
+++ b/core/domain/src/commonMain/kotlin/com/riffle/core/domain/PdfRepository.kt
@@ -16,5 +16,5 @@ interface PdfRepository {
     suspend fun removeDownload(sourceId: String, itemId: String)
     fun isDownloaded(sourceId: String, itemId: String): Boolean
     fun isCached(sourceId: String, itemId: String): Boolean
-    suspend fun saveReadingPosition(itemId: String, locatorJson: String)
+    suspend fun saveReadingPosition(sourceId: String, itemId: String, locatorJson: String)
 }

--- a/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt
+++ b/core/domain/src/jvmTest/kotlin/com/riffle/core/domain/LibraryItemOfflineAvailabilityTest.kt
@@ -150,7 +150,7 @@ class LibraryItemOfflineAvailabilityTest {
             onProgress: (downloaded: Long, total: Long) -> Unit,
         ) = error("unused")
         override suspend fun removeDownload(sourceId: String, itemId: String) = error("unused")
-        override suspend fun saveReadingPosition(itemId: String, locatorJson: String) = error("unused")
+        override suspend fun saveReadingPosition(sourceId: String, itemId: String, locatorJson: String) = error("unused")
         override suspend fun supportsStreaming(sourceId: String) = false
         override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int, maxWidth: Int?) = error("unused")
         override suspend fun awaitCachedSource(item: LibraryItem): com.riffle.core.domain.CbzLocalSource? = null
@@ -231,7 +231,7 @@ class LibraryItemOfflineAvailabilityTest {
             onProgress: (downloaded: Long, total: Long) -> Unit,
         ) = error("unused")
         override suspend fun removeDownload(sourceId: String, itemId: String) = error("unused")
-        override suspend fun saveReadingPosition(itemId: String, cfi: String) = error("unused")
+        override suspend fun saveReadingPosition(sourceId: String, itemId: String, cfi: String) = error("unused")
         override suspend fun cacheEpub(sourceId: String, itemId: String, bytes: ByteArray) {}
     }
 
@@ -247,7 +247,7 @@ class LibraryItemOfflineAvailabilityTest {
             onProgress: (downloaded: Long, total: Long) -> Unit,
         ) = error("unused")
         override suspend fun removeDownload(sourceId: String, itemId: String) = error("unused")
-        override suspend fun saveReadingPosition(itemId: String, locatorJson: String) = error("unused")
+        override suspend fun saveReadingPosition(sourceId: String, itemId: String, locatorJson: String) = error("unused")
     }
 
     private class FakeCbzRepository(
@@ -262,7 +262,7 @@ class LibraryItemOfflineAvailabilityTest {
             onProgress: (downloaded: Long, total: Long) -> Unit,
         ) = error("unused")
         override suspend fun removeDownload(sourceId: String, itemId: String) = error("unused")
-        override suspend fun saveReadingPosition(itemId: String, locatorJson: String) = error("unused")
+        override suspend fun saveReadingPosition(sourceId: String, itemId: String, locatorJson: String) = error("unused")
         override suspend fun supportsStreaming(sourceId: String) = false
         override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int, maxWidth: Int?) = error("unused")
         override suspend fun awaitCachedSource(item: LibraryItem): com.riffle.core.domain.CbzLocalSource? = null

--- a/docs/testing/ios-scenarios/03-epub-reader.md
+++ b/docs/testing/ios-scenarios/03-epub-reader.md
@@ -48,3 +48,19 @@ Corresponds to Android harness tests: `EpubHarnessTest`, `TocIntegrationTest`,
 
 1. In the library, tap an item whose `ebookFormat` is `Unsupported`.
 2. **Expected**: No reader screen is opened (`isReadable == false` gate).
+
+## Scenario 03-H: Progress is restored when opening from the Riffle home screen
+
+1. Open an EPUB book from a non-primary source (e.g. Chitanka/Gutenberg when ABS is active) and advance several pages.
+2. Tap "← Back" to close the reader.
+3. Navigate to the Riffle home (in-progress) screen.
+4. Tap the same book.
+5. **Expected**: The reader reopens at the page where reading stopped — **not** at the beginning.
+
+## Scenario 03-G: Open downloaded EPUB from source browse (sourceId regression)
+
+1. Ensure a downloaded EPUB from a non-primary source (e.g. Chitanka/Gutenberg when ABS is active) exists.
+2. Navigate to that source's browse screen via the drawer.
+3. Tap the downloaded book → detail screen.
+4. Tap **Read**.
+5. **Expected**: The EPUB reader opens successfully — "Book not found" must NOT appear.

--- a/docs/testing/ios-scenarios/06-comics-reader.md
+++ b/docs/testing/ios-scenarios/06-comics-reader.md
@@ -27,6 +27,22 @@ Corresponds to Android harness tests: `CbzThumbnailStripTest`.
 2. Tap "← Back".
 3. **Expected**: The library browser is shown. No crash.
 
+## Scenario 06-E: Open downloaded CBZ book from source browse (sourceId regression)
+
+1. Ensure a CBZ book from a non-primary source (e.g. Komga when ABS is active) is already downloaded.
+2. Navigate to that source's browse screen via the drawer.
+3. Tap the downloaded book to open the detail screen.
+4. Tap **Read**.
+5. **Expected**: The CBZ reader opens successfully — "Book not found" must NOT appear.
+
+## Scenario 06-F: Progress is restored when opening from the Riffle home screen
+
+1. Open a CBZ book from a non-primary source (e.g. Komga when ABS is active) and advance to page 3 or later.
+2. Tap "← Back" to close the reader.
+3. Navigate to the Riffle home (in-progress) screen.
+4. Tap the same book.
+5. **Expected**: The reader reopens at the last page viewed — **not** at page 1.
+
 ## Scenario 06-D: Reading position persists across sessions
 
 1. Open a CBZ book and advance to page 3 or later.

--- a/feature/reader/src/commonMain/kotlin/com/riffle/feature/reader/CbzReaderState.kt
+++ b/feature/reader/src/commonMain/kotlin/com/riffle/feature/reader/CbzReaderState.kt
@@ -4,6 +4,7 @@ import com.riffle.core.domain.comic.ComicPageSource
 
 sealed class CbzReaderState {
     data object Loading : CbzReaderState()
+    data object BookNotFound : CbzReaderState()
     data class Error(val message: String) : CbzReaderState()
     data class Ready(
         val title: String,

--- a/feature/reader/src/commonMain/kotlin/com/riffle/feature/reader/CbzReaderViewModel.kt
+++ b/feature/reader/src/commonMain/kotlin/com/riffle/feature/reader/CbzReaderViewModel.kt
@@ -70,6 +70,7 @@ import kotlinx.serialization.json.put
  */
 class CbzReaderViewModel constructor(
     private val itemId: String,
+    private val sourceId: String? = null,
     private val libraryObserver: LibraryObserver,
     private val cbzRepository: CbzRepository,
     private val readingSessionRepository: ReadingSessionRepository,
@@ -95,6 +96,8 @@ class CbzReaderViewModel constructor(
     private var closeSyncDone: Boolean = false
     var bookId: String = itemId
         private set
+    // Resolved once during openBook() — the item's canonical sourceId used to key position saves.
+    private var resolvedSourceId: String? = null
     private var panelBook: PanelEngine.Book? = null
     // Cancel-and-replace the in-flight panel resolve on every page change so a stale resolver
     // can't overwrite a newer page's PagePanels result.
@@ -268,12 +271,14 @@ class CbzReaderViewModel constructor(
         // (panelViewOn=false), causing a pager flash for books with Panel View enabled.
         comicFormattingPreferencesStore.preferences.first()
 
-        val item = libraryObserver.getItem(itemId)
+        val item = sourceId?.let { libraryObserver.getItem(it, itemId) }
+            ?: libraryObserver.getItem(itemId)
         if (item == null) {
-            _state.value = CbzReaderState.Error("Book not found")
+            _state.value = CbzReaderState.BookNotFound
             return
         }
         bookId = "${item.sourceId}::${item.id}"
+        resolvedSourceId = item.sourceId
         // Load per-book Comic formatting overrides (new store).
         // Also performs a one-time lazy migration from the legacy PanelViewPreferencesStore.
         val existingOverrides = bookComicFormattingPreferencesStore.overrides(bookId).first()
@@ -639,7 +644,8 @@ class CbzReaderViewModel constructor(
         val progression = if (pageCount > 0) (pageIndex + 1).toDouble() / pageCount.toDouble() else 0.0
         val locatorJson = buildLocatorJson(pageIndex + 1, progression)
         viewModelScope.launch {
-            cbzRepository.saveReadingPosition(itemId, locatorJson)
+            val sid = resolvedSourceId ?: return@launch
+            cbzRepository.saveReadingPosition(sid, itemId, locatorJson)
             val progressFraction = if (pageCount > 1) pageIndex.toFloat() / (pageCount - 1).toFloat() else 1f
             updateReadingProgressUseCase(itemId, progressFraction)
         }

--- a/shared/src/commonMain/kotlin/com/riffle/shared/library/IosNoOpLibraryDetailDeps.kt
+++ b/shared/src/commonMain/kotlin/com/riffle/shared/library/IosNoOpLibraryDetailDeps.kt
@@ -75,7 +75,7 @@ internal class IosNoOpEpubRepository : EpubRepository {
     override suspend fun removeDownload(sourceId: String, itemId: String) {}
     override fun isDownloaded(sourceId: String, itemId: String): Boolean = false
     override fun isCached(sourceId: String, itemId: String): Boolean = false
-    override suspend fun saveReadingPosition(itemId: String, cfi: String) {}
+    override suspend fun saveReadingPosition(sourceId: String, itemId: String, cfi: String) {}
 }
 
 internal object IosNoOpEbookCfiTranslatorFactory : EbookCfiTranslatorFactory {
@@ -98,7 +98,7 @@ internal class IosNoOpPdfRepository : PdfRepository {
     override suspend fun removeDownload(sourceId: String, itemId: String) {}
     override fun isDownloaded(sourceId: String, itemId: String): Boolean = false
     override fun isCached(sourceId: String, itemId: String): Boolean = false
-    override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {}
+    override suspend fun saveReadingPosition(sourceId: String, itemId: String, locatorJson: String) {}
 }
 
 internal class IosNoOpCbzRepository : CbzRepository {
@@ -108,7 +108,7 @@ internal class IosNoOpCbzRepository : CbzRepository {
     override suspend fun removeDownload(sourceId: String, itemId: String) {}
     override fun isDownloaded(sourceId: String, itemId: String): Boolean = false
     override fun isCached(sourceId: String, itemId: String): Boolean = false
-    override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {}
+    override suspend fun saveReadingPosition(sourceId: String, itemId: String, locatorJson: String) {}
     override suspend fun supportsStreaming(sourceId: String): Boolean = false
     override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int, maxWidth: Int?): ByteArray =
         ByteArray(0)

--- a/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
@@ -316,7 +316,7 @@ private fun iosLibraryModule(
     factory { params ->
         CbzReaderViewModel(
             itemId = params.get(0),
-            sourceId = params.getOrNull(1),
+            sourceId = params.values.getOrNull(1) as? String,
             libraryObserver = get(),
             cbzRepository = get(),
             readingSessionRepository = get(),

--- a/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
@@ -315,7 +315,8 @@ private fun iosLibraryModule(
     single { ReaderStateHolder() }
     factory { params ->
         CbzReaderViewModel(
-            itemId = params.get(),
+            itemId = params.get(0),
+            sourceId = params.getOrNull(1),
             libraryObserver = get(),
             cbzRepository = get(),
             readingSessionRepository = get(),

--- a/shared/src/iosMain/kotlin/com/riffle/shared/reader/IosCbzReaderBackends.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/reader/IosCbzReaderBackends.kt
@@ -109,7 +109,7 @@ internal class IosCbzRepository(
 
     override fun isCached(sourceId: String, itemId: String): Boolean = false
 
-    override suspend fun saveReadingPosition(itemId: String, locatorJson: String) {}
+    override suspend fun saveReadingPosition(sourceId: String, itemId: String, locatorJson: String) {}
 
     override suspend fun supportsStreaming(sourceId: String): Boolean = true
 

--- a/shared/src/iosMain/kotlin/com/riffle/shared/reader/IosCbzReaderScreen.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/reader/IosCbzReaderScreen.kt
@@ -48,7 +48,7 @@ import platform.UIKit.UIViewContentMode
 @Suppress("ktlint:standard:function-naming")
 @Composable
 actual fun CbzReaderScreen(item: LibraryItem, onBack: () -> Unit) {
-    val vm = koinInject<CbzReaderViewModel> { parametersOf(item.id) }
+    val vm = koinInject<CbzReaderViewModel> { parametersOf(item.id, item.sourceId) }
 
     DisposableEffect(vm) {
         vm.onReaderResumed()
@@ -59,6 +59,9 @@ actual fun CbzReaderScreen(item: LibraryItem, onBack: () -> Unit) {
 
     Box(Modifier.fillMaxSize()) {
         when (val s = state) {
+            CbzReaderState.BookNotFound -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                BasicText("Book not found")
+            }
             is CbzReaderState.Error -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 BasicText(s.message)
             }


### PR DESCRIPTION
## What

Two related bugs affecting books displayed in the Riffle home (in-progress) screen — which shows items across all configured sources, not just the active one.

**Bug 1 — "Book not found" for downloaded books opened from Riffle**

`readerRouteFor()` was not including `sourceId` in the navigation URL. The reader then called `getItem(itemId)` which only queries the active source, so items from non-active sources were not found.

**Bug 2 — Reading progress ignored when opening from Riffle**

All three reader repositories (`EpubRepositoryImpl`, `PdfRepositoryImpl`, `CbzRepositoryImpl`) keyed reading position on `activeSource.id`. For a book from a non-active source (`item.sourceId ≠ activeSource.id`), the position was saved under one key and loaded from another → reader always started from the beginning.

## Changes

### Bug 1 — sourceId threading
- `ReaderRouter`: include `?sourceId=…` in routes for EPUB, PDF, and CBZ
- `MainScreen` / `ReaderNavGraph`: add `sourceId` nav arg to `PDF_READER` and `CBZ_READER`
- `ReaderSessionLifecycle.OpenParams`: add `sourceId` field; use `getItem(sourceId, itemId)` when present
- `EpubReaderViewModel` / `PdfReaderViewModel`: pass `navServerId` / `navSourceId` as `sourceId`
- `CbzReaderViewModel` (commonMain): accept `sourceId` param; resolve item from correct source
- `IosCbzReaderScreen` / `Koin`: pass `item.sourceId` to `CbzReaderViewModel` on iOS
- `CbzReaderState`: add `BookNotFound` typed state for i18n
- `strings.xml` (en/es/bg): add `reader_book_not_found` translation
- `LibraryNavGraph`: fix `onReadItemAtHref` to include `sourceId` in route

### Bug 2 — position keyed by item.sourceId
- `EpubRepository` / `CbzRepository` / `PdfRepository`: add `sourceId: String` as first param to `saveReadingPosition`, removing the `getActive()` call from implementations
- All three `RepositoryImpl`s: load position via `item.sourceId` in `openX(item)`
- `CbzRepositoryImpl`: all three open paths (local-cached, streaming, network-download)
- `EpubReaderViewModel`: pass `navServerId` to `saveReadingPosition`
- `PdfReaderViewModel`: pass `navSourceId` to `saveReadingPosition`
- `CbzReaderViewModel`: track `resolvedSourceId` from item; pass to `saveReadingPosition`
- `ReadaloudSession`: use `readerSyncServerId` already in scope
- All iOS stubs and test fakes updated

## Tests
- `ReaderSessionLifecycleTest`: regression for cross-source open (Bug 1)
- `EpubPositionIntegrationTest`: regression verifying position is restored when active source differs from item's source (Bug 2)
- `ReadaloudSessionTest`: updated `FakeEpubRepository` to assert `sourceId` is passed correctly
- iOS scenario docs: 03-G, 03-H, 06-E, 06-F

## Known limitation
External deep links to the PDF/CBZ reader that bypass `readerRouteFor()` will have `sourceId=null` and fall back to the active-source item lookup. This was already broken pre-fix and is outside the scope of this PR.