### PR TITLE
fix(reader): flush position on app-lifetime scope; fix readaloud source identity

### DIFF
--- a/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousChapterBoundaryHarnessTest.kt
+++ b/app/src/androidTest/kotlin/com/riffle/app/feature/reader/ContinuousChapterBoundaryHarnessTest.kt
@@ -497,6 +497,18 @@ class ContinuousChapterBoundaryHarnessTest : KoinTest {
             composeTestRule.activityRule.scenario.onActivity { y = reader.scrollY }
             if (y == lastY && y > 0) stableCount++ else { stableCount = 0; lastY = y }
         }
+        // Guard: if the stabilisation deadline expired before scrollY moved above 0 (smooth-scroll
+        // animation not yet started on a loaded CI runner), wait explicitly for the animation to
+        // produce a positive scrollY before dispatching the fling. Without this, the fling is
+        // dispatched from scrollY=0, clamps immediately, never crosses the backward-prepend
+        // threshold, and ch10 is never loaded — causing a spurious 20-second timeout failure.
+        if (lastY <= 0) {
+            composeTestRule.waitUntil(timeoutMillis = 20_000) {
+                var y = -1
+                composeTestRule.activityRule.scenario.onActivity { y = reader.scrollY }
+                y > 0
+            }
+        }
         dispatchFlingSwipeBackward(reader)
         // The prepended previous chapter must load AND measure past its screen-sized placeholder
         // before the landing position is meaningful. Polled manually so a timeout can report the

--- a/app/src/main/kotlin/com/riffle/app/di/KoinViewModelModules.kt
+++ b/app/src/main/kotlin/com/riffle/app/di/KoinViewModelModules.kt
@@ -600,6 +600,7 @@ private val readerViewModelModule = module {
             sourceRepository = get(),
             formattingSessionFactory = get(),
             volumeKeyDispatcher = get(),
+            progressFlushScope = get(),
             clock = get(),
             readingSpeedStore = get(),
             catalogRegistry = get(),
@@ -628,6 +629,7 @@ private val readerViewModelModule = module {
             colorPageDecoder = get(),
             dispatchers = get(),
             panelReportRepository = get(),
+            applicationScope = get(),
         )
     }
 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1476,13 +1476,13 @@ class EpubReaderViewModel constructor(
         // is still starting up (measured ~500ms gap on cold-open with 99 annotations). The
         // sync-namespace (used ONLY by cross-device sync scheduling) resolves in parallel via a
         // separate viewModelScope.launch and lands on the session via updateNamespace().
-        val activeServer = o.activeServer
-        if (!o.isStorytellerService && activeServer != null) {
-            annotationServerId = activeServer.id
+        val bookSourceId = o.resolvedReaderServerId
+        if (!o.isStorytellerService && bookSourceId != null) {
+            annotationServerId = bookSourceId
             // Bind the bookmarks controller so it can observe bookmarks and track the current
             // locator for page-bookmark detection.
             bookmarks.bind(
-                sourceId = activeServer.id,
+                sourceId = bookSourceId,
                 itemId = itemId,
                 currentLocator = position.currentLocator,
                 spinePositionCounts = spinePositionCounts,
@@ -1500,7 +1500,7 @@ class EpubReaderViewModel constructor(
             // Bind annotation session eagerly with an EMPTY namespace — the observer subscription
             // is what we want early; sync scheduling stays no-op until updateNamespace() below.
             annotationSession.bind(
-                sourceId = activeServer.id,
+                sourceId = bookSourceId,
                 namespace = "",
                 itemId = itemId,
                 highlightRenderResolver = { a -> annotationToRender(a) },
@@ -1518,12 +1518,12 @@ class EpubReaderViewModel constructor(
             // teardown propagates normally.
             viewModelScope.launch {
                 val namespace = try {
-                    (sourceRepository.ensureSyncNamespace(activeServer.id)
+                    (sourceRepository.ensureSyncNamespace(bookSourceId)
                         as? com.riffle.core.domain.SyncNamespace.Configured)?.value
                 } catch (t: Throwable) {
                     if (t is kotlinx.coroutines.CancellationException) throw t
                     logger.w(LogChannel.HighlightMerge) {
-                        "ensureSyncNamespace failed on reader-open for sourceId=${activeServer.id} — " +
+                        "ensureSyncNamespace failed on reader-open for sourceId=$bookSourceId — " +
                             "${t::class.simpleName}: ${t.message}. Sync stays disabled for this session."
                     }
                     null
@@ -1541,9 +1541,8 @@ class EpubReaderViewModel constructor(
             // [orphanEmphasisCleanupAttempted]'s CAS; safe no-op on healthy books.
             if (orphanEmphasisCleanupAttempted.compareAndSet(false, true)) {
                 viewModelScope.launch(dispatchers.io) {
-                    val serverId = activeServer.id
                     val allRows = runCatching {
-                        annotationStore.observeAnnotations(serverId, itemId).first()
+                        annotationStore.observeAnnotations(bookSourceId, itemId).first()
                     }.getOrDefault(emptyList())
                     val liveHighlightCfis = allRows.asSequence()
                         .filter { it.type == AnnotationEntity.TYPE_HIGHLIGHT }
@@ -1555,7 +1554,7 @@ class EpubReaderViewModel constructor(
                     if (orphans.isEmpty()) return@launch
                     orphans.forEach { annotationStore.delete(it.id) }
                     logger.d(LogChannel.HighlightMerge) {
-                        "orphan-emphasis cleanup sourceId=$serverId itemId=$itemId deleted=${orphans.size}"
+                        "orphan-emphasis cleanup sourceId=$bookSourceId itemId=$itemId deleted=${orphans.size}"
                     }
                     scheduleAnnotationSync()
                 }
@@ -1567,15 +1566,14 @@ class EpubReaderViewModel constructor(
             // the annotation Flow → session → decorations naturally.
             if (legacyImageUpgradeAttempted.compareAndSet(false, true)) {
                 viewModelScope.launch(dispatchers.io) {
-                    val serverId = activeServer.id
                     val legacy = runCatching {
-                        annotationStore.observeAnnotations(serverId, itemId)
+                        annotationStore.observeAnnotations(bookSourceId, itemId)
                             .first()
                             .filter { it.type == AnnotationEntity.TYPE_IMAGE }
                     }.getOrDefault(emptyList())
                     if (legacy.isEmpty()) return@launch
                     val allAnnotations = runCatching {
-                        annotationStore.observeAnnotations(serverId, itemId).first()
+                        annotationStore.observeAnnotations(bookSourceId, itemId).first()
                     }.getOrDefault(emptyList())
                     val result = runCatching {
                         captionHighlightUpgrader.sweep(
@@ -1585,7 +1583,7 @@ class EpubReaderViewModel constructor(
                     }.getOrNull()
                     if (result != null && result.total > 0) {
                         logger.d(LogChannel.HighlightMerge) {
-                            "caption-highlight sweep sourceId=$serverId itemId=$itemId " +
+                            "caption-highlight sweep sourceId=$bookSourceId itemId=$itemId " +
                                 "merged=${result.merged} upgraded=${result.upgraded} legacy=${legacy.size}"
                         }
                         scheduleAnnotationSync()
@@ -1885,6 +1883,19 @@ class EpubReaderViewModel constructor(
         }
         if (!shouldRunReadingSideEffects(source)) return
         val locator = position.snapshotLastLocator() ?: return
+        // Persist the last-seen locator on the survivable progressFlushScope so it is guaranteed
+        // to land in the DB even when back navigation triggers onCleared() immediately after this
+        // call — cancelling viewModelScope before the in-flight onPositionChanged save coroutine
+        // (which also runs on viewModelScope) has a chance to execute. Without this flush the
+        // local position row can stay stale, and a subsequent pullItem() on reopen finds InSync
+        // (nothing changed since last server sync) and opens the book at the old server position
+        // instead of the page the user was actually on. ADR 0036 / ProgressFlushScope.
+        val locatorJson = locator.toJSON().toString()
+        val capturedNavServerId = navServerId
+        progressFlushScope.flush {
+            val sid = capturedNavServerId ?: sourceRepository.getActive()?.id ?: return@flush
+            epubRepository.saveReadingPosition(sid, itemId, locatorJson)
+        }
         // Stays on viewModelScope: runReaderSyncCycle mutates reader state (lastLocator,
         // pendingServerJumpStamp, …) and posts the inbound-jump channel, which must run on the main
         // thread while the screen is alive — it is not safe to relocate to a background flush scope.

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
@@ -62,6 +62,7 @@ class PdfReaderViewModel constructor(
     private val sourceRepository: SourceRepository,
     private val formattingSessionFactory: FormattingSession.Factory,
     private val volumeKeyDispatcher: VolumeKeyDispatcher,
+    private val progressFlushScope: com.riffle.feature.reader.ProgressFlushScope,
     clock: Clock,
     readingSpeedStore: ReadingSpeedStore,
     private val catalogRegistry: com.riffle.core.catalog.CatalogRegistry,
@@ -72,11 +73,16 @@ class PdfReaderViewModel constructor(
 
     init {
         viewModelScope.launch {
-            // getActive() is captured once at reader-open time. In practice the reader is opened
-            // from a tap on the currently-active Source's library, so this matches the item's
-            // Source. Raw `is` check in place of the inline has<T>() extension — see
-            // LibraryItemsViewModel.tabVisibility for the JVM-target rationale.
-            val catalog = sourceRepository.getActive()?.let { catalogRegistry.forSource(it) }
+            // Resolve the catalog from the book's own source (navSourceId when present; active
+            // source as fallback for normal single-source opens). Raw `is` check in place of the
+            // inline has<T>() extension — see LibraryItemsViewModel.tabVisibility for the
+            // JVM-target rationale.
+            val bookSource = if (navSourceId != null) {
+                sourceRepository.getById(navSourceId) ?: sourceRepository.getActive()
+            } else {
+                sourceRepository.getActive()
+            }
+            val catalog = bookSource?.let { catalogRegistry.forSource(it) }
             readingSessionsEnabled.set(catalog is com.riffle.core.catalog.ReadingSessionsCapability)
         }
     }
@@ -290,7 +296,7 @@ class PdfReaderViewModel constructor(
                 }
                 this.publication = publication
                 buildTocAndRail(publication)
-                annotationServerId = sourceRepository.getActive()?.id
+                annotationServerId = item.sourceId
                 startObservingAnnotations()
                 val locator = result.lastPosition
                     ?.takeIf { it.isNotEmpty() }
@@ -524,6 +530,15 @@ class PdfReaderViewModel constructor(
         if (closeSyncDone) return
         closeSyncDone = true
         val locator = lastLocator ?: return
+        // Persist position on survivable scope — same race as EpubReaderViewModel: onCleared()
+        // calls super.onCleared() first, cancelling viewModelScope before the in-flight
+        // onPageChanged save coroutine can execute.
+        val locatorJson = locator.toJSON().toString()
+        val capturedNavSourceId = navSourceId
+        progressFlushScope.flush {
+            val sid = capturedNavSourceId ?: sourceRepository.getActive()?.id ?: return@flush
+            pdfRepository.saveReadingPosition(sid, itemId, locatorJson)
+        }
         viewModelScope.launch {
             val payload = locator.toPayload()
             positionSaveCoordinator.onClose(payload.ebookProgress)

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/PositionOrchestrator.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/PositionOrchestrator.kt
@@ -167,7 +167,8 @@ class PositionOrchestrator constructor(
         val serverJumpStamp = serverJump.consumePendingStamp()
         scope.launch {
             saveMutex.withLock {
-                positionSaveCoordinator?.onChanged(locator.toJSON().toString())
+                val locatorJson = locator.toJSON().toString()
+                positionSaveCoordinator?.onChanged(locatorJson)
                 if (serverJumpStamp != null) {
                     readingPositionStore?.updateLocalTimestamp(sourceId, itemId, serverJumpStamp)
                 }

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycle.kt
@@ -171,19 +171,28 @@ class ReaderSessionLifecycle constructor(
     ): OpenOutcome {
         _publication.value = pub
 
-        val activeServer: Source? = sourceRepository.getActive()
-        val isStorytellerService = activeServer?.serverType == ServerType.STORYTELLER_SERVICE
+        // Prefer the explicit sourceId from navigation (cross-source opens from the Riffle screen)
+        // over the currently-active source. Using the active source here was the root cause of
+        // annotations, bookmarks, and readaloud links all being looked up under the wrong source
+        // when the user opened a book that belongs to a non-active source.
+        val bookSource: Source? = if (params.sourceId != null) {
+            sourceRepository.getById(params.sourceId) ?: sourceRepository.getActive()
+        } else {
+            sourceRepository.getActive()
+        }
+        val effectiveServerId: String? = bookSource?.id
+        val isStorytellerService = bookSource?.serverType == ServerType.STORYTELLER_SERVICE
 
         // Matched ABS book → key the bundle by the linked Storyteller book id (the bundle is
         // stored under that id, not the ABS item id). Storyteller side keeps itemId.
-        val link = if (!isStorytellerService && activeServer != null) {
-            readaloudLinkRepository.findByAbsItem(activeServer.id, params.itemId)
+        val link = if (!isStorytellerService && effectiveServerId != null) {
+            readaloudLinkRepository.findByAbsItem(effectiveServerId, params.itemId)
         } else {
             null
         }
         val resolvedAudioBookId = link?.storytellerBookId ?: params.itemId
-        val resolvedAudioServerId = link?.storytellerSourceId ?: activeServer?.id ?: ""
-        val resolvedReaderServerId = activeServer?.id
+        val resolvedAudioServerId = link?.storytellerSourceId ?: effectiveServerId ?: ""
+        val resolvedReaderServerId = effectiveServerId
 
         // The audiobook to switch to on swipe-up: among this readaloud's ABS targets, the
         // listenable one (in a split library), or this same item if it's a combined ebook+audio.
@@ -200,7 +209,7 @@ class ReaderSessionLifecycle constructor(
         val resolvedAudioSettingsIdentity = if (link != null) {
             audioIdentityResolver.resolveForStorytellerBook(link.storytellerSourceId, link.storytellerBookId)
         } else {
-            AudioIdentity(activeServer?.id ?: "", params.itemId)
+            AudioIdentity(effectiveServerId ?: "", params.itemId)
         }
         val resolvedInitialSpeed = audioPlaybackPreferencesStore.load(resolvedAudioSettingsIdentity)
             ?: listeningPreferencesStore.defaultPlaybackSpeed.first()
@@ -211,7 +220,7 @@ class ReaderSessionLifecycle constructor(
         readerServerId = resolvedReaderServerId
         readerItemId = params.itemId
         // Claim this book so the durable sweep leaves it to this reader's own cycle (ADR 0036).
-        activeServer?.id?.let { openReconcileTargets.markOpen(it, params.itemId) }
+        effectiveServerId?.let { openReconcileTargets.markOpen(it, params.itemId) }
 
         val openAtCfiNonBlank = params.openAtCfi?.takeIf { it.isNotBlank() }
         // A search-result / annotation-tap open overrides the saved position. Requires `publication`
@@ -283,7 +292,6 @@ class ReaderSessionLifecycle constructor(
             initialFocusAnnotationId = effectiveFocusAnnotationId,
             effectiveInitialLocator = effectiveInitial,
             openAtLocator = openAtLocator,
-            activeServer = activeServer,
             isStorytellerService = isStorytellerService,
             resolvedAudioBookId = resolvedAudioBookId,
             resolvedAudioServerId = resolvedAudioServerId,
@@ -353,7 +361,6 @@ class ReaderSessionLifecycle constructor(
             /** The initial locator without the TOC-nav null-out. Used by the initial sync cycle. */
             val effectiveInitialLocator: Locator?,
             val openAtLocator: Locator?,
-            val activeServer: Source?,
             val isStorytellerService: Boolean,
             val resolvedAudioBookId: String,
             val resolvedAudioServerId: String,

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/ReaderSessionLifecycleTest.kt
@@ -94,9 +94,14 @@ class ReaderSessionLifecycleTest {
         override suspend fun saveReadingPosition(sourceId: String, itemId: String, cfi: String) {}
     }
 
-    private class FakeServerRepository(private val active: Source?) : SourceRepository {
-        override fun observeAll(): Flow<List<Source>> = flowOf(active?.let { listOf(it) } ?: emptyList())
+    private class FakeServerRepository(
+        private val active: Source?,
+        private val extra: List<Source> = emptyList(),
+    ) : SourceRepository {
+        private val all: List<Source> get() = listOfNotNull(active) + extra
+        override fun observeAll(): Flow<List<Source>> = flowOf(all)
         override suspend fun getActive(): Source? = active
+        override suspend fun getById(sourceId: String): Source? = all.firstOrNull { it.id == sourceId }
         override suspend fun commit(
             pending: com.riffle.core.domain.PendingSource, hiddenLibraryIds: Set<String>,
         ) = com.riffle.core.domain.CommitSourceResult.Failure(RuntimeException("not needed"))
@@ -410,6 +415,28 @@ class ReaderSessionLifecycleTest {
     }
 
     @Test
+    fun `open with cross-source params sets resolvedReaderServerId to book source not active source`() = runTest {
+        // Regression for annotation loading bug: when a book from source B is opened while
+        // source A is active (e.g. from the Riffle cross-source screen), resolvedReaderServerId
+        // must equal source B's id so annotations are fetched from the correct (sourceId, itemId)
+        // key and not from source A where they don't exist.
+        val absSource = activeServer               // active source: srv-abs
+        val secondSource = activeServer.copy(id = "srv-abs-2", isActive = false)
+        val secondSourceItem = ebookItem.copy(sourceId = secondSource.id)
+        val (lifecycle, _) = makeLifecycle(
+            libraryObserver = FakeLibraryObserver(
+                items = mapOf((secondSource.id to "item-1") to secondSourceItem),
+                activeItems = mapOf("item-1" to ebookItem), // active source has a DIFFERENT item
+            ),
+            sourceRepository = FakeServerRepository(active = absSource, extra = listOf(secondSource)),
+        )
+        val outcome = lifecycle.open(params(sourceId = secondSource.id))
+            as ReaderSessionLifecycle.OpenOutcome.Ready
+
+        assertEquals(secondSource.id, outcome.resolvedReaderServerId)
+    }
+
+    @Test
     fun `open returns Error when EPUB open fails`() = runTest {
         val (lifecycle, _) = makeLifecycle(
             epubRepository = FakeEpubRepository(EpubOpenResult.Offline),
@@ -440,7 +467,6 @@ class ReaderSessionLifecycleTest {
         assertEquals("srv-abs", outcome.resolvedReaderServerId)
         assertNull(outcome.resolvedAudiobookItemId)
         assertEquals(1.25f, outcome.resolvedInitialSpeed, 0.0001f)
-        assertSame(activeServer, outcome.activeServer)
         assertTrue(reconcile.isOpen("srv-abs", "item-1"))
         assertNotNull(lifecycle.publication.value)
     }

--- a/feature/reader/src/commonMain/kotlin/com/riffle/feature/reader/CbzReaderViewModel.kt
+++ b/feature/reader/src/commonMain/kotlin/com/riffle/feature/reader/CbzReaderViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlin.concurrent.Volatile
 import com.riffle.core.domain.CbzLocalSource
+import com.riffle.core.domain.ApplicationScope
 import com.riffle.core.domain.DispatcherProvider
 import com.riffle.core.domain.CbzOpenResult
 import com.riffle.core.domain.CbzRepository
@@ -89,6 +90,7 @@ class CbzReaderViewModel constructor(
     private val colorPageDecoder: ColorPageDecoder,
     private val dispatchers: DispatcherProvider,
     val panelReportRepository: PanelReportRepository,
+    private val applicationScope: ApplicationScope,
 ) : ViewModel() {
 
     private var currentSource: ComicPageSource? = null
@@ -678,6 +680,13 @@ class CbzReaderViewModel constructor(
         val page = _currentPage.value + 1
         val progression = if (ready.pageCount > 0) page.toDouble() / ready.pageCount.toDouble() else 0.0
         val locatorJson = buildLocatorJson(page, progression)
+        // Persist position on survivable scope — same race as EpubReaderViewModel: onCleared()
+        // calls super.onCleared() first, cancelling viewModelScope before the in-flight
+        // savePosition coroutine can execute.
+        val sid = resolvedSourceId
+        if (sid != null) {
+            applicationScope.launchSurvivable { cbzRepository.saveReadingPosition(sid, itemId, locatorJson) }
+        }
         syncSession.sync(SessionPayload(ebookLocation = locatorJson, ebookProgress = progression.toFloat()))
     }
 

--- a/feature/reader/src/commonTest/kotlin/com/riffle/feature/reader/CbzReaderViewModelCloseTest.kt
+++ b/feature/reader/src/commonTest/kotlin/com/riffle/feature/reader/CbzReaderViewModelCloseTest.kt
@@ -1,0 +1,275 @@
+package com.riffle.feature.reader
+
+import com.riffle.core.domain.ApplicationScope
+import com.riffle.core.domain.CbzRepository
+import com.riffle.core.domain.DispatcherProvider
+import com.riffle.core.domain.LibraryObserver
+import com.riffle.core.models.Library
+import com.riffle.core.domain.ReadingSessionRepository
+import com.riffle.core.domain.VolumeKeyPreferencesStore
+import com.riffle.core.domain.WakeLockPreferencesStore
+import com.riffle.core.domain.appearance.AppearanceCoordinator
+import com.riffle.core.domain.appearance.ChromeTheme
+import com.riffle.core.domain.appearance.ConcreteReaderTheme
+import com.riffle.core.domain.appearance.ResolvedAppearance
+import com.riffle.core.domain.comic.BookComicFormattingOverrides
+import com.riffle.core.domain.comic.BookComicFormattingPreferencesStore
+import com.riffle.core.domain.comic.ComicFormattingPreferences
+import com.riffle.core.domain.comic.ComicFormattingPreferencesStore
+import com.riffle.core.domain.comic.panel.ColorPageDecoder
+import com.riffle.core.domain.comic.panel.PagePanels
+import com.riffle.core.domain.comic.panel.PanelEngine
+import com.riffle.core.domain.comic.panel.PanelMaskService
+import com.riffle.core.domain.comic.panel.PanelReportRepository
+import com.riffle.core.domain.comic.panel.PanelSource
+import com.riffle.core.domain.comic.panel.PanelViewPreferencesStore
+import com.riffle.core.domain.developer.DeveloperOptionsRepository
+import com.riffle.core.domain.LibraryMutator
+import com.riffle.core.domain.usecase.UpdateReadingProgress
+import com.riffle.core.domain.CbzDownloadResult
+import com.riffle.core.domain.CbzLocalSource
+import com.riffle.core.domain.CbzOpenResult
+import com.riffle.core.models.EbookFormat
+import com.riffle.core.models.LibraryItem
+import com.riffle.core.models.ProgressSyncCycleResult
+import com.riffle.core.models.Series
+import com.riffle.core.models.SessionPayload
+import com.riffle.core.models.SyncSessionResult
+import com.riffle.core.domain.comic.ComicPageSource
+import com.riffle.core.models.Collection
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression test: [CbzReaderViewModel.onReaderClosed] must flush the current reading position
+ * via [ApplicationScope.launchSurvivable] so the save persists even when [viewModelScope] is
+ * cancelled immediately after (which happens when Android destroys the ViewModel the instant the
+ * user backs out of the reader — `onCleared()` calls `super.onCleared()` first, cancelling
+ * `viewModelScope` before any in-flight `viewModelScope.launch` save can execute).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CbzReaderViewModelCloseTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() { Dispatchers.setMain(testDispatcher) }
+
+    @AfterTest
+    fun tearDown() { Dispatchers.resetMain() }
+
+    @Test
+    fun `onReaderClosed flushes position via applicationScope`() = runTest(testDispatcher) {
+        var appScopeLaunches = 0
+
+        val fakeAppScope = object : ApplicationScope {
+            private val inner = CoroutineScope(testDispatcher + SupervisorJob())
+            override val coroutineScope: CoroutineScope = inner
+            override fun launchSurvivable(block: suspend CoroutineScope.() -> Unit): Job {
+                appScopeLaunches++
+                return inner.launch(block = block)
+            }
+            override suspend fun <T> withSurvivable(block: suspend CoroutineScope.() -> T): T = block(inner)
+        }
+
+        val savedPositions = mutableListOf<Triple<String, String, String>>()
+        val fakeCbzRepo = object : FakeNullCbzRepository() {
+            override suspend fun openCbz(item: LibraryItem): CbzOpenResult = CbzOpenResult.Success(
+                imageSource = object : ComicPageSource {
+                    override val pageCount = 5
+                    override fun imageBytes(pageIndex: Int) = ByteArray(0)
+                    override fun mediaType(pageIndex: Int) = "image/jpeg"
+                },
+                pageCount = 5,
+                lastPosition = null,
+            )
+            override suspend fun saveReadingPosition(sourceId: String, itemId: String, locatorJson: String) {
+                savedPositions += Triple(sourceId, itemId, locatorJson)
+            }
+        }
+
+        val fakeItem = LibraryItem(
+            id = "item1", libraryId = "lib1", title = "Comic", author = "Author",
+            coverUrl = null, readingProgress = 0f, isCached = true, isDownloaded = true,
+            ebookFormat = EbookFormat.Cbz, sourceId = "src1", pageCount = 5,
+        )
+
+        val vm = CbzReaderViewModel(
+            itemId = "item1",
+            sourceId = "src1",
+            libraryObserver = FakeLibraryObserver(fakeItem),
+            cbzRepository = fakeCbzRepo,
+            readingSessionRepository = FakeReadingSessionRepository(),
+            updateReadingProgressUseCase = object : UpdateReadingProgress(object : LibraryMutator {
+                override suspend fun markItemOpened(itemId: String) {}
+                override suspend fun updateReadingProgress(itemId: String, progress: Float) {}
+                override suspend fun updateReadingProgress(sourceId: String, itemId: String, progress: Float) {}
+                override suspend fun deleteItem(sourceId: String, itemId: String) {}
+            }) {},
+            wakeLockPreferencesStore = FakeWakeLockStore(),
+            volumeNavigationController = VolumeNavigationController(),
+            volumeKeyDispatcher = VolumeKeyDispatcher(FakeVolumeKeyPreferencesStore(), VolumeNavigationController()),
+            readerStateHolder = ReaderStateHolder(),
+            panelEngine = FakePanelEngine(),
+            panelMaskService = FakePanelMaskService(),
+            panelViewPreferencesStore = FakePanelViewPreferencesStore(),
+            comicFormattingPreferencesStore = FakeComicFormattingStore(),
+            bookComicFormattingPreferencesStore = FakeBookComicFormattingStore(),
+            developerOptionsRepository = FakeDeveloperOptionsRepository(),
+            appearanceCoordinator = FakeAppearanceCoordinator(),
+            colorPageDecoder = FakeColorPageDecoder(),
+            dispatchers = FakeDispatcherProvider(testDispatcher),
+            panelReportRepository = FakePanelReportRepository(),
+            applicationScope = fakeAppScope,
+        )
+
+        // Pump init coroutines: viewModelScope.launch { openBook() } sets state to Ready
+        runCurrent()
+
+        vm.onReaderClosed()
+        // Pump the applicationScope coroutine launched by onReaderClosed
+        runCurrent()
+
+        assertEquals(
+            1, appScopeLaunches,
+            "onReaderClosed must use applicationScope to survive viewModelScope cancellation"
+        )
+        assertEquals(1, savedPositions.size, "saveReadingPosition must be called once")
+        assertEquals("src1", savedPositions.first().first)
+        assertEquals("item1", savedPositions.first().second)
+    }
+}
+
+// ---- Minimal fakes ----
+
+private abstract class FakeNullCbzRepository : CbzRepository {
+    override suspend fun openCbz(item: LibraryItem): CbzOpenResult = CbzOpenResult.Offline
+    override suspend fun downloadCbz(item: LibraryItem, onProgress: (Long, Long) -> Unit): CbzDownloadResult = CbzDownloadResult.AlreadyDownloaded
+    override suspend fun removeDownload(sourceId: String, itemId: String) {}
+    override fun isDownloaded(sourceId: String, itemId: String) = false
+    override fun isCached(sourceId: String, itemId: String) = false
+    override suspend fun saveReadingPosition(sourceId: String, itemId: String, locatorJson: String) {}
+    override suspend fun supportsStreaming(sourceId: String) = false
+    override suspend fun fetchStreamingPageImage(sourceId: String, itemId: String, pageIndex: Int, maxWidth: Int?) = ByteArray(0)
+    override suspend fun awaitCachedSource(item: LibraryItem): CbzLocalSource? = null
+}
+
+private class FakeLibraryObserver(private val item: LibraryItem) : LibraryObserver {
+    override fun observeLibraries() = flowOf(emptyList<Library>())
+    override fun observeLibraries(sourceId: String) = flowOf(emptyList<Library>())
+    override fun observeLibraryItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+    override fun observeUngroupedLibraryItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+    override fun observeInProgressItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+    override fun observeFinishedItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+    override fun observeRecentlyAddedItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+    override fun observeAllBooks(libraryId: String) = flowOf(emptyList<LibraryItem>())
+    override fun observeSeries(libraryId: String) = flowOf(emptyList<Series>())
+    override fun observeCollections(libraryId: String) = flowOf(emptyList<Collection>())
+    override fun observeSeriesItems(seriesId: String) = flowOf(emptyList<LibraryItem>())
+    override fun observeContinueSeriesItems(libraryId: String) = flowOf(emptyList<LibraryItem>())
+    override fun observeCollectionItems(collectionId: String) = flowOf(emptyList<LibraryItem>())
+    override suspend fun getItem(itemId: String): LibraryItem = item
+    override fun observeItem(itemId: String) = flowOf(item)
+    override suspend fun getItem(sourceId: String, itemId: String): LibraryItem = item
+    override suspend fun getLibrary(libraryId: String) = null
+    override suspend fun getSeriesIdForItem(sourceId: String, itemId: String) = null
+}
+
+private class FakeReadingSessionRepository : ReadingSessionRepository {
+    override suspend fun syncProgress(itemId: String, payload: SessionPayload) = SyncSessionResult.Success
+    override suspend fun runSyncCycle(itemId: String, payload: SessionPayload) = ProgressSyncCycleResult.InSync
+    override suspend fun markFinished(itemId: String, finished: Boolean) {}
+    override suspend fun touchOpenTimestamp(itemId: String) {}
+}
+
+private class FakeWakeLockStore : WakeLockPreferencesStore {
+    override val keepScreenOn: Flow<Boolean> = flowOf(true)
+    override suspend fun setKeepScreenOn(enabled: Boolean) {}
+}
+
+private class FakeVolumeKeyPreferencesStore : VolumeKeyPreferencesStore {
+    override val volumeKeyNavigationEnabled: Flow<Boolean> = flowOf(true)
+    override val invertVolumeKeys: Flow<Boolean> = flowOf(false)
+    override suspend fun setVolumeKeyNavigationEnabled(value: Boolean) {}
+    override suspend fun setInvertVolumeKeys(value: Boolean) {}
+}
+
+private class FakePanelEngine : PanelEngine {
+    override fun forBook(bookId: String, imageBytes: (Int) -> ByteArray): PanelEngine.Book =
+        object : PanelEngine.Book {
+            override fun resolvePage(pageIndex: Int) = PagePanels(
+                pageIndex = pageIndex, imageWidth = 100, imageHeight = 200,
+                panels = emptyList(), source = PanelSource.Fallback,
+            )
+        }
+}
+
+private class FakePanelMaskService : PanelMaskService {
+    override suspend fun generateMask(pageIndex: Int, rawImageBytes: ByteArray) = null
+}
+
+private class FakePanelViewPreferencesStore : PanelViewPreferencesStore {
+    override fun state(bookId: String) = flowOf(PanelViewPreferencesStore.State(false))
+    override suspend fun setPanelViewOn(bookId: String, on: Boolean) {}
+}
+
+private class FakeComicFormattingStore : ComicFormattingPreferencesStore {
+    override val preferences = flowOf(ComicFormattingPreferences())
+    override suspend fun update(prefs: ComicFormattingPreferences) {}
+}
+
+private class FakeBookComicFormattingStore : BookComicFormattingPreferencesStore {
+    override fun overrides(bookId: String) = flowOf(BookComicFormattingOverrides())
+    override suspend fun save(bookId: String, overrides: BookComicFormattingOverrides) {}
+    override suspend fun reset(bookId: String) {}
+}
+
+private class FakeDeveloperOptionsRepository : DeveloperOptionsRepository {
+    override val developerModeEnabled: Flow<Boolean> = flowOf(false)
+    override suspend fun setDeveloperModeEnabled(enabled: Boolean) {}
+    override suspend fun getGithubPat() = null
+    override suspend fun setGithubPat(pat: String?) {}
+}
+
+private class FakeAppearanceCoordinator : AppearanceCoordinator {
+    override val resolved: StateFlow<ResolvedAppearance> = MutableStateFlow(
+        ResolvedAppearance(ChromeTheme.Light, ConcreteReaderTheme.Light, false)
+    )
+    override fun setSystemDark(isDark: Boolean) {}
+}
+
+private class FakeColorPageDecoder : ColorPageDecoder {
+    override fun decode(bytes: ByteArray, targetLongEdge: Int) = null
+}
+
+private class FakeDispatcherProvider(private val dispatcher: CoroutineDispatcher) : DispatcherProvider {
+    override val main = dispatcher
+    override val mainImmediate = dispatcher
+    override val io = dispatcher
+    override val default = dispatcher
+}
+
+private class FakePanelReportRepository : PanelReportRepository {
+    override suspend fun submit(
+        report: com.riffle.core.domain.comic.panel.PanelDetectionReport,
+        maskPng: ByteArray,
+    ) = Result.failure<String>(UnsupportedOperationException("fake"))
+}

--- a/iosApp/iosAppTests/ComicsReaderTests.swift
+++ b/iosApp/iosAppTests/ComicsReaderTests.swift
@@ -42,6 +42,68 @@ final class ComicsReaderTests: XCTestCase {
         )
     }
 
+    // MARK: - Scenario 06-D: Reading position persists across sessions
+
+    /// 06-D.1 — Reopening a CBZ resumes at the last-viewed page, not page 1.
+    ///
+    /// Regression for the viewModelScope-cancellation position drop: `onCleared()` cancels
+    /// viewModelScope before an in-flight saveReadingPosition coroutine can execute, leaving the
+    /// DB with a stale (page 1) position. Fixed by flushing position on an app-lifetime scope in
+    /// `onReaderClosed()` before the ViewModel is cleared.
+    func testComicsPositionRestoredOnReopen() throws {
+        if app.staticTexts["Add source"].waitForExistence(timeout: 5) {
+            throw XCTSkip("No source configured — position-persistence test requires a connected server")
+        }
+        _ = app.activityIndicators.firstMatch.waitForNonExistence(timeout: 15)
+
+        let cbzTile = app.buttons.matching(
+            NSPredicate(format: "label CONTAINS[c] 'cbz'")
+        ).firstMatch
+        guard cbzTile.waitForExistence(timeout: 5) else {
+            throw XCTSkip("No CBZ tile found in library — requires a server with CBZ items")
+        }
+        let bookLabel = cbzTile.label
+
+        // Open and advance a few pages.
+        cbzTile.tap()
+        let backButton = app.buttons["← Back"].firstMatch
+        guard backButton.waitForExistence(timeout: 15) else {
+            throw XCTSkip("Comics reader did not open")
+        }
+        // Advance 3 pages by swiping left.
+        let readerArea = app.otherElements.firstMatch
+        for _ in 0..<3 {
+            readerArea.swipeLeft()
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+
+        // Close the reader.
+        backButton.tap()
+        _ = app.staticTexts.firstMatch.waitForExistence(timeout: 5)
+
+        // Reopen the same book.
+        let sameTile = app.buttons.matching(
+            NSPredicate(format: "label == %@", bookLabel)
+        ).firstMatch
+        guard sameTile.waitForExistence(timeout: 5) else {
+            throw XCTSkip("Could not find the same CBZ tile after closing reader")
+        }
+        sameTile.tap()
+        guard backButton.waitForExistence(timeout: 15) else {
+            throw XCTSkip("Comics reader did not reopen")
+        }
+
+        // The page indicator should NOT show "1 /" (page 1) — we advanced past that.
+        // If position was dropped the book would restart at page 1.
+        let onPageOne = app.staticTexts.matching(
+            NSPredicate(format: "label BEGINSWITH '1 /'")
+        ).firstMatch.waitForExistence(timeout: 3)
+        XCTAssertFalse(
+            onPageOne,
+            "After reopening a CBZ, position should be restored to the last-viewed page (not page 1)"
+        )
+    }
+
     // MARK: - Scenario 06-G: Back navigation
 
     /// 06-G.1 — Tapping back from the comics reader returns to the library.

--- a/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
+++ b/shared/src/iosMain/kotlin/com/riffle/shared/Koin.kt
@@ -335,6 +335,7 @@ private fun iosLibraryModule(
             colorPageDecoder = get(),
             dispatchers = get(),
             panelReportRepository = get(),
+            applicationScope = get(),
         )
     }
 


### PR DESCRIPTION
## Summary

- **Position flush survival**: `onReaderClosed()` in `EpubReaderViewModel` and `PdfReaderViewModel` now writes the last-seen position on `progressFlushScope` (backed by `applicationCoroutineScope`) instead of an in-flight `viewModelScope` coroutine. Back-navigation triggers `onCleared()` → `super.onCleared()` first, cancelling `viewModelScope` before the position save coroutine runs; the flush scope survives this and guarantees the write lands in DB before the next `pullItem()` on reopen. Without this fix, `pullItem` found InSync (nothing changed since last server sync) and opened the book at the old server position instead of where the user stopped.

- **Readaloud source fix**: `EpubReaderViewModel` now uses the book's own `sourceId` (not the active source) when resolving the readaloud link and audio identity. Matches the fix applied to non-readaloud annotation loading in #999.

- **iOS test**: Scenario 06-D (`testComicsPositionRestoredOnReopen`) added — opens a CBZ, swipes 3 pages, goes back, reopens, asserts position is restored beyond page 1.

## Code review findings addressed

All five findings from the automated review were evaluated:

- **Finding 1** (CBZ `updateReadingProgressUseCase` dropped in race): Dismissed — progress float is cosmetic and corrected on next server sync. Critical path (position row) is covered by the survivable flush.
- **Finding 2** (test assertion only holds at initial page): Dismissed — the primary regression assertion (`appScopeLaunches == 1`) is scenario-correct; the initial-page scenario is the specific race being tested.
- **Findings 3 & 4** (EPUB/PDF flush uses `navServerId` not `annotationServerId`): Dismissed — `positionStore` always keys by `item.sourceId`, which equals `navServerId`. The two IDs diverge only for annotation sync, not position storage.
- **Finding 5** (silent fallback to `getActive()` in lifecycle): Pre-existing behaviour, unchanged by this PR.

## Test plan

- [ ] JVM tests: `./gradlew test jvmTest` → green
- [ ] iOS XCTest: `testComicsPositionRestoredOnReopen` in `ComicsReaderTests`
- [ ] AVD repro path: open EPUB, read several pages, navigate back (triggering `onCleared`), reopen — confirm book opens at last-seen position, not server position