### PR TITLE
fix(reader): pause auto-scroll when screen is off

### DIFF
--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderScreen.kt
@@ -265,6 +265,26 @@ fun EpubReaderScreen(
         onDispose { lifecycle.removeObserver(observer) }
     }
 
+    // Pause auto-scroll while the screen is off and resume when the screen comes back on.
+    DisposableEffect(viewModel) {
+        val receiver = object : android.content.BroadcastReceiver() {
+            override fun onReceive(ctx: android.content.Context, intent: android.content.Intent) {
+                when (intent.action) {
+                    android.content.Intent.ACTION_SCREEN_OFF ->
+                        viewModel.pauseAutoScroll(com.riffle.core.domain.autoscroll.PauseCause.ScreenOff)
+                    android.content.Intent.ACTION_SCREEN_ON ->
+                        viewModel.resumeAutoScrollIfPausedBy(com.riffle.core.domain.autoscroll.PauseCause.ScreenOff)
+                }
+            }
+        }
+        val filter = android.content.IntentFilter().apply {
+            addAction(android.content.Intent.ACTION_SCREEN_OFF)
+            addAction(android.content.Intent.ACTION_SCREEN_ON)
+        }
+        context.registerReceiver(receiver, filter)
+        onDispose { context.unregisterReceiver(receiver) }
+    }
+
     // Screen wake lock — gated on user preference
     DisposableEffect(keepScreenOn) {
         val window = (context as? FragmentActivity)?.window

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/EpubReaderViewModel.kt
@@ -655,6 +655,9 @@ class EpubReaderViewModel constructor(
 
     fun resumeAutoScrollIfPaused() = formatting.resumeAutoScrollIfPaused()
 
+    fun resumeAutoScrollIfPausedBy(cause: com.riffle.core.domain.autoscroll.PauseCause) =
+        formatting.resumeAutoScrollIfPausedBy(cause)
+
     fun pauseAutoScrollFromPill() = formatting.pauseAutoScrollFromPill()
 
     fun resumeAutoScrollFromPill() = formatting.resumeAutoScrollIfPaused()

--- a/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
+++ b/app/src/main/kotlin/com/riffle/app/feature/reader/session/FormattingSession.kt
@@ -341,6 +341,13 @@ class FormattingSession constructor(
         autoScrollController.dispatch(AutoScrollEvent.Resume)
     }
 
+    fun resumeAutoScrollIfPausedBy(cause: PauseCause) {
+        val s = autoScrollController.state.value
+        if (s is AutoScrollState.Paused && s.cause == cause) {
+            autoScrollController.dispatch(AutoScrollEvent.Resume)
+        }
+    }
+
     fun reachedEndOfBookForAutoScroll() {
         autoScrollController.dispatch(AutoScrollEvent.Stop)
     }

--- a/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
+++ b/app/src/test/kotlin/com/riffle/app/feature/reader/session/FormattingSessionTest.kt
@@ -729,4 +729,42 @@ class FormattingSessionTest {
             b.sessionScope.cancel()
         }
     }
+
+    // Screen-off pause: resumeAutoScrollIfPausedBy(ScreenOff) must resume a ScreenOff-paused session.
+    @Test
+    fun `resumeAutoScrollIfPausedBy ScreenOff resumes a ScreenOff-paused scroll`() = runTest {
+        val (session, _, _, _, autoScrollController, scope) = makeEager()
+        try {
+            autoScrollController.dispatch(AutoScrollEvent.Start)
+            session.pauseAutoScroll(com.riffle.core.domain.autoscroll.PauseCause.ScreenOff)
+            assertTrue(autoScrollController.state.value is AutoScrollState.Paused)
+
+            session.resumeAutoScrollIfPausedBy(com.riffle.core.domain.autoscroll.PauseCause.ScreenOff)
+            assertTrue(autoScrollController.state.value is AutoScrollState.Running)
+        } finally {
+            autoScrollController.release()
+            scope.cancel()
+        }
+    }
+
+    // Screen-off resume must NOT unpark a UserPausedPill session — the pill-park is sticky.
+    @Test
+    fun `resumeAutoScrollIfPausedBy ScreenOff does not resume a UserPausedPill scroll`() = runTest {
+        val (session, _, _, _, autoScrollController, scope) = makeEager()
+        try {
+            autoScrollController.dispatch(AutoScrollEvent.Start)
+            session.pauseAutoScrollFromPill()
+            val parked = autoScrollController.state.value as AutoScrollState.Paused
+            assertEquals(com.riffle.core.domain.autoscroll.PauseCause.UserPausedPill, parked.cause)
+
+            session.resumeAutoScrollIfPausedBy(com.riffle.core.domain.autoscroll.PauseCause.ScreenOff)
+            assertTrue(
+                "pill-parked scroll must not be resumed by a screen-on event",
+                autoScrollController.state.value is AutoScrollState.Paused,
+            )
+        } finally {
+            autoScrollController.release()
+            scope.cancel()
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Registers a `BroadcastReceiver` in `EpubReaderScreen` for `ACTION_SCREEN_OFF` / `ACTION_SCREEN_ON`
- Screen-off dispatches `Pause(ScreenOff)` to stop auto-scroll
- Screen-on calls `resumeAutoScrollIfPausedBy(ScreenOff)`, which only resumes if the pause cause is exactly `ScreenOff` — a scroll parked by the user via the HUD pill is not silently resumed when the screen comes back on
- Adds `resumeAutoScrollIfPausedBy(cause)` to `FormattingSession` and exposes it from the ViewModel

## Tests

Two new JVM unit tests in `FormattingSessionTest`:
- `resumeAutoScrollIfPausedBy ScreenOff resumes a ScreenOff-paused scroll`
- `resumeAutoScrollIfPausedBy ScreenOff does not resume a UserPausedPill scroll`