### PR TITLE
fix(reader): key book formatting settings on item's own sourceId

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -55,6 +55,10 @@ jobs:
         run: |
           echo "version=$(grep '^kotlin = ' gradle/libs.versions.toml | sed 's/kotlin = "\(.*\)"/\1/')" >> $GITHUB_OUTPUT
 
+      - name: Read Xcode version
+        id: xcode-version
+        run: echo "version=$(xcodebuild -version | head -1 | awk '{print $2}')" >> $GITHUB_OUTPUT
+
       - name: Cache Kotlin/Native toolchain
         uses: actions/cache@v6
         with:
@@ -73,10 +77,10 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/derived-data
-          key: derived-data-${{ runner.os }}-${{ hashFiles('iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ steps.kotlin-version.outputs.version }}
+          key: derived-data-${{ runner.os }}-${{ steps.xcode-version.outputs.version }}-${{ hashFiles('iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-${{ steps.kotlin-version.outputs.version }}
           restore-keys: |
-            derived-data-${{ runner.os }}-${{ hashFiles('iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-
-            derived-data-${{ runner.os }}-
+            derived-data-${{ runner.os }}-${{ steps.xcode-version.outputs.version }}-${{ hashFiles('iosApp/iosApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}-
+            derived-data-${{ runner.os }}-${{ steps.xcode-version.outputs.version }}-
 
       - name: Assemble Riffle XCFramework
         run: ./gradlew assembleRiffleDebugXCFramework

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -1161,7 +1161,10 @@ class EpubReaderViewModel constructor(
             // time first() returned and now. setScreenDimensionBucket only calls bindToBook when
             // previous!=null, so the init coroutine must pick up the latest value here rather
             // than the stale one captured by first().
-            formatting.bindToBook(itemId, checkNotNull(_screenDimensionBucket.value))
+            // Key formatting on the book's own source, not the currently-active one — a book
+            // opened from the Riffle source view carries its real sourceId in navServerId.
+            val formattingSourceId = navServerId ?: sourceRepository.getActive()?.id
+            formatting.bindToBook(itemId, checkNotNull(_screenDimensionBucket.value), formattingSourceId)
             openBook()
         }
         // Readaloud start ⇒ stop Auto-Scroll (mutual exclusion, ADR 0044). Stop (not Pause):

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/PdfReaderViewModel.kt
@@ -263,7 +263,9 @@ class PdfReaderViewModel constructor(
             // Sequential: formatting prefs must be available before openBook() so the
             // navigator never sees the stateIn default on first paint (FormattingSession.bindToBook
             // waits for effectiveFormattingPreferences to reflect the loaded value).
-            formatting.bindToBook(itemId)
+            // Key formatting on the book's own source, not the currently-active one.
+            val formattingSourceId = navSourceId ?: sourceRepository.getActive()?.id
+            formatting.bindToBook(itemId, sourceId = formattingSourceId)
             openBook()
         }
         viewModelScope.launch {

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
@@ -96,6 +96,7 @@ class FormattingSession constructor(
     val autoScrollScrollDeltas: Flow<Int> = autoScrollController.scrollDeltas
 
     private var bookId: String? = null
+    private var boundSourceId: String? = null
     private var activeDimension: ScreenDimensionBucket = ScreenDimensionBucket.PhonePortrait
     private var bindJob: kotlinx.coroutines.Job? = null
 
@@ -189,22 +190,28 @@ class FormattingSession constructor(
      * Load book-specific overrides for the given screen-dimension bucket and mark prefs as ready.
      * Must be called before [effectiveFormattingPreferences] is consumed by the navigator. May be
      * re-called when the device dimension changes (fold/rotate) to switch to the new bucket's row.
-     * If no row exists for this (itemId, dimension), global defaults are seeded as a dense
-     * override row so the dimension's settings are independent going forward.
+     * If no row exists for this (sourceId, itemId, dimension), global defaults are seeded as a
+     * dense override row so the dimension's settings are independent going forward.
+     *
+     * [sourceId] is the book's own source (not the currently-active one). Pass it on the initial
+     * call; subsequent re-binds for dimension changes may omit it to reuse the stored value.
      */
     fun bindToBook(
         itemId: String,
         dimension: ScreenDimensionBucket = ScreenDimensionBucket.PhonePortrait,
+        sourceId: String? = null,
     ) {
         val alreadyReady = _formattingPreferencesReady.value
         bookId = itemId
         activeDimension = dimension
+        if (sourceId != null) boundSourceId = sourceId
+        val sid = boundSourceId
         // Only reset the ready flag on the first bind. Re-binding for a dimension change leaves the
         // prior prefs visible while the new dimension's row loads — avoids a spinner flash on fold/rotate.
         if (!alreadyReady) _formattingPreferencesReady.value = false
         bindJob?.cancel()
         bindJob = this.scope.launch {
-            val existing = bookFormattingPreferencesStore.load(itemId, dimension)
+            val existing = sid?.let { bookFormattingPreferencesStore.load(it, itemId, dimension) }
             val global = formattingPreferencesStoreProvider.store().preferences.first()
             val overrides = if (existing != null) {
                 existing
@@ -226,7 +233,7 @@ class FormattingSession constructor(
                     doublePageSpread = global.doublePageSpread,
                     justifyText = global.justifyText,
                 ).also { seed ->
-                    bookFormattingPreferencesStore.save(itemId, dimension, seed)
+                    if (sid != null) bookFormattingPreferencesStore.save(sid, itemId, dimension, seed)
                 }
             }
             _bookOverrides.value = overrides
@@ -254,8 +261,9 @@ class FormattingSession constructor(
         _bookOverrides.value = updated
         _formattingPreferences.value = prefs
         _hasBookOverrides.value = !updated.isEmpty
+        val sid = boundSourceId ?: return
         val boundDimension = activeDimension
-        scope.launch { bookFormattingPreferencesStore.save(itemId, boundDimension, updated) }
+        scope.launch { bookFormattingPreferencesStore.save(sid, itemId, boundDimension, updated) }
     }
 
     /**
@@ -270,9 +278,10 @@ class FormattingSession constructor(
 
     /** Clear book-level overrides for the current dimension, reverting to global formatting preferences. */
     fun resetToGlobalDefaults(itemId: String) {
+        val sid = boundSourceId
         val boundDimension = activeDimension
         scope.launch {
-            bookFormattingPreferencesStore.clear(itemId, boundDimension)
+            if (sid != null) bookFormattingPreferencesStore.clear(sid, itemId, boundDimension)
             _bookOverrides.value = BookFormattingOverrides()
             _formattingPreferences.value =
                 formattingPreferencesStoreProvider.store().preferences.first()

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/PdfReaderViewModelFormattingTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/PdfReaderViewModelFormattingTest.kt
@@ -48,12 +48,12 @@ class PdfReaderViewModelFormattingTest {
 
     private class FakeBookFormattingPreferencesStore : BookFormattingPreferencesStore {
         private val saved = mutableMapOf<Pair<String, ScreenDimensionBucket>, BookFormattingOverrides>()
-        override suspend fun load(itemId: String, dimension: ScreenDimensionBucket): BookFormattingOverrides? =
+        override suspend fun load(sourceId: String, itemId: String, dimension: ScreenDimensionBucket): BookFormattingOverrides? =
             saved[itemId to dimension]
-        override suspend fun save(itemId: String, dimension: ScreenDimensionBucket, overrides: BookFormattingOverrides) {
+        override suspend fun save(sourceId: String, itemId: String, dimension: ScreenDimensionBucket, overrides: BookFormattingOverrides) {
             saved[itemId to dimension] = overrides
         }
-        override suspend fun clear(itemId: String, dimension: ScreenDimensionBucket) {
+        override suspend fun clear(sourceId: String, itemId: String, dimension: ScreenDimensionBucket) {
             saved.remove(itemId to dimension)
         }
         fun captured(itemId: String, dimension: ScreenDimensionBucket = ScreenDimensionBucket.PhonePortrait): BookFormattingOverrides? =
@@ -120,7 +120,7 @@ class PdfReaderViewModelFormattingTest {
     fun `updateFormatting persists to book override store`() = runTest {
         val fixture = formattingSessionFixture()
         try {
-            fixture.session.bindToBook("book-1")
+            fixture.session.bindToBook("book-1", sourceId = "test-src")
             fixture.session.updateFormatting("book-1", FormattingPreferences(margins = 2.0f))
             assertEquals(2.0f, fixture.bookStore.captured("book-1")?.margins)
         } finally {

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/PdfReaderViewModelFormattingTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/PdfReaderViewModelFormattingTest.kt
@@ -47,17 +47,18 @@ class PdfReaderViewModelFormattingTest {
     }
 
     private class FakeBookFormattingPreferencesStore : BookFormattingPreferencesStore {
-        private val saved = mutableMapOf<Pair<String, ScreenDimensionBucket>, BookFormattingOverrides>()
+        // Keyed by (sourceId, itemId, dimension) so a wrong-sourceId routing regression fails fast.
+        private val saved = mutableMapOf<Triple<String, String, ScreenDimensionBucket>, BookFormattingOverrides>()
         override suspend fun load(sourceId: String, itemId: String, dimension: ScreenDimensionBucket): BookFormattingOverrides? =
-            saved[itemId to dimension]
+            saved[Triple(sourceId, itemId, dimension)]
         override suspend fun save(sourceId: String, itemId: String, dimension: ScreenDimensionBucket, overrides: BookFormattingOverrides) {
-            saved[itemId to dimension] = overrides
+            saved[Triple(sourceId, itemId, dimension)] = overrides
         }
         override suspend fun clear(sourceId: String, itemId: String, dimension: ScreenDimensionBucket) {
-            saved.remove(itemId to dimension)
+            saved.remove(Triple(sourceId, itemId, dimension))
         }
-        fun captured(itemId: String, dimension: ScreenDimensionBucket = ScreenDimensionBucket.PhonePortrait): BookFormattingOverrides? =
-            saved[itemId to dimension]
+        fun captured(sourceId: String, itemId: String, dimension: ScreenDimensionBucket = ScreenDimensionBucket.PhonePortrait): BookFormattingOverrides? =
+            saved[Triple(sourceId, itemId, dimension)]
     }
 
     private class FakeWakeLockPreferencesStore : WakeLockPreferencesStore {
@@ -122,7 +123,7 @@ class PdfReaderViewModelFormattingTest {
         try {
             fixture.session.bindToBook("book-1", sourceId = "test-src")
             fixture.session.updateFormatting("book-1", FormattingPreferences(margins = 2.0f))
-            assertEquals(2.0f, fixture.bookStore.captured("book-1")?.margins)
+            assertEquals(2.0f, fixture.bookStore.captured("test-src", "book-1")?.margins)
         } finally {
             fixture.autoScrollController.release()
             fixture.scope.cancel()

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
@@ -51,19 +51,25 @@ class FormattingSessionTest {
     }
 
     private class FakeBookFormattingPreferencesStore : BookFormattingPreferencesStore {
-        // Keyed by (itemId, dimension) — mirrors the real store's (sourceId, itemId, bucket) PK,
-        // minus the fixed sourceId which is an active-source concern outside the session layer.
         val saved = mutableMapOf<Pair<String, ScreenDimensionBucket>, BookFormattingOverrides>()
+        val loadedSourceIds = mutableListOf<String>()
+        val savedSourceIds = mutableListOf<String>()
         private var toReturn: BookFormattingOverrides? = null
         fun willReturn(o: BookFormattingOverrides?) { toReturn = o }
         override suspend fun load(
-            itemId: String, dimension: ScreenDimensionBucket,
-        ): BookFormattingOverrides? = saved[itemId to dimension] ?: toReturn
+            sourceId: String, itemId: String, dimension: ScreenDimensionBucket,
+        ): BookFormattingOverrides? {
+            loadedSourceIds += sourceId
+            return saved[itemId to dimension] ?: toReturn
+        }
         override suspend fun save(
-            itemId: String, dimension: ScreenDimensionBucket, overrides: BookFormattingOverrides,
-        ) { saved[itemId to dimension] = overrides }
+            sourceId: String, itemId: String, dimension: ScreenDimensionBucket, overrides: BookFormattingOverrides,
+        ) {
+            savedSourceIds += sourceId
+            saved[itemId to dimension] = overrides
+        }
         override suspend fun clear(
-            itemId: String, dimension: ScreenDimensionBucket,
+            sourceId: String, itemId: String, dimension: ScreenDimensionBucket,
         ) { saved.remove(itemId to dimension) }
     }
 
@@ -152,7 +158,7 @@ class FormattingSessionTest {
         val global = FormattingPreferences(fontSize = 1.5f)
         val (session, _, _, _, _, scope) = makeEager(globalPrefs = global)
         try {
-            session.bindToBook("item1")
+            session.bindToBook("item1", sourceId = "test-src")
             assertEquals(1.5f, session.effectiveFormattingPreferences.value.fontSize)
         } finally {
             scope.cancel()
@@ -166,7 +172,7 @@ class FormattingSessionTest {
         val overrides = BookFormattingOverrides(fontSize = 2.0f)
         val (session, _, _, _, _, scope) = makeEager(globalPrefs = global, bookOverrides = overrides)
         try {
-            session.bindToBook("item1")
+            session.bindToBook("item1", sourceId = "test-src")
             assertEquals(2.0f, session.effectiveFormattingPreferences.value.fontSize)
             assertEquals(ReaderTheme.Light, session.effectiveFormattingPreferences.value.theme)
         } finally {
@@ -179,7 +185,7 @@ class FormattingSessionTest {
     fun `updateFormatting persists book overrides to store`() = runTest {
         val (session, _, bookStore, _, _, scope) = makeEager()
         try {
-            session.bindToBook("item1")
+            session.bindToBook("item1", sourceId = "test-src")
             val newPrefs = FormattingPreferences(fontSize = 1.8f)
             session.updateFormatting("item1", newPrefs)
             assertTrue(bookStore.saved.containsKey("item1" to ScreenDimensionBucket.PhonePortrait))
@@ -194,7 +200,7 @@ class FormattingSessionTest {
         val overrides = BookFormattingOverrides(fontSize = 2.0f)
         val (session, _, bookStore, _, _, scope) = makeEager(bookOverrides = overrides)
         try {
-            session.bindToBook("item1")
+            session.bindToBook("item1", sourceId = "test-src")
             assertTrue(session.hasBookOverrides.value)
             session.resetToGlobalDefaults("item1")
             assertFalse(session.hasBookOverrides.value)
@@ -217,7 +223,7 @@ class FormattingSessionTest {
         )
         val (session, _, _, _, _, scope) = makeEager(globalPrefs = global, fakeAppearance = appearance)
         try {
-            session.bindToBook("item1")
+            session.bindToBook("item1", sourceId = "test-src")
             assertEquals(ReaderTheme.Light, session.effectiveFormattingPreferences.value.theme)
 
             // Simulate the coordinator emitting a boundary tick that flips to night.
@@ -315,7 +321,7 @@ class FormattingSessionTest {
         val (session, _, _, _, _, scope) = makeEager()
         try {
             assertFalse(session.formattingPreferencesReady.value)
-            session.bindToBook("item1")
+            session.bindToBook("item1", sourceId = "test-src")
             assertTrue(session.formattingPreferencesReady.value)
         } finally {
             scope.cancel()
@@ -328,7 +334,7 @@ class FormattingSessionTest {
         val overrides = BookFormattingOverrides(theme = ReaderTheme.Dark)
         val (session, _, _, _, _, scope) = makeEager(bookOverrides = overrides)
         try {
-            session.bindToBook("item1")
+            session.bindToBook("item1", sourceId = "test-src")
             assertTrue(session.hasBookOverrides.value)
         } finally {
             scope.cancel()
@@ -344,10 +350,10 @@ class FormattingSessionTest {
         fakeBook.saved["book-b" to ScreenDimensionBucket.PhonePortrait] = BookFormattingOverrides(fontSize = 2.0f)
         val (session, _, _, _, _, scope) = makeEager(fakeGlobal = fakeGlobal, fakeBook = fakeBook)
         try {
-            session.bindToBook("book-a")
+            session.bindToBook("book-a", sourceId = "test-src")
             assertEquals(1.5f, session.effectiveFormattingPreferences.value.fontSize)
 
-            session.bindToBook("book-b")
+            session.bindToBook("book-b", sourceId = "test-src")
             assertEquals(2.0f, session.effectiveFormattingPreferences.value.fontSize)
         } finally {
             scope.cancel()
@@ -359,7 +365,7 @@ class FormattingSessionTest {
     fun `onBookClosed sets formattingPreferencesReady to false`() = runTest {
         val (session, _, _, _, _, scope) = makeEager()
         try {
-            session.bindToBook("item1")
+            session.bindToBook("item1", sourceId = "test-src")
             assertTrue(session.formattingPreferencesReady.value)
 
             session.onBookClosed()
@@ -375,7 +381,7 @@ class FormattingSessionTest {
         val fakeGlobal = FakeFormattingPreferencesStore(FormattingPreferences(autoScrollWpm = 250))
         val (session, _, _, _, autoScrollController, scope) = makeEager(fakeGlobal = fakeGlobal)
         try {
-            session.bindToBook("item1")
+            session.bindToBook("item1", sourceId = "test-src")
 
             autoScrollController.dispatch(AutoScrollEvent.Start)
             assertEquals(250, (autoScrollController.state.value as AutoScrollState.Running).speed.wpm)
@@ -529,7 +535,7 @@ class FormattingSessionTest {
             appearanceCoordinator = FakeAppearanceCoordinator(),
         )
         try {
-            session.bindToBook("item1")
+            session.bindToBook("item1", sourceId = "test-src")
             assertEquals(
                 "Highlights bind must expose the global store's orientation",
                 ReaderOrientation.Continuous,
@@ -557,7 +563,7 @@ class FormattingSessionTest {
             appearanceCoordinator = FakeAppearanceCoordinator(),
         )
         try {
-            session.bindToBook("book-x")
+            session.bindToBook("book-x", sourceId = "test-src")
             session.updateFormatting("book-x", FormattingPreferences(fontSize = 1.75f))
 
             assertTrue(
@@ -611,7 +617,7 @@ class FormattingSessionTest {
         val fakeGlobal = FakeFormattingPreferencesStore(globalPrefs)
         val b = makeEager(fakeGlobal = fakeGlobal, fakeBook = fakeBook)
         try {
-            b.session.bindToBook("book1", ScreenDimensionBucket.PhonePortrait)
+            b.session.bindToBook("book1", ScreenDimensionBucket.PhonePortrait, "test-src")
 
             val seeded = fakeBook.saved["book1" to ScreenDimensionBucket.PhonePortrait]
             assertNotNull(seeded)
@@ -629,9 +635,9 @@ class FormattingSessionTest {
         val dimA = ScreenDimensionBucket.of(SizeClass.Compact, SizeClass.Compact)
         val dimB = ScreenDimensionBucket.PhonePortrait
         try {
-            b.session.bindToBook("book1", dimA)
+            b.session.bindToBook("book1", dimA, "test-src")
             b.session.updateFormatting("book1", b.session.formattingPreferences.value.copy(fontSize = 2.0f))
-            b.session.bindToBook("book1", dimB)
+            b.session.bindToBook("book1", dimB, "test-src")
 
             val dimARow = fakeBook.saved["book1" to dimA]
             val dimBRow = fakeBook.saved["book1" to dimB]
@@ -654,7 +660,7 @@ class FormattingSessionTest {
 
         val b = makeEager(fakeBook = fakeBook)
         try {
-            b.session.bindToBook("book1", dimA)
+            b.session.bindToBook("book1", dimA, "test-src")
             b.session.resetToGlobalDefaults("book1")
 
             assertNull(fakeBook.saved["book1" to dimA])
@@ -673,13 +679,52 @@ class FormattingSessionTest {
         val b = makeEager(fakeBook = fakeBook)
         try {
             // Call bindToBook twice in quick succession — dimB must win.
-            b.session.bindToBook("book1", dimA)
-            b.session.bindToBook("book1", dimB)
+            b.session.bindToBook("book1", dimA, "test-src")
+            b.session.bindToBook("book1", dimB, "test-src")
 
             // activeDimension must reflect the last call's dimension so any subsequent
             // updateFormatting / resetToGlobalDefaults targets dimB, not dimA.
             val seededB = fakeBook.saved["book1" to dimB]
             assertNotNull("dimB row must be seeded by the winning bindToBook call", seededB)
+        } finally {
+            b.sessionScope.cancel()
+        }
+    }
+
+    // Regression: opening a book from the Riffle source view must use the book's own sourceId,
+    // not whatever source happens to be active. Before the fix, FormattingSession ignored the
+    // sourceId in bindToBook and the store always called sourceRepository.getActive(), which
+    // could be null or a different source when the Riffle aggregate view was active.
+    @Test
+    fun `bindToBook passes the provided sourceId to the store, not a hard-coded fallback`() = runTest {
+        val fakeBook = FakeBookFormattingPreferencesStore().also { it.willReturn(null) }
+        val b = makeEager(fakeBook = fakeBook)
+        try {
+            b.session.bindToBook("book1", ScreenDimensionBucket.PhonePortrait, "riffle-source-id")
+
+            assertTrue(
+                "store must have been queried with the provided sourceId",
+                fakeBook.loadedSourceIds.contains("riffle-source-id") ||
+                    fakeBook.savedSourceIds.contains("riffle-source-id"),
+            )
+        } finally {
+            b.sessionScope.cancel()
+        }
+    }
+
+    @Test
+    fun `updateFormatting persists with the sourceId set by the preceding bindToBook`() = runTest {
+        val fakeBook = FakeBookFormattingPreferencesStore().also { it.willReturn(null) }
+        val b = makeEager(fakeBook = fakeBook)
+        try {
+            b.session.bindToBook("book1", ScreenDimensionBucket.PhonePortrait, "my-source")
+            b.session.updateFormatting("book1", FormattingPreferences(fontSize = 1.5f))
+
+            assertEquals(
+                "updateFormatting must use the sourceId from bindToBook",
+                "my-source",
+                fakeBook.savedSourceIds.last(),
+            )
         } finally {
             b.sessionScope.cancel()
         }

--- a/core/data/src/androidHostTest/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImplTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImplTest.kt
@@ -3,17 +3,9 @@ package com.riffle.core.data
 import com.riffle.core.database.BookFormattingPreferencesDao
 import com.riffle.core.database.BookFormattingPreferencesEntity
 import com.riffle.core.domain.BookFormattingOverrides
-import com.riffle.core.domain.CommitSourceResult
-import com.riffle.core.domain.PendingSource
 import com.riffle.core.domain.ReaderTheme
-import com.riffle.core.domain.SourceRepository
 import com.riffle.core.models.ScreenDimensionBucket
 import com.riffle.core.models.ScreenDimensionBucket.SizeClass
-import com.riffle.core.models.ServerType
-import com.riffle.core.models.Source
-import com.riffle.core.models.SourceUrl
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -21,26 +13,8 @@ import org.junit.Test
 
 class BookFormattingPreferencesStoreImplTest {
 
-    private val testSource = Source(
-        id = "src1",
-        url = SourceUrl.parse("http://test")!!,
-        isActive = true,
-        insecureConnectionAllowed = false,
-        username = "",
-        serverType = ServerType.AUDIOBOOKSHELF,
-    )
-
-    private class FakeSourceRepository(private val source: Source?) : SourceRepository {
-        override fun observeAll(): Flow<List<Source>> = MutableStateFlow(listOfNotNull(source))
-        override suspend fun getActive() = source
-        override suspend fun getById(sourceId: String): Source? = source?.takeIf { it.id == sourceId }
-        override suspend fun commit(pending: PendingSource, hiddenLibraryIds: Set<String>): CommitSourceResult = throw UnsupportedOperationException()
-        override suspend fun setActive(sourceId: String) = Unit
-        override suspend fun remove(sourceId: String) = Unit
-        override suspend fun getSourceVersion(sourceId: String): String? = null
-    }
-
     private val capturedGetBuckets = mutableListOf<String>()
+    private val capturedGetSourceIds = mutableListOf<String>()
 
     private inner class FakeDao : BookFormattingPreferencesDao {
         var entityToReturn: BookFormattingPreferencesEntity? = null
@@ -53,6 +27,7 @@ class BookFormattingPreferencesStoreImplTest {
         override suspend fun getByItemId(
             sourceId: String, itemId: String, screenDimensionBucket: String,
         ): BookFormattingPreferencesEntity? {
+            capturedGetSourceIds += sourceId
             capturedGetBuckets += screenDimensionBucket
             return entityToReturn
         }
@@ -66,20 +41,30 @@ class BookFormattingPreferencesStoreImplTest {
     @Test
     fun load_passesEncodedDimensionToDao() = runTest {
         val dao = FakeDao()
-        val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(testSource))
+        val store = BookFormattingPreferencesStoreImpl(dao)
         val bucket = ScreenDimensionBucket.of(SizeClass.Compact, SizeClass.Compact)
 
-        store.load("book1", bucket)
+        store.load("src1", "book1", bucket)
 
         assertEquals(bucket.encode(), capturedGetBuckets.first())
     }
 
     @Test
+    fun load_passesSourceIdToDao() = runTest {
+        val dao = FakeDao()
+        val store = BookFormattingPreferencesStoreImpl(dao)
+
+        store.load("my-source", "book1", ScreenDimensionBucket.PhonePortrait)
+
+        assertEquals("my-source", capturedGetSourceIds.first())
+    }
+
+    @Test
     fun load_returnsNull_whenNoRowFound() = runTest {
         val dao = FakeDao().also { it.entityToReturn = null }
-        val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(testSource))
+        val store = BookFormattingPreferencesStoreImpl(dao)
 
-        val result = store.load("book1", ScreenDimensionBucket.PhonePortrait)
+        val result = store.load("src1", "book1", ScreenDimensionBucket.PhonePortrait)
 
         assertNull(result)
     }
@@ -87,11 +72,11 @@ class BookFormattingPreferencesStoreImplTest {
     @Test
     fun save_includesEncodedDimensionInEntity() = runTest {
         val dao = FakeDao()
-        val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(testSource))
+        val store = BookFormattingPreferencesStoreImpl(dao)
         val bucket = ScreenDimensionBucket.of(SizeClass.Medium, SizeClass.Expanded)
         val overrides = BookFormattingOverrides(theme = ReaderTheme.Dark)
 
-        store.save("book1", bucket, overrides)
+        store.save("src1", "book1", bucket, overrides)
 
         assertEquals(1, dao.upserted.size)
         assertEquals(bucket.encode(), dao.upserted.first().screenDimensionBucket)
@@ -99,24 +84,25 @@ class BookFormattingPreferencesStoreImplTest {
     }
 
     @Test
-    fun clear_passesEncodedDimensionToDao() = runTest {
+    fun save_includesSourceIdInEntity() = runTest {
         val dao = FakeDao()
-        val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(testSource))
-        val bucket = ScreenDimensionBucket.of(SizeClass.Expanded, SizeClass.Compact)
+        val store = BookFormattingPreferencesStoreImpl(dao)
+        val overrides = BookFormattingOverrides(theme = ReaderTheme.Dark)
 
-        store.clear("book1", bucket)
+        store.save("my-source", "book1", ScreenDimensionBucket.PhonePortrait, overrides)
 
-        assertEquals(1, dao.deletedBuckets.size)
-        assertEquals(bucket.encode(), dao.deletedBuckets.first())
+        assertEquals("my-source", dao.upserted.first().sourceId)
     }
 
     @Test
-    fun load_returnsNull_whenNoActiveSource() = runTest {
+    fun clear_passesEncodedDimensionToDao() = runTest {
         val dao = FakeDao()
-        val store = BookFormattingPreferencesStoreImpl(dao, FakeSourceRepository(null))
+        val store = BookFormattingPreferencesStoreImpl(dao)
+        val bucket = ScreenDimensionBucket.of(SizeClass.Expanded, SizeClass.Compact)
 
-        val result = store.load("book1", ScreenDimensionBucket.PhonePortrait)
+        store.clear("src1", "book1", bucket)
 
-        assertNull(result)
+        assertEquals(1, dao.deletedBuckets.size)
+        assertEquals(bucket.encode(), dao.deletedBuckets.first())
     }
 }

--- a/core/data/src/androidHostTest/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreScopeIsolationTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreScopeIsolationTest.kt
@@ -2,19 +2,10 @@ package com.riffle.core.data
 
 import com.riffle.core.database.BookFormattingPreferencesDao
 import com.riffle.core.database.BookFormattingPreferencesEntity
-import com.riffle.core.domain.AuthenticateResult
 import com.riffle.core.domain.BookFormattingOverrides
-import com.riffle.core.domain.CommitSourceResult
 import com.riffle.core.domain.ReaderTheme
 import com.riffle.core.models.ScreenDimensionBucket
 import com.riffle.core.models.ScreenDimensionBucket.SizeClass
-import com.riffle.core.models.ServerType
-import com.riffle.core.models.Source
-import com.riffle.core.domain.PendingSource
-import com.riffle.core.domain.SourceRepository
-import com.riffle.core.models.SourceUrl
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -36,6 +27,7 @@ import org.junit.Test
  */
 class BookFormattingPreferencesStoreScopeIsolationTest {
 
+    private val sourceId = "srv-A"
     private val dim = ScreenDimensionBucket.PhonePortrait
     private val dimLandscape = ScreenDimensionBucket.of(SizeClass.Compact, SizeClass.Compact)
 
@@ -58,82 +50,68 @@ class BookFormattingPreferencesStoreScopeIsolationTest {
         }
     }
 
-    private class FixedActiveSourceRepository(private val active: Source) : SourceRepository {
-        override fun observeAll(): Flow<List<Source>> = MutableStateFlow(listOf(active))
-        override suspend fun getActive(): Source? = active
-        override suspend fun getById(sourceId: String): Source? =
-            active.takeIf { it.id == sourceId }
-        override suspend fun commit(
-            pending: PendingSource,
-            hiddenLibraryIds: Set<String>,
-        ): CommitSourceResult = throw UnsupportedOperationException()
-        override suspend fun setActive(sourceId: String) = Unit
-        override suspend fun remove(sourceId: String) = Unit
-        override suspend fun getSourceVersion(sourceId: String): String? = null
-    }
-
     private fun newStore(): BookFormattingPreferencesStoreImpl = BookFormattingPreferencesStoreImpl(
         dao = InMemoryDao(),
-        sourceRepository = FixedActiveSourceRepository(
-            Source(
-                id = "srv-A",
-                url = SourceUrl.parse("http://localhost")!!,
-                isActive = true,
-                insecureConnectionAllowed = false,
-                username = "",
-                serverType = ServerType.AUDIOBOOKSHELF,
-            ),
-        ),
     )
 
     @Test
     fun `override round-trips for a book`() = runTest {
         val store = newStore()
-        store.save("item-1", dim, BookFormattingOverrides(theme = ReaderTheme.Dark))
+        store.save(sourceId, "item-1", dim, BookFormattingOverrides(theme = ReaderTheme.Dark))
 
         assertEquals(
             ReaderTheme.Dark,
-            store.load("item-1", dim)?.theme,
+            store.load(sourceId, "item-1", dim)?.theme,
         )
     }
 
     @Test
     fun `portrait and landscape dimensions hold independent values for the same book`() = runTest {
         val store = newStore()
-        store.save("item-1", dim, BookFormattingOverrides(fontSize = 1.4f))
-        store.save("item-1", dimLandscape, BookFormattingOverrides(fontSize = 1.8f))
+        store.save(sourceId, "item-1", dim, BookFormattingOverrides(fontSize = 1.4f))
+        store.save(sourceId, "item-1", dimLandscape, BookFormattingOverrides(fontSize = 1.8f))
 
-        assertEquals(1.4f, store.load("item-1", dim)?.fontSize)
-        assertEquals(1.8f, store.load("item-1", dimLandscape)?.fontSize)
+        assertEquals(1.4f, store.load(sourceId, "item-1", dim)?.fontSize)
+        assertEquals(1.8f, store.load(sourceId, "item-1", dimLandscape)?.fontSize)
     }
 
     @Test
     fun `clear removes the row for the targeted dimension only`() = runTest {
         val store = newStore()
-        store.save("item-1", dim, BookFormattingOverrides(fontSize = 1.4f))
-        store.save("item-1", dimLandscape, BookFormattingOverrides(fontSize = 1.8f))
+        store.save(sourceId, "item-1", dim, BookFormattingOverrides(fontSize = 1.4f))
+        store.save(sourceId, "item-1", dimLandscape, BookFormattingOverrides(fontSize = 1.8f))
 
-        store.clear("item-1", dim)
+        store.clear(sourceId, "item-1", dim)
 
         assertNull(
             "Portrait value must be gone after a portrait-scoped clear",
-            store.load("item-1", dim)?.fontSize,
+            store.load(sourceId, "item-1", dim)?.fontSize,
         )
         assertEquals(
             "Landscape value must survive a portrait-scoped clear",
             1.8f,
-            store.load("item-1", dimLandscape)?.fontSize,
+            store.load(sourceId, "item-1", dimLandscape)?.fontSize,
         )
     }
 
     @Test
     fun `colored chapter map override round-trips for a book`() = runTest {
         val store = newStore()
-        store.save("item-1", dim, BookFormattingOverrides(coloredChapterMap = false))
+        store.save(sourceId, "item-1", dim, BookFormattingOverrides(coloredChapterMap = false))
 
         assertEquals(
             false,
-            store.load("item-1", dim)?.coloredChapterMap,
+            store.load(sourceId, "item-1", dim)?.coloredChapterMap,
         )
+    }
+
+    @Test
+    fun `two sources with the same itemId hold independent settings`() = runTest {
+        val store = newStore()
+        store.save("src-A", "item-1", dim, BookFormattingOverrides(fontSize = 1.4f))
+        store.save("src-B", "item-1", dim, BookFormattingOverrides(fontSize = 1.8f))
+
+        assertEquals(1.4f, store.load("src-A", "item-1", dim)?.fontSize)
+        assertEquals(1.8f, store.load("src-B", "item-1", dim)?.fontSize)
     }
 }

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/BookFormattingPreferencesStoreImpl.kt
@@ -8,7 +8,6 @@ import com.riffle.core.models.ScreenDimensionBucket
 import com.riffle.core.domain.ReaderFontFamily
 import com.riffle.core.domain.ReaderOrientation
 import com.riffle.core.domain.ReaderTheme
-import com.riffle.core.domain.SourceRepository
 
 // Formatting is per-device, keyed by (sourceId, itemId, screenDimensionBucket). sourceId
 // prevents colliding item ids across Sources from sharing one row (ADR 0031); screenDimensionBucket
@@ -16,14 +15,13 @@ import com.riffle.core.domain.SourceRepository
 // and the elided (annotations) reader share the same row.
 class BookFormattingPreferencesStoreImpl constructor(
     private val dao: BookFormattingPreferencesDao,
-    private val sourceRepository: SourceRepository,
 ) : BookFormattingPreferencesStore {
 
     override suspend fun load(
+        sourceId: String,
         itemId: String,
         dimension: ScreenDimensionBucket,
     ): BookFormattingOverrides? {
-        val sourceId = sourceRepository.getActive()?.id ?: return null
         val entity = dao.getByItemId(sourceId, itemId, dimension.encode()) ?: return null
         return BookFormattingOverrides(
             fontSize = entity.fontSize,
@@ -43,11 +41,11 @@ class BookFormattingPreferencesStoreImpl constructor(
     }
 
     override suspend fun save(
+        sourceId: String,
         itemId: String,
         dimension: ScreenDimensionBucket,
         overrides: BookFormattingOverrides,
     ) {
-        val sourceId = sourceRepository.getActive()?.id ?: return
         if (overrides.isEmpty) {
             dao.deleteByItemId(sourceId, itemId, dimension.encode())
             return
@@ -75,10 +73,10 @@ class BookFormattingPreferencesStoreImpl constructor(
     }
 
     override suspend fun clear(
+        sourceId: String,
         itemId: String,
         dimension: ScreenDimensionBucket,
     ) {
-        val sourceId = sourceRepository.getActive()?.id ?: return
         dao.deleteByItemId(sourceId, itemId, dimension.encode())
     }
 }

--- a/core/data/src/androidMain/kotlin/com/riffle/core/data/di/CoreDataKoinModules.kt
+++ b/core/data/src/androidMain/kotlin/com/riffle/core/data/di/CoreDataKoinModules.kt
@@ -545,7 +545,7 @@ private val coreDataPreferencesModule = module {
         FormattingPreferencesStoreProviderImpl(fullBook = get<FormattingPreferencesStoreImpl>())
     }
 
-    single<BookFormattingPreferencesStore> { BookFormattingPreferencesStoreImpl(get(), get()) }
+    single<BookFormattingPreferencesStore> { BookFormattingPreferencesStoreImpl(get()) }
     single<AudioPlaybackPreferencesStore> { AudioPlaybackPreferencesStoreImpl(get()) }
     single<LibraryVisibilityPreferencesStore> {
         LibraryVisibilityPreferencesStoreImpl(get(named(DS_LIBRARY_VISIBILITY)))

--- a/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/BookFormattingPreferencesStore.kt
+++ b/core/domain/src/jvmMain/kotlin/com/riffle/core/domain/BookFormattingPreferencesStore.kt
@@ -3,8 +3,8 @@ package com.riffle.core.domain
 import com.riffle.core.models.ScreenDimensionBucket
 
 interface BookFormattingPreferencesStore {
-    // Returns null if no row exists for this (itemId, dimension) — caller is responsible for seeding.
-    suspend fun load(itemId: String, dimension: ScreenDimensionBucket): BookFormattingOverrides?
-    suspend fun save(itemId: String, dimension: ScreenDimensionBucket, overrides: BookFormattingOverrides)
-    suspend fun clear(itemId: String, dimension: ScreenDimensionBucket)
+    // Returns null if no row exists for this (sourceId, itemId, dimension) — caller is responsible for seeding.
+    suspend fun load(sourceId: String, itemId: String, dimension: ScreenDimensionBucket): BookFormattingOverrides?
+    suspend fun save(sourceId: String, itemId: String, dimension: ScreenDimensionBucket, overrides: BookFormattingOverrides)
+    suspend fun clear(sourceId: String, itemId: String, dimension: ScreenDimensionBucket)
 }


### PR DESCRIPTION
## Problem

When a book is opened from the Riffle source view (the aggregate multi-source library shown when 2+ sources are configured), reading settings (font size, theme, margins, etc.) were neither loaded nor saved. The Riffle view clears the active source (#998), so `sourceRepository.getActive()` returns null — and `BookFormattingPreferencesStoreImpl` keyed all three operations (`load/save/clear`) on `getActive()?.id`, silently dropping them when that returned null.

## Fix

Add `sourceId: String` as an explicit parameter to `BookFormattingPreferencesStore.load/save/clear`, removing the `SourceRepository` dependency from the implementation entirely. The sourceId is now threaded in from the reader ViewModels — resolved as `navServerId ?: sourceRepository.getActive()?.id`, the same pattern already used for reading-position saves (#999).

`FormattingSession.bindToBook` accepts an optional `sourceId` parameter, stores it as `boundSourceId`, and passes it to every store call. Subsequent dimension-change re-binds (fold/rotate) omit sourceId and reuse the stored value.

Both EPUB and PDF readers resolve the book's own sourceId before calling `bindToBook`.

## Changes

- `BookFormattingPreferencesStore` interface — `sourceId: String` added as first param to all three methods
- `BookFormattingPreferencesStoreImpl` — uses provided sourceId directly; `SourceRepository` dependency removed
- `FormattingSession` — stores `boundSourceId`; `bindToBook(itemId, dimension, sourceId?)` propagates it to all store calls
- `EpubReaderViewModel`, `PdfReaderViewModel` — resolve `navServerId ?: getActive()` before `bindToBook`
- Tests — updated fakes and `bindToBook` call sites; added regression tests that pin the sourceId threading and verify two-source isolation; `PdfReaderViewModelFormattingTest` fake now keys on `(sourceId, itemId, dimension)` to catch wrong-source routing regressions

Per-screen-dimension isolation (`activeDimension` / `screenDimensionBucket`) is unchanged — the fix only adds sourceId tracking on top of the existing dimension keying.